### PR TITLE
Make aio code use struct io_iocb_common to support 32 bit architectures

### DIFF
--- a/linux/blkdev.c
+++ b/linux/blkdev.c
@@ -76,9 +76,9 @@ void generic_make_request(struct bio *bio)
 	switch (bio_op(bio)) {
 	case REQ_OP_READ:
 		iocb.aio_lio_opcode	= IO_CMD_PREADV;
-		iocb.u.v.vec		= iov;
-		iocb.u.v.nr		= i;
-		iocb.u.v.offset		= bio->bi_iter.bi_sector << 9;
+		iocb.u.c.buf		= iov;
+		iocb.u.c.nbytes		= i;
+		iocb.u.c.offset		= bio->bi_iter.bi_sector << 9;
 
 		atomic_inc(&running_requests);
 		ret = io_submit(aio_ctx, 1, &iocbp);
@@ -87,9 +87,9 @@ void generic_make_request(struct bio *bio)
 		break;
 	case REQ_OP_WRITE:
 		iocb.aio_lio_opcode	= IO_CMD_PWRITEV;
-		iocb.u.v.vec		= iov;
-		iocb.u.v.nr		= i;
-		iocb.u.v.offset		= bio->bi_iter.bi_sector << 9;
+		iocb.u.c.buf		= iov;
+		iocb.u.c.nbytes		= i;
+		iocb.u.c.offset		= bio->bi_iter.bi_sector << 9;
 
 		atomic_inc(&running_requests);
 		ret = io_submit(aio_ctx, 1, &iocbp);


### PR DESCRIPTION
It looks like libaio's `struct io_iocb_vector` doesn't work for aio with 32 bit architectures. See my analysis on this issue [here](https://pagure.io/libaio/issue/16), [here](https://github.com/koverstreet/bcachefs-tools/issues/69#issuecomment-917821738) and [here](https://pagure.io/libaio/pull-request/17).

Thankfully it is not strictly required to use `struct io_iocb_vector` for vectored aio, since the union also contains a `struct io_iocb_common` which can be used for vector IO. This data structure has the appropriate padding to work with 32 bit architectures. In fact, this data structure is the one [tested by the test harness](https://pagure.io/libaio/blob/master/f/harness/cases/15.t) for vector io and is also the one used by the vectored io helpers (`io_prep_p{read,write}v`) in libaio.h.

Given that io_iocb_vector [doesn't appear to work for 32b](https://github.com/koverstreet/bcachefs-tools/issues/69), and io_iocb_common *does* work for 32 bit (and 64 bit), and additionally seems to have better test coverage, I recommend we switch to using `io_iocb_common` now rather than waiting for an upstream fix.