### PR TITLE
treewide: fix typos in docs and comments

### DIFF
--- a/c_src/cmd_migrate.c
+++ b/c_src/cmd_migrate.c
@@ -762,7 +762,7 @@ static int migrate_fs(const char		*fs_path,
 	       "superblock at the default offset and finish the migration run\n"
 	       "  bcachefs migrate-superblock -d %s -o %llu\n"
 	       "\n"
-	       "The new filesystem will have a file at /old_migrated_filestem\n"
+	       "The new filesystem will have a file at /old_migrated_filesystem\n"
 	       "referencing all disk space that might be used by the existing\n"
 	       "filesystem. That file can be deleted once the old filesystem is\n"
 	       "no longer needed (and should be deleted prior to running\n"

--- a/ccan/compiler/compiler.h
+++ b/ccan/compiler/compiler.h
@@ -97,7 +97,7 @@
  * UNNEEDED - a variable/function may not be needed
  *
  * This suppresses warnings about unused variables or functions, but tells
- * the compiler that if it is unused it need not emit it into the source code.
+ * the compiler that if it is unused it needs not emit it into the source code.
  *
  * Example:
  * // With some preprocessor options, this is unnecessary.

--- a/debian/changelog
+++ b/debian/changelog
@@ -23,7 +23,7 @@ bcachefs-tools (1.0.8-1) unstable; urgency=medium
   * Update changelog
   * Adding dep3 headers to the 0001 patch
   * Update watch to use http://evilpiepirate.org/git/bcache-tools.git
-  * Add patch for gcc-5 compatability.
+  * Add patch for gcc-5 compatibility.
     Thanks to James Cowgill (Closes: #777798)
 
  -- David Mohr <david@mcbf.net>  Tue, 26 May 2015 20:57:58 -0600

--- a/doc/bcachefs-principles-of-operation.tex
+++ b/doc/bcachefs-principles-of-operation.tex
@@ -464,7 +464,7 @@ The \texttt{-o verbose} enables additional log output during the mount process.
 
 It is possible to run fsck either in userspace with the \texttt{bcachefs fsck}
 subcommand (also available as \texttt{fsck.bcachefs}, or in the kernel while
-mounting by specifying the \texttt{-o fsck} mount option. In either case the
+mounting by specifying the \texttt{-o fsck} mount option). In either case the
 exact same fsck implementation is being run, only the environment is different.
 Running fsck in the kernel at mount time has the advantage of somewhat better
 performance, while running in userspace has the ability to be stopped with
@@ -528,7 +528,7 @@ filesystem:
 \begin{itemize}
 	\item \texttt{bcachefs device add}: Formats and adds a new device to an
 		existing filesystem.
-	\item \texttt{bcachefs device remove}: Permenantly removes a device from
+	\item \texttt{bcachefs device remove}: Permanently removes a device from
 		an existing filesystem.
 	\item \texttt{bcachefs device online}: Connects a device to a running
 		filesystem that was mounted without it (i.e. in degraded mode)
@@ -912,7 +912,7 @@ quantiles for latency/duration in the
 		\end{itemize}
 
 	\item \texttt{btree\_key\_cache} \\
-		Prints infromation on the btree key cache: number of freed keys
+		Prints information on the btree key cache: number of freed keys
 		(which must wait for a sRCU barrier to complete before being
 		freed), number of cached keys, and number of dirty keys.
 
@@ -1036,7 +1036,7 @@ listing btree nodes and contents, but for offline filesystems.
 \subsubsection{bcachefs list\_journal}
 
 This subcommand lists the contents of the journal, which primarily records btree
-updates ordered by when they occured.
+updates ordered by when they occurred.
 
 \subsubsection{bcachefs dump}
 
@@ -1052,7 +1052,7 @@ This section documents bcachefs-specific ioctls:
 
 \begin{description}
 	\item \texttt{BCH\_IOCTL\_QUERY\_UUID} \\
-		Returs the UUID of the filesystem: used to find the sysfs
+		Returns the UUID of the filesystem: used to find the sysfs
 		directory given a path to a mounted filesystem.
 
 	\item \texttt{BCH\_IOCTL\_FS\_USAGE} \\
@@ -1102,7 +1102,7 @@ This section documents bcachefs-specific ioctls:
 	\item \texttt{BCH\_IOCTL\_DISK\_RESIZE\_JOURNAL} \\
 	\item \texttt{BCH\_IOCTL\_DATA} \\
 		Starts a data job, which walks all data and/or metadata in a
-		filesystem performing, performaing some operation on each btree
+		filesystem performing, performing some operations on each btree
 		node and extent. Returns a file descriptor which can be read
 		from to get the current status of the job, and closing the file
 		descriptor (i.e. on process exit stops the data job.

--- a/doc/bcachefs.5.rst.tmpl
+++ b/doc/bcachefs.5.rst.tmpl
@@ -55,7 +55,7 @@ Device labels, targets
 
 Configuration options that point to targets (i.e. a disk or group of disks) may
 be passed either a device (i.e. /dev/sda), or a label. Labels are assigned to
-disks (and need not be unique), and these labels form a nested heirarchy: this
+disks (and need not be unique), and these labels form a nested hierarchy: this
 allows disks to be grouped together and referred to either individually or as a
 group.
 
@@ -86,7 +86,7 @@ The foreground_target option is used to direct writes from applications. The
 background_target option, if set, will cause data to be moved to that target in
 the background by the rebalance thread some time after it has been initially
 written - leaving behind the original copy, but marking it cached so that it can
-be discarded by the allocator. The promote_target will will cause reads to write
+be discarded by the allocator. The promote_target will cause reads to write
 a cached copy of the data being read to that target, if it doesn't exist.
 
 Together, these options can be used for writeback caching, like so:

--- a/packaging/bcachefs-tools.spec
+++ b/packaging/bcachefs-tools.spec
@@ -72,4 +72,4 @@ rm -f %{buildroot}/usr/lib/libbcachefs.so
 
 * Tue Jan 07 2020 Michael Adams <unquietwiki@gmail.com> - 2020.01.07-1
 - Initial RPM package definition
-- Makefile needs further work to accomodate RPM macros.
+- Makefile needs further work to accommodate RPM macros.


### PR DESCRIPTION
This PR
- Improves documentation by cleaning up typo and spelling mistakes

Closes https://github.com/koverstreet/bcachefs-tools/pull/129

Adopted from the above PR to remove merge conflict.