### PR TITLE
erase block devices' previous filesystems

### DIFF
--- a/tools-util.c
+++ b/tools-util.c
@@ -289,6 +289,8 @@ int open_for_format(const char *dev, bool force)
 		fputs("Proceed anyway?", stdout);
 		if (!ask_yn())
 			exit(EXIT_FAILURE);
+		while (blkid_do_probe(pr) == 0)
+    			blkid_do_wipe(pr, 0);
 	}
 
 	blkid_free_probe(pr);


### PR DESCRIPTION
add a blk_wipe function to remove any possible filesystems left on the block device when formatting
this makes sure the automounter does not accidentally mount it as another filesystem.