### PR TITLE
 Update initramfs after .deb install or uninstall

### DIFF
--- a/cmd_format.c
+++ b/cmd_format.c
@@ -122,7 +122,7 @@ int cmd_format(int argc, char *argv[])
 	struct bch_opts fs_opts = bch2_parse_opts(fs_opt_strs);
 
 	while ((opt = getopt_long(argc, argv,
-				  "-L:U:fqh",
+				  "-L:U:g:fqh",
 				  format_opts,
 				  NULL)) != -1)
 		switch (opt) {

--- a/debian/bcachefs-tools.dirs
+++ b/debian/bcachefs-tools.dirs
@@ -1,2 +1,0 @@
-sbin/
-usr/share/man/man8/

--- a/debian/bcachefs-tools.postinst
+++ b/debian/bcachefs-tools.postinst
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+    configure)
+	if which update-initramfs >/dev/null; then
+	    update-initramfs -u
+	fi
+    ;;
+esac
+

--- a/debian/bcachefs-tools.postrm
+++ b/debian/bcachefs-tools.postrm
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+    remove)
+	if which update-initramfs >/dev/null; then
+	    update-initramfs -u
+	fi
+    ;;
+esac
+


### PR DESCRIPTION
After the bcachefs-tools debian package is installed or uninstalled, we should update the initramfs so the bcachefs utility is added or removed from it accordingly.

This also fixes the -g short opt for the format command to create a disk group.

Finally, make install creates all the necessary directories, so the debian/bcachefs-tools.dirs file is unnecessary.