### PR TITLE
Add bcachefs command compatibility symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /result
-bcachefs
 bcachefs.5
 .*
 *.o

--- a/bcachefs
+++ b/bcachefs
@@ -1,0 +1,1 @@
+target/release/bcachefs


### PR DESCRIPTION
The CLI is now built by Cargo, add a symlink so it can be found at the place it was before so people don't try to run an old binary.