### PR TITLE
debian/control: add linux-headers virtual package fallback (fixes #540)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -64,7 +64,8 @@ Depends: ${misc:Depends},
 	 proxmox-headers-6.17 [amd64] |
 	 linux-headers-amd64 (>= 6.16) [amd64] | linux-headers-cloud-amd64 (>= 6.16) [amd64] | linux-headers-rt-amd64 (>= 6.16) [amd64] |
 	 linux-headers-arm64 (>= 6.16) [arm64] | linux-headers-cloud-arm64 (>= 6.16) [arm64] | linux-headers-rt-arm64 (>= 6.16) [arm64] |
-	 linux-headers-ppc64el (>= 6.16) [ppc64el] | linux-headers-cloud-ppc64el (>= 6.16) [ppc64el] | linux-headers-rt-ppc64el (>= 6.16) [ppc64el]
+	 linux-headers-ppc64el (>= 6.16) [ppc64el] | linux-headers-cloud-ppc64el (>= 6.16) [ppc64el] | linux-headers-rt-ppc64el (>= 6.16) [ppc64el] |
+	 linux-headers (>= 6.16)
 Pre-Depends: bcachefs-tools (= ${binary:Version}),
 Provides: bcachefs-kernel
 Description: bcachefs kernel module DKMS source


### PR DESCRIPTION
## Summary

`bcachefs-kernel-dkms` cannot be installed on systems running third-party kernel packages (e.g. Armbian) because its `Depends` field hardcodes specific Debian/Ubuntu meta-package names without a fallback to the standard virtual package `linux-headers`.

Current Depends alternatives:
- `linux-headers-generic`, `linux-headers-amd64`, `linux-headers-arm64`, `linux-headers-ppc64el` and their `-cloud-`/`-rt-` variants
- `proxmox-headers-6.17`

Third-party kernel header packages (Armbian, Raspberry Pi OS, etc.) correctly provide the virtual package `linux-headers` (as is standard practice), but none of the concrete Debian/Ubuntu meta-package names listed above.

## Fix

Add `linux-headers (>= 6.16)` as the last alternative in the dependency chain — the standard escape hatch for non-Debian kernels.

## Precedent

- **`dkms` itself** ends its `Recommends` chain with `| linux-headers` as fallback:
  ```
  Recommends: …, linux-headers-generic | linux-headers-686-pae | linux-headers-amd64 | linux-headers
  ```
- **Other DKMS packages** (`zfs-dkms`, `v4l2loopback-dkms`, `bbswitch-dkms`, `lime-forensics-dkms`) do not depend on `linux-headers` at all, relying on `dkms` Recommends.
- **Debian Policy Manual §7.5**: virtual packages exist precisely so that dependencies do not hardcode concrete package names when multiple providers are possible.

## Environment tested

- Armbian 26.05.0-trunk, kernel 7.0.0-rc4-edge-rockchip64 (arm64)
- `linux-headers-edge-rockchip64` provides: `linux-headers, linux-headers-armbian, armbian-edge`
- `bcachefs-kernel-dkms` 1:1.37.2