### PR TITLE
Add valgrind suppressions:

### DIFF
--- a/tests/valgrind-suppressions.txt
+++ b/tests/valgrind-suppressions.txt
@@ -15,3 +15,24 @@
    ...
    fun:call_rcu_data_init
 }
+{
+   urcu_memb_call_rcu
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:pthread_create*
+   obj:/*/liburcu.so.*
+   ...
+   fun:urcu_memb_call_rcu
+}
+{
+   pthread_create
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   ...
+   fun:allocate_stack
+   fun:pthread_create*
+   fun:kthread_create
+   fun:bch2_rebalance_start
+}


### PR DESCRIPTION
For context, here are the "exact matches" proposed by Valgrind:

Rebalance leak suppression:
```
E           {
E              <insert_a_suppression_name_here>
E              Memcheck:Leak
E              match-leak-kinds: possible
E              fun:calloc
E              fun:calloc
E              fun:allocate_dtv
E              fun:_dl_allocate_tls
E              fun:allocate_stack
E              fun:pthread_create@@GLIBC_2.34
E              fun:kthread_create
E              fun:bch2_rebalance_start
E              fun:bch2_fs_read_write_late
E              fun:bch2_fs_read_write_late
E              fun:bch2_fs_start
E              fun:bch2_fs_open
E              fun:cmd_format
E              fun:main
E           }
```

liburcu (which is known to leak):
```
E           {
E              <insert_a_suppression_name_here>
E              Memcheck:Leak
E              match-leak-kinds: possible
E              fun:calloc
E              fun:calloc
E              fun:allocate_dtv
E              fun:_dl_allocate_tls
E              fun:allocate_stack
E              fun:pthread_create@@GLIBC_2.34
E              obj:/usr/lib/x86_64-linux-gnu/liburcu.so.8.0.0
E              fun:urcu_memb_get_default_call_rcu_data
E              fun:urcu_memb_call_rcu
E              fun:rhashtable_rehash_table
E              fun:rht_deferred_worker
E              fun:worker_thread
E              fun:kthread_start_fn
E              fun:start_thread
E              fun:clone
E           }
```