### PR TITLE
Makefile: always regenerate initramfs/hook and dkms/dkms.conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ endif
 # Rebuild the 'version' command any time the version string changes
 cmd_version.o : .version
 
+.PHONY: dkms/dkms.conf initramfs/hook
 dkms/dkms.conf: dkms/dkms.conf.in
 	@echo "    [SED]    $@"
 	$(Q)sed "s|@PACKAGE_VERSION@|$(VERSION)|g" dkms/dkms.conf.in > dkms/dkms.conf


### PR DESCRIPTION
These files are generated from .in templates with sed substitutions for PREFIX-dependent paths (ROOT_SBINDIR) and VERSION. Without .PHONY, make only regenerates them when the .in file changes, not when the substituted variables change.

This caused apt.bcachefs.org packages to ship with wrong paths: if the build system previously ran make with the default PREFIX=/usr/local, the generated initramfs/hook would contain /usr/local/sbin paths. A subsequent make PREFIX=/usr for .deb packaging would not regenerate the file since initramfs/hook.in hadn't changed.

Marking these targets as .PHONY so they always reflect the current configuration.

```
root@casrvgitlabrunner2:~# dpkg -l | grep -P '\sbcachefs' | awk '{print $2,$3}'
bcachefs-kernel-dkms 1:1.33.0~20251208233300.gbp63e18f
bcachefs-tools 1:1.33.0~20251208233300.gbp63e18f

root@casrvgitlabrunner2:~# apt install -f
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
0 upgraded, 0 newly installed, 0 to remove and 2 not upgraded.
1 not fully installed or removed.
After this operation, 0 B of additional disk space will be used.
Setting up initramfs-tools (0.142ubuntu25.5) ...
update-initramfs: deferring update (trigger activated)
Processing triggers for initramfs-tools (0.142ubuntu25.5) ...
update-initramfs: Generating /boot/initrd.img-6.17.0-5-generic
E: /etc/initramfs-tools/hooks/bcachefs failed with return 1.
update-initramfs: failed for /boot/initrd.img-6.17.0-5-generic with 1.
dpkg: error processing package initramfs-tools (--configure):
 installed initramfs-tools package post-installation script subprocess returned error exit status 1
Errors were encountered while processing:
 initramfs-tools
needrestart is being skipped since dpkg has failed
E: Sub-process /usr/bin/dpkg returned an error code (1)
```