### PR TITLE
Initramfs script improvements for encrypted bcachefs root filesystems

### DIFF
--- a/initramfs/script
+++ b/initramfs/script
@@ -15,11 +15,40 @@ prereqs)
     ;;
 esac
 
-# Check if it needs unlocking:
-if bcachefs unlock -c $ROOT >/dev/null 2>&1; then
-    echo "Unlocking $ROOT:"
-
-    while true; do
-	bcachefs unlock $ROOT && break
-    done
+# Nothing to do if ROOTFSTYPE is set to something other than bcachefs
+if [ -n "$ROOTFSTYPE" -a "$ROOTFSTYPE" != bcachefs ]; then
+    exit 0
 fi
+
+# source for resolve_device() and panic() functions
+. /scripts/functions
+
+# Resolve the root device (e.g. if root is specified by UUID)
+DEV=$(resolve_device "$ROOT")
+
+# Check if the root device needs unlocking:
+if bcachefs unlock -c $DEV >/dev/null 2>&1; then
+    if [ "$DEV" == "$ROOT" ]; then
+        echo "Please unlock $DEV:"
+    else
+        echo "Please unlock $DEV ($ROOT):"
+    fi
+
+    count=0
+    tries=3
+    while [ $tries -le 0 -o $count -lt $tries ]; do
+        if bcachefs unlock "$DEV"; then
+            echo "Bcachefs: $DEV successfully unlocked"
+            break
+        fi
+
+        let count++
+    done
+
+    if [ $tries -gt 0 -a $count -ge $tries ]; then
+        panic "Bcachefs: maximum number of tries exceeded for $DEV"
+        exit 1
+    fi
+fi
+
+exit 0

--- a/initramfs/script
+++ b/initramfs/script
@@ -23,22 +23,68 @@ fi
 # source for resolve_device() and panic() functions
 . /scripts/functions
 
+#
+# Helper functions
+#
+message()
+{
+    if [ -x /bin/plymouth ] && plymouth --ping; then
+        plymouth message --text="$*"
+    else
+        echo "$*" >&2
+    fi
+}
+
+panic2()
+{
+    # Send the panic message to plymouth
+    if [ -x /bin/plymouth ] && plymouth --ping; then
+        plymouth message --text="$*"
+    fi
+    panic "$@"
+    exit 1
+}
+
+unlock()
+{
+    local msg=$1
+    shift
+
+    if [ -x /bin/plymouth ] && plymouth --ping; then
+        msg=$(plymouth ask-for-password --prompt="$msg" | \
+              bcachefs unlock "$@" 2>&1)
+        # If the unlock failed, send any printed messages to plymouth
+        if [ $? -ne 0 ]; then
+            plymouth message --text="Bcachefs: $msg"
+            return 1
+        fi
+    else
+        # If unlock() is called multiple times, don't re-print the prompt message
+        # unless it has changed
+        if [ "$LAST_UNLOCK_MSG" != "$msg" ]; then
+            echo "$msg" >&2
+            LAST_UNLOCK_MSG=$msg
+        fi
+        bcachefs unlock "$@"
+    fi
+}
+
 # Resolve the root device (e.g. if root is specified by UUID)
 DEV=$(resolve_device "$ROOT")
 
 # Check if the root device needs unlocking:
 if bcachefs unlock -c $DEV >/dev/null 2>&1; then
     if [ "$DEV" == "$ROOT" ]; then
-        echo "Please unlock $DEV:"
+        msg="Please unlock $DEV:"
     else
-        echo "Please unlock $DEV ($ROOT):"
+        msg="Please unlock $DEV ($ROOT):"
     fi
 
     count=0
     tries=3
     while [ $tries -le 0 -o $count -lt $tries ]; do
-        if bcachefs unlock "$DEV"; then
-            echo "Bcachefs: $DEV successfully unlocked"
+        if unlock "$msg" "$DEV"; then
+            message "Bcachefs: $DEV successfully unlocked"
             break
         fi
 
@@ -46,8 +92,7 @@ if bcachefs unlock -c $DEV >/dev/null 2>&1; then
     done
 
     if [ $tries -gt 0 -a $count -ge $tries ]; then
-        panic "Bcachefs: maximum number of tries exceeded for $DEV"
-        exit 1
+        panic2 "Bcachefs: maximum number of tries exceeded for $DEV"
     fi
 fi
 


### PR DESCRIPTION
This PR improves the initramfs script used to unlock encrypted bcachefs root devices.

- Use plymouth if available, otherwise fall back to text consoles.
- Resolve the root device, so it can be specified by UUID, label, etc.
- Only try to unlock the device 3 times before opening a shell (or rebooting if panic= is on the kernel cmdline).
    - If the user runs into an issue, this allows them to try to fix it from an initramfs shell immediately instead of having to physically reboot the box and add break= to the kernel cmdline.
- Don't do anything if the ROOTFSTYPE is not bcachefs (and not empty).