### PR TITLE
libbcachefs/util.h: fix -Wformat-security warning

### DIFF
--- a/libbcachefs/opts.c
+++ b/libbcachefs/opts.c
@@ -324,7 +324,7 @@ void bch2_opt_to_text(struct printbuf *out,
 		if (flags & OPT_SHOW_FULL_LIST)
 			bch2_string_opt_to_text(out, opt->choices, v);
 		else
-			pr_buf(out, opt->choices[v]);
+			pr_buf(out, "%s", opt->choices[v]);
 		break;
 	case BCH_OPT_FN:
 		opt->to_text(out, c, sb, v);

--- a/libbcachefs/util.h
+++ b/libbcachefs/util.h
@@ -386,7 +386,7 @@ static inline void pr_uuid(struct printbuf *out, u8 *uuid)
 	char uuid_str[40];
 
 	uuid_unparse_lower(uuid, uuid_str);
-	pr_buf(out, uuid_str);
+	pr_buf(out, "%s", uuid_str);
 }
 
 int bch2_strtoint_h(const char *, int *);


### PR DESCRIPTION
libbcachefs/util.h:389:14: error: format not a string literal and no format arguments [-Werror=format-security]
  389 |  pr_buf(out, uuid_str);
      |              ^~~~~~~~

libbcachefs/opts.c:327:4: error: format not a string literal and no format arguments [-Werror=format-security]
  327 |    pr_buf(out, opt->choices[v]);
      |    ^~~~~~

Passing a uuid or option choice as a format string is pretty harmless in principle but -Wformat-security trips over it and it is good hygiene in general to only use constant strings as format strings.

Signed-off-by: Wessel Dankers <wsl@fruit.je>