### PR TITLE
Fix C exit code

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -195,7 +195,7 @@
             flakeCheck = false;
 
             programs = {
-              nixfmt-rfc-style.enable = true;
+              nixfmt.enable = true;
               rustfmt.edition = rustfmtToml.edition;
               rustfmt.enable = true;
               rustfmt.package = fenix.packages.${system}.default.rustfmt;

--- a/src/bcachefs.rs
+++ b/src/bcachefs.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use bch_bindgen::c;
+use log::debug;
 
 #[derive(Debug)]
 pub struct ErrnoError(pub errno::Errno);
@@ -110,6 +111,11 @@ fn main() -> ExitCode {
         "list" => commands::list(args[1..].to_vec()).report(),
         "mount" => commands::mount(args, symlink_cmd).report(),
         "subvolume" => commands::subvolume(args[1..].to_vec()).report(),
-        _ => ExitCode::from(u8::try_from(handle_c_command(args, symlink_cmd)).unwrap()),
+        _ => {
+            let r = handle_c_command(args, symlink_cmd);
+
+            debug!("return code from C command: {r}");
+            ExitCode::from(r as u8)
+        }
     }
 }


### PR DESCRIPTION
As reported on IRC:

```
  bi_parent_subvol=0
  bi_nocow=0
, fixing
bcachefs (nvme0n1p7): Ratelimiting new instances of previous error
bcachefs (nvme0n1p7): check_path(): error EEXIST_str_hash_set
bcachefs (nvme0n1p7): bch2_check_directory_structure(): error EEXIST_str_hash_set
bcachefs (nvme0n1p7): bch2_fsck_online_thread_fn(): error EEXIST_str_hash_set
thread 'main' panicked at src/bcachefs.rs:113:79:
called `Result::unwrap()` on an `Err` value: TryFromIntError(())
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Some C command functions return integers that are larger than 255.