### PR TITLE
Update debian URLs and remove libattr from dependencies

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,19 +1,21 @@
 
 Dependencies:
 
- * libattr1
+ * libaio
  * libblkid
- * libuuid
+ * libkeyutils
+ * liblz4
  * libscrypt
  * libsodium
- * libkeyutils
  * liburcu
+ * libuuid
+ * libzstd
  * pkg-config
  * zlib1g
 
 On debian, you can install these with
-    apt install -y pkg-config libblkid-dev uuid-dev libscrypt-dev libsodium-dev
-	libkeyutils-dev liburcu-dev zlib1g-dev libzstd-dev libattr1-dev
-	libaio-dev liblz4-dev
+    apt install -y pkg-config libaio-dev libblkid-dev libkeyutils-dev \
+        liblz4-dev libscrypt-dev libsodium-dev liburcu-dev libzstd-dev \
+        uuid-dev zlib1g-dev
 
 Then, just make && make install

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,13 @@ endif
 PKGCONFIG_LIBS="blkid uuid liburcu libsodium zlib liblz4 libzstd"
 
 PKGCONFIG_CFLAGS:=$(shell pkg-config --cflags $(PKGCONFIG_LIBS))
+ifeq (,$(PKGCONFIG_CFLAGS))
+    $(error pkg-config error)
+endif
 PKGCONFIG_LDLIBS:=$(shell pkg-config --libs   $(PKGCONFIG_LIBS))
+ifeq (,$(PKGCONFIG_LDLIBS))
+    $(error pkg-config error (libs))
+endif
 
 CFLAGS+=$(PKGCONFIG_CFLAGS)
 LDLIBS+=$(PKGCONFIG_LDLIBS)

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Standards-Version: 3.9.5
 Build-Depends: debhelper (>= 9), pkg-config, libaio-dev, libblkid-dev,
 	libkeyutils-dev, liblz4-dev, libscrypt-dev, libsodium-dev, liburcu-dev,
 	libzstd-dev, uuid-dev, zlib1g-dev
-Homepage: http://bcache.evilpiepirate.org/
+Homepage: https://bcachefs.org/
 
 Package: bcachefs-tools
 Architecture: linux-any

--- a/debian/control
+++ b/debian/control
@@ -3,9 +3,9 @@ Maintainer: Kent Overstreet <kent.overstreet@gmail.com>
 Section: utils
 Priority: optional
 Standards-Version: 3.9.5
-Build-Depends: debhelper (>= 9), pkg-config, libblkid-dev, uuid-dev,
-	libscrypt-dev, libsodium-dev, libkeyutils-dev, liburcu-dev, zlib1g-dev,
-	libattr1-dev, libaio-dev, libzstd-dev
+Build-Depends: debhelper (>= 9), pkg-config, libaio-dev, libblkid-dev,
+	libkeyutils-dev, liblz4-dev, libscrypt-dev, libsodium-dev, liburcu-dev,
+	libzstd-dev, uuid-dev, zlib1g-dev
 Homepage: http://bcache.evilpiepirate.org/
 
 Package: bcachefs-tools

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,7 +1,7 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Contact: kmo@daterainc.com
                   linux-bcache@vger.kernel.org
-Source: http://evilpiepirate.org/git/bcache-tools.git
+Source: https://evilpiepirate.org/git/bcachefs-tools.git
 
 Files: *
 Copyright: 2013 Kent Overstreet <kmo@daterainc.com>

--- a/debian/watch
+++ b/debian/watch
@@ -1,3 +1,3 @@
-version=3
-
-http://evilpiepirate.org/git/bcache-tools.git/refs/ /git/bcache-tools.git/tag/\?id=v(\d[\d.]*)
+version=4
+opts=filenamemangle=s/.+\/v?(\d\S+)\.tar\.gz/bcachefs-tools_$1\.tar\.gz/ \
+  https://github.com/koverstreet/bcachefs-tools/tags .*/v?(\d\S+)\.tar\.gz


### PR DESCRIPTION
- Remove libattr from the Debian dependency list (and from the dependencies in INSTALL)
- Abort compilation early if one of the pkg-config commands fails (doesn't print anything)
- Updated the bcachefs URLs in the Debian control, copyright, and watch files.