### PR TITLE
RFC: Allow systemd-ask-password to run forever

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -160,6 +160,7 @@ impl Passphrase {
             .arg("--icon=drive-harddisk")
             .arg(format!("--id=bcachefs:{}", uuid.as_hyphenated()))
             .arg(format!("--keyname={}", uuid.as_hyphenated()))
+            .arg("--timeout=0")
             .arg("--accept-cached")
             .arg("-n")
             .arg("Enter passphrase: ")


### PR DESCRIPTION
The default timeout for `systemd-ask-password` is 1.5 minutes. When mounting my root filesystem on boot, I want my machine to wait indefinitely for me to enter a password, rather than fail to boot.

I don't see a compelling reason to make this configurable, but happy to make that change if folks thing I should.