### PR TITLE
workflows: add monthly flake lock update workflow

### DIFF
--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -1,0 +1,21 @@
+name: update-flake-lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 1 * *' # Run monthly
+  push:
+      paths:
+        - 'flake.nix'
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v21

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tests/__pycache__/
 # dot-files that we don't want to ignore
 !.gitignore
 !.github/dependabot.yml
+!.github/workflows/
 !.editorconfig
 
 bcachefs-principles-of-operation.*


### PR DESCRIPTION
Adds `nix-flake-update` workflow which updates flake.lock nix dependencies every month.

This ensures builds using up to date dependencies for those using this repository to get bcachefs-tools using nix.