### PR TITLE
Fix build against musl libc.

### DIFF
--- a/include/linux/compiler.h
+++ b/include/linux/compiler.h
@@ -10,6 +10,10 @@
 # define __always_inline	inline __attribute__((always_inline))
 #endif
 
+#ifndef __attribute_const__
+#define __attribute_const__     __attribute__((__const__))
+#endif
+
 #ifdef __ANDROID__
 /*
  * FIXME: Big hammer to get rid of tons of:


### PR DESCRIPTION
The musl C library does not define __attribute_const__. Add it to include/linux/compiler.h with a guard to fix build against musl libc.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>