### PR TITLE
Ask for password via systemd-ask-password

### DIFF
--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -331,8 +331,9 @@ fn handle_unlock(cli: &Cli, sb: &bch_sb_handle) -> Result<KeyHandle> {
         return Passphrase::new_from_file(path).and_then(|p| KeyHandle::new(sb, &p));
     }
 
-    KeyHandle::new_from_search(&sb.sb().uuid())
-        .or_else(|_| Passphrase::new().and_then(|p| KeyHandle::new(sb, &p)))
+    let uuid = sb.sb().uuid();
+    KeyHandle::new_from_search(&uuid)
+        .or_else(|_| Passphrase::new(&uuid).and_then(|p| KeyHandle::new(sb, &p)))
 }
 
 fn cmd_mount_inner(cli: &Cli) -> Result<()> {


### PR DESCRIPTION
This would allow to supply the password via the plymouth password input. If systemd-ask-password does not exist or fails to start, falls back to the old-style password request.