### PR TITLE
mount: replace rpassword with rustix::termios

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
  "errno 0.2.8",
  "libc",
  "log",
- "rpassword",
+ "rustix",
  "strum",
  "strum_macros",
  "udev",
@@ -498,27 +498,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
-name = "rpassword"
-version = "7.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
-dependencies = [
- "libc",
- "rtoolbox",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rtoolbox"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,9 +505,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.4.2",
  "errno 0.3.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,12 @@ udev = "0.7.0"
 uuid = "1.2.2"
 errno = "0.2"
 either = "1.5"
-rpassword = "7"
 bch_bindgen = { path = "bch_bindgen" }
 byteorder = "1.3"
 strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
 zeroize = { version = "1", features = ["std", "zeroize_derive"] }
+rustix = { version = "0.38.34", features = ["termios"] }
 
 [dependencies.env_logger]
 version = "0.10"


### PR DESCRIPTION
because rpassword unconditionally open()s /dev/tty, it fails with ENXIO on the console without workarounds like busybox's cttyhack. in contrast, bcachefs unlock works fine on console, so change the passphrase prompt logic in mount to be closer to what it is in unlock.