### PR TITLE
Restore musl compatibility

### DIFF
--- a/src/wrappers/bdev.rs
+++ b/src/wrappers/bdev.rs
@@ -124,7 +124,7 @@ pub fn nonrot(fd: RawFd) -> bool {
     // put_ushort — bdev_nonrot internally uses bdev_get_queue(bdev), which
     // resolves to the parent disk's queue for partitions and handles LVM,
     // md, loop devices, etc. uniformly.
-    const BLKROTATIONAL: libc::c_ulong = 0x127E;
+    const BLKROTATIONAL: libc::Ioctl = 0x127E;
     let mut rotational: u16 = 0;
     let ret = unsafe { libc::ioctl(fd, BLKROTATIONAL, &mut rotational) };
     ret == 0 && rotational == 0


### PR DESCRIPTION
musl uses a different C type for ioctl values.

Was fixed in 08e95f7e3f58510f289859301251c9d7d99486ea and broken again in daa0a61bc782c0ecd85bdaee3693be609784d0b1.