### PR TITLE
Memory Error Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,9 @@
-
 PREFIX?=/usr/local
 PKG_CONFIG?=pkg-config
 INSTALL=install
 PYTEST=pytest-3
 CFLAGS+=-std=gnu89 -O2 -g -MMD -Wall				\
 	-Wno-pointer-sign					\
-	-Wno-zero-length-bounds					\
-	-Wno-stringop-overflow					\
 	-fno-strict-aliasing					\
 	-fno-delete-null-pointer-checks				\
 	-I. -Iinclude -Iraid					\
@@ -28,11 +25,16 @@ VERSION?=$(shell git describe --dirty=+ 2>/dev/null || echo v0.1-nogit)
 CC_VERSION=$(shell $(CC) -v 2>&1|grep -E '(gcc|clang) version')
 
 ifneq (,$(findstring gcc,$(CC_VERSION)))
-	CFLAGS+=-Wno-unused-but-set-variable
+	CFLAGS+=-Wno-unused-but-set-variable			\
+		-Wno-zero-length-bounds				\
+		-Wno-stringop-overflow
 endif
 
 ifneq (,$(findstring clang,$(CC_VERSION)))
-	CFLAGS+=-Wno-missing-braces
+	CFLAGS+=-Wno-missing-braces				\
+		-Wno-zero-length-array				\
+		-Wno-shift-overflow				\
+		-Wno-enum-conversion
 endif
 
 ifdef D

--- a/libbcachefs.c
+++ b/libbcachefs.c
@@ -1100,22 +1100,17 @@ struct bch_opts bch2_parse_opts(struct bch_opt_strs strs)
 	return opts;
 }
 
+#define newline(c)		\
+	do {			\
+		printf("\n");	\
+		c = 0;	 	\
+	} while(0)
 void bch2_opts_usage(unsigned opt_types)
 {
 	const struct bch_option *opt;
 	unsigned i, c = 0, helpcol = 30;
 
-	void tabalign() {
-		while (c < helpcol) {
-			putchar(' ');
-			c++;
-		}
-	}
 
-	void newline() {
-		printf("\n");
-		c = 0;
-	}
 
 	for (opt = bch2_opt_table;
 	     opt < bch2_opt_table + bch2_opts_nr;
@@ -1146,21 +1141,24 @@ void bch2_opts_usage(unsigned opt_types)
 			const char *l = opt->help;
 
 			if (c >= helpcol)
-				newline();
+				newline(c);
 
 			while (1) {
 				const char *n = strchrnul(l, '\n');
 
-				tabalign();
+				while (c < helpcol) {
+					putchar(' ');
+					c++;
+				}
 				printf("%.*s", (int) (n - l), l);
-				newline();
+				newline(c);
 
 				if (!*n)
 					break;
 				l = n + 1;
 			}
 		} else {
-			newline();
+			newline(c);
 		}
 	}
 }

--- a/smoke_test
+++ b/smoke_test
@@ -20,6 +20,7 @@
 
 set -e
 
+PYTEST=pytest-3
 spam=$(tempfile)
 unset BCACHEFS_FUSE BCACHEFS_TEST_USE_VALGRIND D
 
@@ -44,7 +45,7 @@ function test() {
     echo Running tests.
     (
         cd tests
-        pytest-3 -n${JOBS}
+        ${PYTEST} -n${JOBS}
     ) > ${spam} 2>&1
 }
 
@@ -53,7 +54,7 @@ function test_vg() {
     (
         export BCACHEFS_TEST_USE_VALGRIND=yes
         cd tests
-        pytest-3 -n${JOBS}
+        ${PYTEST} -n${JOBS}
     ) > ${spam} 2>&1
 }
 


### PR DESCRIPTION
The Valgrind tests ran by `smoke_test` reveal a couple of memory errors. The first commit fixes a "use-before initialization" error.  There are a couple more bugs to fix as well.