### PR TITLE
nix: add libunwind to build inputs

### DIFF
--- a/crane-build.nix
+++ b/crane-build.nix
@@ -12,6 +12,7 @@
   fuse3,
   keyutils,
   libaio,
+  libunwind,
   libsodium,
   liburcu,
   libuuid,
@@ -58,6 +59,7 @@ let
     buildInputs = [
       keyutils
       libaio
+      libunwind
       libsodium
       liburcu
       libuuid


### PR DESCRIPTION
Add `libunwind` to `crane-build.nix` so the Nix package matches the current upstream build requirements. A recent upstream change added `libunwind` to the `Makefile`'s `PKGCONFIG_LIBS`, but the Nix derivation was not updated accordingly. As a result, Nix builds fail during `pkg-config` resolution with:
 ```text
  No package 'libunwind' found
  Makefile:113: *** pkg-config error ...
```

  ## Validation

  Built the package locally with:

  nix build .#bcachefs-tools

  This moved past the previous pkg-config failure and reached the package build normally.
