### PR TITLE
Deb: sign all binary packages with debsigs

### DIFF
--- a/.github/workflows/deb-buildd.yml
+++ b/.github/workflows/deb-buildd.yml
@@ -134,6 +134,7 @@ jobs:
             arch-test \
             autopkgtest \
             curl \
+            debsig-verify \
             devscripts \
             dosfstools \
             e2fsprogs \
@@ -171,6 +172,11 @@ jobs:
           gpg --import <<EOT
           ${{ secrets.GPG_SECRET_SUBKEYS }}
           EOT
+          gpg \
+            --output /etc/apt/trusted.gpg.d/apt.bcachefs.org.gpg \
+            --export \
+            ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }} \
+          ;
           gpg \
             --output /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc \
             --armor \
@@ -230,11 +236,9 @@ jobs:
           if [ "${{ inputs.dist-name }}" = "debian" ];
           then
           tee -a ~/.sbuildrc > /dev/null <<EOT
-          \$external_commands = {
-            'chroot-setup-commands' => [
-              "export LD_PRELOAD=/usr/lib/$(dpkg-architecture -a "${{ inputs.build-arch }}" -q DEB_HOST_MULTIARCH)/libeatmydata.so"
-            ]
-          };
+          push @{\$external_commands->{'chroot-setup-commands'}},
+            "export LD_PRELOAD=/usr/lib/$(dpkg-architecture -a "${{ inputs.build-arch }}" -q DEB_HOST_MULTIARCH)/libeatmydata.so"
+          ;
           \$build_environment = {
             "LD_PRELOAD" =>
               "/usr/lib/$(dpkg-architecture -a "${{ inputs.build-arch }}" -q DEB_HOST_MULTIARCH)/libeatmydata.so"
@@ -305,6 +309,32 @@ jobs:
             'deb [arch=${{ inputs.host-arch }}] $MIRROR_PORTS ${{ inputs.dist-version }}-security main universe',
             'deb [arch=${{ inputs.host-arch }}] $MIRROR_PORTS ${{ inputs.dist-version }}-backports main universe',
           ];
+          EOT
+          fi
+          if [ "${{ steps.gpg.conclusion }}" != "skipped" ]
+          then
+          tee ~/debsigs-hook.sh > /dev/null <<EOT
+          #!/bin/sh
+          set -xe
+          export GNUPGHOME=/.gnupg
+          find .. -maxdepth 1 -type f \( -name '*.deb' -or -name '*.ddeb' \) -print0 | \
+            xargs --null -I'{}' debsigs --verbose --default-key=${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }} --sign=origin '{}'
+          EOT
+          chmod +x ~/debsigs-hook.sh
+          tee -a ~/.sbuildrc > /dev/null <<EOT
+          push @{\$unshare_mmdebstrap_extra_args}, "*", [
+            '--include=tar,gnupg,debsigs',
+            '--customize-hook=cp ~/debsigs-hook.sh \$1/',
+          ];
+          push @{\$external_commands->{'pre-build-commands'}},
+            'cd $(echo $HOME) && tar -c .gnupg | %SBUILD_CHROOT_EXEC sh -c "tar -x -C / && chown -R sbuild:sbuild /.gnupg"'
+          ;
+          push @{\$external_commands->{'chroot-cleanup-commands'}},
+            'rm -rf /.gnupg'
+          ;
+          push @{\$dpkg_buildpackage_user_options},
+            '--hook-buildinfo=/debsigs-hook.sh'
+          ;
           EOT
           fi
       - name: Ensure that the download directory does not exist
@@ -380,10 +410,6 @@ jobs:
         run: |
           set -xe
           cd "${{ github.workspace }}/deb-bin"
-          if [ "${{ inputs.dist-name }}" = "ubuntu" ];
-          then
-          export DEB_BUILD_OPTIONS=noautodbgsym
-          fi
           echo '::group::Building the package'
           sbuild \
             --verbose \
@@ -392,6 +418,38 @@ jobs:
             "${{ github.workspace }}/deb-src/"*.dsc \
           ;
           echo '::endgroup::'
+      - name: Ensure that deb's are signed
+        timeout-minutes: 1
+        if: steps.gpg.conclusion != 'skipped'
+        shell: sudo podman exec --interactive --tty container eatmydata sh "{0}"
+        run: |
+          set -xe
+          POL_DIR="/etc/debsig/policies/${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}"
+          KEY_DIR="/usr/share/debsig/keyrings/${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}"
+          mkdir $POL_DIR
+          mkdir $KEY_DIR
+          cp /etc/apt/trusted.gpg.d/apt.bcachefs.org.gpg $KEY_DIR/
+          tee $POL_DIR/pol.pol > /dev/null <<EOT
+          <?xml version="1.0"?>
+          <!DOCTYPE Policy SYSTEM "https://www.debian.org/debsig/1.0/policy.dtd">
+          <Policy xmlns="https://www.debian.org/debsig/1.0/">
+            <Origin Name="apt.bcachefs.org" id="${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}"/>
+            <Selection>
+              <Required Type="origin" File="apt.bcachefs.org.gpg" id="${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}"/>
+            </Selection>
+            <Verification MinOptional="0">
+              <Required Type="origin" File="apt.bcachefs.org.gpg" id="${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}"/>
+            </Verification>
+          </Policy>
+          EOT
+          cd "${{ github.workspace }}/deb-bin"
+          find . -type f \( -name '*.deb' -or -name '*.ddeb' \) -print0 | xargs --null -I'{}' sh -c "  \
+            echo '::group::Checking signature on {}' &&                                                \
+            (                                                                                          \
+              debsig-verify --verbose {}                                                               \
+            ) &&                                                                                       \
+            echo '::endgroup::'                                                                        \
+          "
       - name: Ensure that all binary artifacts are signed, or sign them
         timeout-minutes: 1
         if: steps.gpg.conclusion != 'skipped'

--- a/.github/workflows/deb-publish.yml
+++ b/.github/workflows/deb-publish.yml
@@ -112,6 +112,7 @@ jobs:
           eatmydata apt full-upgrade
           eatmydata apt install \
             aptly \
+            debsig-verify \
             devscripts \
             gettext-base \
             gnupg \
@@ -132,6 +133,11 @@ jobs:
           gpg --import <<EOT
           ${{ secrets.GPG_SECRET_SUBKEYS }}
           EOT
+          gpg \
+            --output /etc/apt/trusted.gpg.d/apt.bcachefs.org.gpg \
+            --export \
+            ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }} \
+          ;
           gpg \
             --output /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc \
             --armor \
@@ -225,6 +231,38 @@ jobs:
               )                                                                                        \
             ) &&                                                                                       \
             echo 'ok.' &&                                                                              \
+            echo '::endgroup::'                                                                        \
+          "
+      - name: Ensure that all incoming deb's are signed
+        timeout-minutes: 1
+        if: steps.gpg.conclusion != 'skipped'
+        shell: sudo podman exec --interactive --tty container eatmydata sh "{0}"
+        run: |
+          set -xe
+          POL_DIR="/etc/debsig/policies/${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}"
+          KEY_DIR="/usr/share/debsig/keyrings/${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}"
+          mkdir $POL_DIR
+          mkdir $KEY_DIR
+          cp /etc/apt/trusted.gpg.d/apt.bcachefs.org.gpg $KEY_DIR/
+          tee $POL_DIR/pol.pol > /dev/null <<EOT
+          <?xml version="1.0"?>
+          <!DOCTYPE Policy SYSTEM "https://www.debian.org/debsig/1.0/policy.dtd">
+          <Policy xmlns="https://www.debian.org/debsig/1.0/">
+            <Origin Name="apt.bcachefs.org" id="${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}"/>
+            <Selection>
+              <Required Type="origin" File="apt.bcachefs.org.gpg" id="${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}"/>
+            </Selection>
+            <Verification MinOptional="0">
+              <Required Type="origin" File="apt.bcachefs.org.gpg" id="${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}"/>
+            </Verification>
+          </Policy>
+          EOT
+          cd "${{ github.workspace }}/incoming"
+          find . -type f \( -name '*.deb' -or -name '*.ddeb' \) -print0 | xargs --null -I'{}' sh -c "  \
+            echo '::group::Checking signature on {}' &&                                                \
+            (                                                                                          \
+              debsig-verify --verbose {}                                                               \
+            ) &&                                                                                       \
             echo '::endgroup::'                                                                        \
           "
       - name: Create and populate repos

--- a/doc/apt.bcachefs.org-README.md
+++ b/doc/apt.bcachefs.org-README.md
@@ -50,4 +50,6 @@ and thus pinning by origin label is inherently insecure!
 For more information, see:
 https://wiki.debian.org/DebianRepository/UseThirdParty
 
-Source, Debian tarballs and dsc files can be verified using https://github.com/sigstore/rekor.
+Source, Debian tarballs, dsc files and binary `.deb` packages can be verified using https://github.com/sigstore/rekor.
+
+Binary `.deb` packages are signed with debsigs.


### PR DESCRIPTION
The signature is stored within the `.deb` itself,
and dpkg is theoretically capable of checking this signature, however this is not as useful in practice, on par with attestation.

Oh, and reenable debug packages for ubuntu.