### PR TITLE
`check_for_key` before `ask_for_passphrase`

### DIFF
--- a/include/crypto/skcipher.h
+++ b/include/crypto/skcipher.h
@@ -112,7 +112,7 @@ static inline void skcipher_request_set_sync_tfm(struct skcipher_request *req,
 	skcipher_request_set_tfm(req, &tfm->base);
 }
 
-#define skcipher_request_set_callback(...) do {} while (9)
+#define skcipher_request_set_callback(...) do {} while (0)
 
 static inline void skcipher_request_set_crypt(
 	struct skcipher_request *req,

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -344,8 +344,17 @@ fn cmd_mount_inner(opt: Cli) -> anyhow::Result<()> {
     if block_devices_to_mount.len() == 0 {
         Err(anyhow::anyhow!("No device found from specified parameters"))?;
     }
-    // Check if the filesystem's master key is encrypted
-    if unsafe { bcachefs::bch2_sb_is_encrypted_and_locked(block_devices_to_mount[0].sb) } {
+
+    let key_name = CString::new(format!(
+        "bcachefs:{}",
+        block_devices_to_mount[0].sb().uuid()
+    ))
+    .unwrap();
+
+    // Check if the filesystem's master key is encrypted and we don't have a key
+    if unsafe { bcachefs::bch2_sb_is_encrypted_and_locked(block_devices_to_mount[0].sb) }
+        && !key::check_for_key(&key_name)?
+    {
         // First by password_file, if available
         let fallback_to_unlock_policy = if let Some(passphrase_file) = &opt.passphrase_file {
             match key::read_from_passphrase_file(&block_devices_to_mount[0], passphrase_file.as_path()) {

--- a/src/key.rs
+++ b/src/key.rs
@@ -58,7 +58,7 @@ impl fmt::Display for UnlockPolicy {
     }
 }
 
-fn check_for_key(key_name: &std::ffi::CStr) -> anyhow::Result<bool> {
+pub fn check_for_key(key_name: &std::ffi::CStr) -> anyhow::Result<bool> {
     use bch_bindgen::keyutils::{self, keyctl_search};
     let key_name = key_name.to_bytes_with_nul().as_ptr() as *const _;
     let key_type = c_str!("user");
@@ -86,10 +86,12 @@ fn wait_for_unlock(uuid: &uuid::Uuid) -> anyhow::Result<()> {
     }
 }
 
+// blocks indefinitely if no input is available on stdin
 fn ask_for_passphrase(sb: &bch_sb_handle) -> anyhow::Result<()> {
     let passphrase = if stdin().is_terminal() {
         rpassword::prompt_password("Enter passphrase: ")?
     } else {
+        info!("Trying to read passphrase from stdin...");
         let mut line = String::new();
         stdin().read_line(&mut line)?;
         line


### PR DESCRIPTION
let's always first check if there is already a key in the keyring available before we try to get the key from some more involved means.

Fixes: #261