### PR TITLE
bdev: use libc::Ioctl instead of libc::c_ulong

### DIFF
--- a/src/wrappers/bdev.rs
+++ b/src/wrappers/bdev.rs
@@ -124,7 +124,7 @@ pub fn nonrot(fd: RawFd) -> bool {
     // put_ushort — bdev_nonrot internally uses bdev_get_queue(bdev), which
     // resolves to the parent disk's queue for partitions and handles LVM,
     // md, loop devices, etc. uniformly.
-    const BLKROTATIONAL: libc::c_ulong = 0x127E;
+    const BLKROTATIONAL: libc::Ioctl = 0x127E as libc::Ioctl;
     let mut rotational: u16 = 0;
     let ret = unsafe { libc::ioctl(fd, BLKROTATIONAL, &mut rotational) };
     ret == 0 && rotational == 0


### PR DESCRIPTION
ioctl request numbers are 32-bit values. glibc's ioctl() accepts c_ulong (u64 on 64-bit) but this is wrong — musl correctly uses c_int. Using libc::c_ulong breaks compilation on musl targets.

Fixes: daa0a61bc782 ("tools: use BLKROTATIONAL ioctl for nonrot detection")