### PR TITLE
workaround GNU make executes weird shell on ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,9 @@ else
 	INITRAMFS_DIR=/etc/initramfs-tools
 endif
 
-RST2MAN:=$(shell command -v rst2man)
+RST2MAN:=$(shell /bin/sh -c 'command -v rst2man')
 ifeq ($(RST2MAN),)
-	RST2MAN:=$(shell command -v rst2man.py)
+	RST2MAN:=$(shell /bin/sh -c 'command -v rst2man.py')
 	ifeq ($(RST2MAN),)
 		@echo "WARNING: no rst2man found! Man page not generated."
 	endif


### PR DESCRIPTION
`RST2MAN:=$(shell command -v rst2man)` not work as desired on github and travis ubuntu runners. There are a workaround.