### PR TITLE
cmd_mount: Fix test-only mount path

### DIFF
--- a/rust-src/src/cmd_mount.rs
+++ b/rust-src/src/cmd_mount.rs
@@ -145,7 +145,7 @@ struct Cli {
     /// Where the filesystem should be mounted. If not set, then the filesystem
     /// won't actually be mounted. But all steps preceeding mounting the
     /// filesystem (e.g. asking for passphrase) will still be performed.
-    mountpoint:     std::path::PathBuf,
+    mountpoint:     Option<std::path::PathBuf>,
 
     /// Mount options
     #[arg(short, default_value = "")]
@@ -207,14 +207,23 @@ fn cmd_mount_inner(opt: Cli) -> anyhow::Result<()> {
         key::prepare_key(&sbs[0], key)?;
     }
 
-    info!(
-        "mounting with params: device: {}, target: {}, options: {}",
-        devs,
-        &opt.mountpoint.to_string_lossy(),
-        &opt.options
-    );
+    if let Some(mountpoint) = opt.mountpoint {
+        info!(
+            "mounting with params: device: {}, target: {}, options: {}",
+            devs,
+            mountpoint.to_string_lossy(),
+            &opt.options
+        );
 
-    mount(devs, &opt.mountpoint, &opt.options)?;
+        mount(devs, mountpoint, &opt.options)?;
+    } else {
+        info!(
+            "would mount with params: device: {}, options: {}",
+            devs,
+            &opt.options
+        );
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
The comman line help claims that `bcachefs mount <DEV>` without a mount point will do a dry-run mount - all the steps required to mount the fs, but without actually doing the final real mount.

Make the code actually do this, rather than complain that you haven't supplied a mountpoint if you don't provide a mountpoint