### PR TITLE
nix: add meta.mainProgram to allow directly running from this repo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -107,6 +107,12 @@
               zlib
               zstd
             ];
+
+            meta = {
+              description = "Userspace tools for bcachefs";
+              license = lib.licenses.gpl2Only;
+              mainProgram = "bcachefs";
+            };
           };
 
           cargoArtifacts = craneLib.buildDepsOnly (commonArgs // { pname = cargoToml.package.name; });


### PR DESCRIPTION
```bash
  nix run github:koverstreet/bcachefs-tools#bcachefs-tools -- version
```
currently fails with
```log
error: unable to execute '/nix/store/1sq2i44fjzbc1vyr81b6xr2m3jnci16k-bcachefs-tools-1.9.5+c60ce81/bin/bcachefs-tools': No such file or directory
```
because meta.mainProgram is not set.

Let's set it and set some other stuff like description and license.