### PR TITLE
bcachefs-kernel-dkms: Accept pve-headers as one of alternatives to linux-headers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -52,7 +52,7 @@ Architecture: linux-any
 Section: kernel
 Depends: ${misc:Depends},
 	 initramfs-tools | linux-initramfs-tool,
-	 linux-headers-generic (>= 6.16) |
+	 linux-headers-generic (>= 6.16) | pve-headers (>= 6.16) [amd64] |
 	 linux-headers-amd64 (>= 6.16) [amd64] | linux-headers-cloud-amd64 (>= 6.16) [amd64] | linux-headers-rt-amd64 (>= 6.16) [amd64] |
 	 linux-headers-arm64 (>= 6.16) [arm64] | linux-headers-cloud-arm64 (>= 6.16) [arm64] | linux-headers-rt-arm64 (>= 6.16) [arm64]
 Pre-Depends: bcachefs-tools (= ${binary:Version}),


### PR DESCRIPTION
bcachefs-kernel-dkms in current shape forces installation of generic linux kernel on Proxmox machines.
Add `pve-headers` as one of acceptable Dependencies so Proxmox-flavoured kernel headers are sufficient for solving dependency graph.