### PR TITLE
dkms: Use relative path for TRACE_INCLUDE_PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ install_dkms: dkms/dkms.conf
 	$(INSTALL) -m0644 -D libbcachefs/Makefile	-t $(DESTDIR)$(DKMSDIR)/src/fs/bcachefs
 	$(INSTALL) -m0644 -D libbcachefs/*.[ch]		-t $(DESTDIR)$(DKMSDIR)/src/fs/bcachefs
 	$(INSTALL) -m0644 -D libbcachefs/vendor/*.[ch]	-t $(DESTDIR)$(DKMSDIR)/src/fs/bcachefs/vendor
-	sed -i "s|^#define TRACE_INCLUDE_PATH \\.\\./\\.\\./fs/bcachefs$$|#define TRACE_INCLUDE_PATH $(DKMSDIR)/src/fs/bcachefs|" \
+	sed -i "s|^#define TRACE_INCLUDE_PATH \\.\\./\\.\\./fs/bcachefs$$|#define TRACE_INCLUDE_PATH .|" \
 	  $(DESTDIR)$(DKMSDIR)/src/fs/bcachefs/trace.h
 
 .PHONY: clean

--- a/dkms/Makefile
+++ b/dkms/Makefile
@@ -5,8 +5,8 @@ else
 KDIR ?= /lib/modules/`uname -r`/build
 
 default:
-	$(MAKE) -C $(KDIR) M=$$PWD modules
+	$(MAKE) -C $(KDIR) M=$$PWD BCACHEFS_DKMS=1 modules
 
 clean:
-	$(MAKE) -C $(KDIR) M=$$PWD clean
+	$(MAKE) -C $(KDIR) M=$$PWD BCACHEFS_DKMS=1 clean
 endif

--- a/libbcachefs/Makefile
+++ b/libbcachefs/Makefile
@@ -105,3 +105,7 @@ obj-$(CONFIG_MEAN_AND_VARIANCE_UNIT_TEST)   += mean_and_variance_test.o
 
 # Silence "note: xyz changed in GCC X.X" messages
 subdir-ccflags-y += $(call cc-disable-warning, psabi)
+
+ifdef BCACHEFS_DKMS
+	subdir-ccflags-y += -I$(src)
+endif


### PR DESCRIPTION
install_dkms currently patches the absolute path of DKMSDIR into trace.h, but this is fragile. For instance, if the DKMSDIR path contains the word "linux", then the __stringify in define_trace.h replaces it with its macro expansion "1" and breaks the path. It's better to just keep it relative.

@koverstreet will have to figure out how to merge the libbcachefs part of this correctly.