### PR TITLE
cargo,makefile: bump bcachefs version to 1.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bcachefs-tools"
-version = "1.9.5"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "bch_bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcachefs-tools"
-version = "1.9.5"
+version = "1.11.1"
 authors = ["Yuxuan Shui <yshuiv7@gmail.com>", "Kayla Firestack <dev@kaylafire.me>", "Kent Overstreet <kent.overstreet@linux.dev>" ]
 edition = "2021"
 rust-version = "1.70"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.9.5
+VERSION=1.11.1
 
 PREFIX?=/usr/local
 LIBEXECDIR?=$(PREFIX)/libexec


### PR DESCRIPTION
Would be nice if the version could be bumped automatically!