### PR TITLE
kmalloc: use posix_memalign

### DIFF
--- a/include/linux/slab.h
+++ b/include/linux/slab.h
@@ -20,12 +20,14 @@ static inline void *kmalloc(size_t size, gfp_t flags)
 
 	run_shrinkers();
 
-	size_t alignment = min(rounddown_pow_of_two(size),
-				(size_t)PAGE_SIZE);
-	size = roundup(size, alignment);
-	p = size
-	    ? aligned_alloc(alignment, size)
-	    : malloc(0);
+	if (size) {
+		size_t alignment = min(rounddown_pow_of_two(size), (size_t)PAGE_SIZE);
+		alignment = max(sizeof(void *), alignment);
+		if (posix_memalign(&p, alignment, size))
+			p = NULL;
+	} else {
+		p = malloc(0);
+	}
 	if (p && (flags & __GFP_ZERO))
 		memset(p, 0, size);
 


### PR DESCRIPTION
posix_memalign doesn't have the restriction that size must be a multiply
of alignment.

This also reverts the fix in commit f3fdbbfa92defb1f1d12c0038513b69b52baf33e.

Signed-off-by: Yuxuan Shui <yshuiv7@gmail.com>