### PR TITLE
fs_usage: fix reserved indentation, add Usage column

### DIFF
--- a/src/commands/fs_usage.rs
+++ b/src/commands/fs_usage.rs
@@ -148,7 +148,7 @@ fn fs_usage_v1_to_text(
     // Detailed replicas
     if has(Field::Replicas) {
         out.aligned(|sub| {
-            write!(sub, "\nData type\tRequired/total\tDurability\tDevices\n").unwrap();
+            write!(sub, "\nData type\tRequired/total\tDurability\tDevices\tUsage\n").unwrap();
 
             for entry in &sorted {
                 match entry.pos.decode() {


### PR DESCRIPTION
Before:

```
Filesystem: cff56981-ae6c-4238-bcfd-5a8c0a520ca6
Size:             11.7T  
Used:              540G  
Online reserved:      0  


     undegraded  
2x:        540G  

cached:    249G  
reserved:  361M  


Data type  Required/total  Durability  Devices
reserved:  1/2                [] 361M  
btree:     1/2             2           [dm-7 dm-9]  5.28G  
user:      1/2             2           [dm-6 dm-8]   534G  
cached:    1/1             1           [dm-7]       14.7G  
cached:    1/1             1           [dm-9]        234G  
```

After:

```
Filesystem: cff56981-ae6c-4238-bcfd-5a8c0a520ca6
Size:             11.7T  
Used:              540G  
Online reserved:      0  


     undegraded  
2x:        540G  

cached:    249G  
reserved:  361M  


Data type  Required/total  Durability  Devices      Usage
reserved:  1/2                         []            361M  
btree:     1/2             2           [dm-7 dm-9]  5.28G  
user:      1/2             2           [dm-6 dm-8]   534G  
cached:    1/1             1           [dm-7]       14.7G  
cached:    1/1             1           [dm-9]        234G  
```

