### PR TITLE
nix: Set strictDeps for module

### DIFF
--- a/module-build.nix
+++ b/module-build.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation {
   version = "${kernel.version}-${bcachefs-tools.version}";
 
   __structuredAttrs = true;
+  strictDeps = true;
 
   src = bcachefs-tools.dkms;
 


### PR DESCRIPTION
This is nix best practice and already set for the crane based builds but was missing here.