### PR TITLE
Improve systemd-ask-password integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ bch_bindgen = { path = "bch_bindgen" }
 strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
 zeroize = { version = "1", features = ["std", "zeroize_derive"] }
-rustix = { version = "0.38.34", features = ["termios"] }
+rustix = { version = "0.38.34", features = ["fs", "termios"] }
 owo-colors = "4"
 
 [dependencies.env_logger]

--- a/src/key.rs
+++ b/src/key.rs
@@ -159,6 +159,8 @@ impl Passphrase {
         let output = Command::new("systemd-ask-password")
             .arg("--icon=drive-harddisk")
             .arg(format!("--id=bcachefs:{}", uuid.as_hyphenated()))
+            .arg(format!("--keyname={}", uuid.as_hyphenated()))
+            .arg("--accept-cached")
             .arg("-n")
             .arg("Enter passphrase: ")
             .stdin(Stdio::inherit())


### PR DESCRIPTION
For users that mount the same encrypted bcachefs FS multiple times at boot, this patch makes it so the passphrase is only asked once.

The first commit makes it so `systemd-ask-password` is invoked when stdin is `/dev/null`, instead of using our own passphrase prompting code. This is the case when a bcachefs FS is mounted by systemd: by default, systemd executes the mount helper with stdin set to `/dev/null`.

The second commit fixes a race condition where when multiple `bcachefs mount` commands are executed in parallel, all of them will see that there is no key in the keyring and start an instance of `systemd-ask-password`. We can ask `systemd-ask-password` to try to reuse an existing passphrase in the keyring. `systemd-ask-password` is smart and knows to check again every time another `systemd-ask-password` instance completes, so as soon as the first `systemd-ask-password` command is complete, the others ones will return as well. 