### PR TITLE
Add `bcachefs wait` command that exits when all devices are present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/bcachefs-wait@.service
 /result
 bcachefs.5
 .*

--- a/Makefile
+++ b/Makefile
@@ -137,8 +137,23 @@ else
 	INITRAMFS_DIR=/etc/initramfs-tools
 endif
 
+PKGCONFIG_SERVICEDIR:=$(shell $(PKG_CONFIG) --variable=systemdsystemunitdir systemd)
+ifeq (,$(PKGCONFIG_SERVICEDIR))
+  $(warning skipping systemd integration)
+else
+systemd_services=bcachefs-wait@.service
+built_scripts+=bcachefs-wait@.service
+
+%.service: %.service.in
+	@echo "    [SED]    $@"
+	$(Q)sed -e "s|@sbindir@|$(ROOT_SBINDIR)|g" < $< > $@
+
+optional_build+=$(systemd_services)
+optional_install+=install_systemd
+endif	# PKGCONFIG_SERVICEDIR
+
 .PHONY: all
-all: bcachefs initramfs/hook dkms/dkms.conf
+all: bcachefs initramfs/hook dkms/dkms.conf $(optional_build)
 
 .PHONY: debug
 debug: CFLAGS+=-Werror -DCONFIG_BCACHEFS_DEBUG=y -DCONFIG_VALGRIND=y
@@ -206,7 +221,7 @@ BASH_COMPLETION_DIR?=$(shell $(PKG_CONFIG) --variable=completionsdir bash-comple
 
 install: INITRAMFS_HOOK=$(INITRAMFS_DIR)/hooks/bcachefs
 install: INITRAMFS_SCRIPT=$(INITRAMFS_DIR)/scripts/local-premount/bcachefs
-install: all install_dkms
+install: all install_dkms $(optional_install)
 	$(INSTALL) -m0755 -D $(BUILT_BIN)  -t $(DESTDIR)$(ROOT_SBINDIR)
 	$(INSTALL) -m0644 -D bcachefs.8    -t $(DESTDIR)$(PREFIX)/share/man/man8/
 	$(INSTALL) -m0755 -D initramfs/hook   $(DESTDIR)$(INITRAMFS_HOOK)
@@ -232,6 +247,11 @@ uninstall:
 	$(RM) $(DESTDIR)$(PREFIX)/share/man/man8/bcachefs.8
 	$(RM) $(DESTDIR)$(BASH_COMPLETION_DIR)/bcachefs
 	$(RM) -r $(DESTDIR)$(DKMSDIR)
+	$(RM) $(addprefix $(DESTDIR)$(PKGCONFIG_SERVICEDIR)/,$(systemd_services))
+
+.PHONY: install_systemd
+install_systemd: $(systemd_services) $(systemd_libexecfiles)
+	$(INSTALL) -m0644 -D $(systemd_services) -t $(DESTDIR)$(PKGCONFIG_SERVICEDIR)
 
 .PHONY: install_dkms
 install_dkms: dkms/dkms.conf dkms/module-version.c

--- a/bcachefs-wait@.service.in
+++ b/bcachefs-wait@.service.in
@@ -1,0 +1,7 @@
+[Unit]
+Description=Every device in the Bcachefs filesystem with UUID %i is present
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=@sbindir@/bcachefs wait UUID=%i

--- a/bch_bindgen/src/sb/io.rs
+++ b/bch_bindgen/src/sb/io.rs
@@ -31,7 +31,7 @@ pub fn read_super(path: &std::path::Path) -> anyhow::Result<bch_sb_handle> {
 pub fn read_super_silent(
     path: &std::path::Path,
     mut opts: bch_opts,
-) -> anyhow::Result<bch_sb_handle> {
+) -> Result<bch_sb_handle, BchError> {
     let path = path_to_cstr(path);
     let mut sb = std::mem::MaybeUninit::zeroed();
 
@@ -40,7 +40,7 @@ pub fn read_super_silent(
     };
 
     if ret != 0 {
-        Err(anyhow!(BchError::from_raw(ret)))
+        Err(BchError::from_raw(ret))
     } else {
         Ok(unsafe { sb.assume_init() })
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -74,13 +74,15 @@ macro_rules! raw_cmd {
 pub mod attr;
 pub mod completions;
 pub mod counters;
+pub mod data_read;
 pub mod device;
 pub mod dump;
 pub mod format;
 pub mod format_util;
 pub mod fs_usage;
-pub mod image;
 pub mod fsck;
+pub mod fusemount;
+pub mod image;
 pub mod key;
 pub mod kill_btree_node;
 pub mod list;
@@ -88,8 +90,6 @@ pub mod list_journal;
 pub mod migrate;
 pub mod mount;
 pub mod opts;
-pub mod data_read;
-pub mod unpoison;
 pub mod reconcile;
 pub mod recover_super;
 pub mod recovery_pass;
@@ -100,7 +100,8 @@ pub mod subvolume;
 pub mod super_cmd;
 pub mod timestats;
 pub mod top;
-pub mod fusemount;
+pub mod unpoison;
+pub mod wait;
 
 // ── Dispatch and help ────────────────────────────────────────────────
 
@@ -203,7 +204,7 @@ pub const COMMAND_GROUPS: &[GroupDef] = &[
         &set_option::CMD, &counters::CMD, &strip_alloc::CMD,
     ]},
     GroupDef { heading: "Images",                   commands: &[&image::CMD] },
-    GroupDef { heading: "Mount",                    commands: &[&mount::CMD, &fusemount::CMD] },
+    GroupDef { heading: "Mount",                    commands: &[&mount::CMD, &fusemount::CMD, &wait::CMD] },
     GroupDef { heading: "Repair",                   commands: &[&fsck::CMD, &recovery_pass::CMD] },
     GroupDef { heading: "Running filesystem",       commands: &[&FS_CMD] },
     GroupDef { heading: "Devices",                  commands: &[&device::CMD] },
@@ -218,4 +219,3 @@ pub const COMMAND_GROUPS: &[GroupDef] = &[
     ]},
     GroupDef { heading: "Miscellaneous",            commands: &[&completions::CMD, &VERSION_CMD] },
 ];
-

--- a/src/commands/wait.rs
+++ b/src/commands/wait.rs
@@ -1,0 +1,176 @@
+use std::{
+    collections::{HashMap, HashSet},
+    ffi::OsStr,
+    os::fd::{AsRawFd, BorrowedFd},
+    path::{Path, PathBuf},
+};
+
+use anyhow::bail;
+use bch_bindgen::bcachefs;
+use clap::Parser;
+use log::{debug, warn};
+use rustix::event::{poll, PollFd, PollFlags};
+use uuid::Uuid;
+
+use crate::device_scan;
+
+/// Waits until every device in a filesystem is initialized.
+#[derive(Parser, Debug)]
+#[command(
+    about,
+    long_about = "Waits until every device in a filesystem is initialized. \
+udev is used to scan for devices and be notified of device changes. A zero \
+exit status means that every device was initialized at some point. A non-zero \
+exit status means that an error was encountered."
+)]
+pub struct Cli {
+    /// A device string in the UUID=\<UUID\> format.
+    device: String,
+}
+
+fn cmd_wait(cli: Cli) -> anyhow::Result<()> {
+    let Some(uuid) = device_scan::parse_uuid_equals(&cli.device)? else {
+        bail!("invalid device string: {}", cli.device);
+    };
+
+    let mut wait_initialized = WaitInitialized::new(uuid);
+
+    let socket = udev::MonitorBuilder::new()?
+        .match_subsystem("block")?
+        .listen()?;
+
+    let mut enumerator = udev::Enumerator::new()?;
+    enumerator.match_is_initialized()?;
+    enumerator.match_subsystem("block")?;
+    enumerator.match_property("ID_FS_TYPE", "bcachefs")?;
+
+    for device in enumerator.scan_devices()? {
+        let Some(devnode) = device.devnode() else {
+            continue;
+        };
+        wait_initialized.add(devnode, &device)?;
+    }
+
+    while !wait_initialized.every_device_is_initialized() {
+        let socket_fd = unsafe { BorrowedFd::borrow_raw(socket.as_raw_fd()) };
+
+        let mut fds = [PollFd::new(&socket_fd, PollFlags::IN)];
+        poll(&mut fds, -1)?;
+        if fds.iter().any(|fd| fd.revents().contains(PollFlags::ERR)) {
+            bail!("error on udev socket fd");
+        }
+
+        wait_initialized.process_events(&socket)?;
+    }
+
+    Ok(())
+}
+
+struct WaitInitialized {
+    uuid:               Uuid,
+    number_of_devices:  Option<u32>,
+    dev_idx_by_devnode: HashMap<PathBuf, u8>,
+}
+
+impl WaitInitialized {
+    fn new(uuid: Uuid) -> Self {
+        WaitInitialized {
+            uuid,
+            number_of_devices: None,
+            dev_idx_by_devnode: HashMap::new(),
+        }
+    }
+
+    fn add(&mut self, devnode: &Path, device: &udev::Device) -> anyhow::Result<()> {
+        if !device.is_initialized()
+            || device
+                .property_value("ID_FS_TYPE")
+                .is_none_or(|fs_type| fs_type != "bcachefs")
+            || device
+                .property_value("ID_FS_UUID")
+                .and_then(OsStr::to_str)
+                .and_then(|s| Uuid::parse_str(s).ok())
+                .is_some_and(|device_uuid| device_uuid != self.uuid)
+        {
+            return Ok(());
+        }
+        if device_scan::should_skip_multipath_component(device) {
+            return Ok(());
+        }
+        let opts = bcachefs::bch_opts::default();
+        let sb_handle = match device_scan::read_super_silent(devnode, opts) {
+            Ok(handle) => handle,
+            Err(err) if err.raw() == libc::ENOENT => return Ok(()),
+            Err(err) => return Err(err.into()),
+        };
+        let sb = sb_handle.sb();
+        if sb.uuid() != self.uuid {
+            return Ok(());
+        }
+        let dev_idx = sb.dev_idx;
+        let number_of_devices = sb.number_of_devices();
+        if u32::from(dev_idx) >= number_of_devices {
+            warn!("superblock with invalid dev_idx: {dev_idx} >= {number_of_devices}");
+            return Ok(());
+        }
+        if let Some(n) = self.number_of_devices {
+            if n != number_of_devices {
+                bail!("inconsistent number of devices: {n} != {number_of_devices}");
+            }
+        } else {
+            self.number_of_devices = Some(number_of_devices);
+        }
+        debug!(
+            "adding device at {} with index {dev_idx}",
+            devnode.display()
+        );
+        let old = self
+            .dev_idx_by_devnode
+            .insert(devnode.to_path_buf(), dev_idx);
+        assert!(
+            old.is_none(),
+            "device should have have been removed before readding"
+        );
+        Ok(())
+    }
+
+    fn remove(&mut self, devnode: &Path) {
+        if let Some(dev_idx) = self.dev_idx_by_devnode.remove(devnode) {
+            debug!(
+                "removing device at {} with index {dev_idx}",
+                devnode.display()
+            );
+        }
+    }
+
+    fn process_events(&mut self, socket: &udev::MonitorSocket) -> anyhow::Result<()> {
+        for event in socket.iter() {
+            eprintln!("{:?}", event);
+            let Some(devnode) = event.devnode() else {
+                continue;
+            };
+            let add = match event.event_type() {
+                udev::EventType::Add | udev::EventType::Change => true,
+                udev::EventType::Remove => false,
+                _ => continue,
+            };
+            self.remove(devnode);
+            if add {
+                self.add(devnode, &event.device())?;
+            }
+        }
+        Ok(())
+    }
+
+    fn every_device_is_initialized(&self) -> bool {
+        let Some(number_of_devices) = self.number_of_devices.and_then(|n| usize::try_from(n).ok())
+        else {
+            return false;
+        };
+        let unique_dev_indices: HashSet<u8> = self.dev_idx_by_devnode.values().copied().collect();
+        unique_dev_indices.len() == number_of_devices
+    }
+}
+
+pub const CMD: super::CmdDef =
+    typed_cmd!("wait", "Wait until devices are initialized", Cli, cmd_wait);

--- a/src/device_scan.rs
+++ b/src/device_scan.rs
@@ -24,7 +24,6 @@
 
 use std::{
     ffi::{CStr, CString, c_char, OsString, OsStr},
-    collections::HashMap,
     fs,
     os::unix::ffi::OsStringExt,
     path::{Path, PathBuf},
@@ -49,32 +48,23 @@ fn read_super_silent(path: impl AsRef<Path>, mut opts: bch_opts) -> Result<bch_s
     bch_bindgen::sb::io::read_super_silent(path.as_ref(), opts)
 }
 
-fn device_property_map(dev: &udev::Device) -> HashMap<String, String> {
-    dev.properties()
-        .map(|i| (
-            i.name().to_string_lossy().into_owned(),
-            i.value().to_string_lossy().into_owned(),
-        ))
-        .collect()
-}
-
-fn should_skip_multipath_component(props: &HashMap<String, String>) -> bool {
+fn should_skip_multipath_component(dev: &udev::Device) -> bool {
     // Set by multipath's udev rule; fall back to sysfs if not present.
-    if props
-        .get("DM_MULTIPATH_DEVICE_PATH")
+    if dev
+        .property_value("DM_MULTIPATH_DEVICE_PATH")
         .is_some_and(|v| v == "1")
     {
-        if let Some(devname) = props.get("DEVNAME") {
-            debug!("Skipping multipath component device: {}", devname);
+        if let Some(devnode) = dev.devnode() {
+            debug!("Skipping multipath component device: {}", devnode.display());
         }
         return true;
     }
 
-    if let Some(devname) = props.get("DEVNAME") {
-        if find_multipath_holder(Path::new(devname)).is_some() {
+    if let Some(devnode) = dev.devnode() {
+        if find_multipath_holder(devnode).is_some() {
             debug!(
                 "Skipping multipath component device via sysfs holders: {}",
-                devname
+                devnode.display()
             );
             return true;
         }
@@ -83,56 +73,50 @@ fn should_skip_multipath_component(props: &HashMap<String, String>) -> bool {
     false
 }
 
-fn get_devices_by_uuid_udev(uuid: Uuid) -> anyhow::Result<Vec<String>> {
+fn get_devices_by_uuid_udev(uuid: Uuid) -> anyhow::Result<Vec<PathBuf>> {
     debug!("Walking udev db!");
 
-    let mut udev = udev::Enumerator::new()?;
-    udev.match_subsystem("block")?;
-    udev.match_property("ID_FS_TYPE", "bcachefs")?;
+    let mut enumerator = udev::Enumerator::new()?;
+    enumerator.match_is_initialized()?;
+    enumerator.match_subsystem("block")?;
+    enumerator.match_property("ID_FS_TYPE", "bcachefs")?;
 
-    let uuid = uuid.to_string();
-
-    Ok(udev
+    Ok(enumerator
         .scan_devices()?
-        .filter(udev::Device::is_initialized)
-        .map(|dev| device_property_map(&dev))
-        .filter(|m|
-            m.contains_key("ID_FS_UUID") &&
-            m["ID_FS_UUID"] == uuid &&
-            m.contains_key("DEVNAME") &&
-            !should_skip_multipath_component(m))
-        .map(|m| m["DEVNAME"].clone())
+        .filter(|dev| {
+            dev.property_value("ID_FS_UUID")
+                .and_then(OsStr::to_str)
+                .and_then(|s| Uuid::parse_str(s).ok())
+                .is_some_and(|dev_uuid| dev_uuid == uuid)
+                && !should_skip_multipath_component(dev)
+        })
+        .filter_map(|dev| dev.devnode().map(Path::to_path_buf))
         .collect::<Vec<_>>())
 }
 
-fn get_all_block_devnodes_udev() -> anyhow::Result<Vec<String>> {
+fn get_all_block_devnodes_udev() -> anyhow::Result<Vec<PathBuf>> {
     let mut udev = udev::Enumerator::new()?;
+    udev.match_is_initialized()?;
     udev.match_subsystem("block")?;
 
     let devices = udev
         .scan_devices()?
-        .filter_map(|dev| {
-            if dev.is_initialized() {
-                dev.devnode().map(|dn| dn.to_string_lossy().into_owned())
-            } else {
-                None
-            }
-        })
+        .filter_map(|dev| dev.devnode().map(Path::to_path_buf))
         .collect::<Vec<_>>();
     Ok(devices)
 }
 
 /// Scan /proc/partitions for block devices. Works without udev.
-fn get_all_block_devnodes_procfs() -> anyhow::Result<Vec<String>> {
+fn get_all_block_devnodes_procfs() -> anyhow::Result<Vec<PathBuf>> {
     let contents = fs::read_to_string("/proc/partitions")?;
     let devices = contents
         .lines()
         .skip(2) // skip header lines
         .filter_map(|line| {
             let name = line.split_whitespace().nth(3)?;
-            let path = format!("/dev/{}", name);
-            if Path::new(&path).exists() {
-                Some(path)
+            let path = Path::new("/dev").join(name);
+            if path.exists() {
+                Some(path.to_path_buf())
             } else {
                 None
             }
@@ -141,7 +125,7 @@ fn get_all_block_devnodes_procfs() -> anyhow::Result<Vec<String>> {
     Ok(devices)
 }
 
-fn get_all_block_devnodes() -> anyhow::Result<Vec<String>> {
+fn get_all_block_devnodes() -> anyhow::Result<Vec<PathBuf>> {
     match get_all_block_devnodes_udev() {
         Ok(devs) if !devs.is_empty() => Ok(devs),
         Ok(_) => {
@@ -157,7 +141,7 @@ fn get_all_block_devnodes() -> anyhow::Result<Vec<String>> {
 
 fn read_sbs_matching_uuid(
     uuid: Uuid,
-    devices: &[String],
+    devices: &[PathBuf],
     opts: &bch_opts,
     filter_multipath: bool,
 ) -> Vec<(PathBuf, bch_sb_handle)> {
@@ -165,14 +149,17 @@ fn read_sbs_matching_uuid(
         .iter()
         .filter(|dev| {
             // When not using udev (which already filters), skip multipath components
-            if filter_multipath && find_multipath_holder(Path::new(dev)).is_some() {
-                debug!("Skipping multipath component device in fallback scan: {}", dev);
+            if filter_multipath && find_multipath_holder(dev).is_some() {
+                debug!(
+                    "Skipping multipath component device in fallback scan: {}",
+                    dev.display()
+                );
                 return false;
             }
             true
         })
         .filter_map(|dev| {
-            read_super_silent(PathBuf::from(dev), *opts)
+            read_super_silent(dev, *opts)
                 .ok()
                 .map(|sb| (PathBuf::from(dev), sb))
         })

--- a/src/device_scan.rs
+++ b/src/device_scan.rs
@@ -40,7 +40,7 @@ use log::debug;
 
 use crate::device_multipath::{find_multipath_holder, warn_multipath_component};
 
-fn read_super_silent(path: impl AsRef<Path>, mut opts: bch_opts) -> Result<bch_sb_handle, BchError> {
+pub fn read_super_silent(path: impl AsRef<Path>, mut opts: bch_opts) -> Result<bch_sb_handle, BchError> {
     opt_set!(opts, noexcl, 1);
     opt_set!(opts, nochanges, 1);
     opt_set!(opts, no_version_check, 1);
@@ -48,7 +48,7 @@ fn read_super_silent(path: impl AsRef<Path>, mut opts: bch_opts) -> Result<bch_s
     bch_bindgen::sb::io::read_super_silent(path.as_ref(), opts)
 }
 
-fn should_skip_multipath_component(dev: &udev::Device) -> bool {
+pub fn should_skip_multipath_component(dev: &udev::Device) -> bool {
     // Set by multipath's udev rule; fall back to sysfs if not present.
     if dev
         .property_value("DM_MULTIPATH_DEVICE_PATH")

--- a/src/device_scan.rs
+++ b/src/device_scan.rs
@@ -243,6 +243,13 @@ fn devs_str_sbs_from_device(
     get_devices_by_uuid(uuid, opts, use_udev)
 }
 
+pub fn parse_uuid_equals(s: &str) -> Result<Option<Uuid>> {
+    let Some(("UUID" | "OLD_BLKID_UUID", uuid)) = s.split_once('=') else {
+        return Ok(None);
+    };
+    Ok(Some(Uuid::parse_str(uuid)?))
+}
+
 pub fn scan_sbs(device: &String, opts: &bch_opts) -> Result<Vec<(PathBuf, bch_sb_handle)>> {
     if device.contains(':') {
         let mut opts = *opts;
@@ -271,9 +278,7 @@ pub fn scan_sbs(device: &String, opts: &bch_opts) -> Result<Vec<(PathBuf, bch_sb
 
     let udev = opt_get!(opts, mount_trusts_udev) != 0;
 
-    if let Some(("UUID" | "OLD_BLKID_UUID", uuid)) = device.split_once('=') {
-        let uuid = Uuid::parse_str(uuid)?;
-
+    if let Some(uuid) = parse_uuid_equals(&device)? {
         get_devices_by_uuid(uuid, opts, udev)
     } else {
         devs_str_sbs_from_device(Path::new(device), opts, udev)

--- a/src/device_scan.rs
+++ b/src/device_scan.rs
@@ -41,7 +41,7 @@ use log::debug;
 
 use crate::device_multipath::{find_multipath_holder, warn_multipath_component};
 
-fn read_super_silent(path: impl AsRef<Path>, mut opts: bch_opts) -> anyhow::Result<bch_sb_handle> {
+fn read_super_silent(path: impl AsRef<Path>, mut opts: bch_opts) -> Result<bch_sb_handle, BchError> {
     opt_set!(opts, noexcl, 1);
     opt_set!(opts, nochanges, 1);
     opt_set!(opts, no_version_check, 1);


### PR DESCRIPTION
The command takes a `UUID=<UUID>` argument and waits until all devices for that filesystem are present.

I believe that this could be useful for initramfs (e.g. https://github.com/NixOS/nixpkgs/issues/451418), but I have not tried to actually modify an initramfs to make use of that command.

Ping @ElvishJerricco and @JohnRTitor as you may have opinions.

I have tested the command locally with loop devices:

```console
$ truncate -s 1G a.img
$ truncate -s 1G b.img
$ truncate -s 1G c.img
$ ./bcachefs format a.img b.img c.img --replicas=1
$ ./bcachefs wait UUID=2352db9a-9876-41e2-8dd9-199ae5928330 &
$ losetup -f a.img
$ losetup -f b.img
$ losetup -f c.img
```