### PR TITLE
Add passphrase_file to mount options

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -380,6 +380,12 @@ is the path where the filesystem should be mounted. If not set, then the filesys
 but all steps preceding mounting the filesystem (e.g. asking for passphrase) will still be performed.
 .Pp the options are as follows:
 .Bl -tag -width Ds
+.It Fl f , Fl -passphrase-file Ns = Ns Ar passphrase_file
+Path to passphrase/key file
+.sp
+Precedes key_location/unlock_policy: if the filesystem can be decrypted by the specified passphrase
+file, it is decrypted. (i.e. Regardless if "fail" is specified for key_location/unlock_policy.)
+.El
 .It Fl o Ar options
 Mount options provided as a comma-separated list. See user guide for complete list.
 .Bl -tag -width Ds -compact
@@ -393,6 +399,8 @@ Run fsck during mount
 Fix errors without asking during fsck
 .It Cm read_only
 Mount in read only mode
+.It Cm passphrase_file Ns = Ns Ar passphrase_file
+Path to passphrase/key file
 .It Cm version_upgrade
 .El
 .It Fl k , Fl -key-location Ns = Ns ( Cm fail | wait | ask )
@@ -408,6 +416,7 @@ prompt the user for password.
 .El
 .It Fl c , Fl -colorize Ns = Ns ( Cm true | false )
 Force color on/off. Default: auto-detect TTY
+.El
 .It Fl v
 Be verbose. Can be specified more than once.
 .El

--- a/src/commands/cmd_mount.rs
+++ b/src/commands/cmd_mount.rs
@@ -211,12 +211,12 @@ fn devs_str_sbs_from_device(device: &std::path::PathBuf) -> anyhow::Result<(Stri
     }
 }
 
-fn parse_key_file_from_mount_options(options: impl AsRef<str>) -> Option<PathBuf> {
+fn parse_passphrase_file_from_mount_options(options: impl AsRef<str>) -> Option<PathBuf> {
     options
         .as_ref()
         .split(",")
         .fold(None, |_, next| match next {
-            x if x.starts_with("key_file") => Some(PathBuf::from(x.split("=").nth(1).unwrap().to_string())),
+            x if x.starts_with("passphrase_file") => Some(PathBuf::from(x.split("=").nth(1).unwrap().to_string())),
             _ => None,
         })
 }
@@ -265,7 +265,7 @@ fn cmd_mount_inner(opt: Cli) -> anyhow::Result<()> {
                     true
                 }
             }
-        } else if let Some(passphrase_file) = parse_key_file_from_mount_options(&opt.options) {
+        } else if let Some(passphrase_file) = parse_passphrase_file_from_mount_options(&opt.options) {
             match key::read_from_passphrase_file(&block_devices_to_mount[0], passphrase_file.as_path()) {
                 Ok(()) => {
                     // Decryption succeeded


### PR DESCRIPTION
Based on #241 .

Add passphrase_file to mount options. Can be specified in `-o` or `/etc/fstab`, making it possible to mount encrypted bcachefs partitions as root.

Kept `-f, --passphrase-file` for compatibility.

Also include a patch to `bcachefs.8`.