### PR TITLE
image: fix image size estimation when source fs is compressed

### DIFF
--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -64,7 +64,7 @@ fn count_input_size(dir: &std::fs::File) -> u64 {
             Err(_) => continue,
         };
 
-        bytes += meta.blocks() * 512;
+        bytes += meta.size();
 
         if meta.is_dir() {
             if let Ok(subdir) = std::fs::File::open(entry.path()) {


### PR DESCRIPTION
If the source filesystem is compressed and the created image is not, total disk size of input files will not necessarily match image space requirements, ultimately leading to a failure to create an image with `freelist_empty`. Use total logical size of input files (`meta.size()`) instead of on-disk size (`meta.blocks()`) to estimate image size.