### PR TITLE
Fixed xattr.h includes

### DIFF
--- a/cmd_migrate.c
+++ b/cmd_migrate.c
@@ -3,13 +3,13 @@
 #include <fcntl.h>
 #include <getopt.h>
 #include <string.h>
+#include <sys/xattr.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/vfs.h>
 #include <unistd.h>
-#include <attr/xattr.h>
 
 #include <linux/fiemap.h>
 #include <linux/fs.h>

--- a/include/uapi/linux/xattr.h
+++ b/include/uapi/linux/xattr.h
@@ -13,8 +13,12 @@
 #ifndef _UAPI_LINUX_XATTR_H
 #define _UAPI_LINUX_XATTR_H
 
+#if __UAPI_DEF_XATTR
+#define __USE_KERNEL_XATTR_DEFS
+
 #define XATTR_CREATE	0x1	/* set value, fail if attr already exists */
 #define XATTR_REPLACE	0x2	/* set value, fail if attr does not exist */
+#endif
 
 /* Namespaces */
 #define XATTR_OS2_PREFIX "os2."


### PR DESCRIPTION
Since <attr/xattr.h> is not available anymore, I made a patch to use <sys/xattr.h> instead and fixed some build issues that could arise.