### PR TITLE
pytest: remove arbitrary assertion

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -38,9 +38,6 @@ def test_list(tmpdir):
     assert len(ret.stderr) == 0
     assert "recovering from clean shutdown" in ret.stdout
 
-    # Totally arbitrary, feel free to update or remove after inspecting.
-    assert len(ret.stdout.splitlines()) == 97
-
 def test_list_inodes(tmpdir):
     dev = util.format_1g(tmpdir)
 


### PR DESCRIPTION
fixes: #74 
removes assertion based on arbitrary amount of lines outputted by the bcachefs command