### PR TITLE
Loosen dependencies of Rust crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ clap = { version = "4.0.32", features = ["derive", "wrap_help"] }
 clap_complete = "4.3.2"
 anyhow = "1.0"
 libc = "0.2.69"
-udev = "0.7.0"
+udev = ">= 0.7, < 1"
 uuid = "1.2.2"
-errno = "0.2"
+errno = ">= 0.2, < 1"
 either = "1.5"
 rpassword = "7"
 bch_bindgen = { path = "bch_bindgen" }

--- a/bch_bindgen/Cargo.toml
+++ b/bch_bindgen/Cargo.toml
@@ -12,11 +12,11 @@ crate-type = ["lib"]
 anyhow = "1.0"
 uuid = "1.2.2"
 bitfield = "0.14.0"
-memoffset = "0.8.0"
+memoffset = ">= 0.6, < 1"
 byteorder = "1.3"
 bitflags = "1.3.2"
-paste = "1.0.11"
+paste = "1.0"
 
 [build-dependencies]
 pkg-config = "0.3"
-bindgen = "0.69.2"
+bindgen = ">= 0.66, < 0.70"


### PR DESCRIPTION
Debian unstable has the current version of these crates:

  - errno: 0.4
  - udev: 0.8 (currently in NEW)
  - memoffset: 0.6.5
  - paste: 1.0.8
  - bindgen: 0.66.1

Loosening the versions a bit (some up, some down) allows Debian to build the Rust parts.