### PR TITLE
Fix nix and docs

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation {
     udev
   ] ++ lib.optional fuseSupport fuse3;
 
-  BCACHEFS_FUSE = if fuseSupport then "1" else "";
+  ${if fuseSupport then "BCACHEFS_FUSE" else null} = "1";
 
   cargoRoot = ".";
   # when git-based crates are updated, run:
@@ -49,7 +49,7 @@ in stdenv.mkDerivation {
   makeFlags = [ "DESTDIR=${placeholder "out"}" "PREFIX=" "VERSION=${commit}" ];
 
   dontStrip = true;
-  checkPhase = "./bcachefs version";
+  checkPhase = "./target/release/bcachefs version";
   doCheck = true;
 
   meta = {

--- a/src/commands/cmd_mount.rs
+++ b/src/commands/cmd_mount.rs
@@ -137,7 +137,7 @@ pub struct Cli {
     #[arg(short, long, default_value = "ask", verbatim_doc_comment)]
     key_location:   KeyLocation,
 
-    /// Device, or UUID=<UUID>
+    /// Device, or UUID=\<UUID\>
     dev:            String,
 
     /// Where the filesystem should be mounted. If not set, then the filesystem


### PR DESCRIPTION
This syntax does not set `BCACHEFS_FUSE` at all when fuse is disabled, not even to an empty string. [This line](https://github.com/koverstreet/bcachefs-tools/blob/3da247cd20da37a4d3f4d957a30293261c0e38e2/build.rs#L18) only checks if the variable is set, rather than specifically set to a non-empty string.

`cargo doc` was worried that the `<UUID>` text would be an unclosed HTML tag. This seems to render correctly.