### PR TITLE
man: Fix cmd-option format

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -307,9 +307,9 @@ Enable POSIX acls
 Enable user quotas
 .It Fl -grpquota
 Enable group quotas
-.It Fl prjquota
+.It Fl -prjquota
 Enable project quotas
-.It Fl degraded
+.It Fl -degraded
 Allow mounting in degraded mode
 .It Fl -very_degraded
 Allow mounting in when data will be missing


### PR DESCRIPTION
Current rendered manpage:
```man
             --grpquota
                     Enable group quotas

             -prjquota
                     Enable project quotas

             -degraded
                     Allow mounting in degraded mode

             --very_degraded
                     Allow mounting in when data will be missing

             --discard
                     Enable discard/TRIM support

             --verbose
                     Extra debugging information during mount/recovery

```
After this commit:
```man
             --grpquota
                     Enable group quotas

             --prjquota
                     Enable project quotas

             --degraded
                     Allow mounting in degraded mode

             --very_degraded
                     Allow mounting in when data will be missing

             --discard
                     Enable discard/TRIM support

             --verbose
                     Extra debugging information during mount/recovery

```