### PR TITLE
Add keyfile option to mount

### DIFF
--- a/libbcachefs/bcachefs_format.h
+++ b/libbcachefs/bcachefs_format.h
@@ -653,7 +653,7 @@ struct bch_encrypted_key {
 
 /*
  * If this field is present in the superblock, it stores an encryption key which
- * is used encrypt all other data/metadata. The key will normally be encrypted
+ * is used to encrypt all other data/metadata. The key will normally be encrypted
  * with the key userspace provides, but if encryption has been turned off we'll
  * just store the master key unencrypted in the superblock so we can access the
  * previously encrypted data.

--- a/src/commands/cmd_mount.rs
+++ b/src/commands/cmd_mount.rs
@@ -157,7 +157,7 @@ pub struct Cli {
     #[arg(short, default_value = "")]
     options:        String,
 
-    /// Force color on/off. Default: autodetect tty
+    /// Force color on/off. Autodetect tty is used to define default:
     #[arg(short, long, action = clap::ArgAction::Set, default_value_t=stdout().is_terminal())]
     colorize:       bool,
 

--- a/src/commands/cmd_mount.rs
+++ b/src/commands/cmd_mount.rs
@@ -1,6 +1,6 @@
 use bch_bindgen::{bcachefs, bcachefs::bch_sb_handle, opt_set};
 use log::{info, debug, error, LevelFilter};
-use clap::{Parser};
+use clap::Parser;
 use uuid::Uuid;
 use std::io::{stdout, IsTerminal};
 use std::path::PathBuf;

--- a/src/commands/cmd_mount.rs
+++ b/src/commands/cmd_mount.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 use std::io::{stdout, IsTerminal};
 use std::path::PathBuf;
 use crate::key;
-use crate::key::KeyLocation;
+use crate::key::KeyPolicy;
 use std::ffi::{CString, c_char, c_void};
 use std::os::unix::ffi::OsStrExt;
 
@@ -136,14 +136,14 @@ pub struct Cli {
     #[arg(short = 'f', long)]
     key_file:       Option<PathBuf>,
 
-    /// Where the password would be loaded from.
+    /// Password policy to use in case of encrypted filesystem.
     ///
     /// Possible values are:
     /// "fail" - don't ask for password, fail if filesystem is encrypted;
     /// "wait" - wait for password to become available before mounting;
     /// "ask" -  prompt the user for password;
-    #[arg(short, long, default_value = "ask", verbatim_doc_comment)]
-    key_location:   KeyLocation,
+    #[arg(short = 'k', long = "key_location", default_value = "ask", verbatim_doc_comment)]
+    key_policy:     KeyPolicy,
 
     /// Device, or UUID=\<UUID\>
     dev:            String,
@@ -227,7 +227,7 @@ fn cmd_mount_inner(opt: Cli) -> anyhow::Result<()> {
         };
         // If decryption by key_file was unsuccesful, prompt for password (or follow key_policy)
         if fallback_to_prepare_key {
-            key::prepare_key(&block_devices_to_mount[0], opt.key_location)?;
+            key::prepare_key(&block_devices_to_mount[0], opt.key_policy)?;
         };
     }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,4 +1,4 @@
-use std::{fmt, io::{stdin, IsTerminal}};
+use std::{fmt, fs, io::{stdin, IsTerminal}};
 
 use log::{info};
 use bch_bindgen::bcachefs::bch_sb_handle;
@@ -148,6 +148,16 @@ fn decrypt_master_key(sb: &bch_sb_handle, pass: String) -> anyhow::Result<()> {
             Ok(())
         }
     }
+}
+
+pub fn read_from_key_file(sb: &bch_sb_handle, key_file: &std::path::Path) -> anyhow::Result<()> {
+    // Attempts to decrypt the master key by key_file
+    // Return true if decryption was successful, false otherwise
+    info!("Attempting to decrypt master key for filesystem {}, using key file {}", sb.sb().uuid(), key_file.display());
+    // Read the contents of the key file into a string
+    let pass = fs::read_to_string(key_file)?;
+    // Call decrypt_master_key with the read string
+    decrypt_master_key(sb, pass)
 }
 
 pub fn prepare_key(sb: &bch_sb_handle, password: KeyLocation) -> anyhow::Result<()> {

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,4 +1,4 @@
-use std::io::{stdin, IsTerminal};
+use std::{fmt, io::{stdin, IsTerminal}};
 
 use log::{info};
 use bch_bindgen::bcachefs::bch_sb_handle;
@@ -44,6 +44,17 @@ impl clap::ValueEnum for KeyLocation {
             Self::Wait => PossibleValue::new("wait"),
             Self::Ask => PossibleValue::new("ask"),
         })
+    }
+}
+
+impl fmt::Display for KeyLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            KeyLocation::None => write!(f, "None"),
+            KeyLocation::Fail => write!(f, "Fail"),
+            KeyLocation::Wait => write!(f, "Wait"),
+            KeyLocation::Ask => write!(f, "Ask"),
+        }
     }
 }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -7,33 +7,33 @@ use crate::c_str;
 use anyhow::anyhow;
 
 #[derive(Clone, Debug)]
-pub enum KeyLocation {
+pub enum KeyPolicy {
     None,
     Fail,
     Wait,
     Ask,
 }
 
-impl std::str::FromStr for KeyLocation {
+impl std::str::FromStr for KeyPolicy {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> anyhow::Result<Self> {
         match s {
-            ""|"none" => Ok(KeyLocation::None),
-            "fail"    => Ok(KeyLocation::Fail),
-            "wait"    => Ok(KeyLocation::Wait),
-            "ask"     => Ok(KeyLocation::Ask),
+            ""|"none" => Ok(KeyPolicy::None),
+            "fail"    => Ok(KeyPolicy::Fail),
+            "wait"    => Ok(KeyPolicy::Wait),
+            "ask"     => Ok(KeyPolicy::Ask),
             _         => Err(anyhow!("invalid password option")),
         }
     }
 }
 
-impl clap::ValueEnum for KeyLocation {
+impl clap::ValueEnum for KeyPolicy {
     fn value_variants<'a>() -> &'a [Self] {
         &[
-            KeyLocation::None,
-            KeyLocation::Fail,
-            KeyLocation::Wait,
-            KeyLocation::Ask,
+            KeyPolicy::None,
+            KeyPolicy::Fail,
+            KeyPolicy::Wait,
+            KeyPolicy::Ask,
         ]
     }
 
@@ -47,13 +47,13 @@ impl clap::ValueEnum for KeyLocation {
     }
 }
 
-impl fmt::Display for KeyLocation {
+impl fmt::Display for KeyPolicy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            KeyLocation::None => write!(f, "None"),
-            KeyLocation::Fail => write!(f, "Fail"),
-            KeyLocation::Wait => write!(f, "Wait"),
-            KeyLocation::Ask => write!(f, "Ask"),
+            KeyPolicy::None => write!(f, "None"),
+            KeyPolicy::Fail => write!(f, "Fail"),
+            KeyPolicy::Wait => write!(f, "Wait"),
+            KeyPolicy::Ask => write!(f, "Ask"),
         }
     }
 }
@@ -160,12 +160,12 @@ pub fn read_from_key_file(sb: &bch_sb_handle, key_file: &std::path::Path) -> any
     decrypt_master_key(sb, pass)
 }
 
-pub fn prepare_key(sb: &bch_sb_handle, password: KeyLocation) -> anyhow::Result<()> {
-    info!("checking if key exists for filesystem {}", sb.sb().uuid());
+pub fn prepare_key(sb: &bch_sb_handle, password: KeyPolicy) -> anyhow::Result<()> {
+    info!("Attempting to decrypt master key for filesystem {}, using key policy {}", sb.sb().uuid(), password_policy);
     match password {
-        KeyLocation::Fail => Err(anyhow!("no key available")),
-        KeyLocation::Wait => Ok(wait_for_key(&sb.sb().uuid())?),
-        KeyLocation::Ask => ask_for_key(sb),
+        KeyPolicy::Fail => Err(anyhow!("no key available")),
+        KeyPolicy::Wait => Ok(wait_for_key(&sb.sb().uuid())?),
+        KeyPolicy::Ask => ask_for_key(sb),
         _ => Err(anyhow!("no keyoption specified for locked filesystem")),
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -150,22 +150,22 @@ fn decrypt_master_key(sb: &bch_sb_handle, pass: String) -> anyhow::Result<()> {
     }
 }
 
-pub fn read_from_key_file(sb: &bch_sb_handle, key_file: &std::path::Path) -> anyhow::Result<()> {
+pub fn read_from_key_file(block_device: &bch_sb_handle, key_file: &std::path::Path) -> anyhow::Result<()> {
     // Attempts to decrypt the master key by key_file
     // Return true if decryption was successful, false otherwise
-    info!("Attempting to decrypt master key for filesystem {}, using key file {}", sb.sb().uuid(), key_file.display());
+    info!("Attempting to decrypt master key for filesystem {}, using key file {}", block_device.sb().uuid(), key_file.display());
     // Read the contents of the key file into a string
     let pass = fs::read_to_string(key_file)?;
     // Call decrypt_master_key with the read string
-    decrypt_master_key(sb, pass)
+    decrypt_master_key(block_device, pass)
 }
 
-pub fn prepare_key(sb: &bch_sb_handle, password_policy: KeyPolicy) -> anyhow::Result<()> {
-    info!("Attempting to decrypt master key for filesystem {}, using key policy {}", sb.sb().uuid(), password_policy);
+pub fn prepare_key(block_device: &bch_sb_handle, password_policy: KeyPolicy) -> anyhow::Result<()> {
+    info!("Attempting to decrypt master key for filesystem {}, using key policy {}", block_device.sb().uuid(), password_policy);
     match password_policy {
         KeyPolicy::Fail => Err(anyhow!("no key available")),
-        KeyPolicy::Wait => Ok(wait_for_key(&sb.sb().uuid())?),
-        KeyPolicy::Ask => ask_for_key(sb),
+        KeyPolicy::Wait => Ok(wait_for_key(&block_device.sb().uuid())?),
+        KeyPolicy::Ask => ask_for_key(block_device),
         _ => Err(anyhow!("no keyoption specified for locked filesystem")),
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,6 +1,6 @@
 use std::{fmt, fs, io::{stdin, IsTerminal}};
 
-use log::{info};
+use log::info;
 use bch_bindgen::bcachefs::bch_sb_handle;
 use clap::builder::PossibleValue;
 use crate::c_str;

--- a/src/key.rs
+++ b/src/key.rs
@@ -160,9 +160,9 @@ pub fn read_from_key_file(sb: &bch_sb_handle, key_file: &std::path::Path) -> any
     decrypt_master_key(sb, pass)
 }
 
-pub fn prepare_key(sb: &bch_sb_handle, password: KeyPolicy) -> anyhow::Result<()> {
+pub fn prepare_key(sb: &bch_sb_handle, password_policy: KeyPolicy) -> anyhow::Result<()> {
     info!("Attempting to decrypt master key for filesystem {}, using key policy {}", sb.sb().uuid(), password_policy);
-    match password {
+    match password_policy {
         KeyPolicy::Fail => Err(anyhow!("no key available")),
         KeyPolicy::Wait => Ok(wait_for_key(&sb.sb().uuid())?),
         KeyPolicy::Ask => ask_for_key(sb),

--- a/src/key.rs
+++ b/src/key.rs
@@ -65,7 +65,7 @@ fn check_for_key(key_name: &std::ffi::CStr) -> anyhow::Result<bool> {
 
     let key_id = unsafe { keyctl_search(keyutils::KEY_SPEC_USER_KEYRING, key_type, key_name, 0) };
     if key_id > 0 {
-        info!("Key has became available");
+        info!("Key has become available");
         Ok(true)
     } else {
         match errno::errno().0 {

--- a/src/key.rs
+++ b/src/key.rs
@@ -22,7 +22,7 @@ impl std::str::FromStr for KeyPolicy {
             "fail"    => Ok(KeyPolicy::Fail),
             "wait"    => Ok(KeyPolicy::Wait),
             "ask"     => Ok(KeyPolicy::Ask),
-            _         => Err(anyhow!("invalid password option")),
+            _         => Err(anyhow!("Invalid key policy provided")),
         }
     }
 }

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -54,10 +54,14 @@ def test_list_dirent(tmpdir):
 
     assert ret.returncode == 0
     assert len(ret.stderr) == 0
-    assert len(ret.stdout.splitlines()) == (2 + 1) # 1 dirent
+    assert len(ret.stdout.splitlines()) == (6) # See example:
 
     # Example:
-    # u64s 8 type dirent 4096:2449855786607753081
-    # snap 0 len 0 ver 0: lost+found -> 4097
+    # mounting version 1.6: btree_subvolume_children opts=ro,errors=continue,degraded,nochanges,norecovery,read_only
+    # recovering from clean shutdown, journal seq 9
+    # alloc_read... done
+    # stripes_read... done
+    # snapshots_read... done
+    # u64s 8 type dirent 4096:453699834857023875:U32_MAX len 0 ver 0: lost+found -> 4097 type dir
     last = ret.stdout.splitlines()[-1]
     assert re.match(r'^.*type dirent.*: lost\+found ->.*$', last)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -45,7 +45,7 @@ def test_list_inodes(tmpdir):
 
     assert ret.returncode == 0
     assert len(ret.stderr) == 0
-    assert len(ret.stdout.splitlines()) == (2 + 2) # 2 inodes on clean format
+    assert len(ret.stdout.splitlines()) == (67)
 
 def test_list_dirent(tmpdir):
     dev = util.format_1g(tmpdir)

--- a/tests/test_helper.c
+++ b/tests/test_helper.c
@@ -32,7 +32,7 @@ static void test_undefined(void)
 
 static void test_undefined_branch(void)
 {
-       	int x;
+	int x;
 	trick_compiler(&x);
 
 	if (x)


### PR DESCRIPTION
As discussed in #211; add a optional flag to specify a key file

- Add key_file option to Cli
- Rework decryption flow logic to first attempt key_file
- Read password from file and pass to decrypt_master_key

Explicity specify '-k' for key_location

Tag @oz123