### PR TITLE
add missing \n in fs_usage_usage

### DIFF
--- a/c_src/cmd_fs.c
+++ b/c_src/cmd_fs.c
@@ -465,7 +465,7 @@ static void fs_usage_usage(void)
 	     "\n"
 	     "Options:\n"
 	     "  -f, --fields=FIELDS               List of accounting sections to print\n"
-	     "                                    replicas,btree,compression,rebalance_work,devices"
+	     "                                    replicas,btree,compression,rebalance_work,devices\n"
 	     "  -a                                Print all accounting fields\n"
 	     "  -h, --human-readable              Human readable units\n"
 	     "  -H, --help                        Display this help and exit\n"


### PR DESCRIPTION
Before:
```
bcachefs fs usage - display detailed filesystem usage
Usage: bcachefs fs usage [OPTION]... <mountpoint>

Options:
  -f, --fields=FIELDS               List of accounting sections to print
                                    replicas,btree,compression,rebalance_work,devices  -a                                Print all accounting fields
  -h, --human-readable              Human readable units
  -H, --help                        Display this help and exit
Report bugs to <linux-bcachefs@vger.kernel.org>
```

After:
```
bcachefs fs usage - display detailed filesystem usage
Usage: bcachefs fs usage [OPTION]... <mountpoint>

Options:
  -f, --fields=FIELDS               List of accounting sections to print
                                    replicas,btree,compression,rebalance_work,devices
  -a                                Print all accounting fields
  -h, --human-readable              Human readable units
  -H, --help                        Display this help and exit
Report bugs to <linux-bcachefs@vger.kernel.org>
```
