### PR TITLE
Make initramfs hook install mount.btrfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,7 @@ install: bcachefs $(optional_install)
 
 	sed -i '/^# Note: make install replaces/,$$d' $(DESTDIR)$(INITRAMFS_HOOK)
 	echo "copy_exec $(ROOT_SBINDIR)/bcachefs /sbin/bcachefs" >> $(DESTDIR)$(INITRAMFS_HOOK)
+	echo "copy_exec $(ROOT_SBINDIR)/mount.bcachefs /sbin/mount.bcachefs" >> $(DESTDIR)$(INITRAMFS_HOOK)
 
 .PHONY: install_systemd
 install_systemd: $(systemd_services) $(systemd_libexecfiles)

--- a/initramfs/hook
+++ b/initramfs/hook
@@ -25,3 +25,4 @@ add_loaded_modules 'poly1305[-_]*'
 # Add the bcachefs utility to the initramfs
 # Note: make install replaces this with the install path, so it must be last
 #copy_exec /usr/local/sbin/bcachefs /sbin/bcachefs
+#copy_exec /usr/local/sbin/mount.bcachefs /sbin/mount.bcachefs


### PR DESCRIPTION
Now that the bcachefs tool unconditionally includes the mount parts (or more correctly, you cannot build it at all if you don't have Rust), we can call copy_exec on mount.btrfs, to get the symlink installed. In particular, this helps with mounting UUID mounts as /.

See also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1060411 for the remaining parts needed in initramfs-tools itself.