### PR TITLE
fix: unexpected cfg condition lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ default-features = false
 
 [profile.release]
 strip = "none"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuse)'] }


### PR DESCRIPTION
This commit fixes the following lint:

```
$ cargo check
   Compiling bcachefs-tools v0.0.0 (/home/matthias/prog/bcachefs-tools)
warning: unexpected `cfg` condition name: `fuse`
  --> src/bcachefs.rs:65:19
   |
65 |             #[cfg(fuse)]
   |                   ^^^^
   |
   = help: expected names are: `clippy`, `debug_assertions`, `doc`, `docsrs`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, and `windows`
   = help: consider using a Cargo feature instead
   = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
            [lints.rust]
            unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuse)'] }
   = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(fuse)");` to the top of the `build.rs`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: `#[warn(unexpected_cfgs)]` on by default

warning: `bcachefs-tools` (bin "bcachefs") generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.28s
```