### PR TITLE
fix fsck service location

### DIFF
--- a/fsck/bcachefsck_all.service.in
+++ b/fsck/bcachefsck_all.service.in
@@ -13,7 +13,7 @@ After=paths.target multi-user.target network.target network-online.target system
 [Service]
 Type=oneshot
 Environment=SERVICE_MODE=1
-ExecStart=bcachefsck_all
+ExecStart=@libexecdir@/bcachefsck_all
 SyslogIdentifier=bcachefsck_all
 
 # Create the service underneath the scrub background service slice so that we


### PR DESCRIPTION
Correctly generate libexecdir based path for the bcachefsck_all service, like the bcachefsck_all_fail service already does.

---

This, combined with a downstream AUR PKGBUILD change, should fix the services there as well. Not sure if any other distributions need changes to their build process like Arch does.