### PR TITLE
Sort input file list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ TAGS:
 tags:
 	ctags -R .
 
-SRCS=$(shell find . -type f ! -path '*/.*/*' -iname '*.c')
+SRCS=$(sort $(shell find . -type f ! -path '*/.*/*' -iname '*.c'))
 DEPS=$(SRCS:.c=.d)
 -include $(DEPS)
 


### PR DESCRIPTION
Sort input file list
so that `libbcachefs.so` builds in a reproducible way
in spite of non-deterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this is good.