### PR TITLE
docs: udev.pc now in systemd-dev on Debian

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,6 +34,11 @@ apt install -y pkg-config libaio-dev libblkid-dev libkeyutils-dev \
     python3 python3-docutils libclang-dev debhelper dh-python
 ```
 
+Starting from Debian Trixie and Ubuntu 23.10, you will additionally need:
+```shell
+apt install -y systemd-dev
+```
+
 Fedora: install the "Development tools" group along with:
 ```shell
 dnf install -y libaio-devel libsodium-devel \


### PR DESCRIPTION
Had to spend a few minutes tracking down udev.pc, might save someone else the same.  