### PR TITLE
Added nix tooling for documentation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,16 @@
             inherit system;
             overlays = [ (import rust-overlay) ];
           };
+          latexDerivation = (
+            pkgs.texliveBasic.withPackages (
+              ps: with ps; [
+                imakeidx
+                xkeyval
+                upquote
+                collection-fontsrecommended
+              ]
+            )
+          );
         in
         {
           packages =
@@ -102,6 +112,22 @@
             packages
             // {
               default = self'.packages.${cargoToml.package.name};
+              doc = pkgs.stdenv.mkDerivation {
+                pname = "bcachefs-tools-doc";
+                inherit version;
+                src = ./doc;
+                buildInputs = with pkgs; [
+                  latexDerivation
+                ];
+                buildPhase = ''
+                  pdflatex bcachefs-principles-of-operation.tex
+                  pdflatex bcachefs-principles-of-operation.tex
+                '';
+                installPhase = ''
+                  mkdir -p $out/doc
+                  cp bcachefs-principles-of-operation.pdf $out/doc
+                '';
+              };
             };
 
           checks = {
@@ -154,6 +180,12 @@
                   "rust-src"
                 ];
               })
+            ];
+          };
+
+          devShells.doc = pkgs.mkShell {
+            packages = with pkgs; [
+              latexDerivation
             ];
           };
 


### PR DESCRIPTION
Added a develop shell and a build output with nix
Usage:
`nix develop .#doc` opens a shell with all required dependencies for latex
`nix build .#doc` generates the pdf to result/doc/

Hopefully this makes it easier for some to contribute to the Documentation