### PR TITLE
doc: Bring principles-of-operation up to date

### DIFF
--- a/doc/bcachefs-principles-of-operation.tex
+++ b/doc/bcachefs-principles-of-operation.tex
@@ -1138,11 +1138,13 @@ overriding the filesystem-wide defaults. The per-inode options are:
 \texttt{inodes\_32bit}. Note that \texttt{casefold} and \texttt{inodes\_32bit}
 can only be toggled on empty directories.
 
-Options set on inodes (files and directories) are automatically inherited by
-their descendants, and inodes also record whether a given option was explicitly
-set or inherited from their parent. When renaming a directory would cause
-inherited attributes to change we fail the rename with -EXDEV, causing userspace
-to do the rename file by file so that inherited attributes stay consistent.
+Each inode stores its own copy of these options so that reads never need to
+walk parent directories. Each option has a separate ``defined'' flag that
+records whether the option was explicitly set on this inode; options without
+this flag are propagated from the parent directory on inode creation and rename.
+When renaming a directory would cause inherited attributes to change we fail the
+rename with -EXDEV, causing userspace to do the rename file by file so that
+inherited attributes stay consistent.
 
 Inode options are available as extended attributes. The options that have been
 explicitly set are available under the \texttt{bcachefs} namespace, and the


### PR DESCRIPTION
The principles-of-operation document had fallen behind the current state of the
codebase in several areas. This series brings it up to date with the current
code, adds missing sections, and fixes inaccuracies identified during review
by @himikof.

## Bulk update (d866ec30)

- Fill the empty btrees section with all 28 btrees (including stripe_backpointers)
- Add all missing key types (through extent_whiteout) with descriptions
- Add missing journal entry types (blacklist, overwrite, write_buffer_keys,
  datetime, log_bkey, etc.) with corrected descriptions
- Add xxhash to checksum types
- Replace "Rebalance: To be implemented" with the reconcile subsystem,
  including metadata handling and priority order
- Remove obsolete `data rereplicate` (superseded by reconcile)
- Update SMR/zoned section: explain bucket-to-zone semantic mapping
- Fix stale content in device management and scrub sections
- Rename device state `failed` to `evacuating` throughout
- Fix `-o very_degraded` to `-o degraded=very`
- Restore `-o verbose` paragraph
- Fix `encoded_extent_max` default (256KB not 64KB)
- Fix `shard_inode_numbers` to `shard_inode_numbers_bits` throughout
- Add `fix_safe` as default error action
- Fix fsck section: add online fsck, in-kernel offline mode, `-y`/`-n` flags,
  `-o nochanges` for safe inspection and dry-run repair
- Fix KEY_TYPE_cookie (reconcile option tracking, not unit tests)
- Fix KEY_TYPE_deleted (virtual journal key, stripped during btree writes)
- Fix snapshot-awareness annotations (quotas and reflink are NOT snapshot-aware)
- Fix journal entry types: BCH_JSET_ENTRY_usage (max key version only),
  data_usage/dev_usage (legacy, moved to accounting btree),
  write_buffer_keys (phantom entries transformed before disk write)
- Fix bucket_gens (256 numbers per key, not 8)

## New sections

- **Architectural overview** (6c6e0219): Bridging btrees and buckets as the two
  primitives underlying the entire filesystem; page cache independence
  explanation for large btree nodes
- **Transactions** (354b3788): Optimistic concurrency, six-locks, deadlock
  detection via lock cycle checks, restart-based approach, idempotency making
  the filesystem resilient to interruption including during recovery, sequence
  numbers for efficient relocking, triggers (transactional and atomic), logged
  operations for multi-transaction work
- **Recovery** (354b3788): Journal replay, sequence blacklisting for ordering
  guarantees after crash
- **Recovery passes** (354b3788): ~48 passes with dependency graph, four
  contexts (every mount, unclean, version upgrade, fsck), split before/after
  read-write, dynamic scheduling and rewind, catastrophic rebuild passes
  (scan_for_btree_nodes, reconstruct_snapshots, check_allocations)
- **Online fsck and self-healing** (354b3788): `errors=fix_safe` default since
  v1.19, automatic scheduling of PASS_ONLINE repair passes, emergency
  read-only for unsafe errors with developer reporting suggestion
- **Backpointers** (36ba57b0): Reverse references from physical disk locations
  to logical btree entries, write-buffered btree, discriminator field for
  compressed extents and EC stripes, use by evacuation/scrub/reconcile, three
  named recovery passes for validation
- **Casefolding** (6ba74d3d): Per-directory `casefold` option, inherited by
  subdirectories, empty directory requirement, on-disk dual-name storage,
  Unicode 12.1.0 hardcoded
- **32-bit inodes** (d866ec30): Legacy NFS compatibility, 32-bit userspace,
  Wine/Proton/Steam; per-directory option; `inodes_32bit` silently disables
  `shard_inode_numbers_bits`
- **Inode number sharding** (d866ec30): `shard_inode_numbers_bits` design,
  CPU-based partitioning for contention elimination
- **Journal rewind** (347d2fa0): Mount option to roll back most important
  filesystem metadata to a journal sequence number; `journal_transaction_names`
  required; tool for reverting recovery bugs or (with `-o nochanges`) recovering
  deleted files; nocow data unrollable; rewind window bounded by journal size
- **Journal debug and resize** (347d2fa0): `journal_debug` sysfs documentation,
  journal resize fragmentation note, shrinking not implemented
- **list_journal** (347d2fa0): Complete record of btree updates with transaction
  names for diagnosis before rewind
- **File and directory options** (7fcfafe1): Per-inode options list including
  `inodes_32bit` and `casefold`, inheritance mechanics, `bcachefs` and
  `bcachefs_effective` xattr namespaces, `set-file-option` for recursive
  propagation, `casefold`/`inodes_32bit` empty directory constraint
- **Subvolume/snapshot architecture** (354b3788): Snapshot tree structure,
  4 snapshot-aware btrees, ancestor bitmap + skiplist for O(log n) queries,
  snapshot creation mechanics (two children, no key copying), asynchronous
  deletion with eytzinger-layout search, interior node removal deferred to
  next mount
- **Splitbrain detection** (bd0ac154): Sequence number and write timestamp
  divergence detection since v1.4, partial mount and external snapshot causes,
  `no_splitbrain_check` option
- **Superblock field types** (10843b6e): `errors`, `ext`, `downgrade`,
  `counters`, `recovery_passes`, versioned variants note
- **Missing ioctls** (3c34ed04, 4f56a90a): `FSCK_OFFLINE`, `FSCK_ONLINE`,
  `QUERY_ACCOUNTING`, `SUBVOLUME_LIST`, `SNAPSHOT_TREE`, v2 variants note;
  obsolete markers on `FS_USAGE` and `DEV_USAGE`

## Rewritten sections

- **Encryption** (c8f61318): Replace user-guide content with design document:
  three-level key hierarchy, nonce derivation from bversion, kernel keyring
  integration and its pain points (session isolation, privilege boundaries),
  MAC storage design (80-bit default, `wide_macs` for untrusted storage with
  rollback attack scenario), nonce reuse vulnerability with external snapshots
  and LUKS mitigation, critical nocow+encryption warning, format-time only
- **Erasure coding** (4a40301a, 8a1a3f86, 984e4a7f): Stripe geometry (dynamic
  width, device eligibility, bucket size matching), write lifecycle (staging
  with extra replicas, parity generation, stripe commit, replica drop),
  fragmentation tracking and stripe reuse, re-striping via reconcile, fault
  isolation (EC/non-EC segregation, btree node exclusion, crash safety),
  involved btrees (stripes, bucket_to_stripe, stripe_backpointers, alloc, LRU)
- **Reflink** (e9eb3fc6, d79804c5): On-disk representation (reflink_p with
  pads and flags, reflink_v with refcount), creation and lifecycle (conversion,
  trigger mechanics, one-way transformation rationale, reflink_p non-merging),
  IO option propagation via `bch_extent_reconcile` and
  `REFLINK_P_MAY_UPDATE_OPTIONS`, snapshot interaction (reflink btree not
  snapshot-aware, reflink_p keys are)
- **Debugfs** (7abeac03): Restructured with btrees/ subdirectory layout, added
  `btree_updates`, `journal_pins`, `btree_deadlock`, `cached_btree_nodes`,
  `btree_transaction_stats`, `btree_node_scan`, `write_points`
- **Sysfs** (184161f6, 052ddfca): Fixed renamed entries, removed nonexistent
  `time_stats` entries, corrected descriptions

## Removed

- 120-line full option list (duplicated --help output with no design content)
- `data rereplicate` section (obsolete, superseded by reconcile)
- Stale TODO notes ("regularize force options", "journal space visibility",
  mount-by-label TODO)
- Boot ordering from keyring pain points (not bcachefs-specific)
- Keyring re-requesting complaint (not a real limitation)

## Design motivations (a6b01ee9, 28143fa6)

- Added Kent's explanations from IRC and Patreon for: page cache independence
  and petabyte-scale btree depth, bucket-based allocation evolution from
  scanning threads to btree-based structures, per-extent compression rationale
  vs 4K-page granularity, COW write hole avoidance in erasure coding, AEAD
  encryption vs block-layer AES-XTS and chain of trust from superblock to
  extents