### PR TITLE
Makefile, gitignore, and initramfs hook improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ bcachefs
 tags
 cscope*
 bcachefs-tools
+
+# dot-files that we don't want to ignore
+!.gitignore

--- a/Makefile
+++ b/Makefile
@@ -74,16 +74,17 @@ endif
 cmd_version.o : .version
 
 .PHONY: install
+install: INITRAMFS_HOOK=$(INITRAMFS_DIR)/hooks/bcachefs
+install: INITRAMFS_SCRIPT=$(INITRAMFS_DIR)/scripts/local-premount/bcachefs
 install: bcachefs
-	mkdir -p $(DESTDIR)$(ROOT_SBINDIR)
-	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man8/
-	$(INSTALL) -m0755 bcachefs $(DESTDIR)$(ROOT_SBINDIR)
-	$(INSTALL) -m0755 fsck.bcachefs $(DESTDIR)$(ROOT_SBINDIR)
-	$(INSTALL) -m0755 mkfs.bcachefs $(DESTDIR)$(ROOT_SBINDIR)
-	$(INSTALL) -m0755 -D initramfs/hook $(DESTDIR)$(INITRAMFS_DIR)/hooks/bcachefs
-	echo "copy_exec $(ROOT_SBINDIR)/bcachefs /sbin/bcachefs" >> $(DESTDIR)$(INITRAMFS_DIR)/hooks/bcachefs
-	$(INSTALL) -m0755 -D initramfs/script $(DESTDIR)$(INITRAMFS_DIR)/scripts/local-premount/bcachefs
-	$(INSTALL) -m0644 bcachefs.8 $(DESTDIR)$(PREFIX)/share/man/man8/
+	$(INSTALL) -m0755 -D bcachefs      -t $(DESTDIR)$(ROOT_SBINDIR)
+	$(INSTALL) -m0755    fsck.bcachefs    $(DESTDIR)$(ROOT_SBINDIR)
+	$(INSTALL) -m0755    mkfs.bcachefs    $(DESTDIR)$(ROOT_SBINDIR)
+	$(INSTALL) -m0644 -D bcachefs.8    -t $(DESTDIR)$(PREFIX)/share/man/man8/
+	$(INSTALL) -m0755 -D initramfs/script $(DESTDIR)$(INITRAMFS_SCRIPT)
+	$(INSTALL) -m0755 -D initramfs/hook   $(DESTDIR)$(INITRAMFS_HOOK)
+	sed -i '/^# Note: make install replaces/,$$d' $(DESTDIR)$(INITRAMFS_HOOK)
+	echo "copy_exec $(ROOT_SBINDIR)/bcachefs /sbin/bcachefs" >> $(DESTDIR)$(INITRAMFS_HOOK)
 
 .PHONY: clean
 clean:

--- a/initramfs/hook
+++ b/initramfs/hook
@@ -22,3 +22,6 @@ manual_add_modules 'bcachefs'
 add_loaded_modules 'chacha20[-_]*'
 add_loaded_modules 'poly1305[-_]*'
 
+# Add the bcachefs utility to the initramfs
+# Note: make install replaces this with the install path, so it must be last
+#copy_exec /usr/local/sbin/bcachefs /sbin/bcachefs


### PR DESCRIPTION
A bunch of small tweaks to the top-level Makefile along with a small change to the top-level .gitignore and to the initramfs hook.

### .gitignore
* Don't ignore other .gitignore files that are added

### hooks/initramfs
* Added a comment about the bcachefs utility to the initramfs hook
* To give a better idea of what the installed hook looks like when you're just looking at the source file
* make install was updated to remove the last 2 commented out lines, so the installed file will end up similar to before this commit:
```
# Add the bcachefs utility to the initramfs
copy_exec /usr/local/sbin/bcachefs /sbin/bcachefs
```

### Makefile
* Replaced `mkdir -p` in favor of `install -D` in the install target
* Don't use delayed expansion for the pkg-config output so that pkg-config only gets called twice total instead of once per compile or link command, also changed the command to `$(shell pkg-config ...)` instead of `` `pkg-config ...` `` to accomplish this.
* Added `EXTRA_LDFLAGS` and `EXTRA_LDLIBS` vars
* Removed tabs in the middle of commands to make it easier to manually re-run
  commands manually (e.g. if a compilation fails), so that the shell you're pasting into won't attempt tab completion
* Replaced `` `cd dir; git command` `` in favor of `$(shell git -C dir command)`
* Minor version format change: dirty trees just append "+" instead of "-dirty"
  and if git describe fails, it now sets the version to "**v**0.1-nogit"
