### PR TITLE
Replaces attr/xattr.h include

### DIFF
--- a/cmd_migrate.c
+++ b/cmd_migrate.c
@@ -9,7 +9,7 @@
 #include <sys/types.h>
 #include <sys/vfs.h>
 #include <unistd.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 
 #include <linux/fiemap.h>
 #include <linux/fs.h>


### PR DESCRIPTION
The attr/xattr.h doesn't exist on the newer versions of attr and can be replaced throught the in glibc included sys/xattr.h