### PR TITLE
Bump MSRV to 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "bcachefs-tools"
 version = "1.37.5"
 authors = ["Yuxuan Shui <yshuiv7@gmail.com>", "Kayla Firestack <dev@kaylafire.me>", "Kent Overstreet <kent.overstreet@linux.dev>" ]
 edition = "2021"
-rust-version = "1.77.0"
+rust-version = "1.85.0"
 
 [[bin]]
 name = "bcachefs"


### PR DESCRIPTION
The `fiemap` crate uses the Rust 2024 Edition which was stabilized in 1.85, so bump to MSRV to that. This fixes an error when running `nix build -L '.#githubActions.checks.x86_64-linux."msrv"'` in CI.