### PR TITLE
update nix build to pull version from Cargo.toml

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,10 +77,7 @@
           rustfmtToml = builtins.fromTOML (builtins.readFile ./rustfmt.toml);
 
           rev = self.shortRev or self.dirtyShortRev or (substring 0 8 self.lastModifiedDate);
-          makefileVersion = removePrefix "VERSION=" (
-            findFirst (line: hasPrefix "VERSION=" line) "VERSION=0.0.0" (split "\n" (readFile ./Makefile))
-          );
-          version = "${makefileVersion}+${rev}";
+          version = "${cargoToml.package.version}+${rev}";
 
           mkCommon =
             {


### PR DESCRIPTION
This updates the nix package build to pull the package version from Cargo.toml

Previously the nix package build parsed the `VERSION=` line out of the Makefile, which doesn't work anymore.