### PR TITLE
DKMS: parallelize compilation

### DIFF
--- a/dkms/Makefile
+++ b/dkms/Makefile
@@ -1,4 +1,5 @@
 export BCACHEFS_DKMS=1
+MAKEFLAGS += -j$(nproc --all)
 ifneq (${KERNELRELEASE},)
 ccflags-y := -I$(src)/include
 obj-m += src/fs/bcachefs/


### PR DESCRIPTION
This is much faster, but perhaps there is a particular reason as to why modules should be compiled with a single thread?