### PR TITLE
Don't read meminfo if there are no shrinkers

### DIFF
--- a/linux/shrinker.c
+++ b/linux/shrinker.c
@@ -69,8 +69,15 @@ static struct meminfo read_meminfo(void)
 void run_shrinkers(void)
 {
 	struct shrinker *shrinker;
-	struct meminfo info = read_meminfo();
-	s64 want_shrink = (info.total >> 2) - info.available;
+	struct meminfo info;
+	s64 want_shrink;
+
+	/* Fast out if there are no shrinkers to run. */
+	if (list_empty(&shrinker_list))
+		return;
+
+	info = read_meminfo();
+	want_shrink = (info.total >> 2) - info.available;
 
 	if (want_shrink <= 0)
 		return;


### PR DESCRIPTION
If no shrinkers have been registered, there is no reason to read /proc/meminfo.

This allows some commands to run without needing the /proc filesystem to be mounted including format, show-super, unlock, --help, and version.

Since list_empty only does a simple pointer comparison, it seemed unnecessary to take the shrinker_lock.
(See [urcu/list.h](https://github.com/urcu/userspace-rcu/blob/master/include/urcu/list.h#L184))