### PR TITLE
add mkinitcpio hook for Arch and sample /etc/mkinitcpio.conf

### DIFF
--- a/arch/etc/initcpio/hooks/bcachefs
+++ b/arch/etc/initcpio/hooks/bcachefs
@@ -1,0 +1,14 @@
+#!/usr/bin/ash
+
+run_hook() {
+
+# check if $root needs unlocking
+if bcachefs unlock -c $root >/dev/null 2>&1; then
+    echo "Unlocking $root:"
+    while true; do
+        bcachefs unlock $root && break
+    done
+fi
+}
+
+# vim: set ft=sh ts=4 sw=4 et:

--- a/arch/etc/initcpio/install/bcachefs
+++ b/arch/etc/initcpio/install/bcachefs
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+build() {
+             add_module `bcachefs`
+             add_binary "bcachefs"
+
+             add_runscript
+
+}
+
+help() {
+           cat <<HELPEOF
+This hook is for getting the bcachefs unlock prompt at boot
+HELPEOF
+}
+
+# vim set ft=sh ts=4 sw=4 et:

--- a/arch/etc/mkinitcpio.conf
+++ b/arch/etc/mkinitcpio.conf
@@ -1,0 +1,66 @@
+# vim:set ft=sh
+# MODULES
+# The following modules are loaded before any boot hooks are
+# run.  Advanced users may wish to specify all system modules
+# in this array.  For instance:
+#     MODULES=(piix ide_disk reiserfs)
+MODULES=(bcachefs)
+
+# BINARIES
+# This setting includes any additional binaries a given user may
+# wish into the CPIO image.  This is run last, so it may be used to
+# override the actual binaries included by a given hook
+# BINARIES are dependency parsed, so you may safely ignore libraries
+BINARIES=(bcachefs)
+
+# FILES
+# This setting is similar to BINARIES above, however, files are added
+# as-is and are not parsed in any way.  This is useful for config files.
+FILES=()
+
+# HOOKS
+# This is the most important setting in this file.  The HOOKS control the
+# modules and scripts added to the image, and what happens at boot time.
+# Order is important, and it is recommended that you do not change the
+# order in which HOOKS are added.  Run 'mkinitcpio -H <hook name>' for
+# help on a given hook.
+# 'base' is _required_ unless you know precisely what you are doing.
+# 'udev' is _required_ in order to automatically load modules
+# 'filesystems' is _required_ unless you specify your fs modules in MODULES
+# Examples:
+##   This setup specifies all modules in the MODULES setting above.
+##   No raid, lvm2, or encrypted root is needed.
+#    HOOKS="base"
+#
+##   This setup will autodetect all modules for your system and should
+##   work as a sane default
+#    HOOKS="base udev autodetect block filesystems"
+#
+##   This setup will generate a 'full' image which supports most systems.
+##   No autodetection is done.
+#    HOOKS="base udev block filesystems"
+#
+##   This setup assembles a pata mdadm array with an encrypted root FS.
+##   Note: See 'mkinitcpio -H mdadm' for more information on raid devices.
+#    HOOKS="base udev block mdadm encrypt filesystems"
+#
+##   This setup loads an lvm2 volume group on a usb device.
+#    HOOKS="base udev block lvm2 filesystems"
+#
+##   NOTE: If you have /usr on a separate partition, you MUST include the
+#    usr, fsck and shutdown hooks.
+HOOKS=(base udev autodetect modconf block filesystems bcachefs keyboard fsck)
+
+# COMPRESSION
+# Use this to compress the initramfs image. By default, gzip compression
+# is used. Use 'cat' to create an uncompressed image.
+#COMPRESSION="gzip"
+#COMPRESSION="bzip2"
+#COMPRESSION="lzma"
+#COMPRESSION="xz"
+#COMPRESSION="lzop"
+#COMPRESSION="lz4"
+
+# COMPRESSION_OPTIONS
+# Additional options for the compressor
+#COMPRESSION_OPTIONS=""


### PR DESCRIPTION
This adds the necessary initcpio hook for Arch to boot from an encrypted root bcachefs drive/partition. For the time being, the hook is kept in the custom hooks directory (`/etc/initcpio/hooks`) as per the [Arch wiki](https://wiki.archlinux.org/index.php/Mkinitcpio#HOOKS). As things get mainlined and become part of the kernel, we may want to move the hook into the system hooks directory (`/usr/lib/initcpio/hooks`). There is an example of a working `/etc/mkinitcpio.conf` that calls the bcachefs hook when creating a new initramfs with `mkinitcpio -p linux-bcachefs`.