### PR TITLE
Add a few subcommand aliases

### DIFF
--- a/src/commands/cmd_completions.rs
+++ b/src/commands/cmd_completions.rs
@@ -3,7 +3,7 @@ use clap_complete::{generate, Generator, Shell};
 use std::io;
 
 /// Generate shell completions
-#[derive(clap::Parser, Debug)]
+#[derive(Parser, Debug)]
 pub struct Cli {
     shell: Shell,
 }

--- a/src/commands/cmd_list.rs
+++ b/src/commands/cmd_list.rs
@@ -113,7 +113,7 @@ pub struct Cli {
     mode:       Mode,
 
     /// Check (fsck) the filesystem first
-    #[arg(short, long, default_value_t=false)]
+    #[arg(short, long)]
     fsck:       bool,
 
     /// Force color on/off. Default: autodetect tty

--- a/src/commands/cmd_subvolume.rs
+++ b/src/commands/cmd_subvolume.rs
@@ -14,15 +14,19 @@ pub struct Cli {
 /// Subvolumes-related commands
 #[derive(Subcommand, Debug)]
 enum Subcommands {
+    #[command(visible_aliases = ["new"])]
     Create {
         /// Paths
         targets: Vec<PathBuf>
     },
+
+    #[command(visible_aliases = ["del"])]
     Delete {
         /// Path
         target: PathBuf
     },
-    #[command(allow_missing_positional = true)]
+
+    #[command(allow_missing_positional = true, visible_aliases = ["snap"])]
     Snapshot {
         /// Make snapshot read only
         #[arg(long, short)]

--- a/src/commands/cmd_subvolume.rs
+++ b/src/commands/cmd_subvolume.rs
@@ -25,7 +25,7 @@ enum Subcommands {
     #[command(allow_missing_positional = true)]
     Snapshot {
         /// Make snapshot read only
-        #[arg(long, short = 'r')]
+        #[arg(long, short)]
         read_only: bool,
         source: Option<PathBuf>,
         dest: PathBuf

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,6 +18,7 @@ enum Subcommands {
     List(cmd_list::Cli),
     Mount(cmd_mount::Cli),
     Completions(cmd_completions::Cli),
+    #[command(visible_aliases = ["subvol"])]
     Subvolume(cmd_subvolume::Cli),
 }
 


### PR DESCRIPTION
Added a few aliases to a few subcommands I use often, as well as some minor cleanups.

bcachefs subvolume snapshot -> bcachefs subvol snap

Maybe we should also add this to all other subcommands? Would love to hear your thoughts on this.