### PR TITLE
Fix device add args

### DIFF
--- a/c_src/cmd_device.c
+++ b/c_src/cmd_device.c
@@ -74,7 +74,7 @@ int cmd_device_add(int argc, char *argv[])
 	bool force = false;
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "t:fh",
+	while ((opt = getopt_long(argc, argv, "fh",
 				  longopts, NULL)) != -1)
 		switch (opt) {
 		case 'S':

--- a/c_src/cmd_device.c
+++ b/c_src/cmd_device.c
@@ -74,7 +74,7 @@ int cmd_device_add(int argc, char *argv[])
 	bool force = false;
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "fh",
+	while ((opt = getopt_long(argc, argv, "S:B:Dl:fh",
 				  longopts, NULL)) != -1)
 		switch (opt) {
 		case 'S':


### PR DESCRIPTION
I noticed `device add -l my-label` wasn't working as expected, so I pulled up the code and noticed some other options weren't setup for short args either.

Also I deleted the (now deprecated, seemingly) `--tier` arg parsing.