### PR TITLE
migrate: improve "does not have correct st_dev" error message

### DIFF
--- a/c_src/cmd_migrate.c
+++ b/c_src/cmd_migrate.c
@@ -451,7 +451,8 @@ static void copy_dir(struct copy_fs_state *s,
 		char *child_path = mprintf("%s/%s", src_path, d->d_name);
 
 		if (stat.st_dev != s->dev)
-			die("%s does not have correct st_dev!", child_path);
+			die("%s does not have correct st_dev: expected %d, but got %d, "
+				"does it reside on separate filesystem?", child_path, s->dev, stat.st_dev);
 
 		u64 *dst_inum = S_ISREG(stat.st_mode)
 			? genradix_ptr_alloc(&s->hardlinks, stat.st_ino, GFP_KERNEL)


### PR DESCRIPTION
Better explain which `st_dev` value was expected and which was found and give a hint to why this mismatch might have occurred.