### PR TITLE
cmd_fs: calculate free space

### DIFF
--- a/cmd_fs.c
+++ b/cmd_fs.c
@@ -39,10 +39,22 @@ static void dev_usage_type_to_text(struct printbuf *out,
 				   struct bch_ioctl_dev_usage_v2 *u,
 				   enum bch_data_type type)
 {
+	u64 sectors = 0;
+	switch (type) {
+	case BCH_DATA_free:
+	case BCH_DATA_need_discard:
+	case BCH_DATA_need_gc_gens:
+		/* sectors are 0 for these types so calculate sectors for them */
+		sectors = u->d[type].buckets * u->bucket_size;
+		break;
+	default:
+		sectors = u->d[type].sectors;
+	}
+
 	__dev_usage_type_to_text(out, bch2_data_types[type],
 			u->bucket_size,
 			u->d[type].buckets,
-			u->d[type].sectors,
+			sectors,
 			u->d[type].fragmented);
 }
 


### PR DESCRIPTION
Calculate space based on bucket count and bucket_size for data types where no sectors are available.

Tested on a local fs.

Before:
```
ssd.ssd4 (device 4):             sdc              rw
                                data         buckets    fragmented
  free:                          0 B         1266768
  sb:                       3.00 MiB               7       508 KiB
  journal:                  4.00 GiB            8192
  btree:                    4.42 GiB           14003      2.42 GiB
  user:                      510 MiB            1223       101 MiB
  cached:                    298 GiB          617545
  parity:                        0 B               0
  stripe:                        0 B               0
  need_gc_gens:                  0 B               0
  need_discard:                  0 B               1
  capacity:                  932 GiB         1907739
```
After:
```
ssd.ssd4 (device 4):             sdc              rw
                                data         buckets    fragmented
  free:                      619 GiB         1266768
  sb:                       3.00 MiB               7       508 KiB
  journal:                  4.00 GiB            8192
  btree:                    4.42 GiB           14003      2.42 GiB
  user:                      510 MiB            1223       101 MiB
  cached:                    298 GiB          617545
  parity:                        0 B               0
  stripe:                        0 B               0
  need_gc_gens:                  0 B               0
  need_discard:              512 KiB               1
  capacity:                  932 GiB         1907739

```

fixes #125 