### PR TITLE
Fix timer heap leak

### DIFF
--- a/linux/timer.c
+++ b/linux/timer.c
@@ -41,7 +41,7 @@ struct {								\
 
 #define heap_free(heap)							\
 do {									\
-	kvfree((heap)->data);						\
+	free((heap)->data);						\
 	(heap)->data = NULL;						\
 } while (0)
 
@@ -326,4 +326,5 @@ static void timers_cleanup(void)
 
 	put_task_struct(timer_task);
 	timer_task = NULL;
+	heap_free(&pending_timers);
 }


### PR DESCRIPTION
Before change:
```
==183281== 1,024 bytes in 1 blocks are still reachable in loss record 7 of 7
==183281==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==183281==    by 0x1130C4: timers_init (timer.c:307)
==183281==    by 0x4A64EBA: call_init (libc-start.c:145)
==183281==    by 0x4A64EBA: __libc_start_main@@GLIBC_2.34 (libc-start.c:379)
==183281==    by 0x114384: (below main) (in /home/holmanb/workspace/bcachefs-tools/bcachefs)
```