### PR TITLE
add command to generate Rust-part CLI completions

### DIFF
--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -91,7 +91,6 @@ dependencies = [
  "atty",
  "bch_bindgen",
  "byteorder",
- "cfg-if",
  "chrono",
  "clap",
  "clap_complete",

--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.4.4"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffe91f06a11b4b9420f62103854e90867812cd5d01557f853c5ee8e791b12ae"
+checksum = "5fc443334c81a804575546c5a8a79b4913b50e28d69232903604cada1de817ce"
 dependencies = [
  "clap",
 ]

--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "atty",
  "bch_bindgen",
  "byteorder",
+ "cfg-if",
  "chrono",
  "clap",
  "clap_complete",

--- a/rust-src/Cargo.toml
+++ b/rust-src/Cargo.toml
@@ -28,4 +28,3 @@ either = "1.5"
 rpassword = "4"
 bch_bindgen = { path = "bch_bindgen" }
 byteorder = "1.3"
-cfg-if = "1.0.0"

--- a/rust-src/Cargo.toml
+++ b/rust-src/Cargo.toml
@@ -14,7 +14,7 @@ log = { version = "0.4", features = ["std"] }
 chrono = { version = "0.4", default-features = false }
 colored = "2"
 clap = { version = "4.0.32", features = ["derive", "wrap_help"] }
-clap_complete = "4.4.4"
+clap_complete = "4.3.2"
 anyhow = "1.0"
 libc = "0.2.69"
 udev = "0.7.0"

--- a/rust-src/Cargo.toml
+++ b/rust-src/Cargo.toml
@@ -28,3 +28,4 @@ either = "1.5"
 rpassword = "4"
 bch_bindgen = { path = "bch_bindgen" }
 byteorder = "1.3"
+cfg-if = "1.0.0"

--- a/rust-src/src/lib.rs
+++ b/rust-src/src/lib.rs
@@ -34,12 +34,25 @@ macro_rules! c_str {
 #[macro_export]
 macro_rules! transform_c_args {
     ($var:ident, $argc:expr, $argv:expr) => {
-        // TODO: `OsStr::from_bytes` only exists on *nix
-        use ::std::os::unix::ffi::OsStrExt;
         let $var: Vec<_> = (0..$argc)
-        .map(|i| unsafe { ::std::ffi::CStr::from_ptr(*$argv.add(i as usize)) })
-        .map(|i| ::std::ffi::OsStr::from_bytes(i.to_bytes()))
-        .collect();
+            .map(|i| unsafe { ::std::ffi::CStr::from_ptr(*$argv.add(i as usize)) })
+            .map(|x| {
+                ::cfg_if::cfg_if! {
+                    if #[cfg(unix)] {
+                        use ::std::os::unix::ffi::OsStrExt;
+                        ::std::ffi::OsStr::from_bytes(x.to_bytes())
+                    } else {
+                        // If arbitrary-bytes `OsStr`s are not supported (e.g. MS Windows),
+                        // just assert the arguments are UTF-8 encoded
+                        let Ok(os_str) = cstr.to_str() else {
+                            ::log::error!("Invalid UTF-8 argument meets");
+                            ::std::process::abort()
+                        };
+                        os_str
+                    }
+                }
+            })
+            .collect();
     };
 }
 


### PR DESCRIPTION
An easy way to generate shell completions is to use Rust [`clap_complete`](https://docs.rs/clap_complete/4.4.4/clap_complete) crate. Another method is to manually write the shell completion scripts, like [`cargo`](https://github.com/rust-lang/cargo/tree/master/src/etc) does :).

This PR added
an subcommand to output these completion scripts for shells. I don't know if this approach is idiomatic, however `deno` leaves this command and I just imitate its way:
```console
~ ❯ deno --help                                                                                                             20:21:26
A modern JavaScript and TypeScript runtime
...
Usage: deno [OPTIONS] [COMMAND]

Commands:
...
  completions  Generate shell completions
```

Usage example:
```console
~/bcachefs-tools master ⇡1 ❯ ./bcachefs --help
...
Miscellaneous:
  completions              Generate shell completions
  version                  Display the version of the invoked bcachefs tool
~/bcachefs-tools master ⇡1 ❯ ./bcachefs completions zsh > ~/.zfunc/_bcachefs                                    20:26:44
~/bcachefs-tools master ⇡1 ❯ exec zsh                                                                           20:26:51
~/bcachefs-tools master ⇡1 ❯ ./bcachefs <TAB>                                                             20:26:52
completions  -- Generate shell completions
help         -- Print this message or the help of the given subcommand(s)
list         --
mount        -- Mount a bcachefs filesystem by its UUID
```