### PR TITLE
mount: Handle multi-device with 1 device node

### DIFF
--- a/src/bcachefs.rs
+++ b/src/bcachefs.rs
@@ -1,15 +1,15 @@
-mod wrappers;
 mod commands;
 mod key;
+mod wrappers;
 
 use std::ffi::CString;
 
+use bch_bindgen::c;
 use commands::cmd_completions::cmd_completions;
 use commands::cmd_list::cmd_list;
 use commands::cmd_mount::cmd_mount;
 use commands::cmd_subvolume::cmd_subvolumes;
 use commands::logger::SimpleLogger;
-use bch_bindgen::c;
 
 #[derive(Debug)]
 pub struct ErrnoError(pub errno::Errno);
@@ -48,7 +48,7 @@ fn handle_c_command(args: Vec<String>, symlink_cmd: Option<&str>) -> i32 {
             "--help" => {
                 c::bcachefs_usage();
                 0
-            },
+            }
             "data" => c::data_cmds(argc, argv),
             "device" => c::device_cmds(argc, argv),
             "dump" => c::cmd_dump(argc, argv),

--- a/src/commands/cmd_list.rs
+++ b/src/commands/cmd_list.rs
@@ -1,20 +1,23 @@
-use log::{error};
 use bch_bindgen::bcachefs;
-use bch_bindgen::opt_set;
-use bch_bindgen::fs::Fs;
 use bch_bindgen::bkey::BkeySC;
-use bch_bindgen::btree::BtreeTrans;
 use bch_bindgen::btree::BtreeIter;
-use bch_bindgen::btree::BtreeNodeIter;
 use bch_bindgen::btree::BtreeIterFlags;
-use clap::{Parser};
+use bch_bindgen::btree::BtreeNodeIter;
+use bch_bindgen::btree::BtreeTrans;
+use bch_bindgen::fs::Fs;
+use bch_bindgen::opt_set;
+use clap::Parser;
+use log::error;
 use std::io::{stdout, IsTerminal};
 
 fn list_keys(fs: &Fs, opt: Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
-    let mut iter = BtreeIter::new(&trans, opt.btree, opt.start,
-        BtreeIterFlags::ALL_SNAPSHOTS|
-        BtreeIterFlags::PREFETCH);
+    let mut iter = BtreeIter::new(
+        &trans,
+        opt.btree,
+        opt.start,
+        BtreeIterFlags::ALL_SNAPSHOTS | BtreeIterFlags::PREFETCH,
+    );
 
     while let Some(k) = iter.peek_and_restart()? {
         if k.k.p > opt.end {
@@ -30,9 +33,14 @@ fn list_keys(fs: &Fs, opt: Cli) -> anyhow::Result<()> {
 
 fn list_btree_formats(fs: &Fs, opt: Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
-    let mut iter = BtreeNodeIter::new(&trans, opt.btree, opt.start,
-        0, opt.level,
-        BtreeIterFlags::PREFETCH);
+    let mut iter = BtreeNodeIter::new(
+        &trans,
+        opt.btree,
+        opt.start,
+        0,
+        opt.level,
+        BtreeIterFlags::PREFETCH,
+    );
 
     while let Some(b) = iter.peek_and_restart()? {
         if b.key.k.p > opt.end {
@@ -48,9 +56,14 @@ fn list_btree_formats(fs: &Fs, opt: Cli) -> anyhow::Result<()> {
 
 fn list_btree_nodes(fs: &Fs, opt: Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
-    let mut iter = BtreeNodeIter::new(&trans, opt.btree, opt.start,
-        0, opt.level,
-        BtreeIterFlags::PREFETCH);
+    let mut iter = BtreeNodeIter::new(
+        &trans,
+        opt.btree,
+        opt.start,
+        0,
+        opt.level,
+        BtreeIterFlags::PREFETCH,
+    );
 
     while let Some(b) = iter.peek_and_restart()? {
         if b.key.k.p > opt.end {
@@ -66,9 +79,14 @@ fn list_btree_nodes(fs: &Fs, opt: Cli) -> anyhow::Result<()> {
 
 fn list_nodes_ondisk(fs: &Fs, opt: Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
-    let mut iter = BtreeNodeIter::new(&trans, opt.btree, opt.start,
-        0, opt.level,
-        BtreeIterFlags::PREFETCH);
+    let mut iter = BtreeNodeIter::new(
+        &trans,
+        opt.btree,
+        opt.start,
+        0,
+        opt.level,
+        BtreeIterFlags::PREFETCH,
+    );
 
     while let Some(b) = iter.peek_and_restart()? {
         if b.key.k.p > opt.end {
@@ -95,64 +113,72 @@ enum Mode {
 pub struct Cli {
     /// Btree to list from
     #[arg(short, long, default_value_t=bcachefs::btree_id::BTREE_ID_extents)]
-    btree:      bcachefs::btree_id,
+    btree: bcachefs::btree_id,
 
     /// Btree depth to descend to (0 == leaves)
-    #[arg(short, long, default_value_t=0)]
-    level:      u32,
+    #[arg(short, long, default_value_t = 0)]
+    level: u32,
 
     /// Start position to list from
-    #[arg(short, long, default_value="POS_MIN")]
-    start:      bcachefs::bpos,
+    #[arg(short, long, default_value = "POS_MIN")]
+    start: bcachefs::bpos,
 
     /// End position
-    #[arg(short, long, default_value="SPOS_MAX")]
-    end:        bcachefs::bpos,
+    #[arg(short, long, default_value = "SPOS_MAX")]
+    end: bcachefs::bpos,
 
-    #[arg(short, long, default_value="keys")]
-    mode:       Mode,
+    #[arg(short, long, default_value = "keys")]
+    mode: Mode,
 
     /// Check (fsck) the filesystem first
     #[arg(short, long)]
-    fsck:       bool,
+    fsck: bool,
 
     /// Force color on/off. Default: autodetect tty
     #[arg(short, long, action = clap::ArgAction::Set, default_value_t=stdout().is_terminal())]
-    colorize:   bool,
+    colorize: bool,
 
     /// Verbose mode
     #[arg(short, long)]
-    verbose:    bool,
+    verbose: bool,
 
     #[arg(required(true))]
-    devices:    Vec<std::path::PathBuf>,
+    devices: Vec<std::path::PathBuf>,
 }
 
 fn cmd_list_inner(opt: Cli) -> anyhow::Result<()> {
     let mut fs_opts: bcachefs::bch_opts = Default::default();
 
-    opt_set!(fs_opts, nochanges,        1);
-    opt_set!(fs_opts, read_only,        1);
-    opt_set!(fs_opts, norecovery,       1);
-    opt_set!(fs_opts, degraded,         1);
-    opt_set!(fs_opts, errors,           bcachefs::bch_error_actions::BCH_ON_ERROR_continue as u8);
+    opt_set!(fs_opts, nochanges, 1);
+    opt_set!(fs_opts, read_only, 1);
+    opt_set!(fs_opts, norecovery, 1);
+    opt_set!(fs_opts, degraded, 1);
+    opt_set!(
+        fs_opts,
+        errors,
+        bcachefs::bch_error_actions::BCH_ON_ERROR_continue as u8
+    );
 
     if opt.fsck {
-        opt_set!(fs_opts, fix_errors,   bcachefs::fsck_err_opts::FSCK_FIX_yes as u8);
-        opt_set!(fs_opts, norecovery,   0);
+        opt_set!(
+            fs_opts,
+            fix_errors,
+            bcachefs::fsck_err_opts::FSCK_FIX_yes as u8
+        );
+        opt_set!(fs_opts, norecovery, 0);
     }
 
     if opt.verbose {
-        opt_set!(fs_opts, verbose,      1);
+        opt_set!(fs_opts, verbose, 1);
     }
 
     let fs = Fs::open(&opt.devices, fs_opts)?;
 
     match opt.mode {
-        Mode::Keys          => list_keys(&fs, opt),
-        Mode::Formats       => list_btree_formats(&fs, opt),
-        Mode::Nodes         => list_btree_nodes(&fs, opt),
-        Mode::NodesOndisk   => list_nodes_ondisk(&fs, opt),
+        Mode::Keys => list_keys(&fs, opt),
+        Mode::Formats => list_btree_formats(&fs, opt),
+        Mode::Nodes => list_btree_nodes(&fs, opt),
+        Mode::NodesOndisk => list_nodes_ondisk(&fs, opt),
     }
 }
 

--- a/src/commands/cmd_mount.rs
+++ b/src/commands/cmd_mount.rs
@@ -124,6 +124,24 @@ fn get_devices_by_uuid(uuid: Uuid) -> anyhow::Result<Vec<(PathBuf, bch_sb_handle
     Ok(devs)
 }
 
+fn get_uuid_for_dev_node(device: &std::path::PathBuf) ->  anyhow::Result<Option<Uuid>> {
+    let mut udev = udev::Enumerator::new()?;
+    udev.match_subsystem("block")?;
+
+    for dev in udev.scan_devices()?.into_iter() {
+        if let Some(devnode) = dev.devnode() {
+            if devnode == device {
+                let devnode_owned = devnode.to_owned();
+                let sb_result = read_super_silent(&devnode_owned);
+                if let Ok(sb) = sb_result {
+                    return Ok(Some(sb.sb().uuid()));
+                }
+            }
+        }
+    }
+    Ok(None)
+}
+
 /// Mount a bcachefs filesystem by its UUID.
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -184,6 +202,16 @@ fn devs_str_sbs_from_uuid(uuid: String) -> anyhow::Result<(String, Vec<bch_sb_ha
 
 }
 
+fn devs_str_sbs_from_device(device: &std::path::PathBuf) -> anyhow::Result<(String, Vec<bch_sb_handle>)> {
+    let uuid = get_uuid_for_dev_node(device)?;
+
+    if let Some(bcache_fs_uuid) = uuid {
+        devs_str_sbs_from_uuid(bcache_fs_uuid.to_string())
+    } else {
+        Ok((String::new(), Vec::new()))
+    }
+}
+
 fn cmd_mount_inner(opt: Cli) -> anyhow::Result<()> {
     let (devices, block_devices_to_mount) = if opt.dev.starts_with("UUID=") {
         let uuid = opt.dev.replacen("UUID=", "", 1);
@@ -192,14 +220,22 @@ fn cmd_mount_inner(opt: Cli) -> anyhow::Result<()> {
         let uuid = opt.dev.replacen("OLD_BLKID_UUID=", "", 1);
         devs_str_sbs_from_uuid(uuid)?
     } else {
-        let mut block_devices_to_mount = Vec::new();
+        // If the device string contains ":" we will assume the user knows the entire list.
+        // If they supply a single device it could be either the FS only has 1 device or it's
+        // only 1 of a number of devices which are part of the FS. This appears to be the case
+        // when we get called during fstab mount processing and the fstab specifies a UUID.
+        if opt.dev.contains(":") {
+            let mut block_devices_to_mount = Vec::new();
 
-        for dev in opt.dev.split(':') {
-            let dev = PathBuf::from(dev);
-            block_devices_to_mount.push(read_super_silent(&dev)?);
+            for dev in opt.dev.split(':') {
+                let dev = PathBuf::from(dev);
+                block_devices_to_mount.push(read_super_silent(&dev)?);
+            }
+
+            (opt.dev, block_devices_to_mount)
+        } else {
+            devs_str_sbs_from_device(&PathBuf::from(opt.dev))?
         }
-
-        (opt.dev, block_devices_to_mount)
     };
 
     if block_devices_to_mount.len() == 0 {

--- a/src/commands/cmd_subvolume.rs
+++ b/src/commands/cmd_subvolume.rs
@@ -17,13 +17,13 @@ enum Subcommands {
     #[command(visible_aliases = ["new"])]
     Create {
         /// Paths
-        targets: Vec<PathBuf>
+        targets: Vec<PathBuf>,
     },
 
     #[command(visible_aliases = ["del"])]
     Delete {
         /// Path
-        target: PathBuf
+        target: PathBuf,
     },
 
     #[command(allow_missing_positional = true, visible_aliases = ["snap"])]
@@ -32,8 +32,8 @@ enum Subcommands {
         #[arg(long, short)]
         read_only: bool,
         source: Option<PathBuf>,
-        dest: PathBuf
-    }
+        dest: PathBuf,
+    },
 }
 
 pub fn cmd_subvolumes(argv: Vec<String>) -> i32 {
@@ -44,24 +44,42 @@ pub fn cmd_subvolumes(argv: Vec<String>) -> i32 {
             for target in targets {
                 if let Some(dirname) = target.parent() {
                     let fs = unsafe { BcachefsHandle::open(dirname) };
-                    fs.create_subvolume(target).expect("Failed to create the subvolume");
+                    fs.create_subvolume(target)
+                        .expect("Failed to create the subvolume");
                 }
             }
         }
-        ,
         Subcommands::Delete { target } => {
             if let Some(dirname) = target.parent() {
                 let fs = unsafe { BcachefsHandle::open(dirname) };
-                fs.delete_subvolume(target).expect("Failed to delete the subvolume");
+                fs.delete_subvolume(target)
+                    .expect("Failed to delete the subvolume");
             }
-        },
-        Subcommands::Snapshot { read_only, source, dest } => {
+        }
+        Subcommands::Snapshot {
+            read_only,
+            source,
+            dest,
+        } => {
             if let Some(dirname) = dest.parent() {
                 let dot = PathBuf::from(".");
-                let dir = if dirname.as_os_str().is_empty() { &dot } else { dirname };
+                let dir = if dirname.as_os_str().is_empty() {
+                    &dot
+                } else {
+                    dirname
+                };
                 let fs = unsafe { BcachefsHandle::open(dir) };
 
-                fs.snapshot_subvolume(if read_only { BCH_SUBVOL_SNAPSHOT_RO } else { 0x0 }, source, dest).expect("Failed to snapshot the subvolume");
+                fs.snapshot_subvolume(
+                    if read_only {
+                        BCH_SUBVOL_SNAPSHOT_RO
+                    } else {
+                        0x0
+                    },
+                    source,
+                    dest,
+                )
+                .expect("Failed to snapshot the subvolume");
             }
         }
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,10 +1,10 @@
 use clap::Subcommand;
 
-pub mod logger;
-pub mod cmd_mount;
-pub mod cmd_list;
 pub mod cmd_completions;
+pub mod cmd_list;
+pub mod cmd_mount;
 pub mod cmd_subvolume;
+pub mod logger;
 
 #[derive(clap::Parser, Debug)]
 #[command(name = "bcachefs")]

--- a/src/key.rs
+++ b/src/key.rs
@@ -101,7 +101,7 @@ fn ask_for_passphrase(sb: &bch_sb_handle) -> anyhow::Result<()> {
 }
 
 const BCH_KEY_MAGIC: &str = "bch**key";
-fn unlock_master_key(sb: &bch_sb_handle, passphrase: &String) -> anyhow::Result<()> {
+fn unlock_master_key(sb: &bch_sb_handle, passphrase: &str) -> anyhow::Result<()> {
     use bch_bindgen::bcachefs::{self, bch2_chacha_encrypt_key, bch_encrypted_key, bch_key};
     use byteorder::{LittleEndian, ReadBytesExt};
     use std::os::raw::c_char;
@@ -121,13 +121,13 @@ fn unlock_master_key(sb: &bch_sb_handle, passphrase: &String) -> anyhow::Result<
         )
     };
 
-    let mut key = crypt.key().clone();
+    let mut key = *crypt.key();
     let ret = unsafe {
         bch2_chacha_encrypt_key(
             &mut output as *mut _,
             sb.sb().nonce(),
             &mut key as *mut _ as *mut _,
-            std::mem::size_of::<bch_encrypted_key>() as usize,
+            std::mem::size_of::<bch_encrypted_key>(),
         )
     };
     if ret != 0 {
@@ -141,7 +141,7 @@ fn unlock_master_key(sb: &bch_sb_handle, passphrase: &String) -> anyhow::Result<
                 key_type,
                 key_name.as_c_str().to_bytes_with_nul() as *const _ as *const c_char,
                 &output as *const _ as *const _,
-                std::mem::size_of::<bch_key>() as usize,
+                std::mem::size_of::<bch_key>(),
                 bch_bindgen::keyutils::KEY_SPEC_USER_KEYRING,
             )
         };

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,10 +1,13 @@
-use std::{fmt, fs, io::{stdin, IsTerminal}};
+use std::{
+    fmt, fs,
+    io::{stdin, IsTerminal},
+};
 
-use log::info;
-use bch_bindgen::bcachefs::bch_sb_handle;
-use clap::builder::PossibleValue;
 use crate::c_str;
 use anyhow::anyhow;
+use bch_bindgen::bcachefs::bch_sb_handle;
+use clap::builder::PossibleValue;
+use log::info;
 
 #[derive(Clone, Debug)]
 pub enum UnlockPolicy {
@@ -18,11 +21,11 @@ impl std::str::FromStr for UnlockPolicy {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> anyhow::Result<Self> {
         match s {
-            ""|"none" => Ok(UnlockPolicy::None),
-            "fail"    => Ok(UnlockPolicy::Fail),
-            "wait"    => Ok(UnlockPolicy::Wait),
-            "ask"     => Ok(UnlockPolicy::Ask),
-            _         => Err(anyhow!("Invalid unlock policy provided")),
+            "" | "none" => Ok(UnlockPolicy::None),
+            "fail" => Ok(UnlockPolicy::Fail),
+            "wait" => Ok(UnlockPolicy::Wait),
+            "ask" => Ok(UnlockPolicy::Ask),
+            _ => Err(anyhow!("Invalid unlock policy provided")),
         }
     }
 }
@@ -150,18 +153,32 @@ fn unlock_master_key(sb: &bch_sb_handle, passphrase: &String) -> anyhow::Result<
     }
 }
 
-pub fn read_from_passphrase_file(block_device: &bch_sb_handle, passphrase_file: &std::path::Path) -> anyhow::Result<()> {
+pub fn read_from_passphrase_file(
+    block_device: &bch_sb_handle,
+    passphrase_file: &std::path::Path,
+) -> anyhow::Result<()> {
     // Attempts to unlock the master key by password_file
     // Return true if unlock was successful, false otherwise
-    info!("Attempting to unlock master key for filesystem {}, using password from file {}", block_device.sb().uuid(), passphrase_file.display());
+    info!(
+        "Attempting to unlock master key for filesystem {}, using password from file {}",
+        block_device.sb().uuid(),
+        passphrase_file.display()
+    );
     // Read the contents of the password_file into a string
     let passphrase = fs::read_to_string(passphrase_file)?;
     // Call decrypt_master_key with the read string
     unlock_master_key(block_device, &passphrase)
 }
 
-pub fn apply_key_unlocking_policy(block_device: &bch_sb_handle, unlock_policy: UnlockPolicy) -> anyhow::Result<()> {
-    info!("Attempting to unlock master key for filesystem {}, using unlock policy {}", block_device.sb().uuid(), unlock_policy);
+pub fn apply_key_unlocking_policy(
+    block_device: &bch_sb_handle,
+    unlock_policy: UnlockPolicy,
+) -> anyhow::Result<()> {
+    info!(
+        "Attempting to unlock master key for filesystem {}, using unlock policy {}",
+        block_device.sb().uuid(),
+        unlock_policy
+    );
     match unlock_policy {
         UnlockPolicy::Fail => Err(anyhow!("no passphrase available")),
         UnlockPolicy::Wait => Ok(wait_for_unlock(&block_device.sb().uuid())?),

--- a/src/wrappers/handle.rs
+++ b/src/wrappers/handle.rs
@@ -1,27 +1,31 @@
-use std::{path::Path, os::unix::ffi::OsStrExt, ffi::CString};
+use std::{ffi::CString, os::unix::ffi::OsStrExt, path::Path};
 
-use bch_bindgen::c::{bchfs_handle, BCH_IOCTL_SUBVOLUME_CREATE, BCH_IOCTL_SUBVOLUME_DESTROY, bch_ioctl_subvolume, bcache_fs_open, BCH_SUBVOL_SNAPSHOT_CREATE, bcache_fs_close};
+use bch_bindgen::c::{
+    bcache_fs_close, bcache_fs_open, bch_ioctl_subvolume, bchfs_handle, BCH_IOCTL_SUBVOLUME_CREATE,
+    BCH_IOCTL_SUBVOLUME_DESTROY, BCH_SUBVOL_SNAPSHOT_CREATE,
+};
 use errno::Errno;
 
 /// A handle to a bcachefs filesystem
 /// This can be used to send [`libc::ioctl`] to the underlying filesystem.
 pub(crate) struct BcachefsHandle {
-    inner: bchfs_handle
+    inner: bchfs_handle,
 }
 
 impl BcachefsHandle {
     /// Opens a bcachefs filesystem and returns its handle
     /// TODO(raitobezarius): how can this not be faillible?
     pub(crate) unsafe fn open<P: AsRef<Path>>(path: P) -> Self {
-        let path = CString::new(path.as_ref().as_os_str().as_bytes()).expect("Failed to cast path into a C-style string");
+        let path = CString::new(path.as_ref().as_os_str().as_bytes())
+            .expect("Failed to cast path into a C-style string");
         Self {
-            inner: bcache_fs_open(path.as_ptr())
+            inner: bcache_fs_open(path.as_ptr()),
         }
     }
 }
 
 /// I/O control commands that can be sent to a bcachefs filesystem
-/// Those are non-exhaustive 
+/// Those are non-exhaustive
 #[repr(u32)]
 #[non_exhaustive]
 pub enum BcachefsIoctl {
@@ -38,14 +42,18 @@ pub enum BcachefsIoctlPayload {
 impl From<&BcachefsIoctlPayload> for *const libc::c_void {
     fn from(value: &BcachefsIoctlPayload) -> Self {
         match value {
-            BcachefsIoctlPayload::Subvolume(p) => p as *const _ as *const libc::c_void
+            BcachefsIoctlPayload::Subvolume(p) => p as *const _ as *const libc::c_void,
         }
     }
 }
 
 impl BcachefsHandle {
     /// Type-safe [`libc::ioctl`] for bcachefs filesystems
-    pub fn ioctl(&self, request: BcachefsIoctl, payload: &BcachefsIoctlPayload) -> Result<(), Errno> {
+    pub fn ioctl(
+        &self,
+        request: BcachefsIoctl,
+        payload: &BcachefsIoctlPayload,
+    ) -> Result<(), Errno> {
         let payload_ptr: *const libc::c_void = payload.into();
         let ret = unsafe { libc::ioctl(self.inner.ioctl_fd, request as libc::Ioctl, payload_ptr) };
 
@@ -59,42 +67,62 @@ impl BcachefsHandle {
     /// Create a subvolume for this bcachefs filesystem
     /// at the given path
     pub fn create_subvolume<P: AsRef<Path>>(&self, dst: P) -> Result<(), Errno> {
-        let dst = CString::new(dst.as_ref().as_os_str().as_bytes()).expect("Failed to cast destination path for subvolume in a C-style string");
-        self.ioctl(BcachefsIoctl::SubvolumeCreate, &BcachefsIoctlPayload::Subvolume(bch_ioctl_subvolume {
-            dirfd: libc::AT_FDCWD as u32,
-            mode: 0o777,
-            dst_ptr: dst.as_ptr() as u64,
-            ..Default::default()
-        }))
+        let dst = CString::new(dst.as_ref().as_os_str().as_bytes())
+            .expect("Failed to cast destination path for subvolume in a C-style string");
+        self.ioctl(
+            BcachefsIoctl::SubvolumeCreate,
+            &BcachefsIoctlPayload::Subvolume(bch_ioctl_subvolume {
+                dirfd: libc::AT_FDCWD as u32,
+                mode: 0o777,
+                dst_ptr: dst.as_ptr() as u64,
+                ..Default::default()
+            }),
+        )
     }
 
     /// Delete the subvolume at the given path
     /// for this bcachefs filesystem
     pub fn delete_subvolume<P: AsRef<Path>>(&self, dst: P) -> Result<(), Errno> {
-        let dst = CString::new(dst.as_ref().as_os_str().as_bytes()).expect("Failed to cast destination path for subvolume in a C-style string");
-        self.ioctl(BcachefsIoctl::SubvolumeDestroy, &BcachefsIoctlPayload::Subvolume(bch_ioctl_subvolume {
-            dirfd: libc::AT_FDCWD as u32,
-            mode: 0o777,
-            dst_ptr: dst.as_ptr() as u64,
-            ..Default::default()
-        }))
+        let dst = CString::new(dst.as_ref().as_os_str().as_bytes())
+            .expect("Failed to cast destination path for subvolume in a C-style string");
+        self.ioctl(
+            BcachefsIoctl::SubvolumeDestroy,
+            &BcachefsIoctlPayload::Subvolume(bch_ioctl_subvolume {
+                dirfd: libc::AT_FDCWD as u32,
+                mode: 0o777,
+                dst_ptr: dst.as_ptr() as u64,
+                ..Default::default()
+            }),
+        )
     }
 
     /// Snapshot a subvolume for this bcachefs filesystem
     /// at the given path
-    pub fn snapshot_subvolume<P: AsRef<Path>>(&self, extra_flags: u32, src: Option<P>, dst: P) -> Result<(), Errno> {
-        let src = src.map(|src| CString::new(src.as_ref().as_os_str().as_bytes()).expect("Failed to cast source path for subvolume in a C-style string"));
-        let dst = CString::new(dst.as_ref().as_os_str().as_bytes()).expect("Failed to cast destination path for subvolume in a C-style string");
+    pub fn snapshot_subvolume<P: AsRef<Path>>(
+        &self,
+        extra_flags: u32,
+        src: Option<P>,
+        dst: P,
+    ) -> Result<(), Errno> {
+        let src = src.map(|src| {
+            CString::new(src.as_ref().as_os_str().as_bytes())
+                .expect("Failed to cast source path for subvolume in a C-style string")
+        });
+        let dst = CString::new(dst.as_ref().as_os_str().as_bytes())
+            .expect("Failed to cast destination path for subvolume in a C-style string");
 
-        let res = self.ioctl(BcachefsIoctl::SubvolumeCreate, &BcachefsIoctlPayload::Subvolume(bch_ioctl_subvolume {
-            flags: BCH_SUBVOL_SNAPSHOT_CREATE | extra_flags,
-            dirfd: libc::AT_FDCWD as u32,
-            mode: 0o777,
-            src_ptr: src.as_ref().map_or(0, |x| x.as_ptr() as u64),
-            //src_ptr: if let Some(src) = src { src.as_ptr() } else { std::ptr::null() } as u64,
-            dst_ptr: dst.as_ptr() as u64,
-            ..Default::default()
-        }));
+        let res = self.ioctl(
+            BcachefsIoctl::SubvolumeCreate,
+            &BcachefsIoctlPayload::Subvolume(bch_ioctl_subvolume {
+                flags: BCH_SUBVOL_SNAPSHOT_CREATE | extra_flags,
+                dirfd: libc::AT_FDCWD as u32,
+                mode: 0o777,
+                src_ptr: src.as_ref().map_or(0, |x| x.as_ptr() as u64),
+                //src_ptr: if let Some(src) = src { src.as_ptr() } else { std::ptr::null() } as u64,
+                dst_ptr: dst.as_ptr() as u64,
+                ..Default::default()
+            }),
+        );
 
         drop(src);
         drop(dst);


### PR DESCRIPTION
Instead of requiring the user to supply all the device nodes for a multi-device FS, allow them to specifiy 1 of them.  We then fetch the UUID for the FS and then find all the disks on the system that match this UUID.

This allows me to bring up a bcachefs FS in /etc/fstab by using a UUID.  This works because it appears the mount command looks up the UUID, finds an entry in /dev/disk/by-uuid and then passes that found device node to mount.bcachefs which fails with `insufficient_devices_to_start` as bcachefs is expecting a list of devices with a `":"` between them.  This behavior is preserved if a user specifies a list of all the needed device nodes to bring up the FS.


Notes:
* Maybe this isn't the correct approach, but I think the logic should be here instead of util-linux even if this isn't implemented well.
* I'm using a release candidate util-linux, ref. https://github.com/util-linux/util-linux/archive/refs/tags/v2.40-rc1.tar.gz running on Fedora 39 with `6.7.5-200` Fedora kernel.
* I'm not sure why the existing bcachefs user-space doesn't leverage the udev db more, but that might be due to the fact that we maynot have full udev db information populated with current systems with existing util-linux/blkid functionality.
* I'm not sure why the current code dumps the following out the terminal when mounting via UUID=<uuid> eg.
```
# bcachefs mount UUID=11f32f1f-016d-41c2-afd4-cd341c26f133 /mnt/bcachefs_2_dev
bcachefs (/dev/sda): error reading default superblock: Not a bcachefs superblock (got magic 00000000-0000-0000-0000-000000000000)
bcachefs (/dev/sda): error reading superblock: Not a bcachefs superblock layout
bcachefs (/dev/sda1): error reading default superblock: Not a bcachefs superblock (got magic 00000000-0000-0000-0000-000000000000)
bcachefs (/dev/sda1): error reading superblock: Not a bcachefs superblock layout
bcachefs (/dev/sda2): error reading default superblock: Not a bcachefs superblock (got magic cd69a632-d51f-4ecc-0000-000000000000)
bcachefs (/dev/sda2): error reading superblock: Not a bcachefs superblock layout
bcachefs (/dev/sda3): error reading default superblock: Not a bcachefs superblock (got magic f676ecf2-df1f-6474-0000-000000000000)
bcachefs (/dev/sda3): error reading superblock: Not a bcachefs superblock layout
bcachefs (/dev/sdb): error reading default superblock: Not a bcachefs superblock (got magic 00100000-0000-0000-00f0-0f0000000000)
bcachefs (/dev/sdb): error reading superblock: Not a bcachefs superblock layout
bcachefs (/dev/sdc): error reading default superblock: Not a bcachefs superblock (got magic 00100000-0000-0000-00f0-0f0000000000)
bcachefs (/dev/sdc): error reading superblock: Not a bcachefs superblock layout
bcachefs (/dev/zram0): error reading default superblock: Not a bcachefs superblock (got magic 00000000-0000-0000-0000-000000000000)
bcachefs (/dev/zram0): error reading superblock: IO error: -5
bcachefs (/dev/dm-0): error reading default superblock: Not a bcachefs superblock (got magic 18000000-0000-0000-0100-000000000000)
bcachefs (/dev/dm-0): error reading superblock: Not a bcachefs superblock layout
bcachefs (/dev/dm-1): error reading default superblock: Not a bcachefs superblock (got magic 00000000-0000-0000-0000-000000000000)
bcachefs (/dev/dm-1): error reading superblock: Not a bcachefs superblock layout
bcachefs (/dev/dm-2): error reading default superblock: Not a bcachefs superblock (got magic 00000000-0000-0000-0000-000000000000)
bcachefs (/dev/dm-2): error reading superblock: Not a bcachefs superblock layout
bcachefs (/dev/dm-3): error reading default superblock: Not a bcachefs superblock (got magic 00000000-0000-0000-0000-000000000000)
bcachefs (/dev/dm-3): error reading superblock: Not a bcachefs superblock layout
bcachefs (/dev/dm-4): error reading default superblock: Not a bcachefs superblock (got magic 00000000-0000-0000-0000-000000000000)
bcachefs (/dev/dm-4): error reading superblock: Not a bcachefs superblock layout
bcachefs (/dev/dm-5): error reading default superblock: Not a bcachefs superblock (got magic 00000000-0000-0000-0000-000000000000)
bcachefs (/dev/dm-5): error reading superblock: Not a bcachefs superblock layout
```