### PR TITLE
Fix allow empty passphrases in `unlock`

### DIFF
--- a/c_src/tools-util.c
+++ b/c_src/tools-util.c
@@ -124,10 +124,6 @@ char *read_file_str(int dirfd, const char *path)
 	buf[len] = '\0';
 	if (len && buf[len - 1] == '\n')
 		buf[len - 1] = '\0';
-	if (!strlen(buf)) {
-		free(buf);
-		buf = NULL;
-	}
 
 	close(fd);
 


### PR DESCRIPTION
Fixes issues https://github.com/koverstreet/bcachefs-tools/issues/314

This is a tentative suggestion.  I don't know whether we are making other things worse?