### PR TITLE
Fixes tests which have broken since 'list' improvements

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -37,7 +37,7 @@ def test_list(tmpdir):
     assert ret.returncode == 0
     assert len(ret.stderr) == 0
     assert "recovering from clean shutdown" in ret.stdout
-    assert len(ret.stdout.splitlines()) == 2
+    assert len(ret.stdout.splitlines()) == 95
 
 def test_list_inodes(tmpdir):
     dev = util.format_1g(tmpdir)


### PR DESCRIPTION
Improvements to the 'list' command broke the basic test assertion that the output should be only 2 lines. Now it's 95 lines. This PR fixes this test for now.

Thank you for the great work!