### PR TITLE
Use more similar parameters as systemd-cryptsetup for systemd-ask-password

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "paste",
  "pkg-config",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]

--- a/bch_bindgen/Cargo.toml
+++ b/bch_bindgen/Cargo.toml
@@ -17,6 +17,7 @@ bitflags = "1.3.2"
 fiemap = "0.2"
 libc = "0.2"
 paste = "1.0.11"
+zeroize = "1"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/bch_bindgen/build.rs
+++ b/bch_bindgen/build.rs
@@ -444,6 +444,8 @@ fn main() {
         .no_copy("btree_trans")
         .no_copy("printbuf")
         .no_copy("bch_sb_handle")
+        .no_copy("bch_key")
+        .no_copy("bch_encrypted_key")
         .no_partialeq("bkey")
         .no_partialeq("bpos")
         .generate_inline_functions(true)

--- a/bch_bindgen/src/bcachefs.rs
+++ b/bch_bindgen/src/bcachefs.rs
@@ -9,11 +9,14 @@
 #![allow(unused)]
 #![allow(unnecessary_transmutes)]
 
+use std::{ptr, sync::atomic};
+
 use crate::c;
 
 include!(concat!(env!("OUT_DIR"), "/bcachefs.rs"));
 
 use bitfield::bitfield;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 bitfield! {
     pub struct bch_scrypt_flags(u64);
     pub N, _: 15, 0;
@@ -164,3 +167,60 @@ impl bch_opt_strs {
 // #[repr(u8)]
 pub enum rhash_lock_head {}
 pub enum srcu_struct {}
+
+impl Clone for bch_key {
+    fn clone(&self) -> Self {
+        Self { key: self.key }
+    }
+}
+
+impl Zeroize for bch_key {
+    fn zeroize(&mut self) {
+        self.key.zeroize();
+    }
+}
+
+impl Drop for bch_key {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for bch_key {}
+
+impl bch_encrypted_key {
+    pub const MAGIC: &[u8; 8] = b"bch**key";
+
+    /// Create an unencrypted (plaintext) key for the crypt field (remove-passphrase).
+    pub fn new_unencrypted(key: bch_key) -> Self {
+        Self {
+            magic: u64::from_le_bytes(*Self::MAGIC),
+            key,
+        }
+    }
+
+    pub fn is_encrypted(&self) -> bool {
+        self.magic != u64::from_le_bytes(*Self::MAGIC)
+    }
+
+    pub fn into_key(self) -> bch_key {
+        self.key.clone()
+    }
+}
+
+impl Clone for bch_encrypted_key {
+    fn clone(&self) -> Self {
+        Self {
+            magic: self.magic,
+            key:   self.key.clone(),
+        }
+    }
+}
+
+impl Zeroize for bch_encrypted_key {
+    fn zeroize(&mut self) {
+        self.key.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for bch_encrypted_key {}

--- a/bch_bindgen/src/bcachefs.rs
+++ b/bch_bindgen/src/bcachefs.rs
@@ -63,6 +63,15 @@ impl bch_sb {
         uuid::Uuid::from_bytes(self.user_uuid.b)
     }
 
+    pub fn label(&self) -> &[u8] {
+        let len = self
+            .label
+            .iter()
+            .position(|b| *b == b'\0')
+            .unwrap_or(self.label.len());
+        &self.label[..len]
+    }
+
     pub fn number_of_devices(&self) -> u32 {
         unsafe { c::bch2_sb_nr_devices(self) }
     }

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -391,9 +391,9 @@ fn cmd_format(argv: Vec<String>) -> Result<()> {
     // Handle encryption
     let passphrase: Option<Passphrase> = if cfg.encrypted && !cfg.no_passphrase {
         let p = if let Some(ref path) = cfg.passphrase_file {
-            Passphrase::new_from_file(path)?
+            Passphrase::read_from_file(path)?
         } else {
-            Passphrase::new_from_prompt_twice()?
+            Passphrase::ask_for_new_passphrase()?
         };
         cfg.initialize = false;
         Some(p)

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -926,9 +926,9 @@ fn cmd_image_create(argv: Vec<String>) -> Result<()> {
 
     let passphrase: Option<Passphrase> = if encrypted && !no_passphrase {
         Some(if let Some(ref path) = passphrase_file {
-            Passphrase::new_from_file(path)?
+            Passphrase::read_from_file(path)?
         } else {
-            Passphrase::new_from_prompt_twice()?
+            Passphrase::ask_for_new_passphrase()?
         })
     } else {
         None

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -63,7 +63,7 @@ fn cmd_unlock(cli: UnlockCli) -> Result<()> {
     // Retry up to 2 more times, always interactive
     for _ in 0..2 {
         eprintln!("incorrect passphrase");
-        let passphrase = Passphrase::new_from_prompt(&uuid, true)?;
+        let passphrase = Passphrase::new_from_prompt(&uuid, false)?;
         if let Some(correct) = passphrase.check(&sb)? {
             KeyHandle::new(&correct, cli.keyring)?;
             return Ok(());

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -46,31 +46,10 @@ fn cmd_unlock(cli: UnlockCli) -> Result<()> {
         return Ok(());
     }
 
-    let uuid = sb.sb().uuid();
+    let correct = CorrectPassphrase::new(&sb, cli.file.as_deref())?;
 
-    // First attempt
-    let passphrase = if let Some(ref file) = cli.file {
-        Passphrase::new_from_file(file)?
-    } else {
-        Passphrase::new(&uuid)?
-    };
-
-    if let Some(correct) = passphrase.check(&sb)? {
-        KeyHandle::new(&correct, cli.keyring)?;
-        return Ok(());
-    }
-
-    // Retry up to 2 more times, always interactive
-    for _ in 0..2 {
-        eprintln!("incorrect passphrase");
-        let passphrase = Passphrase::new_from_prompt(&uuid, false)?;
-        if let Some(correct) = passphrase.check(&sb)? {
-            KeyHandle::new(&correct, cli.keyring)?;
-            return Ok(());
-        }
-    }
-
-    bail!("incorrect passphrase limit reached");
+    KeyHandle::new(&correct, cli.keyring)?;
+    Ok(())
 }
 
 // ---- shared helpers for set/remove-passphrase ----

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -8,7 +8,9 @@ use bch_bindgen::opt_set;
 use bch_bindgen::sb::io as sb_io;
 use clap::Parser;
 
-use crate::key::{sb_is_encrypted, unencrypted_key, KeyHandle, Keyring, Passphrase};
+use crate::key::{
+    sb_is_encrypted, unencrypted_key, CorrectPassphrase, KeyHandle, Keyring, Passphrase,
+};
 
 // ---- unlock ----
 
@@ -53,20 +55,18 @@ fn cmd_unlock(cli: UnlockCli) -> Result<()> {
         Passphrase::new(&uuid)?
     };
 
-    match KeyHandle::new(&sb, &passphrase, cli.keyring) {
-        Ok(_) => return Ok(()),
-        Err(e) if e.to_string().contains("incorrect passphrase") => {}
-        Err(e) => return Err(e),
+    if let Some(correct) = passphrase.check(&sb)? {
+        KeyHandle::new(&correct, cli.keyring)?;
+        return Ok(());
     }
 
     // Retry up to 2 more times, always interactive
     for _ in 0..2 {
         eprintln!("incorrect passphrase");
         let passphrase = Passphrase::new_from_prompt(&uuid)?;
-        match KeyHandle::new(&sb, &passphrase, cli.keyring) {
-            Ok(_) => return Ok(()),
-            Err(e) if e.to_string().contains("incorrect passphrase") => continue,
-            Err(e) => return Err(e),
+        if let Some(correct) = passphrase.check(&sb)? {
+            KeyHandle::new(&correct, cli.keyring)?;
+            return Ok(());
         }
     }
 
@@ -106,9 +106,10 @@ fn open_and_verify(devs: &[PathBuf]) -> Result<(Fs, bch_key)> {
 
     if sb_is_encrypted(sb_handle) {
         let uuid = sb_handle.sb().uuid();
-        let old_passphrase = Passphrase::new_from_prompt(&uuid)
-            .context("reading current passphrase")?;
-        let (_, sb_key) = old_passphrase.check(sb_handle)
+        let old_passphrase =
+            Passphrase::new_from_prompt(&uuid).context("reading current passphrase")?;
+        let CorrectPassphrase { sb_key, .. } = old_passphrase
+            .check(sb_handle)?
             .context("verifying current passphrase")?;
         Ok((fs, sb_key.key))
     } else {

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -107,7 +107,7 @@ fn open_and_verify(devs: &[PathBuf]) -> Result<(Fs, bch_key)> {
     if sb_is_encrypted(sb_handle) {
         let uuid = sb_handle.sb().uuid();
         let old_passphrase =
-            Passphrase::new_from_prompt(&uuid, true).context("reading current passphrase")?;
+            Passphrase::new_from_prompt(&uuid, false).context("reading current passphrase")?;
         let CorrectPassphrase { sb_key, .. } = old_passphrase
             .check(sb_handle)?
             .context("verifying current passphrase")?;

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -85,8 +85,11 @@ fn open_and_verify(devs: &[PathBuf]) -> Result<(Fs, bch_key)> {
 
     if sb_is_encrypted(sb_handle) {
         let uuid = sb_handle.sb().uuid();
-        let old_passphrase =
-            Passphrase::new_from_prompt(&uuid, false).context("reading current passphrase")?;
+        let old_passphrase = Passphrase::new_from_prompt(&uuid, false)
+            .context("reading current passphrase")?
+            .into_iter()
+            .next()
+            .expect("Passphase::new_from_prompt should always return at least one passphrase");
         let CorrectPassphrase { sb_key, .. } = old_passphrase
             .check(sb_handle)?
             .context("verifying current passphrase")?;

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -63,7 +63,7 @@ fn cmd_unlock(cli: UnlockCli) -> Result<()> {
     // Retry up to 2 more times, always interactive
     for _ in 0..2 {
         eprintln!("incorrect passphrase");
-        let passphrase = Passphrase::new_from_prompt(&uuid)?;
+        let passphrase = Passphrase::new_from_prompt(&uuid, true)?;
         if let Some(correct) = passphrase.check(&sb)? {
             KeyHandle::new(&correct, cli.keyring)?;
             return Ok(());
@@ -107,7 +107,7 @@ fn open_and_verify(devs: &[PathBuf]) -> Result<(Fs, bch_key)> {
     if sb_is_encrypted(sb_handle) {
         let uuid = sb_handle.sb().uuid();
         let old_passphrase =
-            Passphrase::new_from_prompt(&uuid).context("reading current passphrase")?;
+            Passphrase::new_from_prompt(&uuid, true).context("reading current passphrase")?;
         let CorrectPassphrase { sb_key, .. } = old_passphrase
             .check(sb_handle)?
             .context("verifying current passphrase")?;

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -86,14 +86,9 @@ fn open_and_verify(devs: &[PathBuf]) -> Result<(Fs, bch_key)> {
     }
 
     if sb_is_encrypted(sb_handle) {
-        let uuid = sb_handle.sb().uuid();
-        let old_passphrase =
-            Passphrase::new_from_prompt(&uuid).context("reading current passphrase")?;
         let PassphraseCorrect {
             cleartext_sb_key, ..
-        } = old_passphrase
-            .check(sb_handle)
-            .context("verifying current passphrase")?;
+        } = Passphrase::ask_and_check(&sb_handle)?;
         Ok((fs, cleartext_sb_key.into_key()))
     } else {
         let raw_key = sb_handle.sb().crypt().unwrap().key().key.clone();

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -1,14 +1,14 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
-use bch_bindgen::bcachefs::bch_key;
+use bch_bindgen::bcachefs::{bch_key, bch_encrypted_key};
 use bch_bindgen::c;
 use bch_bindgen::fs::Fs;
 use bch_bindgen::opt_set;
 use bch_bindgen::sb::io as sb_io;
 use clap::Parser;
 
-use crate::key::{sb_is_encrypted, unencrypted_key, KeyHandle, Keyring, Passphrase};
+use crate::key::{sb_is_encrypted, KeyHandle, Keyring, Passphrase};
 
 // ---- unlock ----
 
@@ -110,9 +110,9 @@ fn open_and_verify(devs: &[PathBuf]) -> Result<(Fs, bch_key)> {
             .context("reading current passphrase")?;
         let (_, sb_key) = old_passphrase.check(sb_handle)
             .context("verifying current passphrase")?;
-        Ok((fs, sb_key.key))
+        Ok((fs, sb_key.into_key()))
     } else {
-        let raw_key = sb_handle.sb().crypt().unwrap().key().key;
+        let raw_key = sb_handle.sb().crypt().unwrap().key().key.clone();
         Ok((fs, raw_key))
     }
 }
@@ -144,7 +144,7 @@ fn cmd_set_passphrase(cli: SetPassphraseCli) -> Result<()> {
     let new_passphrase = Passphrase::new_from_prompt_twice()
         .context("reading new passphrase")?;
 
-    let encrypted_key = new_passphrase.encrypt_key(fs.sb_handle(), &raw_key);
+    let encrypted_key = new_passphrase.encrypt_key(fs.sb_handle(), raw_key);
 
     unsafe {
         set_crypt_key(&fs, encrypted_key);
@@ -168,7 +168,7 @@ pub struct RemovePassphraseCli {
 fn cmd_remove_passphrase(cli: RemovePassphraseCli) -> Result<()> {
     let (fs, raw_key) = open_and_verify(&parse_device_list(&cli.devices))?;
 
-    unsafe { set_crypt_key(&fs, unencrypted_key(&raw_key)); }
+    unsafe { set_crypt_key(&fs, bch_encrypted_key::new_unencrypted(raw_key)); }
     fs.write_super();
 
     Ok(())

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -44,33 +44,16 @@ fn cmd_unlock(cli: UnlockCli) -> Result<()> {
         return Ok(());
     }
 
-    let uuid = sb.sb().uuid();
-
-    // First attempt
     let passphrase = if let Some(ref file) = cli.file {
         Passphrase::new_from_file(file)?
     } else {
+        let uuid = sb.sb().uuid();
         Passphrase::new(&uuid)?
     };
 
-    match KeyHandle::new(&sb, &passphrase, cli.keyring) {
-        Ok(_) => return Ok(()),
-        Err(e) if e.to_string().contains("incorrect passphrase") => {}
-        Err(e) => return Err(e),
-    }
+    KeyHandle::new(&sb, &passphrase, cli.keyring)?;
 
-    // Retry up to 2 more times, always interactive
-    for _ in 0..2 {
-        eprintln!("incorrect passphrase");
-        let passphrase = Passphrase::new_from_prompt(&uuid)?;
-        match KeyHandle::new(&sb, &passphrase, cli.keyring) {
-            Ok(_) => return Ok(()),
-            Err(e) if e.to_string().contains("incorrect passphrase") => continue,
-            Err(e) => return Err(e),
-        }
-    }
-
-    bail!("incorrect passphrase limit reached");
+    Ok(())
 }
 
 // ---- shared helpers for set/remove-passphrase ----

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -43,16 +43,12 @@ fn cmd_unlock(cli: UnlockCli) -> Result<()> {
         return Ok(());
     }
 
-    let passphrase = if let Some(ref file) = cli.file {
-        Passphrase::new_from_file(file)?
-    } else {
-        let uuid = sb.sb().uuid();
-        Passphrase::new(&uuid)?
+    let passphrase_correct = match cli.file {
+        Some(file) => Passphrase::new_from_file(file)?
+            .check(&sb)
+            .ok_or_else(|| anyhow!("incorrect passphrase"))?,
+        None => Passphrase::ask_and_check(&sb)?,
     };
-
-    let passphrase_correct = passphrase
-        .check(&sb)
-        .ok_or_else(|| anyhow!("incorrect passphrase"))?;
     KeyHandle::new(&passphrase_correct, cli.keyring)?;
 
     Ok(())

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -44,7 +44,7 @@ fn cmd_unlock(cli: UnlockCli) -> Result<()> {
     }
 
     let passphrase_correct = match cli.file {
-        Some(file) => Passphrase::new_from_file(file)?
+        Some(file) => Passphrase::read_from_file(file)?
             .check(&sb)
             .ok_or_else(|| anyhow!("incorrect passphrase"))?,
         None => Passphrase::ask_and_check(&sb)?,
@@ -120,7 +120,7 @@ pub struct SetPassphraseCli {
 fn cmd_set_passphrase(cli: SetPassphraseCli) -> Result<()> {
     let (fs, raw_key) = open_and_verify(&parse_device_list(&cli.devices))?;
 
-    let new_passphrase = Passphrase::new_from_prompt_twice()
+    let new_passphrase = Passphrase::ask_for_new_passphrase()
         .context("reading new passphrase")?;
 
     let encrypted_key = new_passphrase.encrypt_key(fs.sb_handle(), raw_key);

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use bch_bindgen::bcachefs::{bch_key, bch_encrypted_key};
 use bch_bindgen::c;
 use bch_bindgen::fs::Fs;
@@ -8,7 +8,7 @@ use bch_bindgen::opt_set;
 use bch_bindgen::sb::io as sb_io;
 use clap::Parser;
 
-use crate::key::{sb_is_encrypted, KeyHandle, Keyring, Passphrase};
+use crate::key::{sb_is_encrypted, KeyHandle, Keyring, Passphrase, PassphraseCorrect};
 
 // ---- unlock ----
 
@@ -32,7 +32,6 @@ pub struct UnlockCli {
 }
 
 fn cmd_unlock(cli: UnlockCli) -> Result<()> {
-
     let sb = sb_io::read_super(Path::new(&cli.device))
         .with_context(|| format!("Error opening {}", cli.device))?;
 
@@ -51,7 +50,10 @@ fn cmd_unlock(cli: UnlockCli) -> Result<()> {
         Passphrase::new(&uuid)?
     };
 
-    KeyHandle::new(&sb, &passphrase, cli.keyring)?;
+    let passphrase_correct = passphrase
+        .check(&sb)
+        .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+    KeyHandle::new(&passphrase_correct, cli.keyring)?;
 
     Ok(())
 }
@@ -89,11 +91,14 @@ fn open_and_verify(devs: &[PathBuf]) -> Result<(Fs, bch_key)> {
 
     if sb_is_encrypted(sb_handle) {
         let uuid = sb_handle.sb().uuid();
-        let old_passphrase = Passphrase::new_from_prompt(&uuid)
-            .context("reading current passphrase")?;
-        let (_, sb_key) = old_passphrase.check(sb_handle)
+        let old_passphrase =
+            Passphrase::new_from_prompt(&uuid).context("reading current passphrase")?;
+        let PassphraseCorrect {
+            cleartext_sb_key, ..
+        } = old_passphrase
+            .check(sb_handle)
             .context("verifying current passphrase")?;
-        Ok((fs, sb_key.into_key()))
+        Ok((fs, cleartext_sb_key.into_key()))
     } else {
         let raw_key = sb_handle.sb().crypt().unwrap().key().key.clone();
         Ok((fs, raw_key))

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -669,7 +669,7 @@ fn cmd_migrate(argv: Vec<String>) -> Result<()> {
 
     // Handle encryption passphrase
     let passphrase: Option<Passphrase> = if encrypted && !no_passphrase {
-        Some(Passphrase::new_from_prompt_twice()?)
+        Some(Passphrase::ask_for_new_passphrase()?)
     } else {
         None
     };

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -6,11 +6,11 @@ use std::{
     ptr, str,
 };
 
+use crate::{device_scan, key::CorrectPassphrase};
 use anyhow::{anyhow, ensure, Result};
 use bch_bindgen::{bcachefs, bcachefs::bch_sb_handle, path_to_cstr};
 use clap::Parser;
 use log::{debug, error, info};
-use crate::device_scan;
 
 use crate::{
     key::{KeyHandle, Keyring, Passphrase, UnlockPolicy},
@@ -143,9 +143,7 @@ fn handle_unlock(cli: &Cli, sb: &bch_sb_handle) -> Result<KeyHandle> {
         return Ok(handle);
     }
 
-    let correct = Passphrase::new(&uuid)?
-        .check(sb)?
-        .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+    let correct = CorrectPassphrase::new(sb, None)?;
     KeyHandle::new(&correct, Keyring::User)
 }
 

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -6,7 +6,7 @@ use std::{
     ptr, str,
 };
 
-use anyhow::{ensure, Result};
+use anyhow::{anyhow, ensure, Result};
 use bch_bindgen::{bcachefs, bcachefs::bch_sb_handle, path_to_cstr};
 use clap::Parser;
 use log::{debug, error, info};
@@ -132,12 +132,21 @@ fn handle_unlock(cli: &Cli, sb: &bch_sb_handle) -> Result<KeyHandle> {
     }
 
     if let Some(path) = cli.passphrase_file.as_deref() {
-        return Passphrase::new_from_file(path).and_then(|p| KeyHandle::new(sb, &p, Keyring::User));
+        let correct = Passphrase::new_from_file(path)?
+            .check(sb)?
+            .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+        return KeyHandle::new(&correct, Keyring::User);
     }
 
     let uuid = sb.sb().uuid();
-    KeyHandle::new_from_search(&uuid)
-        .or_else(|_| Passphrase::new(&uuid).and_then(|p| KeyHandle::new(sb, &p, Keyring::User)))
+    if let Ok(handle) = KeyHandle::new_from_search(&uuid) {
+        return Ok(handle);
+    }
+
+    let correct = Passphrase::new(&uuid)?
+        .check(sb)?
+        .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+    KeyHandle::new(&correct, Keyring::User)
 }
 
 fn cmd_mount_inner(cli: &Cli) -> Result<()> {

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -6,7 +6,7 @@ use std::{
     ptr, str,
 };
 
-use anyhow::{ensure, Result};
+use anyhow::{anyhow, ensure, Result};
 use bch_bindgen::{bcachefs, bcachefs::bch_sb_handle, path_to_cstr};
 use clap::Parser;
 use log::{debug, error, info};
@@ -132,12 +132,23 @@ fn handle_unlock(cli: &Cli, sb: &bch_sb_handle) -> Result<KeyHandle> {
     }
 
     if let Some(path) = cli.passphrase_file.as_deref() {
-        return Passphrase::new_from_file(path).and_then(|p| KeyHandle::new(sb, &p, Keyring::User));
+        let passphrase = Passphrase::new_from_file(path)?;
+        let passphrase_correct = passphrase
+            .check(sb)
+            .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+        return KeyHandle::new(&passphrase_correct, Keyring::User);
     }
 
     let uuid = sb.sb().uuid();
-    KeyHandle::new_from_search(&uuid)
-        .or_else(|_| Passphrase::new(&uuid).and_then(|p| KeyHandle::new(sb, &p, Keyring::User)))
+    if let Ok(handle) = KeyHandle::new_from_search(&uuid) {
+        return Ok(handle);
+    }
+
+    let passphrase = Passphrase::new(&uuid)?;
+    let passphrase_correct = passphrase
+        .check(sb)
+        .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+    KeyHandle::new(&passphrase_correct, Keyring::User)
 }
 
 fn cmd_mount_inner(cli: &Cli) -> Result<()> {

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -132,7 +132,7 @@ fn handle_unlock(cli: &Cli, sb: &bch_sb_handle) -> Result<KeyHandle> {
     }
 
     if let Some(path) = cli.passphrase_file.as_deref() {
-        let passphrase = Passphrase::new_from_file(path)?;
+        let passphrase = Passphrase::read_from_file(path)?;
         let passphrase_correct = passphrase
             .check(sb)
             .ok_or_else(|| anyhow!("incorrect passphrase"))?;

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -144,10 +144,7 @@ fn handle_unlock(cli: &Cli, sb: &bch_sb_handle) -> Result<KeyHandle> {
         return Ok(handle);
     }
 
-    let passphrase = Passphrase::new(&uuid)?;
-    let passphrase_correct = passphrase
-        .check(sb)
-        .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+    let passphrase_correct = Passphrase::ask_and_check(sb)?;
     KeyHandle::new(&passphrase_correct, Keyring::User)
 }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -87,6 +87,9 @@ impl UnlockPolicy {
             Self::Wait => Ok(KeyHandle::wait_for_unlock(&uuid)?),
             Self::Ask => {
                 let correct = Passphrase::new_from_prompt(&uuid, false)?
+                    .into_iter()
+                    .next()
+                    .expect("Passphase::new_from_prompt should always return at least one passphrase")
                     .check(sb)?
                     .ok_or_else(|| anyhow!("incorrect passphrase"))?;
                 KeyHandle::new(&correct, Keyring::User)
@@ -193,13 +196,16 @@ impl CorrectPassphrase {
 
         for i in 0..3 {
             let accept_cached = i == 0;
-            let passphrase = match stdin_type {
+            let passphrases = match stdin_type {
                 StdinType::Terminal => Passphrase::new_from_prompt(&uuid, accept_cached)?,
                 StdinType::DevNull => Passphrase::new_from_askpassword(&uuid, accept_cached)??,
                 StdinType::Other => unreachable!(),
             };
-            if let Some(correct) = passphrase.check(sb)? {
-                return Ok(correct);
+            if let Some(correct) = passphrases
+                .into_iter()
+                .find_map(|p| p.check(sb).transpose())
+            {
+                return correct;
             }
         }
 
@@ -219,26 +225,29 @@ impl Passphrase {
     // it is non-critical and will cause the password to be asked internally.
     // The inner result represent a successful request that returned an error
     // this one results in an error.
-    fn new_from_askpassword(uuid: &Uuid, accept_cached: bool) -> Result<Result<Self>> {
+    fn new_from_askpassword(uuid: &Uuid, accept_cached: bool) -> Result<Result<Vec<Self>>> {
         let mut command = Command::new("systemd-ask-password");
         command
             .arg("--icon=drive-harddisk")
-            .arg(format!("--id=bcachefs:{}", uuid.as_hyphenated()))
-            .arg(format!("--keyname={}", uuid.as_hyphenated()))
+            .arg(format!("--id=cryptsetup:UUID={uuid}"))
+            .arg("--keyname=cryptsetup")
+            .arg("--credential=cryptsetup.passphrase")
+            .arg("--timeout=0")
             .arg("-n");
         if accept_cached {
             command.arg("--accept-cached");
         }
         let output = command
-            .arg("Enter passphrase: ")
+            .arg("Please enter passphrase for disk:")
             .stdin(Stdio::inherit())
             .stderr(Stdio::inherit())
             .output()?;
         Ok(if output.status.success() {
-            match CString::new(output.stdout) {
-                Ok(cstr) => Ok(Self(cstr)),
-                Err(e) => Err(e.into()),
-            }
+            Ok(output
+                .stdout
+                .split(|b| *b == b'\0')
+                .map(|passphrase| Self(CString::new(passphrase).expect("passphase should not contain a NUL byte because the output was split on NUL bytes")))
+                .collect())
         } else {
             Err(anyhow!("systemd-ask-password returned an error"))
         })
@@ -263,12 +272,13 @@ impl Passphrase {
     }
 
     // blocks indefinitely if no input is available on stdin
-    pub fn new_from_prompt(uuid: &Uuid, accept_cached: bool) -> Result<Self> {
+    pub fn new_from_prompt(uuid: &Uuid, accept_cached: bool) -> Result<Vec<Self>> {
         match Self::new_from_askpassword(uuid, accept_cached) {
             Ok(phrase) => return phrase,
             Err(_) => debug!("Failed to start systemd-ask-password, doing the prompt ourselves"),
         }
-        Self::prompt_hidden("Enter passphrase: ")
+        let phrase = Self::prompt_hidden("Enter passphrase: ")?;
+        Ok(vec![phrase])
     }
 
     /// Prompt for a new passphrase twice and verify they match.

--- a/src/key.rs
+++ b/src/key.rs
@@ -86,7 +86,7 @@ impl UnlockPolicy {
             Self::Fail => KeyHandle::new_from_search(&uuid),
             Self::Wait => Ok(KeyHandle::wait_for_unlock(&uuid)?),
             Self::Ask => {
-                let correct = Passphrase::new_from_prompt(&uuid, true)?
+                let correct = Passphrase::new_from_prompt(&uuid, false)?
                     .check(sb)?
                     .ok_or_else(|| anyhow!("incorrect passphrase"))?;
                 KeyHandle::new(&correct, Keyring::User)

--- a/src/key.rs
+++ b/src/key.rs
@@ -85,12 +85,21 @@ impl UnlockPolicy {
         match self {
             Self::Fail => KeyHandle::new_from_search(&uuid),
             Self::Wait => Ok(KeyHandle::wait_for_unlock(&uuid)?),
-            Self::Ask => Passphrase::new_from_prompt(&uuid).and_then(|p| KeyHandle::new(sb, &p, Keyring::User)),
-            Self::Stdin => Passphrase::new_from_stdin().and_then(|p| KeyHandle::new(sb, &p, Keyring::User)),
+            Self::Ask => {
+                let correct = Passphrase::new_from_prompt(&uuid)?
+                    .check(sb)?
+                    .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+                KeyHandle::new(&correct, Keyring::User)
+            }
+            Self::Stdin => {
+                let correct = Passphrase::new_from_stdin()?
+                    .check(sb)?
+                    .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+                KeyHandle::new(&correct, Keyring::User)
+            }
         }
     }
 }
-
 
 /// Proof that a bcachefs key has been added to or found in the kernel keyring.
 pub struct KeyHandle;
@@ -100,19 +109,17 @@ impl KeyHandle {
         CString::new(format!("bcachefs:{uuid}")).unwrap()
     }
 
-    pub fn new(sb: &bch_sb_handle, passphrase: &Passphrase, keyring: Keyring) -> Result<Self> {
-        let key_name = Self::format_key_name(&sb.sb().uuid());
+    pub fn new(correct_passphrase: &CorrectPassphrase, keyring: Keyring) -> Result<Self> {
+        let key_name = Self::format_key_name(&correct_passphrase.uuid);
         let key_name = CStr::as_ptr(&key_name);
         let key_type = c"user";
-
-        let (passphrase_key, _sb_key) = passphrase.check(sb)?;
 
         let key_id = unsafe {
             keyutils::add_key(
                 key_type.as_ptr(),
                 key_name,
-                ptr::addr_of!(passphrase_key).cast(),
-                mem::size_of_val(&passphrase_key),
+                ptr::addr_of!(correct_passphrase.passphrase_key).cast(),
+                mem::size_of_val(&correct_passphrase.passphrase_key),
                 keyring.id(),
             )
         };
@@ -156,6 +163,12 @@ impl KeyHandle {
             }
         }
     }
+}
+
+pub struct CorrectPassphrase {
+    pub uuid: Uuid,
+    pub passphrase_key: bch_key,
+    pub sb_key: bch_encrypted_key,
 }
 
 #[derive(ZeroizeOnDrop)]
@@ -293,7 +306,7 @@ impl Passphrase {
         new_key
     }
 
-    pub fn check(&self, sb: &bch_sb_handle) -> Result<(bch_key, bch_encrypted_key)> {
+    pub fn check(&self, sb: &bch_sb_handle) -> Result<Option<CorrectPassphrase>> {
         let bch_key_magic = u64::from_le_bytes(*BCH_KEY_MAGIC);
 
         let crypt = sb
@@ -317,9 +330,15 @@ impl Passphrase {
                 mem::size_of_val(&sb_key),
             )
         };
-        ensure!(sb_key.magic == bch_key_magic, "incorrect passphrase");
+        if sb_key.magic != bch_key_magic {
+            return Ok(None);
+        }
 
-        Ok((passphrase_key, sb_key))
+        Ok(Some(CorrectPassphrase {
+            uuid: sb.sb().uuid(),
+            passphrase_key,
+            sb_key,
+        }))
     }
 }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -86,7 +86,7 @@ impl UnlockPolicy {
             Self::Fail => KeyHandle::new_from_search(&uuid),
             Self::Wait => Ok(KeyHandle::wait_for_unlock(&uuid)?),
             Self::Ask => {
-                let correct = Passphrase::new_from_prompt(&uuid)?
+                let correct = Passphrase::new_from_prompt(&uuid, true)?
                     .check(sb)?
                     .ok_or_else(|| anyhow!("incorrect passphrase"))?;
                 KeyHandle::new(&correct, Keyring::User)
@@ -181,8 +181,8 @@ impl Passphrase {
 
     pub fn new(uuid: &Uuid) -> Result<Self> {
         match get_stdin_type() {
-            StdinType::Terminal => Self::new_from_prompt(uuid),
-            StdinType::DevNull => Self::new_from_askpassword(uuid)?,
+            StdinType::Terminal => Self::new_from_prompt(uuid, true),
+            StdinType::DevNull => Self::new_from_askpassword(uuid, true)?,
             StdinType::Other => Self::new_from_stdin(),
         }
     }
@@ -191,13 +191,17 @@ impl Passphrase {
     // it is non-critical and will cause the password to be asked internally.
     // The inner result represent a successful request that returned an error
     // this one results in an error.
-    fn new_from_askpassword(uuid: &Uuid) -> Result<Result<Self>> {
-        let output = Command::new("systemd-ask-password")
+    fn new_from_askpassword(uuid: &Uuid, accept_cached: bool) -> Result<Result<Self>> {
+        let mut command = Command::new("systemd-ask-password");
+        command
             .arg("--icon=drive-harddisk")
             .arg(format!("--id=bcachefs:{}", uuid.as_hyphenated()))
             .arg(format!("--keyname={}", uuid.as_hyphenated()))
-            .arg("--accept-cached")
-            .arg("-n")
+            .arg("-n");
+        if accept_cached {
+            command.arg("--accept-cached");
+        }
+        let output = command
             .arg("Enter passphrase: ")
             .stdin(Stdio::inherit())
             .stderr(Stdio::inherit())
@@ -231,8 +235,8 @@ impl Passphrase {
     }
 
     // blocks indefinitely if no input is available on stdin
-    pub fn new_from_prompt(uuid: &Uuid) -> Result<Self> {
-        match Self::new_from_askpassword(uuid) {
+    pub fn new_from_prompt(uuid: &Uuid, accept_cached: bool) -> Result<Self> {
+        match Self::new_from_askpassword(uuid, accept_cached) {
             Ok(phrase) => return phrase,
             Err(_) => debug!("Failed to start systemd-ask-password, doing the prompt ourselves"),
         }

--- a/src/key.rs
+++ b/src/key.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{anyhow, bail, ensure, Result};
 use bch_bindgen::{
     bcachefs::{self, bch_key, bch_sb_handle},
     c::{bch2_chacha20, bch_encrypted_key, bch_sb_field_crypt},
@@ -171,20 +171,48 @@ pub struct CorrectPassphrase {
     pub sb_key: bch_encrypted_key,
 }
 
+impl CorrectPassphrase {
+    pub fn new(sb: &bch_sb_handle, file: Option<&Path>) -> Result<Self> {
+        if let Some(f) = file {
+            let passphrase = Passphrase::new_from_file(f)?;
+            if let Some(correct) = passphrase.check(sb)? {
+                return Ok(correct);
+            }
+        }
+
+        let stdin_type = get_stdin_type();
+
+        if stdin_type == StdinType::Other {
+            // Only one try.
+            let passphrase = Passphrase::new_from_stdin()?;
+            return passphrase.check(sb)?
+                .ok_or_else(|| anyhow!("incorrect passphrase"));
+        }
+
+        let uuid = sb.sb().uuid();
+
+        for i in 0..3 {
+            let accept_cached = i == 0;
+            let passphrase = match stdin_type {
+                StdinType::Terminal => Passphrase::new_from_prompt(&uuid, accept_cached)?,
+                StdinType::DevNull => Passphrase::new_from_askpassword(&uuid, accept_cached)??,
+                StdinType::Other => unreachable!(),
+            };
+            if let Some(correct) = passphrase.check(sb)? {
+                return Ok(correct);
+            }
+        }
+
+        bail!("incorrect passphrase limit reached")
+    }
+}
+
 #[derive(ZeroizeOnDrop)]
 pub struct Passphrase(CString);
 
 impl Passphrase {
     pub(crate) fn get(&self) -> &CStr {
         &self.0
-    }
-
-    pub fn new(uuid: &Uuid) -> Result<Self> {
-        match get_stdin_type() {
-            StdinType::Terminal => Self::new_from_prompt(uuid, true),
-            StdinType::DevNull => Self::new_from_askpassword(uuid, true)?,
-            StdinType::Other => Self::new_from_stdin(),
-        }
     }
 
     // The outer result represents a failure when trying to run systemd-ask-password,
@@ -357,6 +385,7 @@ fn is_dev_null(fd: BorrowedFd) -> io::Result<bool> {
     Ok(major == 1 && minor == 3)
 }
 
+#[derive(PartialEq)]
 enum StdinType {
     Terminal,
     DevNull,

--- a/src/key.rs
+++ b/src/key.rs
@@ -75,14 +75,14 @@ impl UnlockPolicy {
             Self::Fail => KeyHandle::new_from_search(&uuid),
             Self::Wait => Ok(KeyHandle::wait_for_unlock(&uuid)?),
             Self::Ask => {
-                let passphrase = Passphrase::new_from_prompt()?;
+                let passphrase = Passphrase::ask_in_terminal()?;
                 let passphrase_correct = passphrase
                     .check(sb)
                     .ok_or_else(|| anyhow!("incorrect passphrase"))?;
                 KeyHandle::new(&passphrase_correct, Keyring::User)
             }
             Self::Stdin => {
-                let passphrase = Passphrase::new_from_stdin()?;
+                let passphrase = Passphrase::read_from_stdin()?;
                 let passphrase_correct = passphrase
                     .check(sb)
                     .ok_or_else(|| anyhow!("incorrect passphrase"))?;
@@ -167,11 +167,11 @@ impl Passphrase {
 
     pub fn ask_and_check(sb: &bch_sb_handle) -> Result<PassphraseCorrect> {
         match StdinType::detect() {
-            StdinType::Terminal => Self::new_from_prompt()?
+            StdinType::Terminal => Self::ask_in_terminal()?
                 .check(sb)
                 .ok_or_else(|| anyhow!("incorrect passphrase")),
             StdinType::DevNull => Self::ask_from_systemd_and_check(sb),
-            StdinType::Other => Self::new_from_stdin()?
+            StdinType::Other => Self::read_from_stdin()?
                 .check(sb)
                 .ok_or_else(|| anyhow!("incorrect passphrase")),
         }
@@ -212,7 +212,7 @@ impl Passphrase {
     }
 
     /// Prompt for a passphrase with echo disabled.
-    fn prompt_hidden(prompt: &str) -> Result<Self> {
+    fn ask_in_terminal_with_prompt(prompt: &str) -> Result<Self> {
         let old = termios::tcgetattr(stdin())?;
         let mut new = old.clone();
         new.local_modes.remove(termios::LocalModes::ECHO);
@@ -230,23 +230,23 @@ impl Passphrase {
     }
 
     // blocks indefinitely if no input is available on stdin
-    pub fn new_from_prompt() -> Result<Self> {
-        Self::prompt_hidden("Enter passphrase: ")
+    pub fn ask_in_terminal() -> Result<Self> {
+        Self::ask_in_terminal_with_prompt("Enter passphrase: ")
     }
 
     /// Prompt for a new passphrase twice and verify they match.
-    pub fn new_from_prompt_twice() -> Result<Self> {
+    pub fn ask_for_new_passphrase() -> Result<Self> {
         if !stdin().is_terminal() {
-            return Self::new_from_stdin();
+            return Self::read_from_stdin();
         }
-        let pass1 = Self::prompt_hidden("Enter new passphrase: ")?;
-        let pass2 = Self::prompt_hidden("Enter same passphrase again: ")?;
+        let pass1 = Self::ask_in_terminal_with_prompt("Enter new passphrase: ")?;
+        let pass2 = Self::ask_in_terminal_with_prompt("Enter same passphrase again: ")?;
         ensure!(pass1.get().to_bytes() == pass2.get().to_bytes(), "Passphrases do not match");
         Ok(pass1)
     }
 
     // blocks indefinitely if no input is available on stdin
-    pub fn new_from_stdin() -> Result<Self> {
+    pub fn read_from_stdin() -> Result<Self> {
         info!("Trying to read passphrase from stdin...");
 
         let mut line = Zeroizing::new(String::new());
@@ -255,7 +255,7 @@ impl Passphrase {
         Ok(Self(CString::new(line.trim_end_matches('\n'))?))
     }
 
-    pub fn new_from_file(passphrase_file: impl AsRef<Path>) -> Result<Self> {
+    pub fn read_from_file(passphrase_file: impl AsRef<Path>) -> Result<Self> {
         let passphrase_file = passphrase_file.as_ref();
 
         info!(

--- a/src/key.rs
+++ b/src/key.rs
@@ -185,6 +185,7 @@ impl Passphrase {
                 .arg("--icon=drive-harddisk")
                 .arg(format!("--id=bcachefs:{}", uuid.as_hyphenated()))
                 .arg(format!("--keyname={}", uuid.as_hyphenated()))
+                .arg("--multiple")
                 .arg("-n");
             if i == 0 {
                 command.arg("--accept-cached");
@@ -197,9 +198,14 @@ impl Passphrase {
             if !output.status.success() {
                 bail!("systemd-ask-password returned an error");
             }
-            let passphrase = Self(CString::new(output.stdout)?);
-            if let Some(passphrase_correct) = passphrase.check(sb) {
-                return Ok(passphrase_correct);
+            for passphrase in output.stdout.split(|b| *b == b'\0') {
+                let p = Self(
+                    CString::new(passphrase)
+                        .expect("passphrase should not contain a NUL byte because the output was split on NUL bytes")
+                );
+                if let Some(passphrase_correct) = p.check(sb) {
+                    return Ok(passphrase_correct);
+                }
             }
         }
         bail!("incorrect passphrase limit reached");

--- a/src/key.rs
+++ b/src/key.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{anyhow, bail, ensure, Result};
 use bch_bindgen::{
     bcachefs::{self, bch_key, bch_sb_handle},
     c::{bch2_chacha20, bch_encrypted_key, bch_sb_field_crypt},
@@ -166,42 +166,43 @@ impl Passphrase {
     }
 
     pub fn ask_and_check(sb: &bch_sb_handle) -> Result<PassphraseCorrect> {
-        let passphrase = match StdinType::detect() {
-            StdinType::Terminal => Self::new_from_prompt()?,
-            StdinType::DevNull => {
-                let uuid = sb.sb().uuid();
-                Self::new_from_askpassword(&uuid)??
-            }
-            StdinType::Other => Self::new_from_stdin()?,
-        };
-        passphrase
-            .check(sb)
-            .ok_or_else(|| anyhow!("incorrect passphrase"))
+        match StdinType::detect() {
+            StdinType::Terminal => Self::new_from_prompt()?
+                .check(sb)
+                .ok_or_else(|| anyhow!("incorrect passphrase")),
+            StdinType::DevNull => Self::ask_from_systemd_and_check(sb),
+            StdinType::Other => Self::new_from_stdin()?
+                .check(sb)
+                .ok_or_else(|| anyhow!("incorrect passphrase")),
+        }
     }
 
-    // The outer result represents a failure when trying to run systemd-ask-password,
-    // it is non-critical and will cause the password to be asked internally.
-    // The inner result represent a successful request that returned an error
-    // this one results in an error.
-    fn new_from_askpassword(uuid: &Uuid) -> Result<Result<Self>> {
-        let output = Command::new("systemd-ask-password")
-            .arg("--icon=drive-harddisk")
-            .arg(format!("--id=bcachefs:{}", uuid.as_hyphenated()))
-            .arg(format!("--keyname={}", uuid.as_hyphenated()))
-            .arg("--accept-cached")
-            .arg("-n")
-            .arg("Enter passphrase: ")
-            .stdin(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .output()?;
-        Ok(if output.status.success() {
-            match CString::new(output.stdout) {
-                Ok(cstr) => Ok(Self(cstr)),
-                Err(e) => Err(e.into()),
+    fn ask_from_systemd_and_check(sb: &bch_sb_handle) -> Result<PassphraseCorrect> {
+        let uuid = sb.sb().uuid();
+        for i in 0..3 {
+            let mut command = Command::new("systemd-ask-password");
+            command
+                .arg("--icon=drive-harddisk")
+                .arg(format!("--id=bcachefs:{}", uuid.as_hyphenated()))
+                .arg(format!("--keyname={}", uuid.as_hyphenated()))
+                .arg("-n");
+            if i == 0 {
+                command.arg("--accept-cached");
             }
-        } else {
-            Err(anyhow!("systemd-ask-password returned an error"))
-        })
+            let output = command
+                .arg("Enter passphrase: ")
+                .stdin(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .output()?;
+            if !output.status.success() {
+                bail!("systemd-ask-password returned an error");
+            }
+            let passphrase = Self(CString::new(output.stdout)?);
+            if let Some(passphrase_correct) = passphrase.check(sb) {
+                return Ok(passphrase_correct);
+            }
+        }
+        bail!("incorrect passphrase limit reached");
     }
 
     /// Prompt for a passphrase with echo disabled.

--- a/src/key.rs
+++ b/src/key.rs
@@ -165,12 +165,16 @@ impl Passphrase {
         &self.0
     }
 
-    pub fn new(uuid: &Uuid) -> Result<Self> {
-        match StdinType::detect() {
-            StdinType::Terminal => Self::new_from_prompt(uuid),
-            StdinType::DevNull => Self::new_from_askpassword(uuid)?,
-            StdinType::Other => Self::new_from_stdin(),
-        }
+    pub fn ask_and_check(sb: &bch_sb_handle) -> Result<PassphraseCorrect> {
+        let uuid = sb.sb().uuid();
+        let passphrase = match StdinType::detect() {
+            StdinType::Terminal => Self::new_from_prompt(&uuid)?,
+            StdinType::DevNull => Self::new_from_askpassword(&uuid)??,
+            StdinType::Other => Self::new_from_stdin()?,
+        };
+        passphrase
+            .check(sb)
+            .ok_or_else(|| anyhow!("incorrect passphrase"))
     }
 
     // The outer result represents a failure when trying to run systemd-ask-password,

--- a/src/key.rs
+++ b/src/key.rs
@@ -183,8 +183,10 @@ impl Passphrase {
             let mut command = Command::new("systemd-ask-password");
             command
                 .arg("--icon=drive-harddisk")
-                .arg(format!("--id=bcachefs:{}", uuid.as_hyphenated()))
-                .arg(format!("--keyname={}", uuid.as_hyphenated()))
+                .arg(format!("--id=cryptsetup:UUID={}", uuid.as_hyphenated()))
+                .arg("--keyname=cryptsetup")
+                .arg("--credential=cryptsetup.passphrase")
+                .arg("--timeout=0")
                 .arg("--multiple")
                 .arg("-n");
             if i == 0 {

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     ffi::{CStr, CString},
     fs,
     io::{self, stdin, IsTerminal},
@@ -179,6 +180,10 @@ impl Passphrase {
 
     fn ask_from_systemd_and_check(sb: &bch_sb_handle) -> Result<PassphraseCorrect> {
         let uuid = sb.sb().uuid();
+        let mut label = String::from_utf8_lossy(sb.sb().label());
+        if label.is_empty() {
+            label = Cow::Owned(uuid.hyphenated().to_string());
+        }
         for i in 0..3 {
             let mut command = Command::new("systemd-ask-password");
             command
@@ -193,7 +198,7 @@ impl Passphrase {
                 command.arg("--accept-cached");
             }
             let output = command
-                .arg("Enter passphrase: ")
+                .arg(format!("Please enter passphrase for disk {label}:"))
                 .stdin(Stdio::inherit())
                 .stderr(Stdio::inherit())
                 .output()?;

--- a/src/key.rs
+++ b/src/key.rs
@@ -74,8 +74,20 @@ impl UnlockPolicy {
         match self {
             Self::Fail => KeyHandle::new_from_search(&uuid),
             Self::Wait => Ok(KeyHandle::wait_for_unlock(&uuid)?),
-            Self::Ask => Passphrase::new_from_prompt(&uuid).and_then(|p| KeyHandle::new(sb, &p, Keyring::User)),
-            Self::Stdin => Passphrase::new_from_stdin().and_then(|p| KeyHandle::new(sb, &p, Keyring::User)),
+            Self::Ask => {
+                let passphrase = Passphrase::new_from_prompt(&uuid)?;
+                let passphrase_correct = passphrase
+                    .check(sb)
+                    .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+                KeyHandle::new(&passphrase_correct, Keyring::User)
+            }
+            Self::Stdin => {
+                let passphrase = Passphrase::new_from_stdin()?;
+                let passphrase_correct = passphrase
+                    .check(sb)
+                    .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+                KeyHandle::new(&passphrase_correct, Keyring::User)
+            }
         }
     }
 }
@@ -89,19 +101,17 @@ impl KeyHandle {
         CString::new(format!("bcachefs:{uuid}")).unwrap()
     }
 
-    pub fn new(sb: &bch_sb_handle, passphrase: &Passphrase, keyring: Keyring) -> Result<Self> {
-        let key_name = Self::format_key_name(&sb.sb().uuid());
+    pub fn new(passphrase_correct: &PassphraseCorrect, keyring: Keyring) -> Result<Self> {
+        let key_name = Self::format_key_name(&passphrase_correct.fs_uuid);
         let key_name = CStr::as_ptr(&key_name);
         let key_type = c"user";
-
-        let (passphrase_key, _sb_key) = passphrase.check(sb)?;
 
         let key_id = unsafe {
             keyutils::add_key(
                 key_type.as_ptr(),
                 key_name,
-                ptr::addr_of!(passphrase_key).cast(),
-                mem::size_of_val(&passphrase_key),
+                ptr::addr_of!(passphrase_correct.passphrase_key).cast(),
+                mem::size_of_val(&passphrase_correct.passphrase_key),
                 keyring.id(),
             )
         };
@@ -279,32 +289,43 @@ impl Passphrase {
         new_key
     }
 
-    pub fn check(&self, sb: &bch_sb_handle) -> Result<(bch_key, bch_encrypted_key)> {
+    pub fn check(&self, sb: &bch_sb_handle) -> Option<PassphraseCorrect> {
         let crypt = sb
             .sb()
             .crypt()
-            .ok_or_else(|| anyhow!("filesystem is not encrypted"))?;
-        let mut sb_key = crypt.key().clone();
-
-        ensure!(
-            sb_key.is_encrypted(),
-            "filesystem encryption key is not passphrase-protected"
+            .expect("superblock should have crypt when calling Passphrase::check");
+        assert!(
+            crypt.key().is_encrypted(),
+            "sb_key should be encrypted when calling Passphrase::check",
         );
 
         let mut passphrase_key: bch_key = self.derive(crypt);
 
+        let mut cleartext_sb_key = crypt.key().clone();
         unsafe {
             bch2_chacha20(
                 ptr::addr_of_mut!(passphrase_key),
                 sb.sb().nonce(),
-                ptr::addr_of_mut!(sb_key).cast(),
-                mem::size_of_val(&sb_key),
+                ptr::addr_of_mut!(cleartext_sb_key).cast(),
+                mem::size_of_val(&cleartext_sb_key),
             )
         };
-        ensure!(!sb_key.is_encrypted(), "incorrect passphrase");
+        if cleartext_sb_key.is_encrypted() {
+            return None;
+        }
 
-        Ok((passphrase_key, sb_key))
+        Some(PassphraseCorrect {
+            fs_uuid: sb.sb().uuid(),
+            passphrase_key,
+            cleartext_sb_key,
+        })
     }
+}
+
+pub struct PassphraseCorrect {
+    pub fs_uuid:          Uuid,
+    pub passphrase_key:   bch_key,
+    pub cleartext_sb_key: bch_encrypted_key,
 }
 
 fn is_dev_null(fd: BorrowedFd) -> io::Result<bool> {

--- a/src/key.rs
+++ b/src/key.rs
@@ -23,23 +23,12 @@ use zeroize::{ZeroizeOnDrop, Zeroizing};
 
 use crate::ErrnoError;
 
-const BCH_KEY_MAGIC: &[u8; 8] = b"bch**key";
-
 /// Check if a superblock has an encrypted passphrase set.
 pub fn sb_is_encrypted(sb: &bch_sb_handle) -> bool {
-    let bch_key_magic = u64::from_le_bytes(*BCH_KEY_MAGIC);
     sb.sb()
         .crypt()
-        .map(|c| c.key().magic != bch_key_magic)
+        .map(|c| c.key().is_encrypted())
         .unwrap_or(false)
-}
-
-/// Create an unencrypted (plaintext) key for the crypt field (remove-passphrase).
-pub fn unencrypted_key(key: &bch_key) -> bch_encrypted_key {
-    bch_encrypted_key {
-        magic: u64::from_le_bytes(*BCH_KEY_MAGIC),
-        key: *key,
-    }
 }
 
 /// Target keyring for key storage.
@@ -271,14 +260,11 @@ impl Passphrase {
     pub fn encrypt_key(
         &self,
         sb: &bch_sb_handle,
-        key: &bch_key,
+        key: bch_key,
     ) -> bch_encrypted_key {
         let crypt = sb.sb().crypt().expect("called on encrypted fs");
-        let mut new_key = bch_encrypted_key {
-            magic: u64::from_le_bytes(*BCH_KEY_MAGIC),
-            key: *key,
-        };
-
+        let mut new_key = bch_encrypted_key::new_unencrypted(key);
+        
         let mut passphrase_key: bch_key = self.derive(crypt);
 
         unsafe {
@@ -294,16 +280,14 @@ impl Passphrase {
     }
 
     pub fn check(&self, sb: &bch_sb_handle) -> Result<(bch_key, bch_encrypted_key)> {
-        let bch_key_magic = u64::from_le_bytes(*BCH_KEY_MAGIC);
-
         let crypt = sb
             .sb()
             .crypt()
             .ok_or_else(|| anyhow!("filesystem is not encrypted"))?;
-        let mut sb_key = *crypt.key();
+        let mut sb_key = crypt.key().clone();
 
         ensure!(
-            sb_key.magic != bch_key_magic,
+            sb_key.is_encrypted(),
             "filesystem encryption key is not passphrase-protected"
         );
 
@@ -317,7 +301,7 @@ impl Passphrase {
                 mem::size_of_val(&sb_key),
             )
         };
-        ensure!(sb_key.magic == bch_key_magic, "incorrect passphrase");
+        ensure!(!sb_key.is_encrypted(), "incorrect passphrase");
 
         Ok((passphrase_key, sb_key))
     }

--- a/src/key.rs
+++ b/src/key.rs
@@ -16,7 +16,7 @@ use bch_bindgen::{
     c::{bch2_chacha20, bch_encrypted_key, bch_sb_field_crypt},
     keyutils::{self, keyctl_search},
 };
-use log::{debug, info};
+use log::info;
 use rustix::termios;
 use uuid::Uuid;
 use zeroize::{ZeroizeOnDrop, Zeroizing};
@@ -166,16 +166,12 @@ impl Passphrase {
     }
 
     pub fn ask_and_check(sb: &bch_sb_handle) -> Result<PassphraseCorrect> {
-        let uuid = sb.sb().uuid();
         let passphrase = match StdinType::detect() {
-            StdinType::Terminal => match Self::new_from_askpassword(&uuid) {
-                Ok(phrase) => phrase?,
-                Err(_) => {
-                    debug!("Failed to start systemd-ask-password, doing the prompt ourselves");
-                    Self::new_from_prompt()?
-                }
-            },
-            StdinType::DevNull => Self::new_from_askpassword(&uuid)??,
+            StdinType::Terminal => Self::new_from_prompt()?,
+            StdinType::DevNull => {
+                let uuid = sb.sb().uuid();
+                Self::new_from_askpassword(&uuid)??
+            }
             StdinType::Other => Self::new_from_stdin()?,
         };
         passphrase

--- a/src/key.rs
+++ b/src/key.rs
@@ -167,7 +167,7 @@ impl Passphrase {
     }
 
     pub fn new(uuid: &Uuid) -> Result<Self> {
-        match get_stdin_type() {
+        match StdinType::detect() {
             StdinType::Terminal => Self::new_from_prompt(uuid),
             StdinType::DevNull => Self::new_from_askpassword(uuid)?,
             StdinType::Other => Self::new_from_stdin(),
@@ -340,13 +340,15 @@ enum StdinType {
     Other,
 }
 
-fn get_stdin_type() -> StdinType {
-    let stdin = stdin();
-    if stdin.is_terminal() {
-        StdinType::Terminal
-    } else if is_dev_null(stdin.as_fd()).unwrap_or(false) {
-        StdinType::DevNull
-    } else {
-        StdinType::Other
+impl StdinType {
+    fn detect() -> StdinType {
+        let stdin = stdin();
+        if stdin.is_terminal() {
+            StdinType::Terminal
+        } else if is_dev_null(stdin.as_fd()).unwrap_or(false) {
+            StdinType::DevNull
+        } else {
+            StdinType::Other
+        }
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -75,7 +75,7 @@ impl UnlockPolicy {
             Self::Fail => KeyHandle::new_from_search(&uuid),
             Self::Wait => Ok(KeyHandle::wait_for_unlock(&uuid)?),
             Self::Ask => {
-                let passphrase = Passphrase::new_from_prompt(&uuid)?;
+                let passphrase = Passphrase::new_from_prompt()?;
                 let passphrase_correct = passphrase
                     .check(sb)
                     .ok_or_else(|| anyhow!("incorrect passphrase"))?;
@@ -168,7 +168,13 @@ impl Passphrase {
     pub fn ask_and_check(sb: &bch_sb_handle) -> Result<PassphraseCorrect> {
         let uuid = sb.sb().uuid();
         let passphrase = match StdinType::detect() {
-            StdinType::Terminal => Self::new_from_prompt(&uuid)?,
+            StdinType::Terminal => match Self::new_from_askpassword(&uuid) {
+                Ok(phrase) => phrase?,
+                Err(_) => {
+                    debug!("Failed to start systemd-ask-password, doing the prompt ourselves");
+                    Self::new_from_prompt()?
+                }
+            },
             StdinType::DevNull => Self::new_from_askpassword(&uuid)??,
             StdinType::Other => Self::new_from_stdin()?,
         };
@@ -221,11 +227,7 @@ impl Passphrase {
     }
 
     // blocks indefinitely if no input is available on stdin
-    pub fn new_from_prompt(uuid: &Uuid) -> Result<Self> {
-        match Self::new_from_askpassword(uuid) {
-            Ok(phrase) => return phrase,
-            Err(_) => debug!("Failed to start systemd-ask-password, doing the prompt ourselves"),
-        }
+    pub fn new_from_prompt() -> Result<Self> {
         Self::prompt_hidden("Enter passphrase: ")
     }
 


### PR DESCRIPTION
Use the same key description as systemd-cryptsetup/GDM autologin/GNOME keyring for storing the passphrase. This way, a user with a cryptsetup volume and a bcachefs filesystem with the same passphrase doesn't have to enter the passphrase twice, and the passphrase can be used for GDM autologin and to unlock the GNOME keyring.

This does not change the way the "passphrase key" is stored in the keyring, only the passphrase itself (when using `systemd-ask-password`).

See https://github.com/koverstreet/bcachefs-tools/pull/413#issuecomment-3322391652.

This also makes the `bcachefs mount` command ask for the passphrase again if the wrong passphrase was entered. This is a step toward removing the custom `bcachefs unlock` service on NixOS (see https://github.com/NixOS/nixpkgs/pull/429126#issuecomment-3321889564).