### PR TITLE
Add libunwind to nix buildInputs

### DIFF
--- a/crane-build.nix
+++ b/crane-build.nix
@@ -13,6 +13,7 @@
   keyutils,
   libaio,
   libsodium,
+  libunwind,
   liburcu,
   libuuid,
   lz4,
@@ -59,6 +60,7 @@ let
       keyutils
       libaio
       libsodium
+      libunwind
       liburcu
       libuuid
       lz4


### PR DESCRIPTION
Nix build fails with
       > Using versionCheckHook
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/4vkm0p520n69a3mxr9sv7p2vvvgb93k3-source
       > source root is source
       > Running phase: patchPhase
       > Executing configureCargoCommonVars
       > decompressing cargo artifacts from /nix/store/cbfiacxas1z1kwg9frzdg0scs6j26n9g-bcachefs-tools-deps-1.38.2+80865cc/target.tar.zst to target
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > will append /build/source/.cargo-home/config.toml with contents of /nix/store/87x75s7dyy1500ryrqzzlvb3dmlcz6bl-vendor-cargo-deps/config.toml
       > default configurePhase, nothing to do
       > Running phase: buildPhase
       > +++ command cargo --version
       > cargo 1.91.0 (ea2d97820 2025-10-10)
       > Package libunwind was not found in the pkg-config search path.
       > Perhaps you should add the directory containing `libunwind.pc'
       > to the PKG_CONFIG_PATH environment variable
       > No package 'libunwind' found
       > Makefile:113: *** pkg-config error, command: pkg-config --cflags "blkid uuid liburcu libsodium zlib liblz4 libzstd libudev libkeyutils libunwind".  Stop.

This PR should fix that.