### PR TITLE
update Cargo.lock (fix nix build)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "bcachefs-tools"
-version = "1.12.0"
+version = "1.20.0"
 dependencies = [
  "anyhow",
  "bch_bindgen",


### PR DESCRIPTION
fixes build failure when built with a "locked" lock file
the nix package build does this and `nix build
github:koverstreet/bcachefs-tools` currently fails