### PR TITLE
Fix potential loss of null termination in fs label

### DIFF
--- a/c_src/libbcachefs.c
+++ b/c_src/libbcachefs.c
@@ -214,9 +214,7 @@ struct bch_sb *bch2_format(struct bch_opt_strs	fs_opt_strs,
 	uuid_generate(sb.sb->uuid.b);
 
 	if (opts.label)
-		memcpy(sb.sb->label,
-		       opts.label,
-		       min(strlen(opts.label), sizeof(sb.sb->label)));
+		snprintf(sb.sb->label, sizeof(sb.sb->label), "%s", opts.label);
 
 	for (opt_id = 0;
 	     opt_id < bch2_opts_nr;


### PR DESCRIPTION
The previous code uses memcpy() and does not copy the null termination character from the source string. Probably the destination buffer is zeroed out, so this doesn't matter unless len(opts.label) >= sizeof(sb.sb->label). then memcpy will fill the entire destination buffer and there will be no null termination.

Because the label is expected to be null-terminated, the lack of a null termination character will cause undefined behavior elsewhere in the code.

Fixed by using snprintf(), which guarantees a null character will be used and also guarantees not to write more bytes than the size specified.