### PR TITLE
Record device serial number in superblock

### DIFF
--- a/bch_bindgen/build.rs
+++ b/bch_bindgen/build.rs
@@ -389,6 +389,7 @@ fn main() {
         .allowlist_function("read_file_u64")
         .allowlist_function("get_size")
         .allowlist_function("fd_to_dev_model")
+        .allowlist_function("fd_to_dev_serial")
         .allowlist_function("copy_fs")
         .allowlist_function("rust_.*")
         .allowlist_function("bch2_dev_resize")

--- a/c_src/tools-util.c
+++ b/c_src/tools-util.c
@@ -411,3 +411,36 @@ got_model:
 		return strdup("(image file)");
 	}
 }
+
+char *fd_to_dev_serial(int fd)
+{
+	struct stat stat = xfstat(fd);
+
+	if (S_ISBLK(stat.st_mode)) {
+		char *sysfs_path = dev_to_sysfs_path(stat.st_rdev);
+
+		char *serial_path = mprintf("%s/device/serial", sysfs_path);
+		if (!access(serial_path, R_OK))
+			goto got_serial;
+		free(serial_path);
+
+		/* partition? try parent */
+
+		serial_path = mprintf("%s/../device/serial", sysfs_path);
+		if (!access(serial_path, R_OK))
+			goto got_serial;
+		free(serial_path);
+
+		free(sysfs_path);
+		return NULL;
+got_serial:
+		{
+			char *serial = read_file_str(AT_FDCWD, serial_path);
+			free(serial_path);
+			free(sysfs_path);
+			return serial;
+		}
+	} else {
+		return NULL;
+	}
+}

--- a/c_src/tools-util.h
+++ b/c_src/tools-util.h
@@ -81,5 +81,6 @@ bool ask_yn(void);
 u32 crc32c(u32, const void *, size_t);
 
 char *fd_to_dev_model(int);
+char *fd_to_dev_serial(int);
 
 #endif /* _TOOLS_UTIL_H */

--- a/libbcachefs/init/dev.c
+++ b/libbcachefs/init/dev.c
@@ -686,6 +686,17 @@ static int __bch2_dev_attach_bdev(struct bch_fs *c, struct bch_dev *ca,
 	if (model.nr && model.data[model.nr - 1] == '\n')
 		model.data[--model.nr] = '\0';
 
+	CLASS(darray_char, serial)();
+	darray_make_room(&serial, 128);
+
+	CLASS(printbuf, serial_path)();
+	prt_printf(&serial_path, "/sys/block/%s/device/serial", name.buf);
+
+	read_file_str(serial_path.buf, &serial);
+
+	if (serial.nr && serial.data[serial.nr - 1] == '\n')
+		serial.data[--serial.nr] = '\0';
+
 	scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
 		guard(mutex)(&c->sb_lock);
 		struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
@@ -694,6 +705,9 @@ static int __bch2_dev_attach_bdev(struct bch_fs *c, struct bch_dev *ca,
 
 		if (model.nr)
 			strtomem_pad(m->device_model, model.data, '\0');
+
+		if (serial.nr)
+			strtomem_pad(m->device_serial, serial.data, '\0');
 	}
 
 	/* Commit: */

--- a/libbcachefs/sb/members.c
+++ b/libbcachefs/sb/members.c
@@ -291,6 +291,7 @@ void bch2_member_to_text(struct printbuf *out,
 
 	prt_printf(out, "Last device name:\t%.*s\n", (int) sizeof(m->device_name), m->device_name);
 	prt_printf(out, "Last device model:\t%.*s\n", (int) sizeof(m->device_model), m->device_model);
+	prt_printf(out, "Last device serial:\t%.*s\n", (int) sizeof(m->device_serial), m->device_serial);
 
 	if (m->flush_errors)
 		prt_printf(out, "Flush errors:\t%llu\n", le64_to_cpu(m->flush_errors));
@@ -314,6 +315,7 @@ static void bch2_member_to_text_short_sb(struct printbuf *out,
 
 	prt_printf(out, "Device:\t%.*s\n", (int) sizeof(m->device_name), m->device_name);
 	prt_printf(out, "Model:\t%.*s\n", (int) sizeof(m->device_model), m->device_model);
+	prt_printf(out, "Serial:\t%.*s\n", (int) sizeof(m->device_serial), m->device_serial);
 
 	prt_printf(out, "State:\t%s\n",
 		   BCH_MEMBER_STATE(m) < BCH_MEMBER_STATE_NR

--- a/libbcachefs/sb/members_format.h
+++ b/libbcachefs/sb/members_format.h
@@ -75,6 +75,7 @@ struct bch_member {
 	__u8			device_name[16] __nonstring;
 	__u8			device_model[64] __nonstring;
 	__le64			flush_errors;
+	__u8			device_serial[64] __nonstring;
 };
 
 /*

--- a/src/wrappers/sb_display.rs
+++ b/src/wrappers/sb_display.rs
@@ -99,8 +99,15 @@ unsafe fn print_one_member(
         let model = c::fd_to_dev_model(sb_handle.bdev().bd_fd);
         if !model.is_null() {
             let model_str = CStr::from_ptr(model).to_string_lossy();
-            write!(out, "{}", model_str).unwrap();
+            write!(out, "{}\t", model_str).unwrap();
             libc::free(model as *mut _);
+        }
+
+        let serial = c::fd_to_dev_serial(sb_handle.bdev().bd_fd);
+        if !serial.is_null() {
+            let serial_str = CStr::from_ptr(serial).to_string_lossy();
+            write!(out, "S/N: {}", serial_str).unwrap();
+            libc::free(serial as *mut _);
         }
     }
     out.newline();


### PR DESCRIPTION
Add device_serial[64] field to bch_member, populated from /sys/block/{name}/device/serial at device attach time. Adds fd_to_dev_serial() for live serial lookup and displays serial in show-super output.

Co-authored by Claude, verified and tested by me.

----

I am not sure what the best way to handle the libbcachefs embed is; I've duplicated it because I did that for testing, but I can remove it if you want. Kernel code PR is at https://github.com/koverstreet/bcachefs/pull/1086 .