### PR TITLE
Update dkms.conf.in

### DIFF
--- a/dkms/dkms.conf.in
+++ b/dkms/dkms.conf.in
@@ -5,3 +5,5 @@ AUTOINSTALL=yes
 BUILT_MODULE_NAME[0]="bcachefs"
 BUILT_MODULE_LOCATION[0]="src/fs/bcachefs"
 DEST_MODULE_LOCATION[0]="/kernel/fs/bcachefs"
+# Regex matches 6.16-6.99.9
+BUILD_EXCLUSIVE_KERNEL="^(6\.(1[6-9]|[2-9][0-9])|[7-9]\d*)\."


### PR DESCRIPTION
Use BUILD_EXCLUSIVE_KERNEL to match against kernels 6.16-6.99 as kernels older than 6.16 are currently not supported