### PR TITLE
apt: publish repository key as binary keyring

### DIFF
--- a/.github/workflows/deb-buildd.yml
+++ b/.github/workflows/deb-buildd.yml
@@ -154,16 +154,17 @@ jobs:
         shell: sudo podman exec --interactive --tty container eatmydata sh "{0}"
         run: |
           set -xe
+          install -d -m 0755 /etc/apt/keyrings
           gpg --import <<EOT
           ${{ secrets.GPG_SECRET_SUBKEYS }}
           EOT
           gpg \
-            --output /etc/apt/trusted.gpg.d/apt.bcachefs.org.gpg \
+            --output /etc/apt/keyrings/apt.bcachefs.org.pgp \
             --export \
             ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }} \
           ;
           gpg \
-            --output /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc \
+            --output /etc/apt/keyrings/apt.bcachefs.org.asc \
             --armor \
             --export \
             ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }} \
@@ -173,7 +174,7 @@ jobs:
             --no-default-keyring \
             --keyring ~/.gnupg/trustedkeys.gpg \
             --import \
-            /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc \
+            /etc/apt/keyrings/apt.bcachefs.org.pgp \
           ;
           tee -a ~/.gnupg/gpg.conf > /dev/null <<EOT
           default-key ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}
@@ -416,7 +417,7 @@ jobs:
           KEY_DIR="/usr/share/debsig/keyrings/${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}"
           mkdir $POL_DIR
           mkdir $KEY_DIR
-          cp /etc/apt/trusted.gpg.d/apt.bcachefs.org.gpg $KEY_DIR/
+          cp /etc/apt/keyrings/apt.bcachefs.org.pgp "$KEY_DIR/apt.bcachefs.org.gpg"
           tee $POL_DIR/pol.pol > /dev/null <<EOT
           <?xml version="1.0"?>
           <!DOCTYPE Policy SYSTEM "https://www.debian.org/debsig/1.0/policy.dtd">
@@ -625,16 +626,17 @@ jobs:
         shell: sudo podman exec --interactive --tty container eatmydata sh "{0}"
         run: |
           set -xe
+          install -d -m 0755 /etc/apt/keyrings
           gpg --import <<EOT
           ${{ secrets.GPG_SECRET_SUBKEYS }}
           EOT
           gpg \
-            --output /etc/apt/trusted.gpg.d/apt.bcachefs.org.gpg \
+            --output /etc/apt/keyrings/apt.bcachefs.org.pgp \
             --export \
             ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }} \
           ;
           gpg \
-            --output /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc \
+            --output /etc/apt/keyrings/apt.bcachefs.org.asc \
             --armor \
             --export \
             ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }} \
@@ -644,7 +646,7 @@ jobs:
             --no-default-keyring \
             --keyring ~/.gnupg/trustedkeys.gpg \
             --import \
-            /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc \
+            /etc/apt/keyrings/apt.bcachefs.org.pgp \
           ;
           tee -a ~/.gnupg/gpg.conf > /dev/null <<EOT
           default-key ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}
@@ -737,7 +739,7 @@ jobs:
           KEY_DIR="/usr/share/debsig/keyrings/${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}"
           mkdir $POL_DIR
           mkdir $KEY_DIR
-          cp /etc/apt/trusted.gpg.d/apt.bcachefs.org.gpg $KEY_DIR/
+          cp /etc/apt/keyrings/apt.bcachefs.org.pgp "$KEY_DIR/apt.bcachefs.org.gpg"
           tee $POL_DIR/pol.pol > /dev/null <<EOT
           <?xml version="1.0"?>
           <!DOCTYPE Policy SYSTEM "https://www.debian.org/debsig/1.0/policy.dtd">

--- a/.github/workflows/deb-publish.yml
+++ b/.github/workflows/deb-publish.yml
@@ -130,16 +130,17 @@ jobs:
         shell: sudo podman exec --interactive --tty container eatmydata sh "{0}"
         run: |
           set -xe
+          install -d -m 0755 /etc/apt/keyrings
           gpg --import <<EOT
           ${{ secrets.GPG_SECRET_SUBKEYS }}
           EOT
           gpg \
-            --output /etc/apt/trusted.gpg.d/apt.bcachefs.org.gpg \
+            --output /etc/apt/keyrings/apt.bcachefs.org.pgp \
             --export \
             ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }} \
           ;
           gpg \
-            --output /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc \
+            --output /etc/apt/keyrings/apt.bcachefs.org.asc \
             --armor \
             --export \
             ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }} \
@@ -149,7 +150,7 @@ jobs:
             --no-default-keyring \
             --keyring ~/.gnupg/trustedkeys.gpg \
             --import \
-            /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc \
+            /etc/apt/keyrings/apt.bcachefs.org.pgp \
           ;
           tee -a ~/.gnupg/gpg.conf > /dev/null <<EOT
           default-key ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}
@@ -243,7 +244,7 @@ jobs:
           KEY_DIR="/usr/share/debsig/keyrings/${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}"
           mkdir $POL_DIR
           mkdir $KEY_DIR
-          cp /etc/apt/trusted.gpg.d/apt.bcachefs.org.gpg $KEY_DIR/
+          cp /etc/apt/keyrings/apt.bcachefs.org.pgp "$KEY_DIR/apt.bcachefs.org.gpg"
           tee $POL_DIR/pol.pol > /dev/null <<EOT
           <?xml version="1.0"?>
           <!DOCTYPE Policy SYSTEM "https://www.debian.org/debsig/1.0/policy.dtd">
@@ -305,7 +306,8 @@ jobs:
           mkdir -p "$PUBLIC_ROOT"
           ln -sr "$PUBLIC_ROOT" "$PUBLIC_ROOT"/dists || /bin/true
           if [ "${{ steps.gpg.conclusion }}" != "skipped" ]; then
-          cp -f /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc "$PUBLIC_ROOT"
+          cp -f /etc/apt/keyrings/apt.bcachefs.org.pgp "$PUBLIC_ROOT"
+          cp -f /etc/apt/keyrings/apt.bcachefs.org.asc "$PUBLIC_ROOT"
           fi
           if [ "${{ (github.event_name == 'push' && github.ref_type == 'branch' && github.ref_name == 'master') && 'true' || 'false' }}" = "true" ]; then
           export GPG_SIGNING_SUBKEY_FINGERPRINT=${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}

--- a/.github/workflows/deb-reprotest.yml
+++ b/.github/workflows/deb-reprotest.yml
@@ -146,8 +146,14 @@ jobs:
           ${{ secrets.GPG_SECRET_SUBKEYS }}
           EOT
           set -xe
+          install -d -m 0755 /etc/apt/keyrings
           gpg \
-            --output /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc \
+            --output /etc/apt/keyrings/apt.bcachefs.org.pgp \
+            --export \
+            ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }} \
+          ;
+          gpg \
+            --output /etc/apt/keyrings/apt.bcachefs.org.asc \
             --armor \
             --export \
             ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }} \
@@ -157,7 +163,7 @@ jobs:
             --no-default-keyring \
             --keyring ~/.gnupg/trustedkeys.gpg \
             --import \
-            /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc \
+            /etc/apt/keyrings/apt.bcachefs.org.pgp \
           ;
       - name: Ensure that the download directory does not exist
         timeout-minutes: 1

--- a/.github/workflows/deb-src.yml
+++ b/.github/workflows/deb-src.yml
@@ -136,11 +136,17 @@ jobs:
         shell: sudo podman exec --interactive --tty container eatmydata sh "{0}"
         run: |
           set -xe
+          install -d -m 0755 /etc/apt/keyrings
           gpg --import <<EOT
           ${{ secrets.GPG_SECRET_SUBKEYS }}
           EOT
           gpg \
-            --output /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc \
+            --output /etc/apt/keyrings/apt.bcachefs.org.pgp \
+            --export \
+            ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }} \
+          ;
+          gpg \
+            --output /etc/apt/keyrings/apt.bcachefs.org.asc \
             --armor \
             --export \
             ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }} \
@@ -150,7 +156,7 @@ jobs:
             --no-default-keyring \
             --keyring ~/.gnupg/trustedkeys.gpg \
             --import \
-            /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc \
+            /etc/apt/keyrings/apt.bcachefs.org.pgp \
           ;
           tee -a ~/.gnupg/gpg.conf > /dev/null <<EOT
           default-key ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }}

--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -148,11 +148,17 @@ jobs:
         shell: sudo podman exec --interactive --tty container eatmydata sh "{0}"
         run: |
           set -xe
+          install -d -m 0755 /etc/apt/keyrings
           gpg --import <<EOT
           ${{ secrets.GPG_SECRET_SUBKEYS }}
           EOT
           gpg \
-            --output /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc \
+            --output /etc/apt/keyrings/apt.bcachefs.org.pgp \
+            --export \
+            ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }} \
+          ;
+          gpg \
+            --output /etc/apt/keyrings/apt.bcachefs.org.asc \
             --armor \
             --export \
             ${{ secrets.GPG_SIGNING_SUBKEY_FINGERPRINT }} \
@@ -162,7 +168,7 @@ jobs:
             --no-default-keyring \
             --keyring ~/.gnupg/trustedkeys.gpg \
             --import \
-            /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc \
+            /etc/apt/keyrings/apt.bcachefs.org.pgp \
           ;
           echo "" >> ~/.gnupg/gpg-agent.conf
           echo "enable-ssh-support" >> ~/.gnupg/gpg-agent.conf
@@ -315,7 +321,7 @@ jobs:
           set -xe
           OBS_REPO_DIR="${{ github.workspace }}/bcachefs-obs"
           cd "$OBS_REPO_DIR"
-          cp /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc apt.bcachefs.org.keyring
+          cp /etc/apt/keyrings/apt.bcachefs.org.pgp apt.bcachefs.org.keyring
           rm -f "${{ github.workspace }}/_service"
           tee -a "${{ github.workspace }}/_service" > /dev/null <<EOT
           <services>

--- a/doc/apt.bcachefs.org-README.md
+++ b/doc/apt.bcachefs.org-README.md
@@ -1,6 +1,8 @@
 To add this repository to your computer, do:
 ```bash
-wget -qO- https://apt.bcachefs.org/apt.bcachefs.org.asc | sudo tee /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc
+sudo install -d -m 0755 /etc/apt/keyrings
+wget -qO- https://apt.bcachefs.org/apt.bcachefs.org.pgp | sudo tee /etc/apt/keyrings/apt.bcachefs.org.pgp > /dev/null
+sudo chmod 0644 /etc/apt/keyrings/apt.bcachefs.org.pgp
 # Fingerprint: EA483B991020C72A8A5035ADA0620B5E0E01C1DD
 sudo tee /etc/apt/sources.list.d/apt.bcachefs.org.sources > /dev/null <<EOF
 Types: deb deb-src
@@ -8,7 +10,7 @@ URIs: https://apt.bcachefs.org/unstable/
 # Or replace unstable with your distro's release name
 Suites: bcachefs-tools-release
 Components: main
-Signed-By: /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc
+Signed-By: /etc/apt/keyrings/apt.bcachefs.org.pgp
 EOF
 sudo apt update
 sudo apt install bcachefs-tools
@@ -19,15 +21,11 @@ This will give you packages for the latest release of `bcachefs-tools`.
 If you need packages for the latest `git master` commit,
 replace `bcachefs-tools-release` with `bcachefs-tools-snapshot`.
 
-Or you can use `add-apt-repository` tool. Stable channel:
-```bash
-sudo add-apt-repository "deb https://apt.bcachefs.org/unstable bcachefs-tools-release main"
-```
+Stable channel:
+`Suites: bcachefs-tools-release`
 
-If you feel like living dangerously, there's also nightly/snapshot packages:
-```bash
-sudo add-apt-repository "deb https://apt.bcachefs.org/unstable bcachefs-tools-snapshot main"
-```
+Snapshot/nightly channel:
+`Suites: bcachefs-tools-snapshot`
 
 If you want to ensure that the packages from this repository are always preferred, do:
 ```bash

--- a/package-ci/scripts/publish.sh
+++ b/package-ci/scripts/publish.sh
@@ -147,6 +147,7 @@ rsync -rlpt --delay-updates "$STAGING_ROOT/" "$PUBLISH_ROOT/"
 
 # Export GPG public key so users can fetch it for apt verification
 echo "--- Exporting GPG public key ---"
+gpg --export "$GPG_SIGNING_SUBKEY_FINGERPRINT" > "$PUBLISH_ROOT/apt.bcachefs.org.pgp"
 gpg --armor --export "$GPG_SIGNING_SUBKEY_FINGERPRINT" > "$PUBLISH_ROOT/apt.bcachefs.org.asc"
 
 # Generate landing page footer (nginx fancyindex_footer)
@@ -155,7 +156,9 @@ mkdir -p "$PUBLISH_ROOT/.footer"
 cat > "$PUBLISH_ROOT/.footer/README.html" << 'FOOTER'
 <hr>
 <h2>Adding this repository</h2>
-<pre><code>wget -qO- https://apt.bcachefs.org/apt.bcachefs.org.asc | sudo tee /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc
+<pre><code>sudo install -d -m 0755 /etc/apt/keyrings
+wget -qO- https://apt.bcachefs.org/apt.bcachefs.org.pgp | sudo tee /etc/apt/keyrings/apt.bcachefs.org.pgp &gt; /dev/null
+sudo chmod 0644 /etc/apt/keyrings/apt.bcachefs.org.pgp
 FOOTER
 
 # Inject the real fingerprint
@@ -170,13 +173,15 @@ Types: deb deb-src
 URIs: https://apt.bcachefs.org/unstable/
 Suites: bcachefs-tools-release
 Components: main
-Signed-By: /etc/apt/trusted.gpg.d/apt.bcachefs.org.asc
+Signed-By: /etc/apt/keyrings/apt.bcachefs.org.pgp
 SOURCES
 
 sudo apt update
 sudo apt install bcachefs-tools
 </code></pre>
 <p><strong>Note:</strong> For latest <code>git master</code> packages, replace <code>bcachefs-tools-release</code> with <code>bcachefs-tools-snapshot</code>.</p>
+<p>Stable channel: <code>Suites: bcachefs-tools-release</code></p>
+<p>Snapshot/nightly channel: <code>Suites: bcachefs-tools-snapshot</code></p>
 <p>For more information, see the <a href="https://wiki.debian.org/DebianRepository/UseThirdParty">Debian third-party repository guide</a>.</p>
 <p>Binary <code>.deb</code> packages are signed with <a href="https://manpages.debian.org/debsigs">debsigs</a>. Source artifacts can be verified using <a href="https://github.com/sigstore/rekor">Rekor</a>.</p>
 FOOTER


### PR DESCRIPTION
## Summary

This fixes the APT repository setup described in #555.

The published setup instructions no longer tell users to install the repository key into `/etc/apt/trusted.gpg.d/`. Instead, they now install a repository-specific keyring into `/etc/apt/keyrings/` and reference it via `Signed-By`.

The setup instructions also keep the important distinction between the stable and snapshot channels:
- `bcachefs-tools-release`
- `bcachefs-tools-snapshot`

In addition, the repository publishing flow now exports and publishes a binary `apt.bcachefs.org.pgp` keyring, while keeping the armored `.asc` export available as a secondary format.

## Changes

- update `doc/apt.bcachefs.org-README.md` to use `/etc/apt/keyrings/apt.bcachefs.org.pgp`
- update the published landing page footer generated by `package-ci/scripts/publish.sh`
- keep the stable/snapshot suite distinction explicit in the published instructions
- export a binary `apt.bcachefs.org.pgp` keyring in addition to the armored `.asc` key
- switch Debian/OBS workflow plumbing to use the binary keyring internally
- keep the armored export available for compatibility

## Why

Using `/etc/apt/trusted.gpg.d/` for third-party repository keys is against Debian's third-party repository guidance and grants broader trust than intended.

I did not restore the old `add-apt-repository` examples. As far as I could verify, `add-apt-repository` itself is not deprecated, but its older implicit `LINE` form is documented as deprecated in current Ubuntu manpages. More importantly, `software-properties` still has an open bug about relying on deprecated `apt-key`, so it is not a good fit for third-party repository setup guidance here.

Publishing a dedicated binary keyring and installing it into `/etc/apt/keyrings/` matches the recommended trust model more closely and keeps the repository setup scoped to this repository.

Closes: #555
