### PR TITLE
Add more specific subcommand usage messages

### DIFF
--- a/cmd_data.c
+++ b/cmd_data.c
@@ -9,6 +9,19 @@
 #include "cmds.h"
 #include "libbcachefs.h"
 
+int data_usage(void)
+{
+	puts("bcachefs data - manage filesystem data\n"
+	     "Usage: bcachefs data <CMD> [OPTIONS]\n"
+	     "\n"
+	     "Commands:\n"
+	     "  rereplicate                     Rereplicate degraded data\n"
+	     "  job                             Kick off low level data jobs\n"
+	     "\n"
+	     "Report bugs to <linux-bcache@vger.kernel.org>");
+	return 0;
+}
+
 static void data_rereplicate_usage(void)
 {
 	puts("bcachefs data rereplicate\n"

--- a/cmd_device.c
+++ b/cmd_device.c
@@ -21,6 +21,25 @@
 #include "libbcachefs/opts.h"
 #include "tools-util.h"
 
+int device_usage(void)
+{
+       puts("bcachefs device - manage devices within a running filesystem\n"
+            "Usage: bcachefs device <CMD> [OPTION]\n"
+            "\n"
+            "Commands:\n"
+            "  add                     add a new device to an existing filesystem\n"
+            "  remove                  remove a device from an existing filesystem\n"
+            "  online                  re-add an existing member to a filesystem\n"
+            "  offline                 take a device offline, without removing it\n"
+            "  evacuate                migrate data off a specific device\n"
+            "  set-state               mark a device as failed\n"
+            "  resize                  resize filesystem on a device\n"
+            "  resize-journal          resize journal on a device\n"
+            "\n"
+            "Report bugs to <linux-bcachefs@vger.kernel.org>");
+       return 0;
+}
+
 static void device_add_usage(void)
 {
 	puts("bcachefs device add - add a device to an existing filesystem\n"

--- a/cmd_fs.c
+++ b/cmd_fs.c
@@ -195,6 +195,18 @@ static void print_fs_usage(const char *path, enum units units)
 	bcache_fs_close(fs);
 }
 
+int fs_usage(void)
+{
+       puts("bcachefs fs - manage a running filesystem\n"
+            "Usage: bcachefs fs <CMD> [OPTION]... path\n"
+            "\n"
+            "Commands:\n"
+            "  usage                      show disk usage\n"
+            "\n"
+            "Report bugs to <linux-bcachefs@vger.kernel.org>");
+       return 0;
+}
+
 int cmd_fs_usage(int argc, char *argv[])
 {
 	enum units units = BYTES;

--- a/cmd_subvolume.c
+++ b/cmd_subvolume.c
@@ -19,6 +19,20 @@
 #include "libbcachefs/opts.h"
 #include "tools-util.h"
 
+int subvolume_usage(void)
+{
+	puts("bcachefs subvolume - manage subvolumes and snapshots\n"
+	     "Usage: bcachefs subvolume <CMD> [OPTION]\n"
+	     "\n"
+	     "Commands:\n"
+	     "  create                  create a subvolume\n"
+	     "  delete                  delete a subvolume\n"
+	     "  snapshot                create a snapshot\n"
+	     "\n"
+	     "Report bugs to <linux-bcachefs@vger.kernel.org>");
+	return 0;
+}
+
 static void subvolume_create_usage(void)
 {
 	puts("bcachefs subvolume create - create a new subvolume\n"

--- a/cmds.h
+++ b/cmds.h
@@ -19,8 +19,10 @@ int cmd_run(int argc, char *argv[]);
 int cmd_stop(int argc, char *argv[]);
 #endif
 
+int fs_usage(void);
 int cmd_fs_usage(int argc, char *argv[]);
 
+int device_usage(void);
 int cmd_device_add(int argc, char *argv[]);
 int cmd_device_remove(int argc, char *argv[]);
 int cmd_device_online(int argc, char *argv[]);
@@ -30,6 +32,7 @@ int cmd_device_set_state(int argc, char *argv[]);
 int cmd_device_resize(int argc, char *argv[]);
 int cmd_device_resize_journal(int argc, char *argv[]);
 
+int data_usage(void);
 int cmd_data_rereplicate(int argc, char *argv[]);
 int cmd_data_job(int argc, char *argv[]);
 
@@ -50,6 +53,7 @@ int cmd_version(int argc, char *argv[]);
 
 int cmd_setattr(int argc, char *argv[]);
 
+int subvolume_usage(void);
 int cmd_subvolume_create(int argc, char *argv[]);
 int cmd_subvolume_delete(int argc, char *argv[]);
 int cmd_subvolume_snapshot(int argc, char *argv[]);


### PR DESCRIPTION
The device, data, fs, and subvolume subcommands currently print out a
generic usage message. Make these more specific.

New output:
```
 > ./bcachefs device
bcachefs device - manage devices within a running filesystem
Usage: bcachefs device <CMD> [OPTION]

Commands:
  add                     add a new device to an existing filesystem
  remove                  remove a device from an existing filesystem
  online                  re-add an existing member to a filesystem
  offline                 take a device offline, without removing it
  evacuate                migrate data off a specific device
  set-state               mark a device as failed
  resize                  resize filesystem on a device
  resize-journal          resize journal on a device

Report bugs to <linux-bcachefs@vger.kernel.org>

 > ./bcachefs fs    
bcachefs fs - manage a running filesystem
Usage: bcachefs fs <CMD> [OPTION]... path

Commands:
  usage                      show disk usage

Report bugs to <linux-bcachefs@vger.kernel.org>

 > ./bcachefs data  
bcachefs data - manage filesystem data
Usage: bcachefs data <CMD> [OPTIONS]

Commands:
  rereplicate                     Rereplicate degraded data
  job                             Kick off low level data jobs

Report bugs to <linux-bcache@vger.kernel.org>

 > ./bcachefs subvolume
bcachefs subvolume - manage subvolumes and snapshots
Usage: bcachefs subvolume <CMD> [OPTION]... path

Commands:
  create                  create a subvolume
  delete                  delete a subvolume
  snapshot                create a snapshot

Report bugs to <linux-bcachefs@vger.kernel.org>
```

`bcachefs <CMD> -h` and `bcachefs <CMD>` (no arguments) both print the same output