### PR TITLE
Makefile: add missing version.h dependency for dkms/module-version.o

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ generate_version: .version version.h
 
 # Rebuild the 'version' command any time the version string changes
 c_src/cmd_version.o : version.h
+dkms/module-version.o : version.h
 
 
 .PHONY: dkms/dkms.conf


### PR DESCRIPTION
since b62c520f, dkms/module-version.c includes version.h, but the Makefile only declares the dependency for c_src/cmd_version.o. with parallel make (-j), dkms/module-version.o can compile before version.h is generated, causing a build failure:
```
dkms/module-version.c:10:10: fatal error: version.h: No such file or directory
```