### PR TITLE
Revert "DKMS: parallelize compilation"

### DIFF
--- a/dkms/Makefile
+++ b/dkms/Makefile
@@ -1,5 +1,4 @@
 export BCACHEFS_DKMS=1
-MAKEFLAGS += -j$(nproc --all)
 ifneq (${KERNELRELEASE},)
 ccflags-y := -I$(src)/include
 obj-m += src/fs/bcachefs/


### PR DESCRIPTION
This is extremely unexpected, but even though by default Qemu in autopkgtest-virt-qemu runs with `-smp 1`,
it //seems// that the guest seems to think that there are more cores than that,
and DKMS build hangs/stalls in qemu guest... Same with `getconf _NPROCESSORS_ONLN`.
This is my guess, and this is really unexpected and i don't know how to deal with this.

Reverts koverstreet/bcachefs-tools#423