### PR TITLE
Add version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ CFLAGS+=-std=gnu89 -O2 -g -MMD -Wall				\
 	$(EXTRA_CFLAGS)
 LDFLAGS+=$(CFLAGS)
 
-VERSION?=$(shell git describe --long --dirty 2>/dev/null || echo 0.1-nogit)
+VERSION?=$(shell git describe --dirty 2>/dev/null || echo 0.1-nogit)
 
 CC_VERSION=$(shell $(CC) -v 2>&1|grep -E '(gcc|clang) version')
 

--- a/bcachefs.8
+++ b/bcachefs.8
@@ -1,5 +1,5 @@
-.Dd February 9, 2018
-.Dt BCACHEFS 8
+.Dd May 26, 2018
+.Dt BCACHEFS 8 SMM
 .Os
 .Sh NAME
 .Nm bcachefs
@@ -86,6 +86,11 @@ Add default superblock, after bcachefs migrate
 Dump filesystem metadata to a qcow2 image
 .It Ic list
 List filesystem metadata in textual form
+.El
+.Ss Miscellaneous commands
+.Bl -tag -width 18n -compact
+.It Ic version
+Display the version of the invoked bcachefs tool
 .El
 .Sh Superblock commands
 .Bl -tag -width Ds
@@ -309,6 +314,11 @@ Force fsck
 Verbose mode
 List mode
 .El
+.El
+.Sh Miscellaneous commands
+.Bl -tag -width Ds
+.It Nm Ic version
+Display the version of the invoked bcachefs tool
 .El
 .Sh EXIT STATUS
 .Ex -std

--- a/bcachefs.c
+++ b/bcachefs.c
@@ -70,7 +70,10 @@ static void usage(void)
 	     "Debug:\n"
 	     "These commands work on offline, unmounted filesystems\n"
 	     "  dump                 Dump filesystem metadata to a qcow2 image\n"
-	     "  list                 List filesystem metadata in textual form\n");
+	     "  list                 List filesystem metadata in textual form\n"
+	     "\n"
+	     "Miscellaneous:\n"
+	     "  version              Display the version of the invoked bcachefs tool\n");
 }
 
 static char *full_cmd;
@@ -144,6 +147,8 @@ int main(int argc, char *argv[])
 
 	char *cmd = pop_cmd(&argc, argv);
 
+	if (!strcmp(cmd, "version"))
+		return cmd_version(argc, argv);
 	if (!strcmp(cmd, "format"))
 		return cmd_format(argc, argv);
 	if (!strcmp(cmd, "show-super"))

--- a/cmd_version.c
+++ b/cmd_version.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+#include "cmds.h"
+
+int cmd_version(int argc, char *argv[])
+{
+	printf("bcachefs tool version %s\n", VERSION_STRING);
+	return 0;
+}

--- a/cmds.h
+++ b/cmds.h
@@ -43,4 +43,6 @@ int cmd_list(int argc, char *argv[]);
 int cmd_migrate(int argc, char *argv[]);
 int cmd_migrate_superblock(int argc, char *argv[]);
 
+int cmd_version(int argc, char *argv[]);
+
 #endif /* _CMDS_H */


### PR DESCRIPTION
It would be nice to have a way to tell whether a compiled version of the bcachefs tool is out of date, so I added a version command to print where the tool was built from.

By default it uses git describe to generate a version string (E.g. 0.1-355-ga5d94ce), but will fall back to the string "0.1-nogit" if git describe fails.

You will need to create an annotated tag somewhere for git describe to work (or change the git describe arguments).

The version string can also be overridden on the make command-line with the VERSION= parameter.