### PR TITLE
Debian: cross-build support

### DIFF
--- a/.github/workflows/deb-buildd.yml
+++ b/.github/workflows/deb-buildd.yml
@@ -247,14 +247,6 @@ jobs:
           if [ "${{ inputs.dist-name }}" = "debian" ];
           then
           MIRROR="http://deb.debian.org/debian"
-          elif [ "${{ inputs.dist-name }}" = "ubuntu" ] && [ "${{ inputs.build-arch }}" = "amd64" ];
-          then
-          MIRROR="http://archive.ubuntu.com/ubuntu"
-          elif [ "${{ inputs.dist-name }}" = "ubuntu" ] && [ "${{ inputs.build-arch }}" != "amd64" ];
-          then
-          MIRROR="http://ports.ubuntu.com/ubuntu-ports"
-          else
-          exit 1
           fi
           if [ "${{ inputs.dist-name }}" = "debian" ];
           then
@@ -287,16 +279,27 @@ jobs:
           fi
           if [ "${{ inputs.dist-name }}" = "ubuntu" ];
           then
+          MIRROR="http://archive.ubuntu.com/ubuntu"
           tee -a ~/.sbuildrc > /dev/null <<EOT
           push @{\$unshare_mmdebstrap_extra_args}, "*", [
-            '$MIRROR',
             '--keyring=$KEYRING',
-            '--components=main,universe'
+            '--components=main,universe',
+            'deb [arch=amd64] $MIRROR ${{ inputs.dist-version }} main universe',
+            'deb [arch=amd64] $MIRROR ${{ inputs.dist-version }}-updates main universe',
+            'deb [arch=amd64] $MIRROR ${{ inputs.dist-version }}-security main universe',
+            'deb [arch=amd64] $MIRROR ${{ inputs.dist-version }}-backports main universe',
           ];
-          \$extra_repositories = [
-            'deb $MIRROR ${{ inputs.dist-version }}-updates main universe',
-            'deb $MIRROR ${{ inputs.dist-version }}-security main universe',
-            'deb $MIRROR ${{ inputs.dist-version }}-backports main universe',
+          EOT
+          fi
+          if [ "${{ inputs.dist-name }}" = "ubuntu" ] && [ "${{ inputs.host-arch }}" != "amd64" ];
+          then
+          MIRROR_PORTS="http://ports.ubuntu.com/ubuntu-ports"
+          tee -a ~/.sbuildrc > /dev/null <<EOT
+          push @{\$unshare_mmdebstrap_extra_args}, "*", [
+            'deb [arch=${{ inputs.host-arch }}] $MIRROR_PORTS ${{ inputs.dist-version }} main universe',
+            'deb [arch=${{ inputs.host-arch }}] $MIRROR_PORTS ${{ inputs.dist-version }}-updates main universe',
+            'deb [arch=${{ inputs.host-arch }}] $MIRROR_PORTS ${{ inputs.dist-version }}-security main universe',
+            'deb [arch=${{ inputs.host-arch }}] $MIRROR_PORTS ${{ inputs.dist-version }}-backports main universe',
           ];
           EOT
           fi

--- a/.github/workflows/deb-orchestrator.yml
+++ b/.github/workflows/deb-orchestrator.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         stack:
           - { runs-on: "ubuntu-24.04",     machine-arch: "amd64", build-arch: "amd64",   host-arch: "amd64" }
-          - { runs-on: "ubuntu-24.04",     machine-arch: "amd64", build-arch: "ppc64el", host-arch: "ppc64el" }
+          - { runs-on: "ubuntu-24.04",     machine-arch: "amd64", build-arch: "amd64",   host-arch: "ppc64el" }
           - { runs-on: "ubuntu-24.04-arm", machine-arch: "arm64", build-arch: "arm64",   host-arch: "arm64" }
         dist:
           - { name: debian, version: unstable }
@@ -45,6 +45,19 @@ jobs:
           - { name: debian, version: trixie   } # Debian 13
           - { name: ubuntu, version: questing } # Ubuntu 25.10       (Questing Quokka) Beta
           - { name: ubuntu, version: plucky   } # Ubuntu 25.04       (Plucky Puffin)
+        exclude:
+          - stack: { runs-on: "ubuntu-24.04",     machine-arch: "amd64", build-arch: "amd64",   host-arch: "ppc64el" }
+            dist: { name: ubuntu, version: questing }
+            # cross-build broken, package conflicts
+          - stack: { runs-on: "ubuntu-24.04",     machine-arch: "amd64", build-arch: "amd64",   host-arch: "ppc64el" }
+            dist: { name: ubuntu, version: plucky   }
+            # cross-build broken, broken packages
+        # # If someone asks for ubuntu ppc64el packages, these can be reenabled:
+        # include:
+        #   - stack: { runs-on: "ubuntu-24.04",     machine-arch: "amd64", build-arch: "ppc64el", host-arch: "ppc64el" }
+        #     dist: { name: ubuntu, version: questing }
+        #   - stack: { runs-on: "ubuntu-24.04",     machine-arch: "amd64", build-arch: "ppc64el", host-arch: "ppc64el" }
+        #     dist: { name: ubuntu, version: plucky   }
     uses: ./.github/workflows/deb-buildd.yml
     with:
       deb-src-artifact-id: ${{ needs.source-only.outputs.deb-src-artifact-id }}

--- a/debian/control
+++ b/debian/control
@@ -4,17 +4,21 @@ Section: utils
 Priority: optional
 Standards-Version: 4.7.0
 Build-Depends: debhelper-compat (= 13),
-               cargo,
+               cargo:native,
+               dh-cargo,
                dh-dkms,
+               gcc:native,
                jq,
                libaio-dev,
                libblkid-dev,
-               libclang-dev,
+               libclang-dev:native,
                libfuse3-dev,
                libkeyutils-dev,
                liblz4-dev,
                libscrypt-dev,
                libsodium-dev,
+               libstd-rust-dev,
+               libstd-rust-dev:native,
                libudev-dev,
                liburcu-dev (>= 0.15),
                libzstd-dev,
@@ -22,7 +26,7 @@ Build-Depends: debhelper-compat (= 13),
                pkgconf,
                python3-docutils,
                python3:native,
-               rustc (>= 1.77),
+               rustc:native (>= 1.77),
                systemd-dev,
                uuid-dev,
                zlib1g-dev,
@@ -41,6 +45,8 @@ Breaks: bcachefs-kernel-dkms (<< ${binary:Version}),
         bcachefs-kernel-dkms (>> ${binary:Version}),
 Replaces: bcachefs-kernel-dkms (<< ${binary:Version}),
           bcachefs-kernel-dkms (>> ${binary:Version}),
+Built-Using: ${cargo:Built-Using}
+Static-Built-Using: ${cargo:Static-Built-Using}
 Description: bcachefs userspace tools
  Userspace tools for bcachefs, a modern copy on write, checksumming, multi
  device filesystem.

--- a/debian/rules
+++ b/debian/rules
@@ -1,35 +1,37 @@
 #!/usr/bin/make -f
 
-include /usr/share/dpkg/architecture.mk
+export DH_VERBOSE = 1
+
+export DPKG_EXPORT_BUILDFLAGS = 1
+export DPKG_EXPORT_BUILDTOOLS = 1
+
+export DEB_BUILD_OPTIONS += nolto
+export DEB_BUILD_MAINT_OPTIONS += optimize=-lto
+
+export DEB_BUILD_MAINT_OPTIONS += hardening=+all
+
+include /usr/share/dpkg/default.mk
 include /usr/share/rustc/architecture.mk
 
-export DH_VERBOSE=1
+export DEB_HOST_RUST_TYPE
+export DEB_HOST_GNU_TYPE
 
-export DEB_HOST_RUST_TYPE DEB_HOST_GNU_TYPE
+export PATH := /usr/share/cargo/bin:$(PATH)
+export CARGO = /usr/share/cargo/bin/cargo
+export CARGO_HOME = $(CURDIR)/debian/cargo_home
+export DEB_CARGO_CRATE = bcachefs-tools_$(DEB_VERSION_UPSTREAM)
 
-export DEB_BUILD_MAINT_OPTIONS=hardening=+all
-export CARGO=/usr/share/cargo/bin/cargo
-export CARGO_HOME=$(CURDIR)/debian/cargo_home
-export DEB_CARGO_CRATE=bcachefs-tools_$(DEB_VERSION_UPSTREAM)
-
-NUMJOBS = 1
-ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
-    NUMJOBS = $(patsubst parallel=%,%,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
-    MAKEFLAGS += -j$(NUMJOBS)
-endif
+export PKG_CONFIG = ${DEB_HOST_MULTIARCH}-pkg-config
+export PKG_CONFIG_PATH = /usr/lib/${DEB_HOST_MULTIARCH}/pkgconfig:/usr/share/pkgconfig
+export PKG_CONFIG_LIBDIR = /usr/lib/${DEB_HOST_MULTIARCH}/pkgconfig
 
 PREFIX := /usr
 ROOT_SBINDIR := /usr/sbin
 
 export PREFIX ROOT_SBINDIR
 
-DEB_BUILD_ARCH ?= $(shell dpkg-architecture -qDEB_BUILD_ARCH)
-
-ifeq ($(DEB_BUILD_ARCH),amd64)
-    DEB_BUILD_MAINT_OPTIONS += optimize=-lto
-endif
-
-export CARGO_ARGS = "--frozen"
+export CARGO_ARGS = --frozen
+export CARGO_BUILD_TARGET = ${DEB_HOST_RUST_TYPE}
 
 # WARNING: split debug info makes the package unreproducible!
 #
@@ -49,25 +51,23 @@ export CARGO_ARGS = "--frozen"
 %:
 	dh $@ --parallel --with dkms
 
+override_dh_auto_clean:
+	$(CARGO) prepare-debian vendor
+	dh_auto_clean
+
+override_dh_auto_configure:
+	$(CARGO) prepare-debian vendor
+	dh_auto_configure
+
 override_dh_clean:
 	# HACK: breaks cargo checksumming by deleting some vendored files.
-
-cargo_config:
-	rm -rf .cargo
-	mkdir -p .cargo
-	cp debian/cargo.config .cargo/config.toml
-
-override_dh_auto_build:
-	$(MAKE) -f debian/rules cargo_config
-	dh_auto_build
-
-override_dh_auto_clean:
-	$(MAKE) -f debian/rules cargo_config
-	dh_auto_clean
-	rm -rf .cargo
 
 override_dh_usrlocal:
 	# FIXME: fails with
 	# dh_usrlocal: error: debian/bcachefs-tools/usr/local/libexec/bcachefsck_all is not a directory
 
 override_dh_auto_test:
+
+# Generate (Static-)Built-Using
+execute_after_dh_auto_install:
+	/usr/share/cargo/bin/dh-cargo-built-using bcachefs-tools


### PR DESCRIPTION
For debian distros, we're lucky and cross-build *now* just works, and is as fast as native amd64 builds.

For ubuntu, things are ugly. On questing it currently does not work, (but maybe they will fix it later), however on plucky it just doesn't work.

So i'm just disabling ppc64el ubuntu builds
since full cross-compilation is really slow,
but if someone actually needs them, those can be reenabled...