### PR TITLE
Format filesystem with encryption using a passphase file

### DIFF
--- a/c_src/libbcachefs.h
+++ b/c_src/libbcachefs.h
@@ -41,6 +41,7 @@ struct format_opts {
 	unsigned	version;
 	unsigned	superblock_size;
 	bool		encrypted;
+	char		*passphrase_file;
 	char		*passphrase;
 	char		*source;
 	bool		no_sb_at_end;


### PR DESCRIPTION
Added an option to format with a passphrase file instead of  stdin - since there are already options for unlocking and mounting.

This checks to verify the encryption flag is set, and verifies that no_passphrase isn't set.