### PR TITLE
Remove trivial deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,12 +66,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "bcachefs-tools"
 version = "1.12.0"
 dependencies = [
@@ -103,7 +97,6 @@ dependencies = [
  "bitfield",
  "bitflags 1.3.2",
  "byteorder",
- "memoffset",
  "paste",
  "pkg-config",
  "uuid",
@@ -378,15 +371,6 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
-
-[[package]]
-name = "memoffset"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "minimal-lexical"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,6 @@ version = "1.12.0"
 dependencies = [
  "anyhow",
  "bch_bindgen",
- "byteorder",
  "clap",
  "clap_complete",
  "either",
@@ -96,7 +95,6 @@ dependencies = [
  "bindgen",
  "bitfield",
  "bitflags 1.3.2",
- "byteorder",
  "paste",
  "pkg-config",
  "uuid",
@@ -142,12 +140,6 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ uuid = "1.2.2"
 errno = "0.2"
 either = "1.5"
 bch_bindgen = { path = "bch_bindgen" }
-byteorder = "1.3"
 strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
 zeroize = { version = "1", features = ["std", "zeroize_derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "bcachefs-tools"
 version = "1.12.0"
 authors = ["Yuxuan Shui <yshuiv7@gmail.com>", "Kayla Firestack <dev@kaylafire.me>", "Kent Overstreet <kent.overstreet@linux.dev>" ]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.77"
 
 [[bin]]
 name = "bcachefs"

--- a/bch_bindgen/Cargo.toml
+++ b/bch_bindgen/Cargo.toml
@@ -3,6 +3,7 @@ name = "bch_bindgen"
 version = "0.1.0"
 authors = [ "Kayla Firestack <dev@kaylafire.me>", "Yuxuan Shui <yshuiv7@gmail.com>", "Kent Overstreet <kent.overstreet@linux.dev>" ]
 edition = "2021"
+rust-version = "1.77"
 
 [lib]
 crate-type = ["lib"]
@@ -12,7 +13,6 @@ crate-type = ["lib"]
 anyhow = "1.0"
 uuid = "1.2.2"
 bitfield = "0.14.0"
-memoffset = "0.8.0"
 byteorder = "1.3"
 bitflags = "1.3.2"
 paste = "1.0.11"

--- a/bch_bindgen/Cargo.toml
+++ b/bch_bindgen/Cargo.toml
@@ -13,7 +13,6 @@ crate-type = ["lib"]
 anyhow = "1.0"
 uuid = "1.2.2"
 bitfield = "0.14.0"
-byteorder = "1.3"
 bitflags = "1.3.2"
 paste = "1.0.11"
 

--- a/bch_bindgen/src/bcachefs.rs
+++ b/bch_bindgen/src/bcachefs.rs
@@ -67,10 +67,9 @@ impl bch_sb {
 
     /// Get the nonce used to encrypt the superblock
     pub fn nonce(&self) -> nonce {
-        use byteorder::{LittleEndian, ReadBytesExt};
-        let mut internal_uuid = &self.uuid.b[..];
-        let dword1 = internal_uuid.read_u32::<LittleEndian>().unwrap();
-        let dword2 = internal_uuid.read_u32::<LittleEndian>().unwrap();
+        let [a, b, c, d, e, f, g, h, _rest @ ..] = self.uuid.b;
+        let dword1 = u32::from_le_bytes([a, b, c, d]);
+        let dword2 = u32::from_le_bytes([e, f, g, h]);
         nonce {
             d: [0, 0, dword1, dword2],
         }

--- a/bch_bindgen/src/bcachefs.rs
+++ b/bch_bindgen/src/bcachefs.rs
@@ -18,7 +18,7 @@ bitfield! {
     pub struct bch_crypt_flags(u64);
     pub TYPE, _: 4, 0;
 }
-use memoffset::offset_of;
+use std::mem::offset_of;
 impl bch_sb_field_crypt {
     pub fn scrypt_flags(&self) -> Option<bch_scrypt_flags> {
         use std::convert::TryInto;

--- a/src/key.rs
+++ b/src/key.rs
@@ -14,7 +14,6 @@ use bch_bindgen::{
     c::{bch2_chacha_encrypt_key, bch_encrypted_key, bch_sb_field_crypt},
     keyutils::{self, keyctl_search},
 };
-use byteorder::{LittleEndian, ReadBytesExt};
 use log::{debug, info};
 use rustix::termios;
 use uuid::Uuid;
@@ -22,7 +21,7 @@ use zeroize::{ZeroizeOnDrop, Zeroizing};
 
 use crate::{c_str, ErrnoError};
 
-const BCH_KEY_MAGIC: &str = "bch**key";
+const BCH_KEY_MAGIC: &[u8; 8] = b"bch**key";
 
 #[derive(Clone, Debug, clap::ValueEnum, strum::Display)]
 pub enum UnlockPolicy {
@@ -225,7 +224,7 @@ impl Passphrase {
     }
 
     pub fn check(&self, sb: &bch_sb_handle) -> Result<(bch_key, bch_encrypted_key)> {
-        let bch_key_magic = BCH_KEY_MAGIC.as_bytes().read_u64::<LittleEndian>().unwrap();
+        let bch_key_magic = u64::from_le_bytes(*BCH_KEY_MAGIC);
 
         let crypt = sb
             .sb()


### PR DESCRIPTION
While bcachefs-tools makes good use of many dependencies that have nontrivial code in them, byteorder and memoffset are easily replaced with standard library code nowadays.