### PR TITLE
Fix human readable units for compressed data

### DIFF
--- a/c_src/cmd_fs.c
+++ b/c_src/cmd_fs.c
@@ -355,13 +355,13 @@ static int fs_usage_v1_to_text(struct printbuf *out,
 			bch2_prt_compression_type(out, acc_k.compression.type);
 			prt_tab(out);
 
-			prt_human_readable_u64(out, sectors_compressed << 9);
+			prt_units_u64(out, sectors_compressed << 9);
 			prt_tab_rjust(out);
 
-			prt_human_readable_u64(out, sectors_uncompressed << 9);
+			prt_units_u64(out, sectors_uncompressed << 9);
 			prt_tab_rjust(out);
 
-			prt_human_readable_u64(out, nr_extents
+			prt_units_u64(out, nr_extents
 					       ? div_u64(sectors_uncompressed << 9, nr_extents)
 					       : 0);
 			prt_tab_rjust(out);


### PR DESCRIPTION
It was forcing human readable units even without the -h flag, so use the functions that respect that configuration.