### PR TITLE
mount: Leverage udev db

### DIFF
--- a/bch_bindgen/src/bcachefs.rs
+++ b/bch_bindgen/src/bcachefs.rs
@@ -59,6 +59,10 @@ impl bch_sb {
         uuid::Uuid::from_bytes(self.user_uuid.b)
     }
 
+    pub fn number_of_devices(&self) -> u8 {
+        self.nr_devices
+    }
+
     /// Get the nonce used to encrypt the superblock
     pub fn nonce(&self) -> nonce {
         use byteorder::{LittleEndian, ReadBytesExt};

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -5,8 +5,7 @@ use clap::Parser;
 use uuid::Uuid;
 use std::io::{stdout, IsTerminal};
 use std::path::PathBuf;
-use std::fs;
-use std::str;
+use std::{fs, str, env};
 use crate::key;
 use crate::key::UnlockPolicy;
 use std::ffi::{CString, c_char, c_void};
@@ -124,6 +123,12 @@ fn device_property_map(dev: &udev::Device) -> HashMap<String, String> {
 
 fn udev_bcachefs_info() -> anyhow::Result<HashMap<String, Vec<String>>> {
     let mut info = HashMap::new();
+
+    if env::var("BCACHEFS_BLOCK_SCAN").is_ok() {
+        debug!("Checking all block devices for bcachefs super block!");
+        return Ok(info);
+    }
+
     let mut udev = udev::Enumerator::new()?;
 
     debug!("Walking udev db!");


### PR DESCRIPTION
If the udev database contains information about bcachefs, utilize it. Otherwise, resort to traversing block devices and checking for bcachefs super blocks.

With this change we no longer get messages like:

```
bcachefs (/dev/sda): error reading default superblock: Not a bcachefs superblock (got magic 00000000-0000-0000-0000-000000000000)
bcachefs (/dev/sda): error reading superblock: Not a bcachefs superblock layout
bcachefs (/dev/sda1): error reading default superblock: Not a bcachefs superblock (got magic 00000000-0000-0000-0000-000000000000)
bcachefs (/dev/sda1): error reading superblock: Not a bcachefs superblock layout
bcachefs (/dev/sda2): error reading default superblock: Not a bcachefs superblock (got magic cd692115-d51f-fa9a-0000-000000000000)
bcachefs (/dev/sda2): error reading superblock: Not a bcachefs superblock layout
bcachefs (/dev/sda3): error reading default superblock: Not a bcachefs superblock (got magic 171d1dfd-dd1f-4950-0000-000000000000)
bcachefs (/dev/sda3): error reading superblock: Not a bcachefs superblock layout
```
when we mount with `UUID=a2c2edcd-9ec6-4067-a648-45cb77006bf9` or with a single device node.  This is because we are only trying to read up the super block when we already know that the device has one.

Tests tried for two device FS
```
# ./bcachefs mount /dev/sdc /mnt/two && umount /mnt/two && echo $?
0
# ./bcachefs mount UUID=a2c2edcd-9ec6-4067-a648-45cb77006bf9 /mnt/two && umount /mnt/two && echo $?
0
# ./bcachefs mount /dev/sdb:/dev/sdc /mnt/two && umount /mnt/two && echo $?
0
# ./bcachefs mount /dev/disk/by-uuid/a2c2edcd-9ec6-4067-a648-45cb77006bf9 /mnt/two && umount /mnt/two && echo $?
0

```