### PR TITLE
bcachefs-principles-of-operation.tex: fix slanted quotes in verbatim

### DIFF
--- a/doc/bcachefs-principles-of-operation.tex
+++ b/doc/bcachefs-principles-of-operation.tex
@@ -3,6 +3,7 @@
 \usepackage{imakeidx}
 \usepackage[pdfborder={0 0 0}]{hyperref}
 \usepackage{longtable}
+\usepackage{upquote}
 
 \title{bcachefs: Principles of Operation}
 \author{Kent Overstreet}


### PR DESCRIPTION
Adding the upquote package makes the lines

$ getfattr -d -m '^bcachefs\.' filename
$ getfattr -d -m '^bcachefs_effective\.' filename

copy-pastable. Otherwise they get compiled as

$ getfattr -d -m ’^bcachefs\.’ filename
$ getfattr -d -m ’^bcachefs_effective\.’ filename

(slanted quotes) in the pdf.