### PR TITLE
fix(subvol): make cmds work with relative paths

### DIFF
--- a/src/commands/subvolume.rs
+++ b/src/commands/subvolume.rs
@@ -42,6 +42,10 @@ pub fn subvolume(argv: Vec<String>) -> i32 {
     match cli.subcommands {
         Subcommands::Create { targets } => {
             for target in targets {
+                let target = target
+                    .canonicalize()
+                    .expect("unable to canonicalize a target path");
+
                 if let Some(dirname) = target.parent() {
                     let fs = unsafe { BcachefsHandle::open(dirname) };
                     fs.create_subvolume(target)
@@ -50,6 +54,10 @@ pub fn subvolume(argv: Vec<String>) -> i32 {
             }
         }
         Subcommands::Delete { target } => {
+            let target = target
+                .canonicalize()
+                .expect("unable to canonicalize a target path");
+
             if let Some(dirname) = target.parent() {
                 let fs = unsafe { BcachefsHandle::open(dirname) };
                 fs.delete_subvolume(target)


### PR DESCRIPTION
`Path::parent()` returns `Some("")` for relative paths with a single component. The simplest fix is to just canonicalize the paths first.

So I actually had a few misconceptions about this issue, at first I thought it
was because I was doing `bcachefs subvolume create my-subvol` within a bind
mount because it worked when I gave the absolute path from the real mount. Then
I thought it was about `CString` lifetime in FFI, which was also incorrect.

In the end it's pretty simple. The `Path::parent()` API doesn't take into
account any side effects from the file system or check the real path. It just
works on the bytes of the `Path` and gives us a slice into the `Path`.