### PR TITLE
Add fuse3 dependency information to INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -5,6 +5,7 @@ Dependencies:
  * libblkid
  * libkeyutils
  * liblz4
+ * libfuse3 >= 3.7
  * libscrypt
  * libsodium
  * liburcu
@@ -14,9 +15,9 @@ Dependencies:
  * zlib1g
  * valgrind
 
-On debian, you can install these with
+On Debian (Bullseye or later), you can install these with
     apt install -y pkg-config libaio-dev libblkid-dev libkeyutils-dev \
         liblz4-dev libscrypt-dev libsodium-dev liburcu-dev libzstd-dev \
-        uuid-dev zlib1g-dev valgrind
+        uuid-dev zlib1g-dev valgrind libfuse3-dev
 
 Then, just make && make install


### PR DESCRIPTION
Debian Buster (currently "stable") uses libfuse3 version 3.4
which doesn't have some of the logging features which
`cmd_fusemount.c` uses. libfuse v3.7 used by Debian Bullseye
works fine.

If you want, I can add install information for some more distros (maybe Arch and CentOS). I am I using Docker to verify the build processes so I can PR those files if they would be helpful as well.