### PR TITLE
Fix pedantic clippy lints

### DIFF
--- a/src/bcachefs.rs
+++ b/src/bcachefs.rs
@@ -28,7 +28,7 @@ fn handle_c_command(mut argv: Vec<String>, symlink_cmd: Option<&str>) -> i32 {
     let argv: Vec<_> = argv.into_iter().map(|s| CString::new(s).unwrap()).collect();
     let mut argv = argv
         .into_iter()
-        .map(|s| Box::into_raw(s.into_boxed_c_str()) as *mut c_char)
+        .map(|s| Box::into_raw(s.into_boxed_c_str()).cast::<c_char>())
         .collect::<Box<[*mut c_char]>>();
     let argv = argv.as_mut_ptr();
 

--- a/src/bcachefs.rs
+++ b/src/bcachefs.rs
@@ -63,7 +63,7 @@ fn handle_c_command(mut argv: Vec<String>, symlink_cmd: Option<&str>) -> i32 {
             "fusemount" => c::cmd_fusemount(argc, argv),
 
             _ => {
-                println!("Unknown command {}", cmd);
+                println!("Unknown command {cmd}");
                 c::bcachefs_usage();
                 1
             }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 use log::error;
 use std::io::{stdout, IsTerminal};
 
-fn list_keys(fs: &Fs, opt: Cli) -> anyhow::Result<()> {
+fn list_keys(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
     let mut iter = BtreeIter::new(
         &trans,
@@ -38,7 +38,7 @@ fn list_keys(fs: &Fs, opt: Cli) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn list_btree_formats(fs: &Fs, opt: Cli) -> anyhow::Result<()> {
+fn list_btree_formats(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
     let mut iter = BtreeNodeIter::new(
         &trans,
@@ -61,7 +61,7 @@ fn list_btree_formats(fs: &Fs, opt: Cli) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn list_btree_nodes(fs: &Fs, opt: Cli) -> anyhow::Result<()> {
+fn list_btree_nodes(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
     let mut iter = BtreeNodeIter::new(
         &trans,
@@ -84,7 +84,7 @@ fn list_btree_nodes(fs: &Fs, opt: Cli) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn list_nodes_ondisk(fs: &Fs, opt: Cli) -> anyhow::Result<()> {
+fn list_nodes_ondisk(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
     let mut iter = BtreeNodeIter::new(
         &trans,
@@ -157,8 +157,8 @@ pub struct Cli {
     devices: Vec<std::path::PathBuf>,
 }
 
-fn cmd_list_inner(opt: Cli) -> anyhow::Result<()> {
-    let mut fs_opts: bcachefs::bch_opts = Default::default();
+fn cmd_list_inner(opt: &Cli) -> anyhow::Result<()> {
+    let mut fs_opts = bcachefs::bch_opts::default();
 
     opt_set!(fs_opts, nochanges, 1);
     opt_set!(fs_opts, read_only, 1);
@@ -197,7 +197,7 @@ fn cmd_list_inner(opt: Cli) -> anyhow::Result<()> {
 pub fn list(argv: Vec<String>) -> i32 {
     let opt = Cli::parse_from(argv);
     colored::control::set_override(opt.colorize);
-    if let Err(e) = cmd_list_inner(opt) {
+    if let Err(e) = cmd_list_inner(&opt) {
         error!("Fatal error: {}", e);
         1
     } else {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -27,13 +27,27 @@ enum Subcommands {
     Subvolume(subvolume::Cli),
 }
 
+// FIXME: Can be removed after bumping MSRV >= 1.77 in favor of `c""` literals
 #[macro_export]
 macro_rules! c_str {
     ($lit:expr) => {
-        unsafe {
-            std::ffi::CStr::from_ptr(concat!($lit, "\0").as_ptr() as *const std::os::raw::c_char)
-                .to_bytes_with_nul()
-                .as_ptr() as *const std::os::raw::c_char
-        }
+        ::std::ffi::CStr::from_bytes_with_nul(concat!($lit, "\0").as_bytes())
+            .unwrap()
+            .as_ptr()
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CStr;
+
+    #[test]
+    fn check_cstr_macro() {
+        let literal = c_str!("hello");
+
+        assert_eq!(
+            literal,
+            CStr::from_bytes_with_nul(b"hello\0").unwrap().as_ptr()
+        );
+    }
 }

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -1,9 +1,11 @@
 use std::{
     collections::HashMap,
-    ffi::{c_char, c_void, CString},
+    env,
+    ffi::CString,
+    fs,
     io::{stdout, IsTerminal},
     path::{Path, PathBuf},
-    {env, fs, str},
+    ptr, str,
 };
 
 use anyhow::{ensure, Result};
@@ -28,12 +30,10 @@ fn mount_inner(
     let fstype = CString::new(fstype)?;
 
     // convert to pointers for ffi
-    let src = src.as_c_str().to_bytes_with_nul().as_ptr() as *const c_char;
-    let target = target.as_c_str().to_bytes_with_nul().as_ptr() as *const c_char;
-    let data = data.as_ref().map_or(std::ptr::null(), |data| {
-        data.as_c_str().to_bytes_with_nul().as_ptr() as *const c_void
-    });
-    let fstype = fstype.as_c_str().to_bytes_with_nul().as_ptr() as *const c_char;
+    let src = src.as_ptr();
+    let target = target.as_ptr();
+    let data = data.map_or(ptr::null(), |data| data.as_ptr().cast());
+    let fstype = fstype.as_ptr();
 
     let ret = {
         info!("mounting filesystem");

--- a/src/commands/subvolume.rs
+++ b/src/commands/subvolume.rs
@@ -37,9 +37,9 @@ enum Subcommands {
 }
 
 pub fn subvolume(argv: Vec<String>) -> i32 {
-    let args = Cli::parse_from(argv);
+    let cli = Cli::parse_from(argv);
 
-    match args.subcommands {
+    match cli.subcommands {
         Subcommands::Create { targets } => {
             for target in targets {
                 if let Some(dirname) = target.parent() {

--- a/src/wrappers/handle.rs
+++ b/src/wrappers/handle.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{path::Path, ptr};
 
 use bch_bindgen::c::{
     bcache_fs_close, bcache_fs_open, bch_ioctl_subvolume, bchfs_handle, BCH_IOCTL_SUBVOLUME_CREATE,
@@ -42,7 +42,7 @@ pub enum BcachefsIoctlPayload {
 impl From<&BcachefsIoctlPayload> for *const libc::c_void {
     fn from(value: &BcachefsIoctlPayload) -> Self {
         match value {
-            BcachefsIoctlPayload::Subvolume(p) => p as *const _ as *const libc::c_void,
+            BcachefsIoctlPayload::Subvolume(p) => ptr::addr_of!(p).cast(),
         }
     }
 }


### PR DESCRIPTION
Not going to enable `clippy::pedantic` lints by default but there is some good advice in there, especially regarding casting.