### PR TITLE
fusemount: unbreak build

### DIFF
--- a/c_src/cmd_fusemount.c
+++ b/c_src/cmd_fusemount.c
@@ -191,7 +191,7 @@ retry:
 	bch2_trans_begin(trans);
 	now = bch2_current_time(c);
 
-	ret = bch2_inode_peek(trans, &iter, &inode_u, inum, BTREE_ITER_INTENT);
+	ret = bch2_inode_peek(trans, &iter, &inode_u, inum, BTREE_ITER_intent);
 	if (ret)
 		goto err;
 
@@ -544,7 +544,7 @@ retry:
 	bch2_trans_begin(trans);
 	now = bch2_current_time(c);
 
-	ret = bch2_inode_peek(trans, &iter, &inode_u, inum, BTREE_ITER_INTENT);
+	ret = bch2_inode_peek(trans, &iter, &inode_u, inum, BTREE_ITER_intent);
 	if (ret)
 		goto err;
 


### PR DESCRIPTION
Commit 477670f4 changed capitalization of `BTREE_ITER_*` flags. Update cmd_fusemount.c accordingly to fix a build error with `BCACHEFS_FUSE=1`:

```console
$ make BCACHEFS_FUSE=1
    [CC]     c_src/cmd_fusemount.o
c_src/cmd_fusemount.c: In function ‘bcachefs_fuse_setattr’:
c_src/cmd_fusemount.c:194:61: error: ‘BTREE_ITER_INTENT’ undeclared (first use in this function); did you mean ‘BTREE_ITER_intent’?
  194 |         ret = bch2_inode_peek(trans, &iter, &inode_u, inum, BTREE_ITER_INTENT);
      |                                                             ^~~~~~~~~~~~~~~~~
      |                                                             BTREE_ITER_intent
c_src/cmd_fusemount.c:194:61: note: each undeclared identifier is reported only once for each function it appears in
c_src/cmd_fusemount.c: In function ‘inode_update_times’:
c_src/cmd_fusemount.c:547:61: error: ‘BTREE_ITER_INTENT’ undeclared (first use in this function); did you mean ‘BTREE_ITER_intent’?
  547 |         ret = bch2_inode_peek(trans, &iter, &inode_u, inum, BTREE_ITER_INTENT);
      |                                                             ^~~~~~~~~~~~~~~~~
      |                                                             BTREE_ITER_intent
make: *** [Makefile:173: c_src/cmd_fusemount.o] Error 1
```

Fixes: 477670f4 ("Update bcachefs sources to 07f9a27f1969 bcachefs: add no_invalid_checks flag")
