### PR TITLE
Debian packaging: depend on linux-headers-generic, it will pull in the right one

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+bcachefs-tools (1:1.31.2~3) unstable; urgency=medium
+
+  * Debian packaging: depend on linux-headers-generic, it will pull in the right one
+
+ -- Roman Lebedev <lebedev.ri@gmail.com>  Sat, 20 Sep 2025 21:18:15 +0300
+
 bcachefs-tools (1:1.31.2) UNRELEASED; urgency=medium
 
   * DKMS now works on 6.16

--- a/debian/control
+++ b/debian/control
@@ -50,8 +50,7 @@ Architecture: linux-any
 Section: kernel
 Depends: ${misc:Depends},
 	 initramfs-tools | linux-initramfs-tool,
-	 linux-headers-amd64 [amd64],
-	 linux-headers-arm64 [arm64],
+	 linux-headers-generic
 Pre-Depends: bcachefs-tools (= ${binary:Version}),
 Provides: bcachefs-kernel
 Description: bcachefs kernel module DKMS source


### PR DESCRIPTION
As noted by Michael Larabel.