### PR TITLE
Dependency cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
  "anyhow",
  "bindgen",
  "bitfield",
- "bitflags 1.3.2",
+ "bitflags",
  "paste",
  "pkg-config",
  "uuid",
@@ -106,7 +106,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -128,12 +128,6 @@ name = "bitfield"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -473,7 +467,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags",
  "errno 0.3.8",
  "libc",
  "linux-raw-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
  "clap_complete",
  "either",
  "env_logger",
- "errno 0.2.8",
+ "errno",
  "libc",
  "log",
  "owo-colors",
@@ -134,15 +134,6 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
-
-[[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cexpr"
@@ -243,33 +234,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -468,7 +438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags",
- "errno 0.3.8",
+ "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
@@ -575,28 +545,6 @@ dependencies = [
  "once_cell",
  "rustix",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,6 @@ dependencies = [
  "owo-colors",
  "rustix",
  "strum",
- "strum_macros",
  "udev",
  "uuid",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,16 @@ path = "src/bcachefs.rs"
 log = { version = "0.4", features = ["std"] }
 clap = { version = "4.0.32", features = ["derive", "wrap_help"] }
 clap_complete = "4.3.2"
-anyhow = "1.0"
+anyhow = "1.0.1"
 libc = "0.2.69"
 udev = "0.7.0"
 uuid = "1.2.2"
-errno = "0.2"
+errno = "0.2.7"
 either = "1.5"
 bch_bindgen = { path = "bch_bindgen" }
 strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
-zeroize = { version = "1", features = ["std", "zeroize_derive"] }
+zeroize = { version = "1.5.5", features = ["std", "zeroize_derive"] }
 rustix = { version = "0.38.34", features = ["termios"] }
 owo-colors = "4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.1"
 libc = "0.2.69"
 udev = "0.7.0"
 uuid = "1.2.2"
-errno = "0.2.7"
+errno = "0.3"
 either = "1.5"
 bch_bindgen = { path = "bch_bindgen" }
 strum = { version = "0.26", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ errno = "0.3"
 either = "1.5"
 bch_bindgen = { path = "bch_bindgen" }
 strum = { version = "0.26", features = ["derive"] }
-strum_macros = "0.26"
 zeroize = { version = "1.5.5", features = ["std", "zeroize_derive"] }
 rustix = { version = "0.38.34", features = ["termios"] }
 owo-colors = "4"

--- a/bch_bindgen/Cargo.toml
+++ b/bch_bindgen/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["lib"]
 anyhow = "1.0"
 uuid = "1.2.2"
 bitfield = "0.14.0"
-bitflags = "1.3.2"
+bitflags = "2"
 paste = "1.0.11"
 
 [build-dependencies]

--- a/bch_bindgen/Cargo.toml
+++ b/bch_bindgen/Cargo.toml
@@ -17,5 +17,5 @@ bitflags = "1.3.2"
 paste = "1.0.11"
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "0.3.7"
 bindgen = "0.69.4"

--- a/bch_bindgen/src/btree.rs
+++ b/bch_bindgen/src/btree.rs
@@ -71,7 +71,7 @@ impl<'t> BtreeIter<'t> {
                 iter.as_mut_ptr(),
                 btree,
                 pos,
-                flags.bits as u32,
+                flags.bits().into(),
             );
 
             BtreeIter {
@@ -156,7 +156,7 @@ impl<'t> BtreeNodeIter<'t> {
                 pos,
                 locks_want,
                 depth,
-                flags.bits as u32,
+                flags.bits().into(),
             );
 
             BtreeNodeIter {


### PR DESCRIPTION
Here are a handful of clean ups to the Cargo.toml
Most important is to correctly specify minimal dependencies.
Also upgrade two outdated dependencies when we already require the newer versions indirectly.