### PR TITLE
cmd_format: enable torture testing

### DIFF
--- a/cmd_format.c
+++ b/cmd_format.c
@@ -40,6 +40,7 @@ x(0,	superblock_size,	required_argument)	\
 x(0,	bucket_size,		required_argument)	\
 x('l',	label,			required_argument)	\
 x(0,	discard,		no_argument)		\
+x(0,	torture,		no_argument)		\
 x(0,	data_allowed,		required_argument)	\
 x(0,	durability,		required_argument)	\
 x(0,	version,		required_argument)	\
@@ -179,6 +180,9 @@ int cmd_format(int argc, char *argv[])
 			break;
 		case O_discard:
 			dev_opts.discard = true;
+			break;
+		case O_torture:
+			opts.torture = true;
 			break;
 		case O_data_allowed:
 			dev_opts.data_allowed =

--- a/libbcachefs.h
+++ b/libbcachefs.h
@@ -37,6 +37,7 @@ struct format_opts {
 	unsigned	superblock_size;
 	bool		encrypted;
 	char		*passphrase;
+	bool		torture;
 };
 
 static inline struct format_opts format_opts_default()
@@ -48,6 +49,7 @@ static inline struct format_opts format_opts_default()
 	return (struct format_opts) {
 		.version		= version,
 		.superblock_size	= SUPERBLOCK_SIZE_DEFAULT,
+		.torture		= false,
 	};
 }
 


### PR DESCRIPTION
This enables a torture testing option,
aimed at testing the reliability of the devices.
due to solid structure, bcachefs may survive HW errors, but this causes difficult-to-diagnose performance drops