### PR TITLE
initcpio: small improvements to the mkinitcpio hooks

### DIFF
--- a/arch/etc/initcpio/hooks/bcachefs
+++ b/arch/etc/initcpio/hooks/bcachefs
@@ -1,14 +1,15 @@
 #!/usr/bin/ash
 
 run_hook() {
-
-# check if $root needs unlocking
-if bcachefs unlock -c $root >/dev/null 2>&1; then
-    echo "Unlocking $root:"
-    while true; do
-        bcachefs unlock $root && break
-    done
-fi
+    local rootdev
+    if rootdev="$(resolve_device "$root")" && bcachefs unlock -c "$rootdev" >/dev/null 2>&1
+    then
+        echo "Unlocking $rootdev:"
+        while true
+        do
+            bcachefs unlock "$rootdev" && break
+        done
+    fi
 }
 
 # vim: set ft=sh ts=4 sw=4 et:

--- a/arch/etc/initcpio/install/bcachefs
+++ b/arch/etc/initcpio/install/bcachefs
@@ -1,15 +1,14 @@
 #!/bin/bash
 
 build() {
-             add_module `bcachefs`
-             add_binary "bcachefs"
+    add_module bcachefs
+    add_binary bcachefs
 
-             add_runscript
-
+    add_runscript
 }
 
 help() {
-           cat <<HELPEOF
+    cat <<HELPEOF
 This hook is for getting the bcachefs unlock prompt at boot
 HELPEOF
 }


### PR DESCRIPTION
Since the mkinitcpio hooks got merged, there were some comments that went unaddressed that improve the quality of the initcpio  scripts, particularly when mounting root device in arch as a UUID as opposed to a `/dev/` node. This has been tested locally on my laptop.