### PR TITLE
doc: correct some spelling errors

### DIFF
--- a/doc/bcachefs-principles-of-operation.tex
+++ b/doc/bcachefs-principles-of-operation.tex
@@ -394,7 +394,7 @@ The following subcommands exist for managing subvolumes and snapshots:
 		existing subvolume
 \end{itemize}
 
-A subvolume can also be deleting with a normal rmdir after deleting all the
+A subvolume can also be deleted with a normal rmdir after deleting all the
 contents, as with \texttt{rm -rf}. Still to be implemented: read-only snapshots,
 recursive snapshot creation, and a method for recursively listing subvolumes.
 
@@ -505,8 +505,8 @@ the \texttt{journal\_reclaim\_delay} parameter, with a default of 100
 milliseconds.
 
 The journal should be sized sufficiently that bursts of activity do not fill up
-the journal too quickly; also, a larger journal mean that we can queue up larger
-btree writes. The \texttt{bcachefs device resize-journal} can be used for
+the journal too quickly; also, a larger journal means that we can queue up
+larger btree writes. The \texttt{bcachefs device resize-journal} can be used for
 resizing the journal on disk on a particular device - it can be used on a
 mounted or unmounted filesystem.
 
@@ -578,8 +578,8 @@ ensuring that checksums are valid, fixing bitrot when a valid copy can be found.
 Most bcachefs options can be set filesystem wide, and a significant subset can
 also be set on inodes (files and directories), overriding the global defaults.
 Filesystem wide options may be set when formatting, when mounting, or at runtime
-via \texttt{/sys/fs/bcachefs/<uuid>/options/}. When set at runtime via sysfs the
-persistent options in the superblock are updated as well; when options are
+via \texttt{/sys/fs/bcachefs/<uuid>/options/}. When set at runtime via sysfs,
+the persistent options in the superblock are updated as well; when options are
 passed as mount parameters the persistent options are unmodified.
 
 \subsection{File and directory options}
@@ -593,8 +593,8 @@ inherited attributes to change we fail the rename with -EXDEV, causing userspace
 to do the rename file by file so that inherited attributes stay consistent.
 
 Inode options are available as extended attributes. The options that have been
-explicitly set are available under the \texttt{bcachefs} namespace, and the effective
-options (explicitly set and inherited options) are available under the
+explicitly set are available under the \texttt{bcachefs} namespace, and the
+effective options (explicitly set and inherited options) are available under the
 \texttt{bcachefs\_effective} namespace. Examples of listing options with the
 getfattr command:
 
@@ -1150,7 +1150,7 @@ variable length sections:
 
 	\item \texttt{BCH\_SB\_FIELD\_replicas} \\
 		Contains a list of replica entries, which are lists of devices
-		that have extents replicated across them. 
+		that have extents replicated across them.
 
 	\item \texttt{BCH\_SB\_FIELD\_quota} \\
 		Contains timelimit and warnlimit fields for each quota type


### PR DESCRIPTION
Just fixing some spelling mistakes I noticed while reading.

Also, it seems that the pdf on bcachefs.org isn't up-to-date with the latest copy of `bcachefs-principles-of-operation.tex`, because I noticed [another error](https://github.com/koverstreet/bcachefs-tools/blob/c36b96d4dc1167bb9d38ba5bd594854e99f1ba9b/doc/bcachefs-principles-of-operation.tex#L1055) ("Returs") in [the copy on the website](https://bcachefs.org/bcachefs-principles-of-operation.pdf) was fixed a few months ago (in 18f9526c45e560df26dfadd5bdef7467aab6c0f7). I don't know who updates the website copy or if it's automated, but it might be good to update it soon.