### PR TITLE
udev rules: Add per-member links in /dev/disk/by-uuid

### DIFF
--- a/udev/64-bcachefs.rules
+++ b/udev/64-bcachefs.rules
@@ -2,7 +2,16 @@
 #
 # Copyright (C) 2024 Oracle.  All rights reserved.
 # Author: Darrick J. Wong <djwong@kernel.org>
-#
+
+SUBSYSTEM!="block", GOTO="bcachefs_end"
+ACTION=="remove", GOTO="bcachefs_end"
+ENV{ID_FS_TYPE}!="bcachefs", GOTO="bcachefs_end"
+ENV{SYSTEMD_READY}=="0", GOTO="bcachefs_end"
+
+# udev has already assigned a by-uuid link using the FS global
+# UUID. We should also have a link for the per-member UUID.
+ENV{ID_FS_UUID_SUB_ENC}=="?*", SYMLINK+="disk/by-uuid/$env{ID_FS_UUID_SUB_ENC}"
+
 # Don't let udisks automount bcachefs filesystems without even asking a user.
 # This doesn't eliminate filesystems as an attack surface; it only prevents
 # evil maid attacks when all sessions are locked.
@@ -10,4 +19,6 @@
 # According to http://storaged.org/doc/udisks2-api/latest/udisks.8.html,
 # supplying UDISKS_AUTO=0 here changes the HintAuto property of the block
 # device abstraction to mean "do not automatically start" (e.g. mount).
-SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="bcachefs", ENV{UDISKS_AUTO}="0"
+ENV{UDISKS_AUTO}="0"
+
+LABEL="bcachefs_end"


### PR DESCRIPTION
The standard udev rules create a `/dev/disk/by-uuid/` link using the FS's global UUID. This is good. It means the FS UUID can be used to wait for *any* device that's a member of the FS. But, for a multi-device file system, users are advised to add the options `x-systemd.wants=/dev/disk/by-id/xyz` using some ID that's unique to each specific disk. This way systemd knows to wait for each member. If any of them times out, the use of `wants` rather than `requires` allows for a degraded mount to be attempted, if the user has configured the `degraded` option.

This adds a per-member UUID link in `/dev/disk/by-uuid/` to use for this purpose.