### PR TITLE
make BIO_MAX_VECS unsigned, like the kernel definition

### DIFF
--- a/include/linux/blkdev.h
+++ b/include/linux/blkdev.h
@@ -6,7 +6,7 @@
 #include <linux/kobject.h>
 #include <linux/types.h>
 
-#define BIO_MAX_VECS	256
+#define BIO_MAX_VECS	256U
 
 typedef unsigned fmode_t;
 


### PR DESCRIPTION
Kernel definition:
```
holmanb@arc:~/workspace/bcachefs > grep BIO_MAX_VECS include/linux/bio.h 
#define BIO_MAX_VECS		256U
```

This cleans up the following gcc warning:

```
libbcachefs/io.c: In function ‘bch2_write_bio_alloc’:
include/linux/kernel.h:108:17: warning: comparison of distinct pointer types lacks a cast
  108 |  (void) (&_min1 == &_min2);  \
      |                 ^~
libbcachefs/io.c:785:10: note: in expansion of macro ‘min’
  785 |  pages = min(pages, BIO_MAX_VECS);
      |          ^~~
```