### PR TITLE
Fix some undefined behaviors

### DIFF
--- a/raid/cpu.h
+++ b/raid/cpu.h
@@ -57,9 +57,9 @@ static inline void raid_cpu_info(char *vendor, unsigned *family, unsigned *model
 
 	raid_cpuid(0, 0, reg);
 
-	((uint32_t*)vendor)[0] = reg[1];
-	((uint32_t*)vendor)[1] = reg[3];
-	((uint32_t*)vendor)[2] = reg[2];
+	memcpy(vendor, &reg[1], 4);
+	memcpy(vendor + 4, &reg[3], 4);
+	memcpy(vendor + 8, &reg[2], 4);
 	vendor[12] = 0;
 
 	raid_cpuid(1, 0, reg);


### PR DESCRIPTION
A user reported that bcachefs-tools built with LTO segfaults in the
bcachefs format subcommand.  On a hunch, I built bcachefs-tools with
UBSan and fixed some undefined behavior reports.  They are not all
fixed, but this is enough to successfully format a disk image.

Link: https://lore.kernel.org/linux-bcachefs/ZnWeguEIABfeP2xV@roethke.info/T/#u
