### PR TITLE
armv7l fixes

### DIFF
--- a/include/linux/atomic.h
+++ b/include/linux/atomic.h
@@ -318,6 +318,12 @@ static inline s64 atomic64_cmpxchg_acquire(atomic64_t *v, s64 old, s64 new)
 	return atomic64_cmpxchg(v, old, new);
 }
 
+static inline s64 atomic64_sub_return_release(s64 i, atomic64_t *v)
+{
+       smp_mb__before_atomic();
+       return atomic64_sub_return(i, v);
+}
+
 #endif
 
 #endif /* __TOOLS_LINUX_ATOMIC_H */

--- a/libbcachefs/btree_write_buffer.c
+++ b/libbcachefs/btree_write_buffer.c
@@ -9,6 +9,7 @@
 #include "journal.h"
 #include "journal_reclaim.h"
 
+#include <linux/atomic.h>
 #include <linux/sort.h>
 
 static int btree_write_buffered_key_cmp(const void *_l, const void *_r)

--- a/rust-src/src/cmd_mount.rs
+++ b/rust-src/src/cmd_mount.rs
@@ -14,7 +14,7 @@ fn mount_inner(
     src: String,
     target: impl AsRef<std::path::Path>,
     fstype: &str,
-    mountflags: u64,
+    mountflags: libc::c_ulong,
     data: Option<String>,
 ) -> anyhow::Result<()> {
 
@@ -45,7 +45,7 @@ fn mount_inner(
 
 /// Parse a comma-separated mount options and split out mountflags and filesystem
 /// specific options.
-fn parse_mount_options(options: impl AsRef<str>) -> (Option<String>, u64) {
+fn parse_mount_options(options: impl AsRef<str>) -> (Option<String>, libc::c_ulong) {
     use either::Either::*;
     debug!("parsing mount options: {}", options.as_ref());
     let (opts, flags) = options


### PR DESCRIPTION
```
commit 8369be0fcdfb796ec63cd91f03103b35f168d2eb (HEAD -> master, origin/master, origin/HEAD)
Author: Nicholas Sielicki <linux@opensource.nslick.com>
Date:   Wed Oct 18 23:39:04 2023 -0500

    btree_write_buffer: ensure atomic64_sub_return_release availability

    prior to this patch, on certain platforms (ie: armv7l), compilation fails due
    to atomic64_sub_return_release not being defined here. Ensure that the atomics
    header is pulled in, and ensure that it is available in all cases, regardless
    of whether ATOMIC64_SPINLOCK is defined.

    Signed-off-by: Nicholas Sielicki <linux@opensource.nslick.com>

commit f2b987745d46e763c63f47ae843d28684041fa48
Author: Nicholas Sielicki <linux@opensource.nslick.com>
Date:   Wed Oct 18 00:59:02 2023 -0500

    rust: mount: use libc::c_ulong for flags

    libc proper treats mount flags as an unsigned long, which is usually u64,
    except when it isn't. When preparing mount flags, use the libc::c_ulong type
    instead of u64 to allow for this.

    This fixes compiling this file under armv7l.

    Signed-off-by: Nicholas Sielicki <linux@opensource.nslick.com>
```