### PR TITLE
man: `set-state` can be used for more than marking a device as failed

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -53,7 +53,7 @@ Take a device offline, without removing it
 .It Ic device evacuate
 Migrate data off of a specific device
 .It Ic device set-state
-Mark a device as failed
+Change the state of a device
 .It Ic device resize
 Resize filesystem on a device
 .It Ic device resize-journal


### PR DESCRIPTION
I learned this from lurking on irc. It's also confirmed from the cli help:

```console
$ bcachefs device set-state --help
bcachefs device set-state - change the state of a device
...
```