### PR TITLE
Preserve RUSTFLAGS from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ CFLAGS+=$(call cc-disable-warning, zero-length-array)
 CFLAGS+=$(call cc-disable-warning, shift-overflow)
 CFLAGS+=$(call cc-disable-warning, enum-conversion)
 CFLAGS+=$(call cc-disable-warning, gnu-variable-sized-type-not-at-end)
-export RUSTFLAGS=-C default-linker-libraries
+export RUSTFLAGS:=$(RUSTFLAGS) -C default-linker-libraries
 
 PKGCONFIG_LIBS="blkid uuid liburcu libsodium zlib liblz4 libzstd libudev libkeyutils"
 ifdef BCACHEFS_FUSE


### PR DESCRIPTION
Since commit https://github.com/koverstreet/bcachefs-tools/commit/3666da87f249b23b2c1f506e0d4157fd56c543e2 `RUSTFLAGS` is always fully replaced but it might be useful/necessary to pass custom flags.

Example:  
Gentoo recently changed the default linker used by `rustc` to generic `cc` (https://github.com/gentoo/gentoo/commit/f65ef3fddd9ef9cc3d2d172f6da9a39231b1e2d1) which on Gentoo is a symlink to `gcc`. Now on mostly LLVM/Clang built systems (like mine) this breaks building `bcachefs-tools` (I guess because `gcc+ld.bfd` doesn't understand `clang` built objects). Passing `RUSTFLAGS=-Clinker=clang` fixes this (and would be passed automagically if the Makefile didn't replace `RUSTFLAGS`).