### PR TITLE
printbuf_to_formatter: Lossy display of non-UTF-8 printbufs

### DIFF
--- a/bch_bindgen/src/lib.rs
+++ b/bch_bindgen/src/lib.rs
@@ -164,5 +164,5 @@ pub fn printbuf_to_formatter<F>(f: &mut fmt::Formatter<'_>, func: F) -> fmt::Res
     func(&mut buf);
 
     let s = unsafe { CStr::from_ptr(buf.buf) };
-    f.write_str(s.to_str().unwrap())
+    f.write_str(&s.to_string_lossy())
 }


### PR DESCRIPTION
Use to_string_lossy in printbuf_to_formatter, which tolerates non-UTF-8 strings (by using replacement characters).

This is used in various Display impls (BkeySCToText was the one that encountered the issue), and allows something like:

    bcachefs list --btree dirents
    
with non-UTF-8 paths.