### PR TITLE
Install information for more distros

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -15,10 +15,20 @@ Dependencies:
  * zlib1g
  * valgrind
 
-On debian, you can install these with
+Debian (Bullseye or later) and Ubuntu (20.04 or later): you can install these with
     apt install -y pkg-config libaio-dev libblkid-dev libkeyutils-dev \
         liblz4-dev libscrypt-dev libsodium-dev liburcu-dev libzstd-dev \
         uuid-dev zlib1g-dev valgrind
+
+Fedora: install the "Development tools" group along with:
+    dnf install -y libaio-devel libsodium-devel \
+        libblkid-devel libzstd-devel zlib-devel userspace-rcu-devel \
+        lz4-devel libuuid-devel valgrind-devel keyutils-libs-devel \
+        libscrypt-devel findutils
+
+Arch: install bcachefs-tools-git from the AUR.
+Or to build from source, install libscrypt from the AUR along with,
+    pacman -S base-devel libaio keyutils libsodium liburcu zstd valgrind
 
 Then, just make && make install
 
@@ -29,14 +39,20 @@ Experimental fuse support is currently disabled by default. Fuse support is at
 an early stage and may corrupt your filesystem, so it should only be used for
 testing. To enable, you'll also need to add:
 
-* libfuse3
+* libfuse3 >= 3.7
 
-On debian:
+On Debian/Ubuntu (Bullseye/20.04 or later needed for libfuse >= 3.7):
     apt install -y libfuse3-dev
+
+On Fedora (32 or later needed for lbifuse >= 3.7):
+    dnf install -y fuse3-devel
+
+Arch:
+    pacman -S fuse3
 
 Then, make using the BCACHEFS_FUSE environment variable:
 
-BCACHEFS_FUSE=1 make &&
+BCACHEFS_FUSE=1 make && make install
 
 
 -- Tests --
@@ -50,6 +66,8 @@ On debian:
 Then, you can run the tests via:
 
     make check
+    # or if pytest has a different name
+    make check PYTEST=pytest
 
 Optionally, you may wish to run tests in parallel using python3-pytest-xdist:
 

--- a/INSTALL
+++ b/INSTALL
@@ -50,7 +50,8 @@ On Fedora (32 or later needed for lbifuse >= 3.7):
 Arch:
     pacman -S fuse3
 
-Then, make using the BCACHEFS_FUSE environment variable:
+Then, make using the BCACHEFS_FUSE environment variable (make clean first if
+previously built without fuse support):
 
 BCACHEFS_FUSE=1 make && make install
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ endif
 
 PKGCONFIG_LIBS="blkid uuid liburcu libsodium zlib liblz4 libzstd"
 ifdef BCACHEFS_FUSE
-	PKGCONFIG_LIBS+="fuse3"
+	PKGCONFIG_LIBS+="fuse3 >= 3.7"
 	CFLAGS+=-DBCACHEFS_FUSE
 endif
 


### PR DESCRIPTION
I have been testing the builds with Dockerfile like so:
```Docker
FROM debian:bullseye-slim

RUN apt-get update && apt-get install -y \
    build-essential git pkg-config libaio-dev libblkid-dev \
    libkeyutils-dev liblz4-dev libscrypt-dev libsodium-dev \
    liburcu-dev libzstd-dev uuid-dev zlib1g-dev valgrind

WORKDIR /build
RUN git clone https://github.com/koverstreet/bcachefs-tools.git .
RUN make && make install
```
If you think incorporating these into the repo would be helpful, let me know.

Also, the build (even without fuse) fails on CentOS 7 and 8 (for different reasons). Is there somewhere I should report that? (Using Dockerfile should also make it easily reproducible.)