### PR TITLE
docs: mention that libclang is required

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,6 +5,7 @@ Build dependencies:
 
  * libaio
  * libblkid
+ * libclang
  * libkeyutils
  * liblz4
  * libsodium
@@ -25,7 +26,7 @@ Debian (Bullseye or later) and Ubuntu (20.04 or later): you can install these wi
 apt install -y pkg-config libaio-dev libblkid-dev libkeyutils-dev \
     liblz4-dev libsodium-dev liburcu-dev libzstd-dev \
     uuid-dev zlib1g-dev valgrind libudev-dev git build-essential \
-    python3 python3-docutils
+    python3 python3-docutils libclang-dev
 ```
 
 Fedora: install the "Development tools" group along with:


### PR DESCRIPTION
This fixes the following build failure on Debian bookworm:

    error: failed to run custom build command for `clang-sys v1.6.1`

    Caused by:
      process didn't exit successfully: `/home/minoru/src/bcachefs-tools/rust-src/target/release/build/clang-sys-df95f6d1266be773/build-script-build` (exit status: 101)
      --- stdout
      cargo:warning=could not execute `llvm-config` one or more times, if the LLVM_CONFIG_PATH environment variable is set to a full path to valid `llvm-config` executable it will be used to try to find an instance of `libclang` on your system: "couldn't execute `llvm-config --prefix` (path=llvm-config) (error: No such file or directory (os error 2))"

      --- stderr
      thread 'main' panicked at /home/minoru/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clang-sys-1.6.1/build/dynamic.rs:206:45:
      called `Result::unwrap()` on an `Err` value: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"
      note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

I didn't touch instructions for Fedora and Arch because I don't have those OSes to test the changes.