### PR TITLE
nix: Facilitate overriding kernel module

### DIFF
--- a/crane-build.nix
+++ b/crane-build.nix
@@ -76,8 +76,9 @@ let
         make ''${enableParallelBuilding:+-j''${NIX_BUILD_CORES}} $makeFlags
       '';
       doNotPostBuildInstallCargoBinaries = true;
+      enableParallelInstalling = true;
       installPhaseCommand = ''
-        make ''${enableParallelBuilding:+-j''${NIX_BUILD_CORES}} $makeFlags install
+        make ''${enableParallelInstalling:+-j''${NIX_BUILD_CORES}} $makeFlags install
       '';
 
       doInstallCheck = true;

--- a/crane-build.nix
+++ b/crane-build.nix
@@ -30,7 +30,10 @@ let
 
   args = {
     inherit version;
-    src = ./.;
+    src = lib.fileset.toSource {
+      root = ./.;
+      fileset = lib.fileset.fileFilter ({ hasExt, ... }: !hasExt "nix") ./.;
+    };
     strictDeps = true;
 
     env = {

--- a/crane-build.nix
+++ b/crane-build.nix
@@ -74,6 +74,15 @@ let
     // {
       inherit cargoArtifacts;
 
+      outputs = [
+        "out"
+        "dkms"
+      ];
+
+      makeFlags = args.makeFlags ++ [
+        "DKMSDIR=${placeholder "dkms"}"
+      ];
+
       enableParallelBuilding = true;
       buildPhaseCargoCommand = ''
         make ''${enableParallelBuilding:+-j''${NIX_BUILD_CORES}} $makeFlags
@@ -81,12 +90,14 @@ let
       doNotPostBuildInstallCargoBinaries = true;
       enableParallelInstalling = true;
       installPhaseCommand = ''
-        make ''${enableParallelInstalling:+-j''${NIX_BUILD_CORES}} $makeFlags install
+        make ''${enableParallelInstalling:+-j''${NIX_BUILD_CORES}} $makeFlags install install_dkms
       '';
 
       doInstallCheck = true;
       nativeInstallCheckInputs = [ versionCheckHook ];
       versionCheckProgramArg = "version";
+
+      passthru.kernelModule = import ./module-build.nix package;
 
       meta = {
         description = "Userspace tools for bcachefs";

--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,12 @@
                   crossPackages = {
                     "bcachefs-tools" = craneBuild.package;
                     "bcachefs-tools-fuse" = craneBuild.packageFuse;
+                    "bcachefs-module-linux-latest" =
+                      pkgs'.linuxPackages_latest.callPackage craneBuild.package.kernelModule
+                        { };
+                    "bcachefs-module-linux-testing" =
+                      pkgs'.linuxPackages_testing.callPackage craneBuild.package.kernelModule
+                        { };
                   };
                 in
                 (withCrossName crossPackages) // lib.optionalAttrs (crossSystem == localSystem) crossPackages;
@@ -109,6 +115,8 @@
               bcachefs-tools-aarch64-linux
               bcachefs-tools-fuse
               bcachefs-tools-fuse-i686-linux
+              bcachefs-module-linux-latest
+              bcachefs-module-linux-testing
               ;
             inherit (pkgs.callPackage ./crane-build.nix { inherit crane version; })
               # cargo-clippy

--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,8 @@
                   pname = "${prev.pname}-msrv";
                 }
               );
+
+            nixos-test = pkgs.nixosTest (import ./nixos-test.nix self');
           };
 
           devShells.default = pkgs.mkShell {

--- a/module-build.nix
+++ b/module-build.nix
@@ -1,0 +1,67 @@
+/*
+  Copyright (c) 2003-2025 Eelco Dolstra and the Nixpkgs/NixOS contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the
+  "Software"), to deal in the Software without restriction, including
+  without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so, subject to
+  the following conditions:
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+bcachefs-tools:
+{
+  lib,
+  stdenv,
+  kernelModuleMakeFlags,
+  kernel,
+}:
+
+stdenv.mkDerivation {
+  pname = "bcachefs";
+  version = "${kernel.version}-${bcachefs-tools.version}";
+
+  __structuredAttrs = true;
+
+  src = bcachefs-tools.dkms;
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  enableParallelBuilding = true;
+
+  makeFlags = kernelModuleMakeFlags ++ [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=${placeholder "out"}"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    make -C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build M=$(pwd) modules_install "''${makeFlags[@]}" "''${installFlags[@]}"
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit (bcachefs-tools.passthru) tests;
+  };
+
+  meta = {
+    description = "out-of-tree bcachefs kernel module";
+
+    inherit (bcachefs-tools.meta)
+      license
+      maintainers
+      ;
+  };
+}

--- a/nixos-test.nix
+++ b/nixos-test.nix
@@ -1,0 +1,34 @@
+self': {
+  name = "bcachefs-nixos";
+
+  nodes.machine =
+    { config, ... }:
+    {
+      assertions = [
+        {
+          assertion =
+            config.boot.bcachefs.modulePackage or null == self'.packages.bcachefs-module-linux-latest;
+          message = "Local bcachefs module isn't being used; update nixpkgs?";
+        }
+      ];
+
+      virtualisation.emptyDiskImages = [
+        {
+          size = 4096;
+          driveConfig.deviceExtraOpts.serial = "test-disk";
+        }
+      ];
+
+      boot.supportedFilesystems.bcachefs = true;
+      boot.bcachefs.package = self'.packages.bcachefs-tools;
+    };
+
+  testScript = ''
+    machine.succeed(
+      "modinfo bcachefs | grep updates/src/fs/bcachefs > /dev/null",
+      "mkfs.bcachefs /dev/disk/by-id/virtio-test-disk",
+      "mkdir /mnt",
+      "mount /dev/disk/by-id/virtio-test-disk /mnt",
+    )
+  '';
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,20 @@
+{ inputs, version }:
+final: prev:
+let
+  craneBuild = prev.callPackage ./crane-build.nix {
+    inherit version;
+    inherit (inputs) crane;
+  };
+in
+{
+  bcachefsPackages = {
+    "bcachefs-tools" = craneBuild.package;
+    "bcachefs-tools-fuse" = craneBuild.packageFuse;
+    "bcachefs-module-linux-latest" =
+      final.linuxPackages_latest.callPackage craneBuild.package.kernelModule
+        { };
+    "bcachefs-module-linux-testing" =
+      final.linuxPackages_testing.callPackage craneBuild.package.kernelModule
+        { };
+  };
+}


### PR DESCRIPTION
Once https://github.com/NixOS/nixpkgs/pull/446975 is merged, users will be able to override both userspace tools and kernel module with just:

```nix
boot.bcachefs.package = inputs.bcachefs-tools.packages.${pkgs.system}.bcachefs-tools;
```

The package and module build in this repo's nix expressions without the linked PR just fine. The linked PR is just needed for NixOS users to be able to do the above.