### PR TITLE
add crc32c bitflip repair as last resort.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,23 @@ install_dkms: dkms/dkms.conf dkms/module-version.c
 	sed -i "s|^#define TRACE_INCLUDE_PATH \\.\\./\\.\\./fs/bcachefs$$|#define TRACE_INCLUDE_PATH .|" \
 	  $(DESTDIR)$(DKMSDIR)/src/fs/bcachefs/debug/trace.h
 
+# Build the kernel module via DKMS and load it. Must run as root
+# (sudo make dkms-reload). Idempotent — re-running rebuilds + reloads.
+.PHONY: dkms-reload
+dkms-reload: all
+	@if [ "$$(id -u)" -ne 0 ]; then \
+		echo "dkms-reload: must run as root (sudo make $@)"; exit 1; \
+	fi
+	$(Q)$(MAKE) install_dkms
+	@echo "    [DKMS]   bcachefs/$(VERSION)"
+	$(Q)dkms remove  -m bcachefs -v $(VERSION) --all 2>/dev/null || true
+	$(Q)dkms add     -m bcachefs -v $(VERSION)
+	$(Q)dkms build   -m bcachefs -v $(VERSION)
+	$(Q)dkms install -m bcachefs -v $(VERSION)
+	$(Q)modprobe -r bcachefs 2>/dev/null || true
+	$(Q)modprobe bcachefs
+	@modinfo bcachefs | grep -E '^(version|filename|srcversion):'
+
 .PHONY: clean
 clean:
 	@echo "Cleaning all"

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
+# `:=` (simple expansion) is load-bearing here: VERSION feeds into DKMSDIR,
+# the dkms.conf PACKAGE_VERSION, version.h, and the `dkms add/remove` args.
+# With recursive `=` the $(shell git describe) re-runs on every $(VERSION)
+# expansion — so HEAD moving mid-recipe (e.g. a commit/rebase landing during
+# a long `make install_dkms`) can land the six install steps in two
+# different /usr/src/bcachefs-vN/ trees. Lock VERSION once at make start.
 ifneq ($(wildcard .git),)
-VERSION=$(shell git -c safe.directory=$$PWD -c core.abbrev=12 describe)
+VERSION:=$(shell git -c safe.directory=$$PWD -c core.abbrev=12 describe)
 else ifneq ($(wildcard .version),)
-VERSION=$(shell cat .version)
+VERSION:=$(shell cat .version)
 else
-VERSION=$(shell cargo metadata --format-version 1 | jq -r '.packages[] | select(.name | test("bcachefs-tools")) | .version')
+VERSION:=$(shell cargo metadata --format-version 1 | jq -r '.packages[] | select(.name | test("bcachefs-tools")) | .version')
 endif
 
 PREFIX?=/usr/local
@@ -195,7 +201,7 @@ libbcachefs.a: $(OBJS)
 	$(Q)echo "$(VERSION)" > .version.new
 	$(Q)cmp -s .version.new .version || mv .version.new .version
 
-VERSION_H=$(shell echo "#define bcachefs_version \\\"$(VERSION)\\\"")
+VERSION_H:=$(shell echo "#define bcachefs_version \\\"$(VERSION)\\\"")
 
 version.h: force
 	$(Q)echo "$(VERSION_H)" > version.h.new
@@ -264,8 +270,6 @@ install_dkms: dkms/dkms.conf dkms/module-version.c
 	(cd fs; find -name '*.[ch]' -exec install -m0644 -D {} $(DESTDIR)$(DKMSDIR)/src/fs/bcachefs/{} \; )
 	$(INSTALL) -m0644 -D dkms/module-version.c	-t $(DESTDIR)$(DKMSDIR)/src/fs/bcachefs
 	$(INSTALL) -m0644 -D version.h			-t $(DESTDIR)$(DKMSDIR)/src/fs/bcachefs
-	sed -i "s|^#define TRACE_INCLUDE_PATH \\.\\./\\.\\./fs/bcachefs$$|#define TRACE_INCLUDE_PATH .|" \
-	  $(DESTDIR)$(DKMSDIR)/src/fs/bcachefs/debug/trace.h
 
 # Build the kernel module via DKMS and load it. Must run as root
 # (sudo make dkms-reload). Idempotent — re-running rebuilds + reloads.

--- a/fs/Makefile
+++ b/fs/Makefile
@@ -36,6 +36,7 @@ bcachefs-y		:=			\
 	btree/write.o				\
 	btree/write_buffer.o			\
 	data/checksum.o				\
+	data/bitflip_repair.o			\
 	data/compress.o				\
 	data/copygc.o				\
 	data/ec/create.o			\

--- a/fs/alloc/accounting.c
+++ b/fs/alloc/accounting.c
@@ -182,7 +182,7 @@ static inline bool is_zero(char *start, char *end)
 #define field_end(p, member)	(((void *) (&p.member)) + sizeof(p.member))
 
 int bch2_accounting_validate(struct bch_fs *c, struct bkey_s_c k,
-			     struct bkey_validate_context from)
+			     const struct bkey_validate_context *from)
 {
 	struct disk_accounting_pos acc_k;
 	bpos_to_disk_accounting_pos(&acc_k, k.k->p);
@@ -192,7 +192,7 @@ int bch2_accounting_validate(struct bch_fs *c, struct bkey_s_c k,
 	if (acc_k.type >= BCH_DISK_ACCOUNTING_TYPE_NR)
 		return 0;
 
-	bkey_fsck_err_on((from.flags & BCH_VALIDATE_commit) &&
+	bkey_fsck_err_on((from->flags & BCH_VALIDATE_commit) &&
 			 bversion_zero(k.k->bversion),
 			 c, accounting_key_version_0,
 			 "accounting key with version=0");

--- a/fs/alloc/accounting.h
+++ b/fs/alloc/accounting.h
@@ -117,7 +117,7 @@ do {									\
 int bch2_mod_dev_cached_sectors(struct btree_trans *, unsigned, s64, bool);
 
 int bch2_accounting_validate(struct bch_fs *, struct bkey_s_c,
-			     struct bkey_validate_context);
+			     const struct bkey_validate_context *);
 void bch2_accounting_key_to_text(struct printbuf *, struct bch_fs *, struct disk_accounting_pos *);
 void bch2_accounting_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 void bch2_accounting_swab(const struct bch_fs *, struct bkey_s);

--- a/fs/alloc/background.c
+++ b/fs/alloc/background.c
@@ -1712,7 +1712,7 @@ void bch2_fs_capacity_exit(struct bch_fs *c)
 
 int bch2_fs_capacity_init(struct bch_fs *c)
 {
-	mutex_init(&c->capacity.sectors_available_lock);
+	spin_lock_init(&c->capacity.sectors_available_lock);
 	seqcount_init(&c->capacity.usage_lock);
 
 	try(percpu_init_rwsem(&c->capacity.mark_lock));

--- a/fs/alloc/background.c
+++ b/fs/alloc/background.c
@@ -1281,6 +1281,66 @@ int bch2_trigger_alloc(struct btree_trans *trans, struct btree_trigger_op op)
 			SET_BCH_ALLOC_V4_NEED_DISCARD(new_a, true);
 		}
 
+		if (statechange_to(a->data_type == BCH_DATA_free)) {
+			/*
+			 * Legitimate paths to free:
+			 *   - from need_discard via the discard path (with
+			 *     BTREE_TRIGGER_is_discard)
+			 *   - from need_gc_gens via bch2_gc_gens() bumping
+			 *     oldest_gen (bucket was empty the whole time;
+			 *     no discard needed)
+			 */
+			WARN_ON(old_a->data_type != BCH_DATA_need_discard &&
+				old_a->data_type != BCH_DATA_need_gc_gens);
+		}
+
+		if (statechange_from(a->data_type == BCH_DATA_need_discard)) {
+			if (data_type_is_empty(new_a->data_type))
+				WARN_ON(!(op.flags & BTREE_TRIGGER_is_discard));
+			else
+				WARN_ON(!bch2_bucket_is_open_safe(c, op.new.k->p.inode, op.new.k->p.offset));
+		}
+
+		/*
+		 * Catch buckets at data_type=free that still carry
+		 * empty/discard bookkeeping. The legitimate writer of free
+		 * state is __discard_mark_free() in alloc/discard.c, which
+		 * clears NEED_DISCARD and both journal_seq_* fields in the
+		 * same update that sets data_type=free; anything reaching
+		 * here with dirty bookkeeping bypassed that path - either
+		 * upgrade residue (old kernel set NEED_DISCARD without the
+		 * new data_type framing, then alloc_data_type_set at the top
+		 * of this trigger normalized the bucket to free), or a
+		 * caller that wrote data_type=free without going through
+		 * discard.c.
+		 *
+		 * Repair: if NEED_DISCARD is set, the bucket may genuinely
+		 * still need discarding - walk data_type back to need_discard
+		 * so the discard worker re-handles it. Otherwise the
+		 * journal_seq_* are stale residue; clear them.
+		 */
+		if (new_a->data_type == BCH_DATA_free &&
+		    (BCH_ALLOC_V4_NEED_DISCARD(new_a) ||
+		     new_a->journal_seq_nonempty ||
+		     new_a->journal_seq_empty)) {
+			CLASS(printbuf, buf)();
+			prt_printf(&buf, "bucket marked free still has discard/journal bookkeeping\n");
+			prt_printf(&buf, "NEED_DISCARD=%llu, journal_seq_nonempty=%llu, journal_seq_empty=%llu\n",
+				   BCH_ALLOC_V4_NEED_DISCARD(new_a),
+				   new_a->journal_seq_nonempty,
+				   new_a->journal_seq_empty);
+			bch2_bkey_val_to_text(&buf, c, op.new.s_c);
+			log_fsck_err(trans,
+				     alloc_key_data_type_free_dirty_bookkeeping,
+				     "%s", buf.buf);
+			if (BCH_ALLOC_V4_NEED_DISCARD(new_a)) {
+				new_a->data_type = BCH_DATA_need_discard;
+			} else {
+				new_a->journal_seq_nonempty = 0;
+				new_a->journal_seq_empty = 0;
+			}
+		}
+
 		if (data_type_is_empty(new_a->data_type) &&
 		    BCH_ALLOC_V4_NEED_INC_GEN(new_a) &&
 		    !bch2_bucket_is_open_safe(c, op.new.k->p.inode, op.new.k->p.offset)) {
@@ -1333,13 +1393,14 @@ int bch2_trigger_alloc(struct btree_trans *trans, struct btree_trigger_op op)
 		u64 transaction_seq = trans->journal_res.seq;
 		BUG_ON(!transaction_seq);
 
-		CLASS(printbuf, buf)();
-		if (log_fsck_err_on(transaction_seq && new_a->journal_seq_nonempty > transaction_seq,
-				    trans, alloc_key_journal_seq_in_future,
-				    "bucket journal seq in future (currently at %llu)\n%s",
-				    journal_cur_seq(&c->journal),
-				    (bch2_bkey_val_to_text(&buf, c, op.new.s_c), buf.buf)))
+		if (transaction_seq && new_a->journal_seq_nonempty > transaction_seq) {
+			CLASS(printbuf, buf)();
+			prt_printf(&buf, "bucket journal seq in future (currently at %llu)\n",
+				   journal_cur_seq(&c->journal));
+			bch2_bkey_val_to_text(&buf, c, op.new.s_c);
+			log_fsck_err(trans, alloc_key_journal_seq_in_future, "%s", buf.buf);
 			new_a->journal_seq_nonempty = transaction_seq;
+		}
 
 		if (new_a->gen != old_a->gen) {
 			guard(rcu)();
@@ -1349,22 +1410,8 @@ int bch2_trigger_alloc(struct btree_trans *trans, struct btree_trigger_op op)
 			*gen = new_a->gen;
 		}
 
-		if (statechange_to(a->data_type == BCH_DATA_free)) {
-			/*
-			 * Legitimate paths to free:
-			 *   - from need_discard via the discard path (with
-			 *     BTREE_TRIGGER_is_discard)
-			 *   - from need_gc_gens via bch2_gc_gens() bumping
-			 *     oldest_gen (bucket was empty the whole time;
-			 *     no discard needed)
-			 */
-			WARN_ON(old_a->data_type != BCH_DATA_need_discard &&
-				old_a->data_type != BCH_DATA_need_gc_gens);
-
-			new_a->journal_seq_nonempty = new_a->journal_seq_empty = 0;
-
+		if (statechange_to(a->data_type == BCH_DATA_free))
 			bch2_alloc_wake_dev(ca);
-		}
 
 		if (statechange_to(!data_type_is_empty(a->data_type))) {
 			/*
@@ -1376,13 +1423,6 @@ int bch2_trigger_alloc(struct btree_trans *trans, struct btree_trigger_op op)
 			 */
 			if (!new_a->journal_seq_nonempty)
 				new_a->journal_seq_nonempty = transaction_seq;
-		}
-
-		if (statechange_from(a->data_type == BCH_DATA_need_discard)) {
-			if (data_type_is_empty(new_a->data_type))
-				BUG_ON(!(op.flags & BTREE_TRIGGER_is_discard));
-			else
-				BUG_ON(!bch2_bucket_is_open_safe(c, op.new.k->p.inode, op.new.k->p.offset));
 		}
 
 		if (statechange_to(a->data_type == BCH_DATA_need_discard)) {
@@ -1418,17 +1458,6 @@ int bch2_trigger_alloc(struct btree_trans *trans, struct btree_trigger_op op)
 
 		if (statechange_to(a->data_type == BCH_DATA_need_gc_gens))
 			bch2_gc_gens_async(c);
-
-		/*
-		 * Catch bad transitions that leave the bucket pretending to be
-		 * free while still carrying empty/discard bookkeeping. If the
-		 * bucket really transitioned to free legitimately the discard
-		 * path / statechange_to(free) clears these.
-		 */
-		BUG_ON(new_a->data_type == BCH_DATA_free &&
-		       (BCH_ALLOC_V4_NEED_DISCARD(new_a) ||
-			new_a->journal_seq_nonempty ||
-			new_a->journal_seq_empty));
 	}
 
 	if ((op.flags & BTREE_TRIGGER_gc) && (op.flags & BTREE_TRIGGER_insert)) {

--- a/fs/alloc/background.c
+++ b/fs/alloc/background.c
@@ -652,7 +652,7 @@ static unsigned bch_alloc_v1_val_u64s(const struct bch_alloc *a)
 }
 
 int bch2_alloc_v1_validate(struct bch_fs *c, struct bkey_s_c k,
-			   struct bkey_validate_context from)
+			   const struct bkey_validate_context *from)
 {
 	struct bkey_s_c_alloc a = bkey_s_c_to_alloc(k);
 	int ret = 0;
@@ -667,7 +667,7 @@ fsck_err:
 }
 
 int bch2_alloc_v2_validate(struct bch_fs *c, struct bkey_s_c k,
-			   struct bkey_validate_context from)
+			   const struct bkey_validate_context *from)
 {
 	struct bkey_alloc_unpacked u;
 	int ret = 0;
@@ -680,7 +680,7 @@ fsck_err:
 }
 
 int bch2_alloc_v3_validate(struct bch_fs *c, struct bkey_s_c k,
-			   struct bkey_validate_context from)
+			   const struct bkey_validate_context *from)
 {
 	struct bkey_alloc_unpacked u;
 	int ret = 0;
@@ -693,7 +693,7 @@ fsck_err:
 }
 
 int bch2_alloc_v4_validate(struct bch_fs *c, struct bkey_s_c k,
-			   struct bkey_validate_context from)
+			   const struct bkey_validate_context *from)
 {
 	struct bch_alloc_v4 a;
 	int ret = 0;
@@ -952,7 +952,7 @@ struct bkey_i_alloc_v4 *bch2_trans_start_alloc_update(struct btree_trans *trans,
 }
 
 int bch2_bucket_gens_validate(struct bch_fs *c, struct bkey_s_c k,
-			      struct bkey_validate_context from)
+			      const struct bkey_validate_context *from)
 {
 	int ret = 0;
 

--- a/fs/alloc/background.h
+++ b/fs/alloc/background.h
@@ -272,13 +272,13 @@ struct bkey_i_alloc_v4 *bch2_alloc_to_v4_mut(struct btree_trans *, struct bkey_s
 int bch2_bucket_io_time_reset(struct btree_trans *, unsigned, size_t, int);
 
 int bch2_alloc_v1_validate(struct bch_fs *, struct bkey_s_c,
-			   struct bkey_validate_context);
+			   const struct bkey_validate_context *);
 int bch2_alloc_v2_validate(struct bch_fs *, struct bkey_s_c,
-			   struct bkey_validate_context);
+			   const struct bkey_validate_context *);
 int bch2_alloc_v3_validate(struct bch_fs *, struct bkey_s_c,
-			   struct bkey_validate_context);
+			   const struct bkey_validate_context *);
 int bch2_alloc_v4_validate(struct bch_fs *, struct bkey_s_c,
-			   struct bkey_validate_context);
+			   const struct bkey_validate_context *);
 void bch2_alloc_v4_swab(const struct bch_fs *, struct bkey_s);
 void bch2_alloc_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 void bch2_alloc_v4_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
@@ -313,7 +313,7 @@ void bch2_alloc_v4_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 })
 
 int bch2_bucket_gens_validate(struct bch_fs *, struct bkey_s_c,
-			      struct bkey_validate_context);
+			      const struct bkey_validate_context *);
 void bch2_bucket_gens_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 
 #define bch2_bkey_ops_bucket_gens ((struct bkey_ops) {	\

--- a/fs/alloc/backpointers.c
+++ b/fs/alloc/backpointers.c
@@ -33,7 +33,7 @@ static inline struct bbpos bp_to_bbpos(struct bch_backpointer bp)
 }
 
 int bch2_backpointer_validate(struct bch_fs *c, struct bkey_s_c k,
-			      struct bkey_validate_context from)
+			      const struct bkey_validate_context *from)
 {
 	struct bkey_s_c_backpointer bp = bkey_s_c_to_backpointer(k);
 	int ret = 0;

--- a/fs/alloc/backpointers.h
+++ b/fs/alloc/backpointers.h
@@ -22,7 +22,7 @@ static inline u64 swab40(u64 x)
 }
 
 int bch2_backpointer_validate(struct bch_fs *, struct bkey_s_c k,
-			      struct bkey_validate_context);
+			      const struct bkey_validate_context *);
 void bch2_backpointer_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 void bch2_backpointer_swab(const struct bch_fs *, struct bkey_s);
 

--- a/fs/alloc/buckets.c
+++ b/fs/alloc/buckets.c
@@ -1174,7 +1174,7 @@ static int disk_reservation_recalc_sectors_available(struct bch_fs *c,
 			struct disk_reservation *res,
 			u64 sectors, enum bch_reservation_flags flags)
 {
-	guard(mutex)(&c->capacity.sectors_available_lock);
+	guard(spinlock)(&c->capacity.sectors_available_lock);
 
 	percpu_u64_set(&c->capacity.pcpu->sectors_available, 0);
 	u64 sectors_available = avail_factor(__bch2_fs_usage_read_short(c).free);
@@ -1198,23 +1198,18 @@ static int disk_reservation_recalc_sectors_available(struct bch_fs *c,
 int __bch2_disk_reservation_add(struct bch_fs *c, struct disk_reservation *res,
 				u64 sectors, enum bch_reservation_flags flags)
 {
-	struct bch_fs_capacity_pcpu *pcpu;
-	u64 old, get;
-
-	guard(percpu_read)(&c->capacity.mark_lock);
-	preempt_disable();
-	pcpu = this_cpu_ptr(c->capacity.pcpu);
+	guard(preempt)();
+	struct bch_fs_capacity_pcpu *pcpu = this_cpu_ptr(c->capacity.pcpu);
 
 	if (unlikely(sectors > pcpu->sectors_available)) {
-		old = atomic64_read(&c->capacity.sectors_available);
+		u64 get, old = atomic64_read(&c->capacity.sectors_available);
+
 		do {
 			get = min((u64) sectors + SECTORS_CACHE, old);
 
-			if (unlikely(get < sectors)) {
-				preempt_enable();
+			if (unlikely(get < sectors))
 				return disk_reservation_recalc_sectors_available(c,
 								res, sectors, flags);
-			}
 		} while (!atomic64_try_cmpxchg(&c->capacity.sectors_available,
 					       &old, old - get));
 
@@ -1224,7 +1219,6 @@ int __bch2_disk_reservation_add(struct bch_fs *c, struct disk_reservation *res,
 	pcpu->sectors_available		-= sectors;
 	pcpu->online_reserved		+= sectors;
 	res->sectors			+= sectors;
-	preempt_enable();
 	return 0;
 }
 

--- a/fs/alloc/discard.c
+++ b/fs/alloc/discard.c
@@ -185,6 +185,8 @@ static int __discard_mark_free(struct btree_trans *trans,
 	/* Bit kept in sync for downgrade compat; alloc_data_type() no longer reads it. */
 	SET_BCH_ALLOC_V4_NEED_DISCARD(&a->v, false);
 	a->v.data_type = BCH_DATA_free;
+	a->v.journal_seq_nonempty = 0;
+	a->v.journal_seq_empty = 0;
 	alloc_data_type_set(&a->v, a->v.data_type);
 
 	try(bch2_trans_update(trans, iter, &a->k_i, BTREE_TRIGGER_is_discard));

--- a/fs/alloc/discard.c
+++ b/fs/alloc/discard.c
@@ -76,6 +76,20 @@ void bch2_discards_to_text(struct printbuf *out, struct bch_fs *c, struct discar
 	prt_printf(out, "journal seq:\t%llu\n",			journal_cur_seq(j));
 	prt_printf(out, "journal flushed seq:\t%llu -> %llu\n",	j->flushing_seq, j->flushed_seq_ondisk);
 	prt_printf(out, "journal rewind seq:\t%llu -> %llu\n",	j->rewind_seq, j->rewind_seq_ondisk);
+
+	prt_printf(out, "In flight:\n");
+	struct bch_fs_discards *d = &c->discards;
+	guard(printbuf_indent)(out);
+	guard(printbuf_atomic)(out);
+	guard(spinlock_irq)(&d->lock);
+	darray_for_each(d->in_flight, i) {
+		prt_printf(out, "%s:%llu", i->ca->name, u64_to_bucket(i->dev_bucket).offset);
+		if (i->complete)
+			prt_str(out, " complete");
+		if (i->marking_free)
+			prt_str(out, " marking_free");
+		prt_newline(out);
+	}
 }
 
 struct discard_bio {

--- a/fs/alloc/discard.c
+++ b/fs/alloc/discard.c
@@ -16,13 +16,6 @@
 
 #include "journal/journal.h"
 
-static bool discard_opt_enabled_idx(struct bch_fs *c, unsigned dev)
-{
-	guard(rcu)();
-	struct bch_dev *ca = bch2_dev_rcu_noerror(c, dev);
-	return ca && bch2_discard_opt_enabled(c, ca);
-}
-
 static u32 dev_bucket_size(struct bch_fs *c, unsigned dev)
 {
 	guard(rcu)();
@@ -341,23 +334,24 @@ static int bch2_discard_one_bucket(struct btree_trans *trans,
 		return 0;
 	}
 
-	if (discard_opt_enabled_idx(c, bucket.inode) && !c->opts.nochanges) {
-		struct bch_dev *ca = bch2_dev_get_ioref(trans->c, bucket.inode, WRITE,
-							BCH_DEV_WRITE_REF_discard_bucket);
-		if (!ca) {
-			s->not_rw += bucket_size;
-			return 0;
-		}
+	struct bch_dev *ca = bch2_dev_get_ioref(trans->c, bucket.inode, WRITE,
+						BCH_DEV_WRITE_REF_discard_bucket);
+	if (!ca) {
+		s->not_rw += bucket_size;
+		return 0;
+	}
 
+	if (bch2_discard_opt_enabled(c, ca) &&
+	    bdev_max_discard_sectors(ca->disk_sb.bdev) &&
+	    !c->opts.nochanges) {
 		ret = discard_in_flight_add(c, ca, bucket, fastpath, false);
 		if (!ret) {
 			bch2_trans_unlock(trans);
+			/* consumes ioref */
 			discard_submit(ca, bucket, fastpath);
 			s->discarded += bucket_size;
 			return 0;
 		}
-
-		enumerated_ref_put(&ca->io_ref[WRITE], BCH_DEV_WRITE_REF_discard_bucket);
 
 		if (ret == -EEXIST) {
 			s->eexist += bucket_size;
@@ -365,10 +359,13 @@ static int bch2_discard_one_bucket(struct btree_trans *trans,
 		} else {
 			s->eagain += bucket_size;
 		}
-		return ret;
 	} else {
-		return __discard_mark_free(trans, s, fastpath, &iter, a);
+		ret = __discard_mark_free(trans, s, fastpath, &iter, a);
 	}
+
+	enumerated_ref_put(&ca->io_ref[WRITE], BCH_DEV_WRITE_REF_discard_bucket);
+
+	return ret;
 }
 
 static void calculate_discard_sectors_to_release(struct btree_trans *trans)
@@ -445,6 +442,7 @@ static void calculate_discard_sectors_to_release(struct btree_trans *trans)
 
 static void bch2_do_discards(struct bch_fs *c)
 {
+	struct bch_fs_discards *d = &c->discards;
 	int ret = 0;
 	bool again;
 	unsigned flushed_wb = 0;
@@ -478,9 +476,29 @@ static void bch2_do_discards(struct bch_fs *c)
 			int ret2 = bch2_discard_one_bucket(trans,
 						bucket, bucket_size,
 						s, false);
-			if (ret2 == -BCH_ERR_max_discards_in_flight)
+			/*
+			 * Reap completed discards as we go: in_flight entries
+			 * are only freed in bch2_discards_complete(), so if we
+			 * never reach DEV_IN_FLIGHT_MAX - the device completes
+			 * discards inline, or doesn't support REQ_OP_DISCARD -
+			 * the in_flight darray would otherwise grow without
+			 * bound and turn the linear scans in
+			 * discard_in_flight_add()/discard_endio() into O(n^2).
+			 * in_flight.nr > ref means there are completed entries
+			 * waiting to be reaped.
+			 *
+			 * On success the bucket's been handled, so advance the
+			 * iterator before the nested restart so we don't
+			 * reprocess it; on -max_discards_in_flight leave it put
+			 * so we retry the bucket after draining.
+			 */
+			if (ret2 == -BCH_ERR_max_discards_in_flight ||
+			    (!ret2 && READ_ONCE(d->in_flight.nr) > READ_ONCE(d->ref))) {
+				if (!ret2)
+					bch2_btree_iter_advance(&iter);
 				ret2 = bch2_discards_complete(trans, s, false, false) ?:
 				btree_trans_restart(trans, BCH_ERR_transaction_restart_nested);
+			}
 			ret2;
 		}));
 

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -611,8 +611,8 @@ static bool req_alloc_should_bail(struct bch_fs *c, struct alloc_request *req)
  *
  * Returns:	an open_bucket on success, or an ERR_PTR() on failure.
  */
-static struct open_bucket *bch2_bucket_alloc_trans(struct btree_trans *trans,
-						   struct alloc_request *req)
+struct open_bucket *bch2_bucket_alloc_trans(struct btree_trans *trans,
+					    struct alloc_request *req)
 {
 	struct bch_fs *c = trans->c;
 	struct bch_dev *ca = req->ca;
@@ -710,26 +710,6 @@ err:
 
 	alloc_trace_add(req, ca->dev_idx, ret, wake_counter_snapshot);
 
-	return ob;
-}
-
-struct open_bucket *bch2_bucket_alloc(struct bch_fs *c, struct bch_dev *ca,
-				      enum bch_watermark watermark,
-				      enum bch_data_type data_type,
-				      struct closure *cl)
-{
-	struct open_bucket *ob;
-	struct alloc_request req = {
-		.cl		= cl,
-		.watermark	= watermark,
-		.data_type	= data_type,
-		.ca		= ca,
-	};
-	darray_init(&req.trace);
-
-	CLASS(btree_trans, trans)(c);
-	lockrestart_do(trans, PTR_ERR_OR_ZERO(ob = bch2_bucket_alloc_trans(trans, &req)));
-	darray_exit(&req.trace);
 	return ob;
 }
 
@@ -1803,8 +1783,8 @@ static void alloc_trace_to_text(struct printbuf *out, struct bch_fs *c,
 		}
 }
 
-static void bch2_alloc_request_to_text(struct printbuf *out, struct bch_fs *c,
-				       struct alloc_request *req)
+void bch2_alloc_request_to_text(struct printbuf *out, struct bch_fs *c,
+				struct alloc_request *req)
 {
 	prt_printf(out, "nr_replicas:\t%u\n", req->nr_replicas);
 	prt_str(out, "target:\t");

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -1657,8 +1657,12 @@ void bch2_fs_open_buckets_to_text(struct printbuf *out, struct bch_fs *c)
 	for (struct open_bucket *ob = a->open_buckets;
 	     ob < a->open_buckets + ARRAY_SIZE(a->open_buckets);
 	     ob++)
-		if (atomic_read(&ob->pin))
-			nr[ob->data_type]++;
+		if (atomic_read(&ob->pin)) {
+			unsigned t = ob->data_type;
+			barrier(); /* can't READ_ONCE() a bitfield */
+			if (t < BCH_DATA_NR)
+				nr[t]++;
+		}
 
 	prt_printf(out, "open buckets allocated\t%i\n",		OPEN_BUCKETS_COUNT - a->open_buckets_nr_free);
 	prt_printf(out, "open buckets total\t%u\n",		OPEN_BUCKETS_COUNT);
@@ -1701,8 +1705,12 @@ void bch2_dev_alloc_debug_to_text(struct printbuf *out, struct bch_dev *ca)
 
 	memset(nr, 0, sizeof(nr));
 
-	for (unsigned i = 0; i < ARRAY_SIZE(a->open_buckets); i++)
-		nr[a->open_buckets[i].data_type]++;
+	for (unsigned i = 0; i < ARRAY_SIZE(a->open_buckets); i++) {
+		unsigned t = a->open_buckets[i].data_type;
+		barrier(); /* can't READ_ONCE() a bitfield */
+		if (t < BCH_DATA_NR)
+			nr[t]++;
+	}
 
 	bch2_dev_usage_to_text(out, ca, &stats);
 

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -49,6 +49,7 @@
 #include <linux/math64.h>
 #include <linux/rculist.h>
 #include <linux/rcupdate.h>
+#include <linux/sched/signal.h>
 
 static void bch2_trans_mutex_lock_norelock(struct btree_trans *trans,
 					   struct mutex *lock)

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -1939,14 +1939,14 @@ static bool alloc_wait_advanced(struct bch_fs *c, struct alloc_request *req)
 	return false;
 }
 
-void __bch2_wait_on_allocator(struct btree_trans *trans, struct bch_fs *c,
+void __bch2_wait_on_allocator(struct btree_trans *trans,
 			      struct alloc_request *req,
 			      int err, struct closure *cl)
 {
+	struct bch_fs *c = trans->c;
 	unsigned long until = jiffies + c->opts.allocator_stuck_timeout * HZ;
 
-	if (trans)
-		bch2_trans_unlock(trans);
+	bch2_trans_unlock(trans);
 
 	while (1) {
 		long t = until - jiffies;

--- a/fs/alloc/foreground.h
+++ b/fs/alloc/foreground.h
@@ -335,6 +335,7 @@ static inline struct alloc_request *alloc_request_get(struct btree_trans *trans,
 	req->ca				= NULL;
 	req->cl				= cl;
 	req->nr_replicas		= nr_replicas;
+	req->nr_effective		= 0;
 	req->ec_replicas		= ec_replicas;
 	req->ec				= erasure_code;
 	req->target			= target;
@@ -347,6 +348,10 @@ static inline struct alloc_request *alloc_request_get(struct btree_trans *trans,
 	req->will_retry_set_devices	= false;
 	req->copygc_can_make_progress	= false;
 	req->trace_alloc_failed		= false;
+	req->devs_sorted.nr		= 0;
+	/* bch2_alloc_sectors_req() overwrites this; bch2_bucket_alloc_trans()
+	 * callers (e.g. journal resize) don't, so zero it here for them: */
+	memset(&req->devs_may_alloc, 0, sizeof(req->devs_may_alloc));
 	darray_init(&req->trace);
 	return req;
 }

--- a/fs/alloc/foreground.h
+++ b/fs/alloc/foreground.h
@@ -150,9 +150,7 @@ static inline unsigned bch2_open_buckets_reserved(enum bch_watermark watermark)
 	}
 }
 
-struct open_bucket *bch2_bucket_alloc(struct bch_fs *, struct bch_dev *,
-				      enum bch_watermark, enum bch_data_type,
-				      struct closure *);
+struct open_bucket *bch2_bucket_alloc_trans(struct btree_trans *, struct alloc_request *);
 
 /*
  * freelist_wait wake helpers. Every wake_up site on
@@ -334,15 +332,21 @@ static inline struct alloc_request *alloc_request_get(struct btree_trans *trans,
 	if (ec_replicas < 2)
 		erasure_code = false;
 
-	req->cl			= cl;
-	req->nr_replicas	= nr_replicas;
-	req->ec_replicas	= ec_replicas;
-	req->ec			= erasure_code;
-	req->target		= target;
-	req->watermark		= watermark;
-	req->flags		= flags;
-	req->devs_have		= devs_have;
-	req->have_cache		= false;
+	req->ca				= NULL;
+	req->cl				= cl;
+	req->nr_replicas		= nr_replicas;
+	req->ec_replicas		= ec_replicas;
+	req->ec				= erasure_code;
+	req->target			= target;
+	req->watermark			= watermark;
+	req->flags			= flags;
+	req->devs_have			= devs_have;
+	req->have_cache			= false;
+	req->will_retry_all_devices	= false;
+	req->will_retry_target_devices	= false;
+	req->will_retry_set_devices	= false;
+	req->copygc_can_make_progress	= false;
+	req->trace_alloc_failed		= false;
 	darray_init(&req->trace);
 	return req;
 }
@@ -442,6 +446,8 @@ void bch2_fs_open_buckets_to_text(struct printbuf *, struct bch_fs *);
 void bch2_fs_alloc_debug_to_text(struct printbuf *, struct bch_fs *);
 void bch2_dev_alloc_debug_to_text(struct printbuf *, struct bch_dev *);
 
+void bch2_alloc_request_to_text(struct printbuf *, struct bch_fs *,
+				struct alloc_request *);
 void __bch2_wait_on_allocator(struct btree_trans *, struct bch_fs *,
 			      struct alloc_request *, int, struct closure *);
 

--- a/fs/alloc/foreground.h
+++ b/fs/alloc/foreground.h
@@ -448,17 +448,16 @@ void bch2_dev_alloc_debug_to_text(struct printbuf *, struct bch_dev *);
 
 void bch2_alloc_request_to_text(struct printbuf *, struct bch_fs *,
 				struct alloc_request *);
-void __bch2_wait_on_allocator(struct btree_trans *, struct bch_fs *,
-			      struct alloc_request *, int, struct closure *);
+void __bch2_wait_on_allocator(struct btree_trans *, struct alloc_request *,
+			      int, struct closure *);
 
 static inline void bch2_wait_on_allocator(struct btree_trans *trans,
-					  struct bch_fs *c,
 					  struct alloc_request *req,
 					  int err,
 					  struct closure *cl)
 {
 	if (closure_nr_remaining(cl) > 1)
-		__bch2_wait_on_allocator(trans, c, req, err, cl);
+		__bch2_wait_on_allocator(trans, req, err, cl);
 }
 
 #endif /* _BCACHEFS_ALLOC_FOREGROUND_H */

--- a/fs/alloc/lru.c
+++ b/fs/alloc/lru.c
@@ -18,7 +18,7 @@
 
 /* KEY_TYPE_lru is obsolete: */
 int bch2_lru_validate(struct bch_fs *c, struct bkey_s_c k,
-		      struct bkey_validate_context from)
+		      const struct bkey_validate_context *from)
 {
 	int ret = 0;
 

--- a/fs/alloc/lru.h
+++ b/fs/alloc/lru.h
@@ -48,7 +48,7 @@ static inline enum bch_lru_type lru_type(struct bkey_s_c l)
 	}
 }
 
-int bch2_lru_validate(struct bch_fs *, struct bkey_s_c, struct bkey_validate_context);
+int bch2_lru_validate(struct bch_fs *, struct bkey_s_c, const struct bkey_validate_context *);
 void bch2_lru_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 
 void bch2_lru_pos_to_text(struct printbuf *, struct bpos);

--- a/fs/alloc/types.h
+++ b/fs/alloc/types.h
@@ -154,7 +154,7 @@ struct bch_fs_capacity {
 	unsigned		bucket_size_max;
 
 	atomic64_t		sectors_available;
-	struct mutex		sectors_available_lock;
+	spinlock_t		sectors_available_lock;
 
 	struct bch_fs_capacity_pcpu __percpu	*pcpu;
 

--- a/fs/alloc/types.h
+++ b/fs/alloc/types.h
@@ -50,7 +50,7 @@ struct open_bucket {
 	 * the block in the stripe this open_bucket corresponds to:
 	 */
 	u8			ec_idx;
-	enum bch_data_type	data_type:6;
+	enum bch_data_type	data_type:5;
 	bool			valid:1;
 	bool			on_partial_list:1;
 	bool			do_discards_fast:1;

--- a/fs/bcachefs_format.h
+++ b/fs/bcachefs_format.h
@@ -542,6 +542,23 @@ struct bch_backpointer {
 	struct bpos		pos;
 } __packed __aligned(8);
 
+/*
+ * Denormalized cache of "is this bp's extent listed in reconcile_phys?":
+ *
+ * fsck needs to check that the reconcile_phys btrees agree with the extents
+ * btree, but a direct reconcile_phys <-> extents check would be expensive:
+ * for every reconcile_phys entry (keyed by bucket position), we'd have to do
+ * a random lookup against the extents btree. Instead, mirror the work_id into
+ * the backpointer so fsck can do two cheap pairwise checks:
+ *
+ *   - reconcile_phys <-> backpointers: both keyed by bucket position, indexed
+ *   - backpointers   <-> extents:	already required for backpointer fsck
+ *
+ * Invariant: when bp.flags PHYS != 0, reconcile_phys[PHYS] must have an entry
+ * at bp.k.p, and the extent must carry a bch_extent_reconcile entry whose
+ * rb_work_id_phys() equals PHYS. Every path that mutates reconcile_opts on an
+ * extent must keep the bp's PHYS flag in sync.
+ */
 BITMASK(BACKPOINTER_RECONCILE_PHYS,	struct bch_backpointer, flags, 0, 2);
 BITMASK(BACKPOINTER_ERASURE_CODED,	struct bch_backpointer, flags, 2, 3);
 BITMASK(BACKPOINTER_STRIPE_PTR,		struct bch_backpointer, flags, 3, 4);

--- a/fs/btree/bkey.c
+++ b/fs/btree/bkey.c
@@ -62,7 +62,7 @@ static void __bch2_bkey_pack_verify(const struct bkey_packed *packed,
 
 	BUG_ON(packed->u64s < bkeyp_key_u64s(format, packed));
 
-	tmp = __bch2_bkey_unpack_key(format, packed);
+	__bch2_bkey_unpack_key(format, &tmp, packed);
 
 	if (memcmp(&tmp, unpacked, sizeof(struct bkey))) {
 		struct printbuf buf = PRINTBUF;
@@ -267,28 +267,26 @@ bool bch2_bkey_transform(const struct bkey_format *out_f,
 	return true;
 }
 
-struct bkey __bch2_bkey_unpack_key(const struct bkey_format *format,
-			      const struct bkey_packed *in)
+void __bch2_bkey_unpack_key(const struct bkey_format *format,
+			    struct bkey *out,
+			    const struct bkey_packed *in)
 {
 	struct unpack_state state = unpack_state_init(format, in);
-	struct bkey out;
 
 	EBUG_ON(format->nr_fields != BKEY_NR_FIELDS);
 	EBUG_ON(in->u64s < format->key_u64s);
 	EBUG_ON(in->format != KEY_FORMAT_LOCAL_BTREE);
 	EBUG_ON(in->u64s - format->key_u64s + BKEY_U64s > U8_MAX);
 
-	out.u64s	= BKEY_U64s + in->u64s - format->key_u64s;
-	out.format	= KEY_FORMAT_CURRENT;
-	out.needs_whiteout = in->needs_whiteout;
-	out.type	= in->type;
-	out.pad[0]	= 0;
+	out->u64s	= BKEY_U64s + in->u64s - format->key_u64s;
+	out->format	= KEY_FORMAT_CURRENT;
+	out->needs_whiteout = in->needs_whiteout;
+	out->type	= in->type;
+	out->pad[0]	= 0;
 
-#define x(id, field)	out.field = get_inc_field(&state, id);
+#define x(id, field)	out->field = get_inc_field(&state, id);
 	bkey_fields()
 #undef x
-
-	return out;
 }
 
 /*
@@ -392,10 +390,10 @@ static u64 unpack_field_fast(const u8 *bytes,
 	return ((raw >> uf->shift) & (~0ULL >> (64 - bits))) + offset;
 }
 
-struct bkey __bch2_bkey_unpack_key_b(const struct btree *b,
-				     const struct bkey_packed *in)
+void __bch2_bkey_unpack_key_b(const struct btree *b,
+			      struct bkey *out,
+			      const struct bkey_packed *in)
 {
-	struct bkey out;
 	const u8 *bytes = (const u8 *) in;
 
 	/*
@@ -409,8 +407,10 @@ struct bkey __bch2_bkey_unpack_key_b(const struct btree *b,
 	EBUG_ON(in->u64s - b->format.key_u64s + BKEY_U64s > U8_MAX);
 
 	/* fall back to slow path if any field flagged */
-	if (unlikely(b->unpack[0].load_size == 0xff))
-		return __bch2_bkey_unpack_key(&b->format, in);
+	if (unlikely(b->unpack[0].load_size == 0xff)) {
+		__bch2_bkey_unpack_key(&b->format, out, in);
+		return;
+	}
 
 	/*
 	 * Header trick (mirrors compile_bkey_field's prologue): the first 4
@@ -430,30 +430,31 @@ struct bkey __bch2_bkey_unpack_key_b(const struct btree *b,
 		hdr += (u32)(BKEY_U64s - b->format.key_u64s) |
 		       ((u32)(KEY_FORMAT_CURRENT - KEY_FORMAT_LOCAL_BTREE) << 8);
 		hdr &= 0x00ffffff;	/* clear pad byte */
-		put_unaligned(hdr, (u32 *) &out);
+		put_unaligned(hdr, (u32 *) out);
 	}
 
 #define x(id, field)							\
-	out.field = unpack_field_fast(bytes, &b->unpack[id],		\
-				      b->format.bits_per_field[id],	\
-				      le64_to_cpu(b->format.field_offset[id]));
+	out->field = unpack_field_fast(bytes, &b->unpack[id],		\
+				       b->format.bits_per_field[id],	\
+				       le64_to_cpu(b->format.field_offset[id]));
 	bkey_fields()
 #undef x
 
 #ifdef CONFIG_BCACHEFS_DEBUG
 	{
-		struct bkey check = __bch2_bkey_unpack_key(&b->format, in);
-		EBUG_ON(memcmp(&out, &check, sizeof(out)));
+		struct bkey check;
+
+		__bch2_bkey_unpack_key(&b->format, &check, in);
+		EBUG_ON(memcmp(out, &check, sizeof(*out)));
 	}
 #endif
-
-	return out;
 }
 #else
-struct bkey __bch2_bkey_unpack_key_b(const struct btree *b,
-				     const struct bkey_packed *in)
+void __bch2_bkey_unpack_key_b(const struct btree *b,
+			      struct bkey *out,
+			      const struct bkey_packed *in)
 {
-	return __bch2_bkey_unpack_key(&b->format, in);
+	__bch2_bkey_unpack_key(&b->format, out, in);
 }
 #endif
 

--- a/fs/btree/bkey.c
+++ b/fs/btree/bkey.c
@@ -444,6 +444,54 @@ struct bpos __bkey_unpack_pos(const struct bkey_format *format,
 
 	return out;
 }
+
+/*
+ * Position-only sibling of __bch2_bkey_unpack_key_b: byte-aligned fast path
+ * for the 3 bpos fields, avoiding the bit-stream state machine. Mirrors the
+ * gate (byte_aligned_fields) and the precomputed @b->unpack[] constants.
+ *
+ * Profiling (sqlite-bench under FUSE, vtune): __bkey_unpack_pos was 7.5% of
+ * total instructions retired via get_inc_field()'s ~25-insn-per-field state
+ * machine. unpack_field_fast() is ~3 insns/field, so this trims ~70%+ of the
+ * per-call cost on byte-aligned formats - which is the common case.
+ */
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+struct bpos __bkey_unpack_pos_b(const struct btree *b,
+				const struct bkey_packed *in)
+{
+	const u8 *bytes = (const u8 *) in;
+
+	EBUG_ON(b->format.nr_fields != BKEY_NR_FIELDS);
+	EBUG_ON(in->u64s < b->format.key_u64s);
+	EBUG_ON(in->format != KEY_FORMAT_LOCAL_BTREE);
+
+	if (unlikely(!b->byte_aligned_fields))
+		return __bkey_unpack_pos(&b->format, in);
+
+	struct bpos out = {
+		.inode    = unpack_field_fast(bytes, &b->unpack[BKEY_FIELD_INODE],
+				le64_to_cpu(b->format.field_offset[BKEY_FIELD_INODE])),
+		.offset   = unpack_field_fast(bytes, &b->unpack[BKEY_FIELD_OFFSET],
+				le64_to_cpu(b->format.field_offset[BKEY_FIELD_OFFSET])),
+		.snapshot = (u32) unpack_field_fast(bytes, &b->unpack[BKEY_FIELD_SNAPSHOT],
+				le64_to_cpu(b->format.field_offset[BKEY_FIELD_SNAPSHOT])),
+	};
+
+#ifdef CONFIG_BCACHEFS_DEBUG
+	{
+		struct bpos check = __bkey_unpack_pos(&b->format, in);
+		EBUG_ON(memcmp(&out, &check, sizeof(out)));
+	}
+#endif
+	return out;
+}
+#else
+struct bpos __bkey_unpack_pos_b(const struct btree *b,
+				const struct bkey_packed *in)
+{
+	return __bkey_unpack_pos(&b->format, in);
+}
+#endif
 #endif
 
 /**

--- a/fs/btree/bkey.c
+++ b/fs/btree/bkey.c
@@ -292,15 +292,15 @@ void __bch2_bkey_unpack_key(const struct bkey_format *format,
 /*
  * Precompute per-field unpack constants from b->format, stored in struct btree.
  *
- * For each field, picks the smallest aligned load (u8/u16/u32/u64) that
- * contains it, plus a shift and mask that extract the field value. This lets
- * the unpack fast path skip the per-field state machine in get_inc_field()
- * and instead emit straight-line, ILP-friendly load/shift/mask/add.
+ * For each field, picks byte_offset such that an 8-byte unaligned load ends
+ * exactly at the byte after the field's MSB byte. The field lands in the
+ * top of the loaded value, junk from earlier-in-memory fields lands in the
+ * low bits. A single >> (64 - bits) then extracts the field cleanly.
  *
- * Mirrors the logic in compile_bkey_field() (the JIT compiler) — anything
- * the JIT could compile cleanly, this can interpret with precomputed consts.
- * Fields wider than 64 bits or that don't fit a single aligned 8-byte load
- * are flagged with load_size = 0xff and the unpack falls back to slow path.
+ * Only works when each field's MSB is at a byte boundary
+ * (field_msb_bit % 8 == 7). bch2_bkey_format_done() rounds fields up to
+ * byte width when there are spare bits, so this is the common case.
+ * Formats too tight to byte-align fall back via byte_aligned_fields = false.
  */
 void bch2_compute_bkey_unpack_consts(struct btree *b)
 {
@@ -309,62 +309,39 @@ void bch2_compute_bkey_unpack_consts(struct btree *b)
 	unsigned bit_offset = format->key_u64s * 64;
 	unsigned i;
 
+	b->byte_aligned_fields = true;
+
 	for (i = 0; i < BKEY_NR_FIELDS; i++) {
 		struct bkey_unpack_field *uf = &b->unpack[i];
 		unsigned bits = format->bits_per_field[i];
-		unsigned byte, bit_in_byte, span_bits, align;
 
-		uf->shift = 0;
 		uf->byte_offset = 0;
+		uf->shift_right = 64;	/* sentinel: skip load, return offset */
 
-		if (!bits) {
-			uf->load_size = 0;	/* no bits in packed; offset only */
+		if (!bits)
 			continue;
+
+		if (bits > 64) {
+			b->byte_aligned_fields = false;
+			return;
 		}
 
 		bit_offset -= bits;
-		byte = bit_offset / 8;
-		bit_in_byte = bit_offset - byte * 8;
-		span_bits = bit_in_byte + bits;
+		unsigned field_msb_bit = bit_offset + bits - 1;
 
-		if (bit_in_byte == 0 && bits == 8) {
-			uf->load_size = 1;
-		} else if (bit_in_byte == 0 && bits == 16) {
-			uf->load_size = 2;
-		} else if (span_bits <= 32) {
-			align = min(4 - DIV_ROUND_UP(span_bits, 8), byte & 3);
-			byte -= align;
-			bit_in_byte += align * 8;
-			uf->load_size = 4;
-		} else if (span_bits <= 64) {
-			align = min(8 - DIV_ROUND_UP(span_bits, 8), byte & 7);
-			byte -= align;
-			bit_in_byte += align * 8;
-			uf->load_size = 8;
-		} else {
-			/* field doesn't fit in a single aligned load — fallback */
-			uf->load_size = 0xff;
-			continue;
+		/* Need MSB at a byte boundary for single-shift extraction */
+		if (field_msb_bit % 8 != 7) {
+			b->byte_aligned_fields = false;
+			return;
 		}
 
-		uf->byte_offset = byte;
-		uf->shift = bit_in_byte;
+		/* Load 8 bytes ending at field's MSB byte + 1 */
+		uf->byte_offset = (s8)((field_msb_bit + 1) / 8 - 8);
+		uf->shift_right = 64 - bits;
 	}
-
-	/*
-	 * Track whether any field needs the slow path so the fast path can
-	 * short-circuit the check.
-	 */
-	for (i = 0; i < BKEY_NR_FIELDS; i++)
-		if (b->unpack[i].load_size == 0xff) {
-			b->unpack[0].load_size = 0xff; /* sentinel */
-			break;
-		}
 #else
 	/* big-endian: not implemented yet, force fallback */
-	unsigned i;
-	for (i = 0; i < BKEY_NR_FIELDS; i++)
-		b->unpack[i].load_size = 0xff;
+	b->byte_aligned_fields = false;
 #endif
 }
 
@@ -372,22 +349,15 @@ void bch2_compute_bkey_unpack_consts(struct btree *b)
 __always_inline
 static u64 unpack_field_fast(const u8 *bytes,
 			     const struct bkey_unpack_field *uf,
-			     unsigned bits, u64 offset)
+			     u64 offset)
 {
-	u64 raw;
-
-	if (!uf->load_size)
+	if (uf->shift_right == 64)
 		return offset;
 
-	switch (uf->load_size) {
-	case 1: raw = bytes[uf->byte_offset]; break;
-	case 2: raw = get_unaligned_le16(bytes + uf->byte_offset); break;
-	case 4: raw = get_unaligned_le32(bytes + uf->byte_offset); break;
-	default: raw = get_unaligned_le64(bytes + uf->byte_offset); break;
-	}
+	u64 raw = get_unaligned_le64(bytes + uf->byte_offset);
 
-	/* mask = ~0ULL >> (64 - bits); safe because bits > 0 here (load_size != 0) */
-	return ((raw >> uf->shift) & (~0ULL >> (64 - bits))) + offset;
+	/* Field ends at top of register; shr brings it to bit 0 cleanly */
+	return (raw >> uf->shift_right) + offset;
 }
 
 void __bch2_bkey_unpack_key_b(const struct btree *b,
@@ -406,36 +376,35 @@ void __bch2_bkey_unpack_key_b(const struct btree *b,
 	EBUG_ON(in->format != KEY_FORMAT_LOCAL_BTREE);
 	EBUG_ON(in->u64s - b->format.key_u64s + BKEY_U64s > U8_MAX);
 
-	/* fall back to slow path if any field flagged */
-	if (unlikely(b->unpack[0].load_size == 0xff)) {
+	/* fall back to slow path if format has fields that don't fit a single load */
+	if (unlikely(!b->byte_aligned_fields)) {
 		__bch2_bkey_unpack_key(&b->format, out, in);
 		return;
 	}
 
 	/*
-	 * Header trick (mirrors compile_bkey_field's prologue): the first 4
-	 * bytes of struct bkey are { u64s, format/needs_whiteout, type, pad }.
-	 * Load as a u32, add an immediate that bumps u64s by
-	 * (BKEY_U64s - key_u64s) and changes format from LOCAL_BTREE (0) to
-	 * CURRENT (1) without disturbing needs_whiteout, then clear the pad
-	 * byte. One u32 load + one add + one and + one u32 store, replaces
-	 * three byte loads + three byte stores + bitfield manipulation.
+	 * Header trick: the first 4 bytes of struct bkey are
+	 * { u64s, format/needs_whiteout, type, pad }. Load 4 bytes
+	 * starting one byte BEFORE @in — so the loaded bytes are
+	 * [junk, u64s, format, type]. A single >> 8 drops the junk,
+	 * positions u64s/format/type at bytes 0/1/2, and zero-fills
+	 * byte 3 (the pad). Then add an immediate to bump u64s by
+	 * (BKEY_U64s - key_u64s) and change format from LOCAL_BTREE
+	 * (0) to CURRENT (1).
 	 *
-	 * The carry from u64s into the next byte can't fire: BKEY_U64s is
-	 * small (<= 16) and key_u64s <= BKEY_U64s, so the addition to byte 0
-	 * stays within byte 0.
+	 * The carry from u64s into the next byte can't fire: BKEY_U64s
+	 * is small (<= 16) and key_u64s <= BKEY_U64s, so the addition
+	 * to byte 0 stays within byte 0.
 	 */
 	{
-		u32 hdr = get_unaligned((const u32 *) in);
+		u32 hdr = get_unaligned((const u32 *)(bytes - 1)) >> 8;
 		hdr += (u32)(BKEY_U64s - b->format.key_u64s) |
 		       ((u32)(KEY_FORMAT_CURRENT - KEY_FORMAT_LOCAL_BTREE) << 8);
-		hdr &= 0x00ffffff;	/* clear pad byte */
 		put_unaligned(hdr, (u32 *) out);
 	}
 
 #define x(id, field)							\
 	out->field = unpack_field_fast(bytes, &b->unpack[id],		\
-				       b->format.bits_per_field[id],	\
 				       le64_to_cpu(b->format.field_offset[id]));
 	bkey_fields()
 #undef x

--- a/fs/btree/bkey.h
+++ b/fs/btree/bkey.h
@@ -391,6 +391,8 @@ void bch2_compute_bkey_unpack_consts(struct btree *);
 #ifndef HAVE_BCACHEFS_COMPILED_UNPACK
 struct bpos __bkey_unpack_pos(const struct bkey_format *,
 			      const struct bkey_packed *);
+struct bpos __bkey_unpack_pos_b(const struct btree *,
+				const struct bkey_packed *);
 #endif
 
 bool bch2_bkey_pack_key(struct bkey_packed *, const struct bkey *,
@@ -483,7 +485,7 @@ bkey_unpack_pos_format_checked(const struct btree *b,
 #ifdef HAVE_BCACHEFS_COMPILED_UNPACK
 	return bkey_unpack_key_format_checked(b, src).p;
 #else
-	return __bkey_unpack_pos(&b->format, src);
+	return __bkey_unpack_pos_b(b, src);
 #endif
 }
 

--- a/fs/btree/bkey.h
+++ b/fs/btree/bkey.h
@@ -382,10 +382,10 @@ bool bch2_bkey_transform(const struct bkey_format *,
 			 const struct bkey_format *,
 			 const struct bkey_packed *);
 
-struct bkey __bch2_bkey_unpack_key(const struct bkey_format *,
-				   const struct bkey_packed *);
-struct bkey __bch2_bkey_unpack_key_b(const struct btree *,
-				     const struct bkey_packed *);
+void __bch2_bkey_unpack_key(const struct bkey_format *, struct bkey *,
+			    const struct bkey_packed *);
+void __bch2_bkey_unpack_key_b(const struct btree *, struct bkey *,
+			      const struct bkey_packed *);
 void bch2_compute_bkey_unpack_consts(struct btree *);
 
 #ifndef HAVE_BCACHEFS_COMPILED_UNPACK
@@ -428,16 +428,18 @@ __bkey_unpack_key_format_checked(const struct btree *b,
 		unpack_fn(dst, src);
 
 		if (static_branch_unlikely(&bch2_debug_check_bkey_unpack)) {
-			struct bkey dst2 = __bch2_bkey_unpack_key(&b->format, src);
+			struct bkey dst2;
 
+			__bch2_bkey_unpack_key(&b->format, &dst2, src);
 			BUG_ON(memcmp(dst, &dst2, sizeof(*dst)));
 		}
 	} else {
-		*dst = __bch2_bkey_unpack_key_b(b, src);
+		__bch2_bkey_unpack_key_b(b, dst, src);
 
 		if (static_branch_unlikely(&bch2_debug_check_bkey_unpack)) {
-			struct bkey dst2 = __bch2_bkey_unpack_key(&b->format, src);
+			struct bkey dst2;
 
+			__bch2_bkey_unpack_key(&b->format, &dst2, src);
 			BUG_ON(memcmp(dst, &dst2, sizeof(*dst)));
 		}
 	}

--- a/fs/btree/bkey_cmp.h
+++ b/fs/btree/bkey_cmp.h
@@ -110,11 +110,16 @@ int bch2_bkey_cmp_packed_inlined(const struct btree *b,
 			 const struct bkey_packed *l,
 			 const struct bkey_packed *r)
 {
-	struct bkey unpacked;
-
 	if (likely(bkey_packed(l) && bkey_packed(r)))
 		return __bch2_bkey_cmp_packed_format_checked_inlined(l, r, b);
 
+	/*
+	 * Declare in the cold mixed packed/unpacked branch so the
+	 * CONFIG_INIT_STACK_ALL_PATTERN auto-init (5 x mov of the 0xFE
+	 * pattern over sizeof(struct bkey) == 40 bytes) doesn't run on
+	 * every hot-path call where the buffer is never touched.
+	 */
+	struct bkey unpacked;
 	if (bkey_packed(l)) {
 		__bkey_unpack_key_format_checked(b, &unpacked, l);
 		l = (void *) &unpacked;

--- a/fs/btree/bkey_methods.c
+++ b/fs/btree/bkey_methods.c
@@ -463,7 +463,7 @@ void __bch2_bkey_compat(const struct bch_fs *c,
 				if (!write)
 					swap(in, out);
 
-				uk = __bch2_bkey_unpack_key(in, k);
+				__bch2_bkey_unpack_key(in, &uk, k);
 				swap(uk.p.inode, uk.p.offset);
 				BUG_ON(!bch2_bkey_pack_key(k, &uk, out));
 			}
@@ -482,7 +482,7 @@ void __bch2_bkey_compat(const struct bch_fs *c,
 				u64 max_packed = min_packed +
 					~(~0ULL << f->bits_per_field[BKEY_FIELD_SNAPSHOT]);
 
-				uk = __bch2_bkey_unpack_key(f, k);
+				__bch2_bkey_unpack_key(f, &uk, k);
 				uk.p.snapshot = write
 					? min_packed : min_t(u64, U32_MAX, max_packed);
 
@@ -497,7 +497,7 @@ void __bch2_bkey_compat(const struct bch_fs *c,
 		if (!bkey_packed(k)) {
 			u = bkey_i_to_s(packed_to_bkey(k));
 		} else {
-			uk = __bch2_bkey_unpack_key(f, k);
+			__bch2_bkey_unpack_key(f, &uk, k);
 			u.k = &uk;
 			u.v = bkeyp_val(f, k);
 		}

--- a/fs/btree/bkey_methods.c
+++ b/fs/btree/bkey_methods.c
@@ -295,23 +295,6 @@ int bch2_bkey_validate(struct bch_fs *c, struct bkey_s_c k,
 		bch2_bkey_val_validate(c, k, from);
 }
 
-int bch2_bkey_in_btree_node(struct bch_fs *c, struct btree *b,
-			    struct bkey_s_c k,
-			    struct bkey_validate_context from)
-{
-	int ret = 0;
-
-	bkey_fsck_err_on(bpos_lt(k.k->p, b->data->min_key),
-			 c, bkey_before_start_of_btree_node,
-			 "key before start of btree node");
-
-	bkey_fsck_err_on(bpos_gt(k.k->p, b->data->max_key),
-			 c, bkey_after_end_of_btree_node,
-			 "key past end of btree node");
-fsck_err:
-	return ret;
-}
-
 void bch2_bpos_to_text(struct printbuf *out, struct bpos pos)
 {
 	if (bpos_eq(pos, POS_MIN))

--- a/fs/btree/bkey_methods.c
+++ b/fs/btree/bkey_methods.c
@@ -36,7 +36,7 @@ const char * const bch2_bkey_types[] = {
 };
 
 static int deleted_key_validate(struct bch_fs *c, struct bkey_s_c k,
-				struct bkey_validate_context from)
+				const struct bkey_validate_context *from)
 {
 	return 0;
 }
@@ -54,7 +54,7 @@ static int deleted_key_validate(struct bch_fs *c, struct bkey_s_c k,
 })
 
 static int empty_val_key_validate(struct bch_fs *c, struct bkey_s_c k,
-				  struct bkey_validate_context from)
+				  const struct bkey_validate_context *from)
 {
 	int ret = 0;
 
@@ -67,7 +67,7 @@ fsck_err:
 }
 
 static int key_type_error_validate(struct bch_fs *c, struct bkey_s_c k,
-				   struct bkey_validate_context from)
+				   const struct bkey_validate_context *from)
 {
 	return 0;
 }
@@ -103,7 +103,7 @@ void bch2_set_bkey_error(struct bch_fs *c, struct bkey_i *k, enum bch_key_type_e
 }
 
 static int key_type_cookie_validate(struct bch_fs *c, struct bkey_s_c k,
-				    struct bkey_validate_context from)
+				    const struct bkey_validate_context *from)
 {
 	return 0;
 }
@@ -127,7 +127,7 @@ static void key_type_cookie_to_text(struct printbuf *out, struct bch_fs *c,
 })
 
 static int key_type_inline_data_validate(struct bch_fs *c, struct bkey_s_c k,
-					 struct bkey_validate_context from)
+					 const struct bkey_validate_context *from)
 {
 	return 0;
 }
@@ -168,7 +168,7 @@ const struct bkey_ops bch2_bkey_null_ops = {
 };
 
 int bch2_bkey_val_validate(struct bch_fs *c, struct bkey_s_c k,
-			   struct bkey_validate_context from)
+			   const struct bkey_validate_context *from)
 {
 	if (test_bit(BCH_FS_no_invalid_checks, &c->flags))
 		return 0;
@@ -211,9 +211,9 @@ const char *bch2_btree_node_type_str(enum btree_node_type type)
 }
 
 int __bch2_bkey_validate(struct bch_fs *c, struct bkey_s_c k,
-			 struct bkey_validate_context from)
+			 const struct bkey_validate_context *from)
 {
-	enum btree_node_type type = __btree_node_type(from.level, from.btree);
+	enum btree_node_type type = __btree_node_type(from->level, from->btree);
 
 	if (test_bit(BCH_FS_no_invalid_checks, &c->flags))
 		return 0;
@@ -232,9 +232,9 @@ int __bch2_bkey_validate(struct bch_fs *c, struct bkey_s_c k,
 		: 0;
 
 	bool strict_key_type_allowed =
-		(from.flags & BCH_VALIDATE_commit) ||
+		(from->flags & BCH_VALIDATE_commit) ||
 		type == BKEY_TYPE_btree ||
-		(from.btree < BTREE_ID_NR &&
+		(from->btree < BTREE_ID_NR &&
 		 (bkey_flags & BKEY_TYPE_strict_btree_checks));
 
 	bkey_fsck_err_on(strict_key_type_allowed &&
@@ -289,7 +289,7 @@ fsck_err:
 }
 
 int bch2_bkey_validate(struct bch_fs *c, struct bkey_s_c k,
-		       struct bkey_validate_context from)
+		       const struct bkey_validate_context *from)
 {
 	return __bch2_bkey_validate(c, k, from) ?:
 		bch2_bkey_val_validate(c, k, from);

--- a/fs/btree/bkey_methods.h
+++ b/fs/btree/bkey_methods.h
@@ -130,7 +130,7 @@ static inline void bch2_bkey_compat(const struct bch_fs *c, unsigned level, enum
 			       struct bkey_format *f,
 			       struct bkey_packed *k)
 {
-	if (version < bcachefs_metadata_version_current ||
+	if (unlikely(version < bcachefs_metadata_version_current) ||
 	    big_endian != CPU_BIG_ENDIAN ||
 	    IS_ENABLED(CONFIG_BCACHEFS_DEBUG))
 		__bch2_bkey_compat(c, level, btree_id, version,

--- a/fs/btree/bkey_methods.h
+++ b/fs/btree/bkey_methods.h
@@ -51,9 +51,6 @@ int __bch2_bkey_validate(struct bch_fs *, struct bkey_s_c,
 			 struct bkey_validate_context);
 int bch2_bkey_validate(struct bch_fs *, struct bkey_s_c,
 		       struct bkey_validate_context);
-int bch2_bkey_in_btree_node(struct bch_fs *, struct btree *, struct bkey_s_c,
-			    struct bkey_validate_context from);
-
 void bch2_bpos_to_text(struct printbuf *, struct bpos);
 void bch2_bkey_to_text(struct printbuf *, const struct bkey *);
 void bch2_val_to_text(struct printbuf *, struct bch_fs *,

--- a/fs/btree/bkey_methods.h
+++ b/fs/btree/bkey_methods.h
@@ -22,7 +22,7 @@ extern const struct bkey_ops bch2_bkey_null_ops;
  */
 struct bkey_ops {
 	int		(*key_validate)(struct bch_fs *c, struct bkey_s_c k,
-					struct bkey_validate_context from);
+					const struct bkey_validate_context *from);
 	void		(*val_to_text)(struct printbuf *, struct bch_fs *,
 				       struct bkey_s_c);
 	void		(*swab)(const struct bch_fs *, struct bkey_s);
@@ -46,11 +46,11 @@ static inline const struct bkey_ops *bch2_bkey_type_ops(enum bch_bkey_type type)
 }
 
 int bch2_bkey_val_validate(struct bch_fs *, struct bkey_s_c,
-			   struct bkey_validate_context);
+			   const struct bkey_validate_context *);
 int __bch2_bkey_validate(struct bch_fs *, struct bkey_s_c,
-			 struct bkey_validate_context);
+			 const struct bkey_validate_context *);
 int bch2_bkey_validate(struct bch_fs *, struct bkey_s_c,
-		       struct bkey_validate_context);
+		       const struct bkey_validate_context *);
 void bch2_bpos_to_text(struct printbuf *, struct bpos);
 void bch2_bkey_to_text(struct printbuf *, const struct bkey *);
 void bch2_val_to_text(struct printbuf *, struct bch_fs *,

--- a/fs/btree/cache.c
+++ b/fs/btree/cache.c
@@ -797,6 +797,7 @@ void bch2_btree_cache_cannibalize_unlock(struct btree_trans *trans)
 		bc->alloc_lock = NULL;
 		closure_wake_up(&bc->alloc_wait);
 	}
+	trans->btree_cache_cannibalize_locked = false;
 }
 
 static int __btree_cache_cannibalize_lock(struct bch_fs *c, struct closure *cl)
@@ -828,10 +829,12 @@ int bch2_btree_cache_cannibalize_lock(struct btree_trans *trans, struct closure 
 {
 	struct bch_fs *c = trans->c;
 	int ret = __btree_cache_cannibalize_lock(c, cl);
-	if (!ret)
+	if (!ret) {
+		trans->btree_cache_cannibalize_locked = true;
 		event_inc_trace(c, btree_cache_cannibalize_lock, buf, prt_str(&buf, trans->fn));
-	else
+	} else {
 		event_inc_trace(c, btree_cache_cannibalize_lock_fail, buf, prt_str(&buf, trans->fn));
+	}
 	return ret;
 }
 

--- a/fs/btree/commit.c
+++ b/fs/btree/commit.c
@@ -772,7 +772,7 @@ bch2_trans_commit_write_locked(struct btree_trans *trans,
 		validate_context.level	= i->level;
 		validate_context.btree	= i->btree_id;
 
-		ret = bch2_bkey_validate(c, bkey_i_to_s_c(i->k), validate_context);
+		ret = bch2_bkey_validate(c, bkey_i_to_s_c(i->k), &validate_context);
 		if (unlikely(ret)){
 			bch2_trans_inconsistent(trans, "invalid bkey on insert from %s -> %ps\n",
 						trans->fn, (void *) i->ip_allocated);

--- a/fs/btree/interior.c
+++ b/fs/btree/interior.c
@@ -1619,8 +1619,8 @@ static void bch2_insert_fixup_btree_ptr(struct btree_update *as,
 		.btree	= b->c.btree_id,
 		.flags	= BCH_VALIDATE_commit,
 	};
-	if (bch2_bkey_validate(c, bkey_i_to_s_c(insert), from) ?:
-	    bch2_bkey_in_btree_node(c, b, bkey_i_to_s_c(insert), from)) {
+	if (bch2_bkey_validate(c, bkey_i_to_s_c(insert), &from) ?:
+	    bch2_bkey_in_btree_node(c, b, bkey_i_to_s_c(insert), &from)) {
 		bch2_fs_inconsistent(c, "%s: inserting invalid bkey", __func__);
 		dump_stack();
 	}

--- a/fs/btree/interior.c
+++ b/fs/btree/interior.c
@@ -1515,7 +1515,7 @@ bch2_btree_update_start(struct btree_trans *trans, struct btree_path *path,
 			ret = bch2_btree_reserve_get(trans, as, nr_nodes, req);
 			if (!bch2_err_matches(ret, BCH_ERR_operation_blocked))
 				break;
-			bch2_wait_on_allocator(trans, c, req, ret, &cl);
+			bch2_wait_on_allocator(trans, req, ret, &cl);
 		} while (1);
 
 		/*

--- a/fs/btree/interior.c
+++ b/fs/btree/interior.c
@@ -174,7 +174,7 @@ static void __bch2_btree_calc_format(struct bkey_format_state *s, struct btree *
 	for_each_bset(b, t)
 		bset_tree_for_each_key(b, t, k)
 			if (!bkey_deleted(k)) {
-				uk = bkey_unpack_key(b, k);
+				__bkey_unpack_key(b, &uk, k);
 				bch2_bkey_format_add_key(s, &uk);
 			}
 }
@@ -1790,7 +1790,8 @@ static void btree_pack_into_dsts(struct btree_update *as,
 			if (bkey_deleted(k))
 				continue;
 
-			struct bkey uk = bkey_unpack_key(src_b, k);
+			struct bkey uk;
+			__bkey_unpack_key(src_b, &uk, k);
 			unsigned i = bpos_le(uk.p, pivot) ? 0 : 1;
 
 			struct btree *n = dsts->data[i].b;
@@ -2589,7 +2590,8 @@ static void predict_split(struct btree_trans *trans,
 			if (bkey_deleted(k))
 				continue;
 
-			struct bkey uk = bkey_unpack_key(src_b, k);
+			struct bkey uk;
+			__bkey_unpack_key(src_b, &uk, k);
 			unsigned i;
 
 			if (n1_target_u64s) {
@@ -2682,7 +2684,8 @@ static bool find_balanced_split(struct btree_trans *trans,
 					continue;
 				curr += k->u64s;
 				if (curr >= target) {
-					struct bkey uk = bkey_unpack_key(s->b, k);
+					struct bkey uk;
+					__bkey_unpack_key(s->b, &uk, k);
 					candidates[nr_candidates++] = uk.p;
 					found = true;
 					break;

--- a/fs/btree/locking.c
+++ b/fs/btree/locking.c
@@ -1030,6 +1030,18 @@ void bch2_trans_unlock(struct btree_trans *trans)
 	trans_set_unlocked(trans);
 
 	__bch2_trans_unlock(trans);
+
+	/*
+	 * Drop the btree cache cannibalize lock too. Holding it across a
+	 * trans_unlock - i.e. across a sleep - is the recipe for a resource
+	 * deadlock: cannibalize-holder sleeps waiting on the allocator,
+	 * allocator needs to grow the btree cache, growing the cache needs
+	 * cannibalize, but we're holding it. Releasing on trans_unlock means
+	 * cannibalize is only held over non-sleeping critical sections;
+	 * callers that need it after a wake re-acquire normally.
+	 */
+	if (unlikely(trans->btree_cache_cannibalize_locked))
+		bch2_btree_cache_cannibalize_unlock(trans);
 }
 
 void bch2_trans_unlock_long(struct btree_trans *trans)

--- a/fs/btree/node_scan.c
+++ b/fs/btree/node_scan.c
@@ -566,12 +566,12 @@ int bch2_get_scanned_nodes(struct bch_fs *c, enum btree_id btree,
 
 		found_btree_node_to_key(&tmp.k, &n);
 
-		BUG_ON(bch2_bkey_validate(c, bkey_i_to_s_c(&tmp.k),
-					  (struct bkey_validate_context) {
-						.from	= BKEY_VALIDATE_btree_node,
-						.level	= level + 1,
-						.btree	= btree,
-					  }));
+		struct bkey_validate_context from = {
+			.from	= BKEY_VALIDATE_btree_node,
+			.level	= level + 1,
+			.btree	= btree,
+		};
+		BUG_ON(bch2_bkey_validate(c, bkey_i_to_s_c(&tmp.k), &from));
 
 		if (!*nodes_found) {
 			prt_printf(out, "recovering from btree node scan at ");

--- a/fs/btree/read.c
+++ b/fs/btree/read.c
@@ -383,22 +383,23 @@ static int btree_node_bkey_val_validate(struct bch_fs *c, struct btree *b,
 					struct bkey_s_c k,
 					enum bch_validate_flags flags)
 {
-	return bch2_bkey_val_validate(c, k, (struct bkey_validate_context) {
+	struct bkey_validate_context from = {
 		.from	= BKEY_VALIDATE_btree_node,
 		.level	= b->c.level,
 		.btree	= b->c.btree_id,
-		.flags	= flags
-	});
+		.flags	= flags,
+	};
+	return bch2_bkey_val_validate(c, k, &from);
 }
 
 static int bset_key_validate(struct bch_fs *c, struct btree *b,
 			     struct bkey_s_c k,
 			     bool updated_range,
-			     struct bkey_validate_context from)
+			     const struct bkey_validate_context *from)
 {
 	return __bch2_bkey_validate(c, k, from) ?:
 		(!updated_range ? bch2_bkey_in_btree_node(c, b, k, from) : 0) ?:
-		(from.flags & BCH_VALIDATE_write ? btree_node_bkey_val_validate(c, b, k, from.flags) : 0);
+		(from->flags & BCH_VALIDATE_write ? btree_node_bkey_val_validate(c, b, k, from->flags) : 0);
 }
 
 static bool bkey_packed_valid(struct bch_fs *c, struct btree *b,
@@ -415,13 +416,13 @@ static bool bkey_packed_valid(struct bch_fs *c, struct btree *b,
 
 	struct bkey tmp;
 	struct bkey_s u = __bkey_disassemble(b, k, &tmp);
-	return !__bch2_bkey_validate(c, u.s_c,
-				     (struct bkey_validate_context) {
-					.from	= BKEY_VALIDATE_btree_node,
-					.level	= b->c.level,
-					.btree	= b->c.btree_id,
-					.flags	= BCH_VALIDATE_silent
-				     });
+	struct bkey_validate_context from = {
+		.from	= BKEY_VALIDATE_btree_node,
+		.level	= b->c.level,
+		.btree	= b->c.btree_id,
+		.flags	= BCH_VALIDATE_silent,
+	};
+	return !__bch2_bkey_validate(c, u.s_c, &from);
 }
 
 static inline int btree_node_read_bkey_cmp(const struct btree *b,
@@ -490,7 +491,7 @@ int bch2_validate_bset_keys(struct bch_fs *c,
 
 		u = __bkey_disassemble(b, k, &tmp);
 
-		ret = bset_key_validate(c, b, u.s_c, updated_range, from);
+		ret = bset_key_validate(c, b, u.s_c, updated_range, &from);
 		if (unlikely(ret == -BCH_ERR_fsck_delete_bkey))
 			goto drop_this_key;
 		if (unlikely(ret))

--- a/fs/btree/read.c
+++ b/fs/btree/read.c
@@ -5,6 +5,7 @@
 #include "alloc/buckets.h"
 
 #include "btree/bkey_buf.h"
+#include "btree/bkey_cmp.h"
 #include "btree/bkey_methods.h"
 #include "btree/cache.h"
 #include "btree/iter.h"
@@ -433,7 +434,7 @@ static inline int btree_node_read_bkey_cmp(const struct btree *b,
 				const struct bkey_packed *l,
 				const struct bkey_packed *r)
 {
-	return bch2_bkey_cmp_packed(b, l, r)
+	return bch2_bkey_cmp_packed_inlined(b, l, r)
 		?: (int) bkey_deleted(r) - (int) bkey_deleted(l);
 }
 

--- a/fs/btree/read.c
+++ b/fs/btree/read.c
@@ -394,17 +394,11 @@ static int btree_node_bkey_val_validate(struct bch_fs *c, struct btree *b,
 static int bset_key_validate(struct bch_fs *c, struct btree *b,
 			     struct bkey_s_c k,
 			     bool updated_range,
-			     enum bch_validate_flags flags)
+			     struct bkey_validate_context from)
 {
-	struct bkey_validate_context from = (struct bkey_validate_context) {
-		.from	= BKEY_VALIDATE_btree_node,
-		.level	= b->c.level,
-		.btree	= b->c.btree_id,
-		.flags	= flags,
-	};
 	return __bch2_bkey_validate(c, k, from) ?:
 		(!updated_range ? bch2_bkey_in_btree_node(c, b, k, from) : 0) ?:
-		(flags & BCH_VALIDATE_write ? btree_node_bkey_val_validate(c, b, k, flags) : 0);
+		(from.flags & BCH_VALIDATE_write ? btree_node_bkey_val_validate(c, b, k, from.flags) : 0);
 }
 
 static bool bkey_packed_valid(struct bch_fs *c, struct btree *b,
@@ -450,6 +444,12 @@ int bch2_validate_bset_keys(struct bch_fs *c,
 	CLASS(printbuf, buf)();
 	bool updated_range = b->key.k.type == KEY_TYPE_btree_ptr_v2 &&
 		BTREE_PTR_RANGE_UPDATED(&bkey_i_to_btree_ptr_v2(&b->key)->v);
+	struct bkey_validate_context from = (struct bkey_validate_context) {
+		.from	= BKEY_VALIDATE_btree_node,
+		.level	= b->c.level,
+		.btree	= b->c.btree_id,
+		.flags	= write,
+	};
 	int ret = 0;
 
 	for (k = i->start;
@@ -490,7 +490,7 @@ int bch2_validate_bset_keys(struct bch_fs *c,
 
 		u = __bkey_disassemble(b, k, &tmp);
 
-		ret = bset_key_validate(c, b, u.s_c, updated_range, write);
+		ret = bset_key_validate(c, b, u.s_c, updated_range, from);
 		if (unlikely(ret == -BCH_ERR_fsck_delete_bkey))
 			goto drop_this_key;
 		if (unlikely(ret))

--- a/fs/btree/read.h
+++ b/fs/btree/read.h
@@ -7,6 +7,7 @@
 #include "btree/locking.h"
 #include "data/checksum.h"
 #include "data/extents.h"
+#include "init/error.h"
 
 struct bch_fs;
 struct btree;
@@ -16,6 +17,23 @@ static inline unsigned btree_ptr_sectors_written(struct bkey_s_c k)
 	return k.k->type == KEY_TYPE_btree_ptr_v2
 		? le16_to_cpu(bkey_s_c_to_btree_ptr_v2(k).v->sectors_written)
 		: 0;
+}
+
+static inline int bch2_bkey_in_btree_node(struct bch_fs *c, struct btree *b,
+					  struct bkey_s_c k,
+					  struct bkey_validate_context from)
+{
+	int ret = 0;
+
+	bkey_fsck_err_on(bpos_lt(k.k->p, b->data->min_key),
+			 c, bkey_before_start_of_btree_node,
+			 "key before start of btree node");
+
+	bkey_fsck_err_on(bpos_gt(k.k->p, b->data->max_key),
+			 c, bkey_after_end_of_btree_node,
+			 "key past end of btree node");
+fsck_err:
+	return ret;
 }
 
 struct btree_read_bio {

--- a/fs/btree/read.h
+++ b/fs/btree/read.h
@@ -21,7 +21,7 @@ static inline unsigned btree_ptr_sectors_written(struct bkey_s_c k)
 
 static inline int bch2_bkey_in_btree_node(struct bch_fs *c, struct btree *b,
 					  struct bkey_s_c k,
-					  struct bkey_validate_context from)
+					  const struct bkey_validate_context *from)
 {
 	int ret = 0;
 

--- a/fs/btree/sort.c
+++ b/fs/btree/sort.c
@@ -310,11 +310,18 @@ void bch2_sort_whiteouts(struct bch_fs *c, struct btree *b)
 	struct bkey_packed *new_whiteouts, **ptrs, **ptrs_end, *k;
 	bool used_mempool = false;
 	size_t bytes = b->whiteout_u64s * sizeof(u64);
+	/*
+	 * __bch2_bkey_unpack_key_b reads one byte before the key for its
+	 * header trick; pad the start of the bounce buffer so that read is
+	 * always against valid memory.
+	 */
+	size_t alloc_bytes = bytes + sizeof(u64);
 
 	if (!b->whiteout_u64s)
 		return;
 
-	new_whiteouts = bch2_btree_bounce_alloc(c, bytes, &used_mempool);
+	void *bounce = bch2_btree_bounce_alloc(c, alloc_bytes, &used_mempool);
+	new_whiteouts = bounce + sizeof(u64);
 
 	ptrs = ptrs_end = ((void *) new_whiteouts + bytes);
 
@@ -339,7 +346,7 @@ void bch2_sort_whiteouts(struct bch_fs *c, struct btree *b)
 	memcpy_u64s(unwritten_whiteouts_start(b),
 		    new_whiteouts, b->whiteout_u64s);
 
-	bch2_btree_bounce_free(c, bytes, used_mempool, new_whiteouts);
+	bch2_btree_bounce_free(c, alloc_bytes, used_mempool, bounce);
 }
 
 static bool should_compact_bset(struct btree *b, struct bset_tree *t,

--- a/fs/btree/types.h
+++ b/fs/btree/types.h
@@ -650,6 +650,7 @@ struct btree_trans {
 	bool			locked:1;
 	bool			write_locked:1;
 	bool			srcu_held:1;
+	bool			btree_cache_cannibalize_locked:1;
 	bool			pf_memalloc_nofs:1;
 	bool			used_mempool:1;
 	bool			in_traverse_all:1;

--- a/fs/btree/types.h
+++ b/fs/btree/types.h
@@ -104,15 +104,30 @@ struct btree {
 
 	/*
 	 * Per-field unpack constants, derived from @format at node init.
-	 * Lets __bch2_bkey_unpack_key skip the per-field state machine in
-	 * the common case where the field can be extracted by a single
-	 * aligned load + shift + mask.
+	 * Extract each field with:
+	 *
+	 *   field = (load_8_unaligned(bytes + byte_offset) >> (64 - bits))
+	 *           + field_offset
+	 *
+	 * Load position chosen so the field ends at the top of the loaded
+	 * value (load_offset + 8 == byte after field's MSB byte); junk from
+	 * earlier-in-memory fields lands in the low bits and shifts off.
+	 *
+	 * byte_offset is signed: for a field near the start of @in, the
+	 * load can need to start before @in. The byte(s) before @in are
+	 * always valid memory in the callers we care about (bset payload
+	 * after the bset header, or other bkeys in the same bset).
+	 *
+	 * Only handles formats where every field's MSB sits at a byte
+	 * boundary (field_msb_bit % 8 == 7). bch2_bkey_format_done()
+	 * rounds fields up to byte width when there are spare bits, so
+	 * this is the common case. Formats too tight to byte-align take
+	 * the slow path via byte_aligned_fields = false.
 	 */
+	bool				byte_aligned_fields;
 	struct bkey_unpack_field {
-		u8	byte_offset;	/* byte within packed key */
-		u8	load_size;	/* 1, 2, 4, 8; 0 = no bits in packed; 0xff = fallback */
-		u8	shift;		/* shift right after load */
-		u8	_pad;
+		s8	byte_offset;
+		u8	shift_right;	/* 64 - bits, or 64 if field has no bits in packed */
 	} unpack[BKEY_NR_FIELDS];
 
 	struct btree_node	*data;

--- a/fs/btree/write.c
+++ b/fs/btree/write.c
@@ -233,13 +233,13 @@ static void btree_node_write_endio(struct bio *bio)
 static int validate_bset_for_write(struct bch_fs *c, struct btree *b,
 				   struct bset *i)
 {
-	int ret = bch2_bkey_validate(c, bkey_i_to_s_c(&b->key),
-				     (struct bkey_validate_context) {
-					.from	= BKEY_VALIDATE_btree_node,
-					.level	= b->c.level + 1,
-					.btree	= b->c.btree_id,
-					.flags	= BCH_VALIDATE_write,
-				     });
+	struct bkey_validate_context from = {
+		.from	= BKEY_VALIDATE_btree_node,
+		.level	= b->c.level + 1,
+		.btree	= b->c.btree_id,
+		.flags	= BCH_VALIDATE_write,
+	};
+	int ret = bch2_bkey_validate(c, bkey_i_to_s_c(&b->key), &from);
 	if (ret) {
 		bch2_fs_inconsistent(c, "invalid btree node key before write");
 		return ret;

--- a/fs/data/bitflip_repair.c
+++ b/fs/data/bitflip_repair.c
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * bcachefs CRC32C single-bit error correction
+ *
+ * When a CRC32C checksum mismatch is detected on read and no other
+ * replica is available, attempt to locate and correct a single-bit
+ * error using syndrome analysis.
+ *
+ * CRC is linear over GF(2): CRC(A ^ B) = CRC(A) ^ CRC(B).
+ * The syndrome S = CRC(received) ^ CRC(expected) equals CRC(error_pattern).
+ * For a single-bit flip at position i, S = CRC of a buffer with only
+ * bit i set.  CRC32C has minimum Hamming distance >= 3, so each
+ * single-bit syndrome is unique — no false positives.
+ *
+ * Optimization: for reflected CRC32C, the syndrome for bit j in byte b
+ * of an L-byte buffer equals T[0x80>>j] advanced through (L-b-1) zero
+ * bytes, where T[] is the standard CRC32C byte lookup table and zero-byte
+ * advancement Z(s) = T[s & 0xFF] ^ (s >> 8) is GF(2)-linear.  By
+ * iterating right-to-left we compute all syndromes in O(L) with O(1)
+ * per bit — 8 table lookups + 8 XOR/shift per byte position.
+ *
+ * Reference: Stefan Filipek, "On correcting bit errors with CRCs"
+ *   https://srfilipek.medium.com/on-correcting-bit-errors-with-crcs-1f1c98fc58b
+ */
+
+#include "bcachefs.h"
+#include "data/bitflip_repair.h"
+#include "data/checksum.h"
+
+#include <linux/bio.h>
+#include <linux/crc32c.h>
+#include <linux/sort.h>
+#include <linux/slab.h>
+
+#define CRC32C_POLY	0x82F63B78U
+
+/* CRC32C byte lookup table — matches the kernel's reflected convention */
+static u32 bch2_crc32c_table[256];
+static bool bch2_crc32c_table_ready;
+static DEFINE_MUTEX(bch2_crc32c_table_lock);
+
+static void bch2_init_crc32c_table(void)
+{
+	unsigned int i, j;
+
+	mutex_lock(&bch2_crc32c_table_lock);
+	if (bch2_crc32c_table_ready)
+		goto out;
+
+	for (i = 0; i < 256; i++) {
+		u32 c = i;
+
+		for (j = 0; j < 8; j++) {
+			if (c & 1)
+				c = (c >> 1) ^ CRC32C_POLY;
+			else
+				c >>= 1;
+		}
+		bch2_crc32c_table[i] = c;
+	}
+	smp_wmb();
+	bch2_crc32c_table_ready = true;
+out:
+	mutex_unlock(&bch2_crc32c_table_lock);
+}
+
+/* Advance CRC state through one zero byte */
+static inline u32 crc32c_advance_zero(u32 s)
+{
+	return bch2_crc32c_table[s & 0xFF] ^ (s >> 8);
+}
+
+struct syndrome_entry {
+	u32	syndrome;
+	u32	bit_pos;
+};
+
+static int syndrome_cmp(const void *a, const void *b)
+{
+	const struct syndrome_entry *sa = a;
+	const struct syndrome_entry *sb = b;
+
+	if (sa->syndrome < sb->syndrome)
+		return -1;
+	if (sa->syndrome > sb->syndrome)
+		return 1;
+	return 0;
+}
+
+/*
+ * Build syndrome table in O(n) by iterating byte positions right-to-left.
+ *
+ * At the rightmost byte (0 trailing zeros):
+ *   syndrome for bit j = T[0x80 >> j]
+ * Moving one byte left:
+ *   syndrome = Z(old) = advance through one more trailing zero byte
+ */
+static struct syndrome_entry *bch2_build_syndrome_table(unsigned long total_bits,
+							unsigned long byte_count)
+{
+	struct syndrome_entry *table;
+	u32 basis[8];
+	long b;
+	int j;
+
+	table = kvmalloc_array(total_bits, sizeof(*table), GFP_KERNEL);
+	if (!table)
+		return NULL;
+
+	for (j = 0; j < 8; j++)
+		basis[j] = bch2_crc32c_table[0x80U >> j];
+
+	for (b = byte_count - 1; b >= 0; b--) {
+		for (j = 0; j < 8; j++) {
+			unsigned long idx = (unsigned long)b * 8 + j;
+
+			table[idx].syndrome = basis[j];
+			table[idx].bit_pos  = idx;
+		}
+		if (b > 0) {
+			for (j = 0; j < 8; j++)
+				basis[j] = crc32c_advance_zero(basis[j]);
+		}
+	}
+
+	sort(table, total_bits, sizeof(*table), syndrome_cmp, NULL);
+	return table;
+}
+
+static struct syndrome_entry *
+syndrome_bsearch(struct syndrome_entry *table, unsigned long count, u32 target)
+{
+	unsigned long lo = 0, hi = count;
+
+	while (lo < hi) {
+		unsigned long mid = lo + (hi - lo) / 2;
+
+		if (table[mid].syndrome < target)
+			lo = mid + 1;
+		else
+			hi = mid;
+	}
+	if (lo < count && table[lo].syndrome == target)
+		return &table[lo];
+	return NULL;
+}
+
+static inline void bio_flip_bit(struct bio *bio, unsigned long bit_pos)
+{
+	unsigned long byte_pos = bit_pos / 8;
+	unsigned int  bit_off  = bit_pos % 8;
+	struct bio_vec bv;
+	struct bvec_iter iter;
+	unsigned long offset = 0;
+
+	bio_for_each_segment(bv, bio, iter) {
+		if (byte_pos < offset + bv.bv_len) {
+			unsigned page_off = bv.bv_offset + (byte_pos - offset);
+			u8 *p = kmap_local_page(bv.bv_page);
+
+			p[page_off] ^= 0x80U >> bit_off;
+			kunmap_local(p);
+			return;
+		}
+		offset += bv.bv_len;
+	}
+}
+
+/*
+ * Attempt single-bit error correction on a bio with a CRC32C checksum
+ * mismatch.  Only applies to BCH_CSUM_crc32c and BCH_CSUM_crc32c_nonzero.
+ *
+ * Returns 0 on successful repair, -errno on failure.
+ */
+int bch2_try_bitflip_repair_bio(struct bch_fs *c, struct bio *bio,
+				struct bch_extent_crc_unpacked *crc,
+				struct bch_csum expected)
+{
+	struct bch_csum computed;
+	struct nonce nonce = { .d = { 0 } };
+	struct syndrome_entry *table, *match;
+	unsigned long total_bytes, total_bits;
+	u32 syndrome;
+
+	if (crc->csum_type != BCH_CSUM_crc32c &&
+	    crc->csum_type != BCH_CSUM_crc32c_nonzero)
+		return -EINVAL;
+
+	total_bytes = bio->bi_iter.bi_size;
+	total_bits  = total_bytes * 8;
+	if (!total_bits || total_bits > (unsigned long)U32_MAX)
+		return -EINVAL;
+
+	/* Compute syndrome: XOR of computed and expected CRC values.
+	 * The syndrome is identical regardless of init value (zero vs
+	 * nonzero) because the init XOR cancels out. */
+	computed = bch2_checksum_bio(c, crc->csum_type, nonce, bio);
+	syndrome = (u32)(le64_to_cpu(computed.lo) ^ le64_to_cpu(expected.lo));
+
+	if (!syndrome)
+		return 0;  /* no error */
+
+	bch2_init_crc32c_table();
+
+	table = bch2_build_syndrome_table(total_bits, total_bytes);
+	if (!table)
+		return -ENOMEM;
+
+	match = syndrome_bsearch(table, total_bits, syndrome);
+	if (!match) {
+		kvfree(table);
+		return -ENODATA; /* multi-bit error, can't fix */
+	}
+
+	bio_flip_bit(bio, match->bit_pos);
+	kvfree(table);
+
+	/* Verify repair by recomputing checksum */
+	computed = bch2_checksum_bio(c, crc->csum_type, nonce, bio);
+	if (bch2_crc_cmp(computed, expected)) {
+		/* Shouldn't happen for a true 1-bit error; undo */
+		bio_flip_bit(bio, match->bit_pos);
+		return -ENODATA;
+	}
+
+	bch_info(c, "bitflip repair: corrected single-bit error at bit %u (byte %u, bit %u in byte)",
+		 match->bit_pos, match->bit_pos / 8, match->bit_pos % 8);
+	return 0;
+}

--- a/fs/data/bitflip_repair.h
+++ b/fs/data/bitflip_repair.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef _BCACHEFS_BITFLIP_REPAIR_H
+#define _BCACHEFS_BITFLIP_REPAIR_H
+
+#include "bcachefs.h"
+
+struct bio;
+struct bch_extent_crc_unpacked;
+
+int bch2_try_bitflip_repair_bio(struct bch_fs *, struct bio *,
+				struct bch_extent_crc_unpacked *,
+				struct bch_csum expected);
+
+#endif /* _BCACHEFS_BITFLIP_REPAIR_H */

--- a/fs/data/ec/create.c
+++ b/fs/data/ec/create.c
@@ -1860,7 +1860,7 @@ int bch2_stripe_repair(struct moving_context *ctxt,
 			mutex_unlock(&dev_stripe->lock);
 
 		if (bch2_err_matches(ret2, BCH_ERR_operation_blocked)) {
-			bch2_wait_on_allocator(trans, c, req, ret2, &cl);
+			bch2_wait_on_allocator(trans, req, ret2, &cl);
 			ret2 = bch_err_throw(c, transaction_restart_nested);
 		}
 		ret2;

--- a/fs/data/ec/trigger.c
+++ b/fs/data/ec/trigger.c
@@ -43,7 +43,7 @@
 /* Stripes btree keys: */
 
 int bch2_stripe_validate(struct bch_fs *c, struct bkey_s_c k,
-			 struct bkey_validate_context from)
+			 const struct bkey_validate_context *from)
 {
 	const struct bch_stripe *s = bkey_s_c_to_stripe(k).v;
 	int ret = 0;

--- a/fs/data/ec/trigger.h
+++ b/fs/data/ec/trigger.h
@@ -3,7 +3,7 @@
 #define _BCACHEFS_DATA_EC_TRIGGER_H
 
 int bch2_stripe_validate(struct bch_fs *, struct bkey_s_c,
-			 struct bkey_validate_context);
+			 const struct bkey_validate_context *);
 void bch2_stripe_to_text(struct printbuf *, struct bch_fs *,
 			 struct bkey_s_c);
 int bch2_trigger_stripe(struct btree_trans *, struct btree_trigger_op);

--- a/fs/data/extents.c
+++ b/fs/data/extents.c
@@ -312,7 +312,7 @@ int bch2_bkey_pick_read_device(struct bch_fs *c, struct bkey_s_c k,
 /* KEY_TYPE_btree_ptr: */
 
 int bch2_btree_ptr_validate(struct bch_fs *c, struct bkey_s_c k,
-			    struct bkey_validate_context from)
+			    const struct bkey_validate_context *from)
 {
 	int ret = 0;
 
@@ -332,7 +332,7 @@ void bch2_btree_ptr_to_text(struct printbuf *out, struct bch_fs *c,
 }
 
 int bch2_btree_ptr_v2_validate(struct bch_fs *c, struct bkey_s_c k,
-			       struct bkey_validate_context from)
+			       const struct bkey_validate_context *from)
 {
 	struct bkey_s_c_btree_ptr_v2 bp = bkey_s_c_to_btree_ptr_v2(k);
 	int ret = 0;
@@ -346,7 +346,7 @@ int bch2_btree_ptr_v2_validate(struct bch_fs *c, struct bkey_s_c k,
 			 c, btree_ptr_v2_min_key_bad,
 			 "min_key > key");
 
-	if ((from.flags & BCH_VALIDATE_write) &&
+	if ((from->flags & BCH_VALIDATE_write) &&
 	    c->sb.version_min >= bcachefs_metadata_version_btree_ptr_sectors_written)
 		bkey_fsck_err_on(!bp.v->sectors_written,
 				 c, btree_ptr_v2_written_0,
@@ -539,7 +539,7 @@ bool bch2_extent_merge(struct bch_fs *c, struct bkey_s l, struct bkey_s_c r)
 /* KEY_TYPE_reservation: */
 
 int bch2_reservation_validate(struct bch_fs *c, struct bkey_s_c k,
-			      struct bkey_validate_context from)
+			      const struct bkey_validate_context *from)
 {
 	struct bkey_s_c_reservation r = bkey_s_c_to_reservation(k);
 	int ret = 0;
@@ -1702,7 +1702,7 @@ void bch2_bkey_ptrs_to_text(struct printbuf *out, struct bch_fs *c,
 
 static int extent_ptr_validate(struct bch_fs *c,
 			       struct bkey_s_c k,
-			       struct bkey_validate_context from,
+			       const struct bkey_validate_context *from,
 			       const struct bch_extent_ptr *ptr,
 			       unsigned size_ondisk,
 			       bool metadata)
@@ -1759,7 +1759,7 @@ static inline bool btree_ptr_entry_type_allowed(enum bch_extent_entry_type type)
 }
 
 int bch2_bkey_ptrs_validate(struct bch_fs *c, struct bkey_s_c k,
-			    struct bkey_validate_context from)
+			    const struct bkey_validate_context *from)
 {
 	struct bkey_ptrs_c ptrs = bch2_bkey_ptrs_c(k);
 	const union bch_extent_entry *entry;
@@ -1831,7 +1831,7 @@ int bch2_bkey_ptrs_validate(struct bch_fs *c, struct bkey_s_c k,
 					 "checksum offset + key size > uncompressed size");
 			bkey_fsck_err_on(crc_is_encoded(crc) &&
 					 (crc.uncompressed_size > c->opts.encoded_extent_max >> 9) &&
-					 (from.flags & (BCH_VALIDATE_write|BCH_VALIDATE_commit)),
+					 (from->flags & (BCH_VALIDATE_write|BCH_VALIDATE_commit)),
 					 c, ptr_crc_uncompressed_size_too_big,
 					 "too large encoded extent");
 			bkey_fsck_err_on(!crc_is_compressed(crc) &&
@@ -1901,7 +1901,7 @@ int bch2_bkey_ptrs_validate(struct bch_fs *c, struct bkey_s_c k,
 				 c, extent_ptrs_all_invalid,
 				 "extent without valid pointers");
 
-		bkey_fsck_err_on(from.from == BKEY_VALIDATE_commit &&
+		bkey_fsck_err_on(from->from == BKEY_VALIDATE_commit &&
 				 !have_non_inval_dev_ptrs_dirty,
 				 c, extent_ptrs_all_invalid,
 				 "extent without valid dirty pointers");

--- a/fs/data/extents.h
+++ b/fs/data/extents.h
@@ -404,12 +404,12 @@ int bch2_bkey_pick_read_device(struct bch_fs *, struct bkey_s_c,
 /* KEY_TYPE_btree_ptr: */
 
 int bch2_btree_ptr_validate(struct bch_fs *, struct bkey_s_c,
-			    struct bkey_validate_context);
+			    const struct bkey_validate_context *);
 void bch2_btree_ptr_to_text(struct printbuf *, struct bch_fs *,
 			    struct bkey_s_c);
 
 int bch2_btree_ptr_v2_validate(struct bch_fs *, struct bkey_s_c,
-			       struct bkey_validate_context);
+			       const struct bkey_validate_context *);
 void bch2_btree_ptr_v2_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 void bch2_btree_ptr_v2_compat(enum btree_id, unsigned, unsigned,
 			      int, struct bkey_s);
@@ -445,7 +445,7 @@ bool bch2_extent_merge(struct bch_fs *, struct bkey_s, struct bkey_s_c);
 /* KEY_TYPE_reservation: */
 
 int bch2_reservation_validate(struct bch_fs *, struct bkey_s_c,
-			      struct bkey_validate_context);
+			      const struct bkey_validate_context *);
 void bch2_reservation_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 bool bch2_reservation_merge(struct bch_fs *, struct bkey_s, struct bkey_s_c);
 
@@ -711,7 +711,7 @@ void bch2_extent_ptr_to_text(struct printbuf *out, struct bch_fs *, const struct
 void bch2_bkey_ptrs_to_text(struct printbuf *, struct bch_fs *,
 			    struct bkey_s_c);
 int bch2_bkey_ptrs_validate(struct bch_fs *, struct bkey_s_c,
-			    struct bkey_validate_context);
+			    const struct bkey_validate_context *);
 
 static inline bool bch2_extent_ptr_eq(struct bch_extent_ptr ptr1,
 				      struct bch_extent_ptr ptr2)

--- a/fs/data/io_misc.c
+++ b/fs/data/io_misc.c
@@ -305,7 +305,7 @@ int bch2_truncate(struct bch_fs *c, subvol_inum inum, u64 new_i_size, u64 *i_sec
 	 * snapshot while they're in progress, then crashing, will result in the
 	 * resume only proceeding in one of the snapshots
 	 */
-	guard(rwsem_read)(&c->snapshots.create_lock);
+	guard(percpu_read)(&c->snapshots.create_lock);
 	CLASS(btree_trans, trans)(c);
 	try(bch2_logged_op_start(trans, &op.k_i));
 	int ret = __bch2_resume_logged_op_truncate(trans, &op.k_i, i_sectors_delta);
@@ -521,7 +521,7 @@ int bch2_fcollapse_finsert(struct bch_fs *c, subvol_inum inum,
 	 * snapshot while they're in progress, then crashing, will result in the
 	 * resume only proceeding in one of the snapshots
 	 */
-	guard(rwsem_read)(&c->snapshots.create_lock);
+	guard(percpu_read)(&c->snapshots.create_lock);
 	CLASS(btree_trans, trans)(c);
 	try(bch2_logged_op_start(trans, &op.k_i));
 	int ret = __bch2_resume_logged_op_finsert(trans, &op.k_i, i_sectors_delta);

--- a/fs/data/io_misc.c
+++ b/fs/data/io_misc.c
@@ -106,7 +106,7 @@ int bch2_extent_fallocate(struct btree_trans *trans,
 						0, &cl)) ?:
 			bch2_alloc_sectors_req(trans, req, write_point, &wp);
 		if (bch2_err_matches(ret, BCH_ERR_operation_blocked)) {
-			bch2_wait_on_allocator(trans, c, req, ret, &cl);
+			bch2_wait_on_allocator(trans, req, ret, &cl);
 			ret = bch_err_throw(c, transaction_restart_nested);
 		}
 		if (ret)

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -49,6 +49,7 @@ const char * const bch2_data_ops_strs[] = {
 struct evacuate_bucket_arg {
 	struct bpos		bucket;
 	int			gen;
+	u32			sectors;
 	struct data_update_opts	data_opts;
 };
 
@@ -811,12 +812,16 @@ static int evacuate_bucket_pred(struct btree_trans *trans, void *_arg,
 	*data_opts = arg->data_opts;
 	data_opts->read_dev = -1;
 
+	const union bch_extent_entry *entry;
+	struct extent_ptr_decoded p;
 	unsigned i = 0;
-	bkey_for_each_ptr(bch2_bkey_ptrs_c(k), ptr) {
-		if (ptr->dev == arg->bucket.inode &&
-		    (arg->gen < 0 || arg->gen == ptr->gen) &&
-		    !ptr->cached)
+	bkey_for_each_ptr_decode(k.k, bch2_bkey_ptrs_c(k), p, entry) {
+		if (p.ptr.dev == arg->bucket.inode &&
+		    (arg->gen < 0 || arg->gen == p.ptr.gen) &&
+		    !p.ptr.cached) {
 			data_opts->ptrs_kill |= BIT(i);
+			arg->sectors += p.crc.compressed_size;
+		}
 		i++;
 	}
 
@@ -829,7 +834,7 @@ int bch2_evacuate_bucket(struct moving_context *ctxt,
 			 struct data_update_opts data_opts)
 {
 	struct bch_fs *c = ctxt->trans->c;
-	struct evacuate_bucket_arg arg = { bucket, gen, data_opts, };
+	struct evacuate_bucket_arg arg = { bucket, gen, 0, data_opts, };
 
 	/* Userspace might have supplied @dev: */
 	CLASS(bch2_dev_tryget_noerror, ca)(c, bucket.inode);
@@ -850,6 +855,7 @@ int bch2_evacuate_bucket(struct moving_context *ctxt,
 		prt_printf(&buf, "bucket: ");
 		bch2_bpos_to_text(&buf, bucket);
 		prt_printf(&buf, " gen: %i ret %s\n", gen, bch2_err_str(ret));
+		prt_printf(&buf, "%u/%u sectors\n", arg.sectors, ca->mi.bucket_size);
 	}));
 
 	return ret;

--- a/fs/data/read.c
+++ b/fs/data/read.c
@@ -33,6 +33,7 @@
 
 #include "data/checksum.h"
 #include "data/compress.h"
+#include "data/bitflip_repair.h"
 #include "data/ec/io.h"
 #include "data/io_misc.h"
 #include "data/read.h"
@@ -909,6 +910,36 @@ static int __bch2_read_endio_work(struct bch_read_bio *rbio)
 	if (!csum_good && !rbio->bounce && (rbio->flags & BCH_READ_user_mapped)) {
 		rbio->flags |= BCH_READ_must_bounce;
 		return bch_err_throw(c, data_read_retry_csum_err_maybe_userspace);
+	}
+
+	/*
+	 * CRC32C single-bit repair — last resort only.
+	 *
+	 * Only attempt after all normal checksum retries have been
+	 * exhausted (crc_retry_nr >= checksum_err_retry_nr).  This
+	 * ensures replicas, EC reconstruction, and plain re-reads
+	 * are all tried first.  Safe when the bio uses kernel-owned
+	 * pages (bounced or not user-mapped).
+	 */
+	if (!csum_good &&
+	    rbio->pick.crc_retry_nr >= c->opts.checksum_err_retry_nr &&
+	    (rbio->bounce || !(rbio->flags & BCH_READ_user_mapped)) &&
+	    (crc.csum_type == BCH_CSUM_crc32c ||
+	     crc.csum_type == BCH_CSUM_crc32c_nonzero) &&
+	    !crc_is_compressed(crc)) {
+		int repair_ret = bch2_try_bitflip_repair_bio(c, src,
+					&crc, rbio->pick.crc.csum);
+		if (!repair_ret) {
+			csum_good = true;
+			/*
+			 * Data is now corrected in the bio.  Recompute the
+			 * checksum so that any downstream write-back (e.g.
+			 * data_update / self-heal) persists the fix with a
+			 * matching CRC rather than carrying the stale one.
+			 */
+			csum = bch2_checksum_bio(c, crc.csum_type, nonce, src);
+			rbio->pick.crc.csum = csum;
+		}
 	}
 
 	bch2_account_io_completion(ca, BCH_MEMBER_ERROR_checksum, 0, csum_good);

--- a/fs/data/reconcile/trigger.c
+++ b/fs/data/reconcile/trigger.c
@@ -21,7 +21,7 @@
 
 int bch2_extent_reconcile_validate(struct bch_fs *c,
 				   struct bkey_s_c k,
-				   struct bkey_validate_context from,
+				   const struct bkey_validate_context *from,
 				   const struct bch_extent_reconcile *r)
 {
 	int ret = 0;

--- a/fs/data/reconcile/trigger.h
+++ b/fs/data/reconcile/trigger.h
@@ -5,7 +5,7 @@
 #include "data/extents.h"
 
 int bch2_extent_reconcile_validate(struct bch_fs *, struct bkey_s_c,
-				   struct bkey_validate_context,
+				   const struct bkey_validate_context *,
 				   const struct bch_extent_reconcile *);
 
 static inline struct bpos data_to_rb_work_pos(enum btree_id btree, struct bpos pos)

--- a/fs/data/reconcile/types.h
+++ b/fs/data/reconcile/types.h
@@ -6,6 +6,9 @@
 #include "data/move_types.h"
 #include "init/progress.h"
 
+#include <linux/mutex.h>
+#include <linux/rhashtable-types.h>
+
 struct bch_fs_reconcile {
 	struct task_struct __rcu	*thread;
 	u32				kick;
@@ -23,6 +26,11 @@ struct bch_fs_reconcile {
 	struct bbpos			scan_start;
 	struct bbpos			scan_end;
 	struct bch_move_stats		scan_stats;
+
+	/* In-flight opt changes - see bch2_set_reconcile_needs_scan_pre/post() */
+	struct rhashtable		scans_in_flight;
+	bool				scans_in_flight_init_done;
+	struct mutex			scans_in_flight_lock;
 
 	bool				on_battery;
 #ifdef CONFIG_POWER_SUPPLY

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -242,41 +242,51 @@ static void reconcile_scan_in_flight_put(struct bch_fs *c, u64 cookie)
 	}
 }
 
+static void opt_change_scope_push(struct opt_change_scope *scope, u64 cookie)
+{
+	BUG_ON(scope->nr >= ARRAY_SIZE(scope->cookies));
+	scope->cookies[scope->nr++] = cookie;
+}
+
+void bch2_opt_change_scope_exit(struct opt_change_scope *scope)
+{
+	while (scope->nr)
+		reconcile_scan_in_flight_put(scope->c, scope->cookies[--scope->nr]);
+}
+
 /*
- * An opt change is about to start: register the cookie so the reconcile thread
- * won't complete a pass against the intermediate state, then bump the cookie so
- * writers' extent triggers re-derive against the new option as it lands. Must
- * be paired with bch2_set_reconcile_needs_scan_post().
+ * An opt change is about to start: register the cookie (recording it in the
+ * caller's opt_change_scope, whose destructor unregisters it) so the reconcile
+ * thread won't complete a pass against the intermediate state, then bump the
+ * cookie so writers' extent triggers re-derive against the new option as it
+ * lands. Should be paired with bch2_set_reconcile_needs_scan_post() once the
+ * change has settled - but the registration is dropped by the scope destructor
+ * regardless, so an erroring-out change doesn't strand it.
  */
-int bch2_set_reconcile_needs_scan_pre(struct bch_fs *c, struct reconcile_scan s)
+int bch2_set_reconcile_needs_scan_pre(struct bch_fs *c, struct reconcile_scan s,
+				      struct opt_change_scope *scope)
 {
 	u64 cookie = reconcile_scan_encode(s);
 
 	try(reconcile_scan_in_flight_get(c, cookie));
+	opt_change_scope_push(scope, cookie);
 
 	CLASS(btree_trans, trans)(c);
-	int ret = commit_do(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc,
-			    bch2_set_reconcile_needs_scan_trans(trans, s));
-	if (ret)
-		reconcile_scan_in_flight_put(c, cookie);
-	return ret;
+	return commit_do(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc,
+			 bch2_set_reconcile_needs_scan_trans(trans, s));
 }
 
 /*
- * The opt change is done (or failed): bump the cookie to reflect the settled
- * option, unregister, and kick the reconcile thread. The unregister and the
- * wakeup happen even if the cookie bump failed - the pre-set bump still stands,
- * so a later pass will scan against whatever the option settled to.
+ * The opt change has settled: bump the cookie again so it reflects the new
+ * option, and kick the reconcile thread. (The in-flight registration is
+ * released by the caller's opt_change_scope destructor, not here.)
  */
 int bch2_set_reconcile_needs_scan_post(struct bch_fs *c, struct reconcile_scan s)
 {
-	u64 cookie = reconcile_scan_encode(s);
-
 	CLASS(btree_trans, trans)(c);
 	int ret = commit_do(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc,
 			    bch2_set_reconcile_needs_scan_trans(trans, s));
 
-	reconcile_scan_in_flight_put(c, cookie);
 	bch2_reconcile_wakeup(c);
 	return ret;
 }

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -159,6 +159,128 @@ int bch2_set_reconcile_needs_scan(struct bch_fs *c, struct reconcile_scan s, boo
 	return 0;
 }
 
+/*
+ * In-flight opt changes:
+ *
+ * An opt change is a multi-step operation - it brackets the actual change with
+ * scan-cookie bumps (see opts.c) so writers' extent triggers re-derive against
+ * the new option as it lands. But the reconcile thread mustn't *complete*
+ * (delete) a scan cookie for a pass that overlapped a half-applied opt change:
+ * such a pass scanned against the intermediate option value, and on the
+ * ERO/error path nothing bumps the cookie afterwards to force another pass. So
+ * an opt change registers the cookie it touches here for its duration;
+ * bch2_clear_reconcile_needs_scan() refuses to delete a registered cookie.
+ *
+ * Refcounted: more than one opt change can target the same cookie at once.
+ *
+ * Registration also lets the reconcile thread skip *starting* a scan it
+ * couldn't complete anyway - but that's just sparing wasted work; the
+ * don't-delete is what's load-bearing.
+ */
+struct reconcile_scan_in_flight {
+	struct rhash_head	hash;
+	u64			cookie;
+	unsigned		ref;	/* protected by scans_in_flight_lock */
+	struct rcu_head		rcu;
+};
+
+static const struct rhashtable_params reconcile_scan_in_flight_params = {
+	.head_offset		= offsetof(struct reconcile_scan_in_flight, hash),
+	.key_offset		= offsetof(struct reconcile_scan_in_flight, cookie),
+	.key_len		= sizeof(u64),
+	.automatic_shrinking	= true,
+};
+
+/* Lockless - called by the reconcile thread when deciding whether to clear a cookie: */
+static bool reconcile_scan_in_flight(struct bch_fs *c, u64 cookie)
+{
+	return rhashtable_lookup_fast(&c->reconcile.scans_in_flight, &cookie,
+				      reconcile_scan_in_flight_params) != NULL;
+}
+
+static int reconcile_scan_in_flight_get(struct bch_fs *c, u64 cookie)
+{
+	struct bch_fs_reconcile *r = &c->reconcile;
+
+	guard(mutex)(&r->scans_in_flight_lock);
+
+	struct reconcile_scan_in_flight *e =
+		rhashtable_lookup_fast(&r->scans_in_flight, &cookie,
+				       reconcile_scan_in_flight_params);
+	if (e) {
+		e->ref++;
+		return 0;
+	}
+
+	e = kzalloc(sizeof(*e), GFP_KERNEL);
+	if (!e)
+		return bch_err_throw(c, ENOMEM_reconcile_scan_in_flight);
+	e->cookie	= cookie;
+	e->ref		= 1;
+
+	int ret = rhashtable_insert_fast(&r->scans_in_flight, &e->hash,
+					 reconcile_scan_in_flight_params);
+	if (ret)
+		kfree(e);
+	return ret;
+}
+
+static void reconcile_scan_in_flight_put(struct bch_fs *c, u64 cookie)
+{
+	struct bch_fs_reconcile *r = &c->reconcile;
+
+	guard(mutex)(&r->scans_in_flight_lock);
+
+	struct reconcile_scan_in_flight *e =
+		rhashtable_lookup_fast(&r->scans_in_flight, &cookie,
+				       reconcile_scan_in_flight_params);
+	BUG_ON(!e);
+	if (!--e->ref) {
+		BUG_ON(rhashtable_remove_fast(&r->scans_in_flight, &e->hash,
+					      reconcile_scan_in_flight_params));
+		kfree_rcu(e, rcu);
+	}
+}
+
+/*
+ * An opt change is about to start: register the cookie so the reconcile thread
+ * won't complete a pass against the intermediate state, then bump the cookie so
+ * writers' extent triggers re-derive against the new option as it lands. Must
+ * be paired with bch2_set_reconcile_needs_scan_post().
+ */
+int bch2_set_reconcile_needs_scan_pre(struct bch_fs *c, struct reconcile_scan s)
+{
+	u64 cookie = reconcile_scan_encode(s);
+
+	try(reconcile_scan_in_flight_get(c, cookie));
+
+	CLASS(btree_trans, trans)(c);
+	int ret = commit_do(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc,
+			    bch2_set_reconcile_needs_scan_trans(trans, s));
+	if (ret)
+		reconcile_scan_in_flight_put(c, cookie);
+	return ret;
+}
+
+/*
+ * The opt change is done (or failed): bump the cookie to reflect the settled
+ * option, unregister, and kick the reconcile thread. The unregister and the
+ * wakeup happen even if the cookie bump failed - the pre-set bump still stands,
+ * so a later pass will scan against whatever the option settled to.
+ */
+int bch2_set_reconcile_needs_scan_post(struct bch_fs *c, struct reconcile_scan s)
+{
+	u64 cookie = reconcile_scan_encode(s);
+
+	CLASS(btree_trans, trans)(c);
+	int ret = commit_do(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc,
+			    bch2_set_reconcile_needs_scan_trans(trans, s));
+
+	reconcile_scan_in_flight_put(c, cookie);
+	bch2_reconcile_wakeup(c);
+	return ret;
+}
+
 int bch2_set_fs_needs_reconcile(struct bch_fs *c)
 {
 	return bch2_set_reconcile_needs_scan(c,
@@ -1094,6 +1216,16 @@ static int do_reconcile_scan(struct moving_context *ctxt,
 	struct bch_fs *c = trans->c;
 	struct bch_fs_reconcile *r = &c->reconcile;
 
+	/*
+	 * If an opt change is still mid-flight for this cookie we couldn't
+	 * complete the scan anyway - bch2_clear_reconcile_needs_scan() would
+	 * refuse to delete the cookie - so don't burn a full pass on it;
+	 * bch2_set_reconcile_needs_scan_post()'s wakeup brings us back once the
+	 * change settles.
+	 */
+	if (reconcile_scan_in_flight(c, cookie_pos.offset))
+		return 0;
+
 	bch2_move_stats_init(&r->scan_stats, "reconcile_scan");
 	ctxt->stats = &r->scan_stats;
 
@@ -1788,18 +1920,34 @@ static int bch2_reconcile_power_notifier(struct notifier_block *nb,
 }
 #endif
 
+static void reconcile_scan_in_flight_free(void *p, void *arg)
+{
+	WARN_ON_ONCE(1);
+	kfree(p);
+}
+
 void bch2_fs_reconcile_exit(struct bch_fs *c)
 {
+	struct bch_fs_reconcile *r = &c->reconcile;
+
+	if (r->scans_in_flight_init_done)
+		rhashtable_free_and_destroy(&r->scans_in_flight,
+					    reconcile_scan_in_flight_free, NULL);
+
 #ifdef CONFIG_POWER_SUPPLY
-	power_supply_unreg_notifier(&c->reconcile.power_notifier);
+	power_supply_unreg_notifier(&r->power_notifier);
 #endif
 }
 
 int bch2_fs_reconcile_init(struct bch_fs *c)
 {
-#ifdef CONFIG_POWER_SUPPLY
 	struct bch_fs_reconcile *r = &c->reconcile;
 
+	mutex_init(&r->scans_in_flight_lock);
+	try(rhashtable_init(&r->scans_in_flight, &reconcile_scan_in_flight_params));
+	r->scans_in_flight_init_done = true;
+
+#ifdef CONFIG_POWER_SUPPLY
 	r->power_notifier.notifier_call = bch2_reconcile_power_notifier;
 	try(power_supply_reg_notifier(&r->power_notifier));
 

--- a/fs/data/reconcile/work.h
+++ b/fs/data/reconcile/work.h
@@ -30,6 +30,8 @@ struct reconcile_scan {
 
 int bch2_set_reconcile_needs_scan_trans(struct btree_trans *, struct reconcile_scan);
 int bch2_set_reconcile_needs_scan(struct bch_fs *, struct reconcile_scan, bool);
+int bch2_set_reconcile_needs_scan_pre(struct bch_fs *, struct reconcile_scan);
+int bch2_set_reconcile_needs_scan_post(struct bch_fs *, struct reconcile_scan);
 int bch2_set_fs_needs_reconcile(struct bch_fs *);
 
 int bch2_reconcile_scan_cookie_is_set(struct btree_trans *, u64);

--- a/fs/data/reconcile/work.h
+++ b/fs/data/reconcile/work.h
@@ -28,9 +28,37 @@ struct reconcile_scan {
 	};
 };
 
+/* No opt change touches more than one bracketed reconcile scan today: */
+#define BCH_OPT_CHANGE_SCANS_MAX	4
+
+/*
+ * The reconcile-scan cookies an opt change registered as in-flight - see
+ * bch2_set_reconcile_needs_scan_pre(). Constructed empty, populated by
+ * bch2_opt_hook_pre_set(); the destructor unregisters them, so an opt change
+ * that errors out (or never reaches bch2_opt_hook_post_set()) doesn't leak a
+ * registration and wedge the reconcile thread on that cookie.
+ */
+struct opt_change_scope {
+	struct bch_fs		*c;
+	unsigned		nr;
+	u64			cookies[BCH_OPT_CHANGE_SCANS_MAX];
+};
+
+static inline struct opt_change_scope bch2_opt_change_scope_init(struct bch_fs *c)
+{
+	return (struct opt_change_scope) { .c = c };
+}
+
+void bch2_opt_change_scope_exit(struct opt_change_scope *);
+
+DEFINE_CLASS(opt_change_scope, struct opt_change_scope,
+	     bch2_opt_change_scope_exit(&_T),
+	     bch2_opt_change_scope_init(c),
+	     struct bch_fs *c);
+
 int bch2_set_reconcile_needs_scan_trans(struct btree_trans *, struct reconcile_scan);
 int bch2_set_reconcile_needs_scan(struct bch_fs *, struct reconcile_scan, bool);
-int bch2_set_reconcile_needs_scan_pre(struct bch_fs *, struct reconcile_scan);
+int bch2_set_reconcile_needs_scan_pre(struct bch_fs *, struct reconcile_scan, struct opt_change_scope *);
 int bch2_set_reconcile_needs_scan_post(struct bch_fs *, struct reconcile_scan);
 int bch2_set_fs_needs_reconcile(struct bch_fs *);
 

--- a/fs/data/reflink.c
+++ b/fs/data/reflink.c
@@ -470,6 +470,19 @@ static int bch2_make_extent_indirect(struct btree_trans *trans,
 	if (orig->k.type == KEY_TYPE_inline_data)
 		bch2_check_set_feature(c, BCH_FEATURE_reflink_inline_data);
 
+	/*
+	 * A non-degraded extent carries no bch_extent_reconcile entry - for a
+	 * data extent that's fine, reconcile re-derives the io options from the
+	 * inode each pass. But once it's indirect there's no inode to derive
+	 * from, so snapshot the inode's options onto the reflink_v now;
+	 * otherwise reconcile would reconcile it against the filesystem
+	 * defaults instead. (If the source extent already carries the entry,
+	 * or the inode's options match the defaults, this is a no-op.) The
+	 * kmalloc below reserves room for the entry + invalid-device padding.
+	 */
+	struct bch_inode_opts opts;
+	try(bch2_bkey_get_io_opts(trans, NULL, bkey_i_to_s_c(orig), &opts));
+
 	CLASS(btree_iter, reflink_iter)(trans, BTREE_ID_reflink, POS_MAX,
 					BTREE_ITER_intent);
 	bkey_try(bch2_btree_iter_peek_prev(&reflink_iter));
@@ -482,7 +495,8 @@ static int bch2_make_extent_indirect(struct btree_trans *trans,
 	if (bkey_ge(reflink_iter.pos, POS(0, REFLINK_P_IDX_MAX - orig->k.size)))
 		return -ENOSPC;
 
-	struct bkey_i *r_v = errptr_try(bch2_trans_kmalloc(trans, sizeof(__le64) + bkey_bytes(&orig->k)));
+	unsigned r_v_buf_u64s = orig->k.u64s + 2 + BCH_REPLICAS_MAX;
+	struct bkey_i *r_v = errptr_try(bch2_trans_kmalloc(trans, r_v_buf_u64s * sizeof(u64)));
 
 	bkey_init(&r_v->k);
 	r_v->k.type	= bkey_type_to_indirect(&orig->k);
@@ -495,6 +509,9 @@ static int bch2_make_extent_indirect(struct btree_trans *trans,
 	__le64 *refcount = bkey_refcount(bkey_i_to_s(r_v));
 	*refcount	= 0;
 	memcpy(refcount + 1, &orig->v, bkey_val_bytes(&orig->k));
+
+	try(bch2_bkey_set_needs_reconcile(trans, NULL, &opts, bkey_i_to_s(r_v),
+					  r_v_buf_u64s, SET_NEEDS_RECONCILE_other, 0));
 
 	try(bch2_trans_update(trans, &reflink_iter, r_v, 0));
 

--- a/fs/data/reflink.c
+++ b/fs/data/reflink.c
@@ -50,7 +50,7 @@ static inline unsigned bkey_type_to_indirect(const struct bkey *k)
 /* reflink pointers */
 
 int bch2_reflink_p_validate(struct bch_fs *c, struct bkey_s_c k,
-			    struct bkey_validate_context from)
+			    const struct bkey_validate_context *from)
 {
 	struct bkey_s_c_reflink_p p = bkey_s_c_to_reflink_p(k);
 	int ret = 0;
@@ -104,7 +104,7 @@ bool bch2_reflink_p_merge(struct bch_fs *c, struct bkey_s _l, struct bkey_s_c _r
 /* indirect extents */
 
 int bch2_reflink_v_validate(struct bch_fs *c, struct bkey_s_c k,
-			    struct bkey_validate_context from)
+			    const struct bkey_validate_context *from)
 {
 	int ret = 0;
 
@@ -143,7 +143,7 @@ bool bch2_reflink_v_merge(struct bch_fs *c, struct bkey_s _l, struct bkey_s_c _r
 /* indirect inline data */
 
 int bch2_indirect_inline_data_validate(struct bch_fs *c, struct bkey_s_c k,
-				       struct bkey_validate_context from)
+				       const struct bkey_validate_context *from)
 {
 	return 0;
 }

--- a/fs/data/reflink.h
+++ b/fs/data/reflink.h
@@ -3,7 +3,7 @@
 #define _BCACHEFS_REFLINK_H
 
 int bch2_reflink_p_validate(struct bch_fs *, struct bkey_s_c,
-			    struct bkey_validate_context);
+			    const struct bkey_validate_context *);
 void bch2_reflink_p_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 bool bch2_reflink_p_merge(struct bch_fs *, struct bkey_s, struct bkey_s_c);
 int bch2_trigger_reflink_p(struct btree_trans *, struct btree_trigger_op);
@@ -17,7 +17,7 @@ int bch2_trigger_reflink_p(struct btree_trans *, struct btree_trigger_op);
 })
 
 int bch2_reflink_v_validate(struct bch_fs *, struct bkey_s_c,
-			    struct bkey_validate_context);
+			    const struct bkey_validate_context *);
 void bch2_reflink_v_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 int bch2_trigger_reflink_v(struct btree_trans *, struct btree_trigger_op);
 
@@ -30,7 +30,7 @@ int bch2_trigger_reflink_v(struct btree_trans *, struct btree_trigger_op);
 })
 
 int bch2_indirect_inline_data_validate(struct bch_fs *, struct bkey_s_c,
-				       struct bkey_validate_context);
+				       const struct bkey_validate_context *);
 void bch2_indirect_inline_data_to_text(struct printbuf *,
 				struct bch_fs *, struct bkey_s_c);
 int bch2_trigger_indirect_inline_data(struct btree_trans *, struct btree_trigger_op);

--- a/fs/data/write.c
+++ b/fs/data/write.c
@@ -2335,7 +2335,7 @@ again:
 
 			if (bch2_err_matches(ret2, BCH_ERR_operation_blocked) &&
 			    wait_on_allocator_sync) {
-				bch2_wait_on_allocator(trans, c, req, ret2, &op->cl);
+				bch2_wait_on_allocator(trans, req, ret2, &op->cl);
 				__bch2_write_index(op);
 				op->wbio.failed.nr = 0;
 				ret2 = bch_err_throw(c, transaction_restart_nested);

--- a/fs/debug/sysfs.c
+++ b/fs/debug/sysfs.c
@@ -801,10 +801,11 @@ static ssize_t sysfs_opt_store(struct bch_fs *c,
 
 	guard(memalloc_flags)(PF_MEMALLOC_NOFS);
 	guard(opt_change_lock)(c);
+	CLASS(opt_change_scope, opt_scope)(c);
 
 	u64 v;
 	ret =   bch2_opt_parse(c, opt, strim(tmp), &v, NULL) ?:
-		bch2_opt_hook_pre_set(c, ca, 0, id, v, true);
+		bch2_opt_hook_pre_set(c, ca, 0, id, v, true, &opt_scope);
 
 	if (!ret) {
 		bool is_sb = opt->get_sb || opt->get_member || opt->get_ext;

--- a/fs/errcode.h
+++ b/fs/errcode.h
@@ -156,6 +156,7 @@
 	x(ENOMEM,                       ENOMEM_journal_read_bucket)             \
 	x(ENOMEM,                       ENOMEM_acl)				\
 	x(ENOMEM,                       ENOMEM_move_extent)			\
+	x(ENOMEM,			ENOMEM_reconcile_scan_in_flight)	\
 	x(ENOSPC,			ENOSPC_disk_reservation)		\
 	x(ENOSPC,			ENOSPC_bucket_alloc)			\
 	x(ENOSPC,			ENOSPC_disk_label_add)			\

--- a/fs/fs/dirent.c
+++ b/fs/fs/dirent.c
@@ -147,7 +147,7 @@ const struct bch_hash_desc bch2_dirent_hash_desc = {
 };
 
 int bch2_dirent_validate(struct bch_fs *c, struct bkey_s_c k,
-			 struct bkey_validate_context from)
+			 const struct bkey_validate_context *from)
 {
 	struct bkey_s_c_dirent d = bkey_s_c_to_dirent(k);
 	unsigned name_block_len = bch2_dirent_name_bytes(d);
@@ -168,7 +168,7 @@ int bch2_dirent_validate(struct bch_fs *c, struct bkey_s_c k,
 	 * Check new keys don't exceed the max length
 	 * (older keys may be larger.)
 	 */
-	bkey_fsck_err_on((from.flags & BCH_VALIDATE_commit) && d_name.len > BCH_NAME_MAX,
+	bkey_fsck_err_on((from->flags & BCH_VALIDATE_commit) && d_name.len > BCH_NAME_MAX,
 			 c, dirent_name_too_long,
 			 "dirent name too big (%u > %u)",
 			 d_name.len, BCH_NAME_MAX);
@@ -192,7 +192,7 @@ int bch2_dirent_validate(struct bch_fs *c, struct bkey_s_c k,
 			 "dirent points to own directory");
 
 	if (d.v->d_casefold) {
-		bkey_fsck_err_on(from.from == BKEY_VALIDATE_commit &&
+		bkey_fsck_err_on(from->from == BKEY_VALIDATE_commit &&
 				 d_cf_name.len > BCH_NAME_MAX,
 				 c, dirent_cf_name_too_big,
 				 "dirent w/ cf name too big (%u > %u)",

--- a/fs/fs/dirent.h
+++ b/fs/fs/dirent.h
@@ -7,7 +7,7 @@
 extern const struct bch_hash_desc bch2_dirent_hash_desc;
 
 int bch2_dirent_validate(struct bch_fs *, struct bkey_s_c,
-			 struct bkey_validate_context);
+			 const struct bkey_validate_context *);
 void bch2_dirent_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 
 #define bch2_bkey_ops_dirent ((struct bkey_ops) {	\

--- a/fs/fs/inode.c
+++ b/fs/fs/inode.c
@@ -474,7 +474,7 @@ struct bkey_i *bch2_inode_to_v3(struct btree_trans *trans, struct bkey_i *k)
 }
 
 static int __bch2_inode_validate(struct bch_fs *c, struct bkey_s_c k,
-				 struct bkey_validate_context from)
+				 const struct bkey_validate_context *from)
 {
 	struct bch_inode_unpacked unpacked;
 	int ret = 0;
@@ -514,7 +514,7 @@ fsck_err:
 }
 
 int bch2_inode_validate(struct bch_fs *c, struct bkey_s_c k,
-			struct bkey_validate_context from)
+			const struct bkey_validate_context *from)
 {
 	struct bkey_s_c_inode inode = bkey_s_c_to_inode(k);
 	int ret = 0;
@@ -530,7 +530,7 @@ fsck_err:
 }
 
 int bch2_inode_v2_validate(struct bch_fs *c, struct bkey_s_c k,
-			   struct bkey_validate_context from)
+			   const struct bkey_validate_context *from)
 {
 	struct bkey_s_c_inode_v2 inode = bkey_s_c_to_inode_v2(k);
 	int ret = 0;
@@ -546,7 +546,7 @@ fsck_err:
 }
 
 int bch2_inode_v3_validate(struct bch_fs *c, struct bkey_s_c k,
-			   struct bkey_validate_context from)
+			   const struct bkey_validate_context *from)
 {
 	struct bkey_s_c_inode_v3 inode = bkey_s_c_to_inode_v3(k);
 	int ret = 0;
@@ -793,7 +793,7 @@ int bch2_trigger_inode(struct btree_trans *trans, struct btree_trigger_op op)
 }
 
 int bch2_inode_generation_validate(struct bch_fs *c, struct bkey_s_c k,
-				   struct bkey_validate_context from)
+				   const struct bkey_validate_context *from)
 {
 	int ret = 0;
 
@@ -813,7 +813,7 @@ void bch2_inode_generation_to_text(struct printbuf *out, struct bch_fs *c,
 }
 
 int bch2_inode_alloc_cursor_validate(struct bch_fs *c, struct bkey_s_c k,
-				   struct bkey_validate_context from)
+				   const struct bkey_validate_context *from)
 {
 	int ret = 0;
 

--- a/fs/fs/inode.h
+++ b/fs/fs/inode.h
@@ -9,11 +9,11 @@
 extern const char * const bch2_inode_opts[];
 
 int bch2_inode_validate(struct bch_fs *, struct bkey_s_c,
-			struct bkey_validate_context);
+			const struct bkey_validate_context *);
 int bch2_inode_v2_validate(struct bch_fs *, struct bkey_s_c,
-			   struct bkey_validate_context);
+			   const struct bkey_validate_context *);
 int bch2_inode_v3_validate(struct bch_fs *, struct bkey_s_c,
-			   struct bkey_validate_context);
+			   const struct bkey_validate_context *);
 void bch2_inode_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 
 int __bch2_inode_has_child_snapshots(struct btree_trans *, struct bpos);
@@ -56,7 +56,7 @@ static inline bool bkey_is_inode(const struct bkey *k)
 }
 
 int bch2_inode_generation_validate(struct bch_fs *, struct bkey_s_c,
-				   struct bkey_validate_context);
+				   const struct bkey_validate_context *);
 void bch2_inode_generation_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 
 #define bch2_bkey_ops_inode_generation ((struct bkey_ops) {	\
@@ -66,7 +66,7 @@ void bch2_inode_generation_to_text(struct printbuf *, struct bch_fs *, struct bk
 })
 
 int bch2_inode_alloc_cursor_validate(struct bch_fs *, struct bkey_s_c,
-				     struct bkey_validate_context);
+				     const struct bkey_validate_context *);
 void bch2_inode_alloc_cursor_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 
 #define bch2_bkey_ops_inode_alloc_cursor ((struct bkey_ops) {	\

--- a/fs/fs/quota.c
+++ b/fs/fs/quota.c
@@ -66,7 +66,7 @@ const struct bch_sb_field_ops bch_sb_field_ops_quota = {
 };
 
 int bch2_quota_validate(struct bch_fs *c, struct bkey_s_c k,
-			struct bkey_validate_context from)
+			const struct bkey_validate_context *from)
 {
 	int ret = 0;
 

--- a/fs/fs/quota.h
+++ b/fs/fs/quota.h
@@ -8,7 +8,7 @@
 extern const struct bch_sb_field_ops bch_sb_field_ops_quota;
 
 int bch2_quota_validate(struct bch_fs *, struct bkey_s_c,
-			struct bkey_validate_context);
+			const struct bkey_validate_context *);
 void bch2_quota_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 
 #define bch2_bkey_ops_quota ((struct bkey_ops) {	\

--- a/fs/fs/xattr.c
+++ b/fs/fs/xattr.c
@@ -526,6 +526,7 @@ static int __bch2_xattr_bcachefs_set(const struct xattr_handler *handler,
 
 	guard(memalloc_flags)(PF_MEMALLOC_NOFS);
 	guard(opt_change_lock)(c);
+	CLASS(opt_change_scope, opt_scope)(c);
 
 	if (value) {
 		char *buf __free(kfree) = kmalloc(size + 1, GFP_KERNEL);
@@ -535,7 +536,7 @@ static int __bch2_xattr_bcachefs_set(const struct xattr_handler *handler,
 		buf[size] = '\0';
 
 		try(bch2_opt_parse(c, opt, buf, &v, NULL));
-		try(bch2_opt_hook_pre_set(c, NULL, inode->ei_inode.bi_inum, opt_id, v, true));
+		try(bch2_opt_hook_pre_set(c, NULL, inode->ei_inode.bi_inum, opt_id, v, true, &opt_scope));
 
 		/* +1 bias for inode options: */
 		s.v = v + 1;

--- a/fs/fs/xattr.c
+++ b/fs/fs/xattr.c
@@ -76,7 +76,7 @@ const struct bch_hash_desc bch2_xattr_hash_desc = {
 };
 
 int bch2_xattr_validate(struct bch_fs *c, struct bkey_s_c k,
-			struct bkey_validate_context from)
+			const struct bkey_validate_context *from)
 {
 	struct bkey_s_c_xattr xattr = bkey_s_c_to_xattr(k);
 	unsigned val_u64s = xattr_val_u64s(xattr.v->x_name_len,

--- a/fs/fs/xattr.h
+++ b/fs/fs/xattr.h
@@ -7,7 +7,7 @@
 extern const struct bch_hash_desc bch2_xattr_hash_desc;
 
 int bch2_xattr_validate(struct bch_fs *, struct bkey_s_c,
-			struct bkey_validate_context);
+			const struct bkey_validate_context *);
 void bch2_xattr_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 
 #define bch2_bkey_ops_xattr ((struct bkey_ops) {	\

--- a/fs/init/error.c
+++ b/fs/init/error.c
@@ -677,15 +677,15 @@ static const char * const bch2_bkey_validate_contexts[] = {
 
 int __bch2_bkey_fsck_err(struct bch_fs *c,
 			 struct bkey_s_c k,
-			 struct bkey_validate_context from,
+			 const struct bkey_validate_context *from,
 			 enum bch_sb_error_id err,
 			 const char *fmt, ...)
 {
-	if (from.flags & BCH_VALIDATE_silent)
+	if (from->flags & BCH_VALIDATE_silent)
 		return bch_err_throw(c, fsck_delete_bkey);
 
 	unsigned fsck_flags = 0;
-	if (!(from.flags & (BCH_VALIDATE_write|BCH_VALIDATE_commit))) {
+	if (!(from->flags & (BCH_VALIDATE_write|BCH_VALIDATE_commit))) {
 		if (test_bit(err, c->sb.errors_silent))
 			return bch_err_throw(c, fsck_delete_bkey);
 
@@ -696,15 +696,15 @@ int __bch2_bkey_fsck_err(struct bch_fs *c,
 
 	CLASS(printbuf, buf)();
 	prt_printf(&buf, "invalid bkey in %s",
-		   bch2_bkey_validate_contexts[from.from]);
+		   bch2_bkey_validate_contexts[from->from]);
 
-	if (from.from == BKEY_VALIDATE_journal)
+	if (from->from == BKEY_VALIDATE_journal)
 		prt_printf(&buf, " journal seq=%llu offset=%u",
-			   from.journal_seq, from.journal_offset);
+			   from->journal_seq, from->journal_offset);
 
 	prt_str(&buf, " btree=");
-	bch2_btree_id_to_text(&buf, from.btree);
-	prt_printf(&buf, " level=%u: ", from.level);
+	bch2_btree_id_to_text(&buf, from->btree);
+	prt_printf(&buf, " level=%u: ", from->level);
 
 	bch2_bkey_val_to_text(&buf, c, k);
 	prt_newline(&buf);

--- a/fs/init/error.h
+++ b/fs/init/error.h
@@ -189,7 +189,7 @@ enum bch_validate_flags;
 __printf(5, 6)
 int __bch2_bkey_fsck_err(struct bch_fs *,
 			 struct bkey_s_c,
-			 struct bkey_validate_context from,
+			 const struct bkey_validate_context *from,
 			 enum bch_sb_error_id,
 			 const char *, ...);
 

--- a/fs/init/fs.c
+++ b/fs/init/fs.c
@@ -1301,6 +1301,7 @@ static int bch2_fs_init(struct bch_fs *c, struct bch_sb *sb,
 	try(bch2_fs_errors_init(c));
 	try(bch2_fs_encryption_init(c));
 	try(bch2_fs_io_read_init(c));
+	try(bch2_fs_snapshots_init(c));
 	try(bch2_fs_vfs_init(c));
 	try(bch2_io_clock_init(&c->io_clock[READ]));
 	try(bch2_io_clock_init(&c->io_clock[WRITE]));

--- a/fs/journal/init.c
+++ b/fs/journal/init.c
@@ -46,7 +46,7 @@ static int bch2_set_nr_journal_buckets_iter(struct bch_dev *ca, unsigned nr,
 			 PTR_ERR_OR_ZERO(ob[nr_got] = bch2_bucket_alloc_trans(trans, req)));
 
 			if (bch2_err_matches(ret2, BCH_ERR_operation_blocked)) {
-				bch2_wait_on_allocator(trans, c, req, ret2, cl);
+				bch2_wait_on_allocator(trans, req, ret2, cl);
 				ret2 = bch_err_throw(c, transaction_restart_nested);
 			}
 

--- a/fs/journal/init.c
+++ b/fs/journal/init.c
@@ -34,19 +34,27 @@ static int bch2_set_nr_journal_buckets_iter(struct bch_dev *ca, unsigned nr,
 		return bch_err_throw(c, ENOMEM_set_nr_journal_buckets);
 
 	for (nr_got = 0; nr_got < nr_want; nr_got++) {
-		ob[nr_got] = bch2_bucket_alloc(c, ca, watermark,
-					       BCH_DATA_journal, cl);
-		ret = PTR_ERR_OR_ZERO(ob[nr_got]);
+		CLASS(btree_trans, trans)(c);
 
-		if (ret == -BCH_ERR_bucket_alloc_blocked)
-			ret = bch_err_throw(c, freelist_empty);
-		if (ret == -BCH_ERR_freelist_empty) /* don't if we're actually out of buckets */
-			bch2_alloc_wake_dev(ca);
+		ret = lockrestart_do(trans, ({
+			struct alloc_request *req __free(alloc_request_put) =
+				alloc_request_get(trans,
+						  0, false, NULL, 1, 0, watermark, 0,
+						  !nr_got ? cl : 0);
+			int ret2 = PTR_ERR_OR_ZERO(req) ?:
+			(req->ca = ca,
+			 PTR_ERR_OR_ZERO(ob[nr_got] = bch2_bucket_alloc_trans(trans, req)));
 
+			if (bch2_err_matches(ret2, BCH_ERR_operation_blocked)) {
+				bch2_wait_on_allocator(trans, c, req, ret2, cl);
+				ret2 = bch_err_throw(c, transaction_restart_nested);
+			}
+
+			ret2;
+		}));
 		if (ret)
 			break;
 
-		CLASS(btree_trans, trans)(c);
 		ret = bch2_trans_mark_metadata_bucket(trans, ca,
 					ob[nr_got]->bucket, BCH_DATA_journal,
 					ca->mi.bucket_size, BTREE_TRIGGER_transactional);
@@ -144,6 +152,7 @@ static int bch2_set_nr_journal_buckets_loop(struct bch_fs *c, struct bch_dev *ca
 		return 0;
 
 	while (!ret && ja->nr < nr) {
+
 		/*
 		 * note: journal buckets aren't really counted as _sectors_ used yet, so
 		 * we don't need the disk reservation to avoid the BUG_ON() in buckets.c
@@ -160,10 +169,6 @@ static int bch2_set_nr_journal_buckets_loop(struct bch_fs *c, struct bch_dev *ca
 						bucket_to_sector(ca, nr - ja->nr), 1, 0));
 
 		ret = bch2_set_nr_journal_buckets_iter(ca, nr, new_fs, watermark, &cl);
-		if (bch2_err_matches(ret, BCH_ERR_operation_blocked))
-			ret = 0; /* wait and retry */
-
-		bch2_wait_on_allocator(NULL, c, NULL, ret, &cl);
 	}
 
 	return ret;

--- a/fs/journal/validate.c
+++ b/fs/journal/validate.c
@@ -95,7 +95,7 @@ static int journal_validate_key(struct bch_fs *c,
 		bch2_bkey_compat(c, from.level, from.btree, version, big_endian,
 				 write, NULL, bkey_to_packed(k));
 
-	if (journal_entry_err_on(ret = bch2_bkey_validate(c, bkey_i_to_s_c(k), from),
+	if (journal_entry_err_on(ret = bch2_bkey_validate(c, bkey_i_to_s_c(k), &from),
 				 c, version, jset, entry,
 				 journal_entry_bkey_bad_format,
 				 "bkey validate error %s", bch2_err_str(ret))) {

--- a/fs/opts.c
+++ b/fs/opts.c
@@ -568,8 +568,16 @@ void bch2_opts_to_text(struct printbuf *out,
 	}
 }
 
+static int reconcile_scan_bracket(struct bch_fs *c, struct reconcile_scan s, bool post,
+				  struct opt_change_scope *scope)
+{
+	return post
+		? bch2_set_reconcile_needs_scan_post(c, s)
+		: bch2_set_reconcile_needs_scan_pre(c, s, scope);
+}
+
 static int opt_hook_io(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum bch_opt_id id,
-		       u64 v, bool post)
+		       u64 v, bool post, struct opt_change_scope *scope)
 {
 	if (!test_bit(BCH_FS_started, &c->flags))
 		return 0;
@@ -589,22 +597,22 @@ static int opt_hook_io(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum bch_
 			.inum = inum,
 		};
 
-		try(bch2_set_reconcile_needs_scan(c, s, post));
+		try(reconcile_scan_bracket(c, s, post, scope));
 		break;
 	}
 	case Opt_metadata_target:
 	case Opt_metadata_checksum:
 	case Opt_metadata_replicas:
-		try(bch2_set_reconcile_needs_scan(c,
-			(struct reconcile_scan) { .type = RECONCILE_SCAN_metadata, .dev = inum }, post));
+		try(reconcile_scan_bracket(c,
+			(struct reconcile_scan) { .type = RECONCILE_SCAN_metadata, .dev = inum }, post, scope));
 		break;
 	case Opt_durability:
 		if (!post && v > ca->mi.durability)
 			try(bch2_set_reconcile_needs_scan(c,
-				(struct reconcile_scan) { .type = RECONCILE_SCAN_pending}, post));
+				(struct reconcile_scan) { .type = RECONCILE_SCAN_pending}, false));
 
-		try(bch2_set_reconcile_needs_scan(c,
-			(struct reconcile_scan) { .type = RECONCILE_SCAN_device, .dev = inum }, post));
+		try(reconcile_scan_bracket(c,
+			(struct reconcile_scan) { .type = RECONCILE_SCAN_device, .dev = inum }, post, scope));
 		break;
 	case Opt_ec_max_data_blocks:
 		/*
@@ -613,8 +621,8 @@ static int opt_hook_io(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum bch_
 		 * stripes scan so existing stripes converge to the new
 		 * target.
 		 */
-		try(bch2_set_reconcile_needs_scan(c,
-			(struct reconcile_scan) { .type = RECONCILE_SCAN_stripes }, post));
+		try(reconcile_scan_bracket(c,
+			(struct reconcile_scan) { .type = RECONCILE_SCAN_stripes }, post, scope));
 		break;
 	default:
 		break;
@@ -624,7 +632,7 @@ static int opt_hook_io(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum bch_
 }
 
 int bch2_opt_hook_pre_set(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum bch_opt_id id, u64 v,
-			  bool change)
+			  bool change, struct opt_change_scope *scope)
 {
 	switch (id) {
 	case Opt_state:
@@ -651,7 +659,7 @@ int bch2_opt_hook_pre_set(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum b
 	}
 
 	if (change)
-		try(opt_hook_io(c, ca, inum, id, v, false));
+		try(opt_hook_io(c, ca, inum, id, v, false, scope));
 
 	return 0;
 }
@@ -659,7 +667,7 @@ int bch2_opt_hook_pre_set(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum b
 int bch2_opts_hooks_pre_set(struct bch_fs *c)
 {
 	for (unsigned i = 0; i < bch2_opts_nr; i++)
-		try(bch2_opt_hook_pre_set(c, NULL, 0, i, bch2_opt_get_by_id(&c->opts, i), false));
+		try(bch2_opt_hook_pre_set(c, NULL, 0, i, bch2_opt_get_by_id(&c->opts, i), false, NULL));
 
 	return 0;
 }
@@ -678,7 +686,7 @@ void bch2_opt_hook_post_set(struct bch_fs *c, struct bch_dev *ca, u64 inum,
 		bch2_fs_log_msg(c, "%s", buf.buf);
 	}
 
-	opt_hook_io(c, ca, inum, id, v, true);
+	opt_hook_io(c, ca, inum, id, v, true, NULL);
 
 	switch (id) {
 	case Opt_reconcile_enabled:

--- a/fs/opts.c
+++ b/fs/opts.c
@@ -9,6 +9,8 @@
 #include "alloc/background.h"
 #include "alloc/disk_groups.h"
 
+#include "btree/update.h"
+
 #include "data/compress.h"
 #include "data/copygc.h"
 #include "data/reconcile/work.h"
@@ -665,6 +667,17 @@ int bch2_opts_hooks_pre_set(struct bch_fs *c)
 void bch2_opt_hook_post_set(struct bch_fs *c, struct bch_dev *ca, u64 inum,
 			    enum bch_opt_id id, u64 v)
 {
+	if (test_bit(BCH_FS_started, &c->flags)) {
+		CLASS(printbuf, buf)();
+		prt_printf(&buf, "opt change: %s=", bch2_opt_table[id].attr.name);
+		bch2_opt_to_text(&buf, c, c->disk_sb.sb, &bch2_opt_table[id], v, 0);
+		if (ca)
+			prt_printf(&buf, " dev %u", ca->dev_idx);
+		if (inum)
+			prt_printf(&buf, " inum %llu", inum);
+		bch2_fs_log_msg(c, "%s", buf.buf);
+	}
+
 	opt_hook_io(c, ca, inum, id, v, true);
 
 	switch (id) {

--- a/fs/opts.h
+++ b/fs/opts.h
@@ -699,7 +699,9 @@ void bch2_opts_to_text(struct printbuf *,
 		       struct bch_opts_mask *,
 		       unsigned, unsigned, unsigned);
 
-int bch2_opt_hook_pre_set(struct bch_fs *, struct bch_dev *, u64, enum bch_opt_id, u64, bool);
+struct opt_change_scope;
+int bch2_opt_hook_pre_set(struct bch_fs *, struct bch_dev *, u64, enum bch_opt_id, u64, bool,
+			  struct opt_change_scope *);
 int bch2_opts_hooks_pre_set(struct bch_fs *);
 void bch2_opt_hook_post_set(struct bch_fs *, struct bch_dev *, u64, enum bch_opt_id, u64);
 

--- a/fs/sb/errors_format.h
+++ b/fs/sb/errors_format.h
@@ -131,6 +131,7 @@ enum bch_fsck_flags {
 	x(alloc_key_journal_seq_in_future,			298,	FSCK_AUTOFIX)	\
 	x(alloc_key_stripe_refcount_wrong,			345,	FSCK_AUTOFIX)	\
 	x(alloc_key_bucket_nonempty_to_empty_not_open,		353,	0)		\
+	x(alloc_key_data_type_free_dirty_bookkeeping,		359,	FSCK_AUTOFIX)	\
 	x(bucket_sector_count_overflow,				112,	0)		\
 	x(bucket_metadata_type_mismatch,			113,	0)		\
 	x(need_discard_key_wrong,				114,	FSCK_AUTOFIX)	\
@@ -372,7 +373,7 @@ enum bch_fsck_flags {
 	x(vfs_unlink_got_wrong_inum,				349,	0)		\
 	x(device_bad_flush,					357,	0)		\
 	x(journal_bucket_seq_not_monotonic,			358,	0)		\
-	x(MAX,							359,	0)
+	x(MAX,							362,	0)
 
 enum bch_sb_error_id {
 #define x(t, n, ...) BCH_FSCK_ERR_##t = n,

--- a/fs/sb/io.c
+++ b/fs/sb/io.c
@@ -1076,7 +1076,7 @@ int bch2_read_super(const char *path, struct bch_opts *opts,
 		bch2_print_opts(opts, KERN_ERR "bcachefs (%s): error reading superblock: %s",
 				path, bch2_err_str(ret));
 	else if (err.pos) {
-		prt_printf(&err, "successful read from backup");
+		prt_printf(&err, "successful read from backup\n");
 		bch2_print_opts(opts, KERN_NOTICE "bcachefs (%s): %s", path, err.buf);
 	}
 

--- a/fs/snapshots/snapshot.c
+++ b/fs/snapshots/snapshot.c
@@ -814,19 +814,24 @@ int bch2_snapshots_read(struct bch_fs *c)
 
 void bch2_fs_snapshots_exit(struct bch_fs *c)
 {
+	percpu_free_rwsem(&c->snapshots.create_lock);
 	kvfree(rcu_dereference_protected(c->snapshots.table, true));
 }
 
 void bch2_fs_snapshots_init_early(struct bch_fs *c)
 {
 	mutex_init(&c->snapshots.table_lock);
-	init_rwsem(&c->snapshots.create_lock);
 
 	INIT_WORK(&c->snapshots.delete.work, bch2_delete_dead_snapshots_work);
 	mutex_init(&c->snapshots.delete.lock);
 	mutex_init(&c->snapshots.delete.progress_lock);
 
 	mutex_init(&c->snapshots.unlinked_lock);
+}
+
+int bch2_fs_snapshots_init(struct bch_fs *c)
+{
+	return percpu_init_rwsem(&c->snapshots.create_lock);
 }
 
 /* to_text() methods: */

--- a/fs/snapshots/snapshot.c
+++ b/fs/snapshots/snapshot.c
@@ -164,7 +164,7 @@ void bch2_snapshot_tree_to_text(struct printbuf *out, struct bch_fs *c,
 }
 
 int bch2_snapshot_tree_validate(struct bch_fs *c, struct bkey_s_c k,
-				struct bkey_validate_context from)
+				const struct bkey_validate_context *from)
 {
 	int ret = 0;
 
@@ -431,7 +431,7 @@ void bch2_snapshot_key_to_text(struct printbuf *out, struct bch_fs *c,
 }
 
 int bch2_snapshot_validate(struct bch_fs *c, struct bkey_s_c k,
-			   struct bkey_validate_context from)
+			   const struct bkey_validate_context *from)
 {
 	struct bkey_s_c_snapshot s;
 	u32 i, id;

--- a/fs/snapshots/snapshot.h
+++ b/fs/snapshots/snapshot.h
@@ -4,7 +4,7 @@
 
 void bch2_snapshot_tree_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 int bch2_snapshot_tree_validate(struct bch_fs *, struct bkey_s_c,
-				struct bkey_validate_context);
+				const struct bkey_validate_context *);
 
 #define bch2_bkey_ops_snapshot_tree ((struct bkey_ops) {	\
 	.key_validate	= bch2_snapshot_tree_validate,		\
@@ -19,7 +19,7 @@ int bch2_snapshot_tree_lookup(struct btree_trans *, u32, struct bch_snapshot_tre
 void bch2_snapshot_to_text(struct printbuf *, const struct bch_snapshot *);
 void bch2_snapshot_key_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 int bch2_snapshot_validate(struct bch_fs *, struct bkey_s_c,
-			   struct bkey_validate_context);
+			   const struct bkey_validate_context *);
 int bch2_mark_snapshot(struct btree_trans *, struct btree_trigger_op);
 
 int bch2_snapshot_tree_keys_to_text(struct printbuf *, struct btree_trans *, u32);

--- a/fs/snapshots/snapshot.h
+++ b/fs/snapshots/snapshot.h
@@ -334,5 +334,6 @@ int bch2_delete_dead_interior_snapshots(struct bch_fs *);
 int bch2_snapshots_read(struct bch_fs *);
 void bch2_fs_snapshots_exit(struct bch_fs *);
 void bch2_fs_snapshots_init_early(struct bch_fs *);
+int bch2_fs_snapshots_init(struct bch_fs *);
 
 #endif /* _BCACHEFS_SNAPSHOT_H */

--- a/fs/snapshots/subvolume.c
+++ b/fs/snapshots/subvolume.c
@@ -219,7 +219,7 @@ int bch2_check_subvol_children(struct bch_fs *c)
 /* Subvolumes: */
 
 int bch2_subvolume_validate(struct bch_fs *c, struct bkey_s_c k,
-			    struct bkey_validate_context from)
+			    const struct bkey_validate_context *from)
 {
 	struct bkey_s_c_subvolume subvol = bkey_s_c_to_subvolume(k);
 	int ret = 0;

--- a/fs/snapshots/subvolume.c
+++ b/fs/snapshots/subvolume.c
@@ -318,7 +318,8 @@ int bch2_subvol_is_ro_trans(struct btree_trans *trans, u32 subvol)
 	struct bch_subvolume s;
 	try(bch2_subvolume_get_inlined(trans, subvol, true, &s));
 
-	if (BCH_SUBVOLUME_RO(&s))
+	if (BCH_SUBVOLUME_RO(&s) ||
+	    BCH_SUBVOLUME_UNLINKED(&s))
 		return -EROFS;
 	return 0;
 }

--- a/fs/snapshots/subvolume.h
+++ b/fs/snapshots/subvolume.h
@@ -9,7 +9,7 @@ int bch2_check_subvols(struct bch_fs *);
 int bch2_check_subvol_children(struct bch_fs *);
 
 int bch2_subvolume_validate(struct bch_fs *, struct bkey_s_c,
-			    struct bkey_validate_context);
+			    const struct bkey_validate_context *);
 void bch2_subvolume_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_c);
 int bch2_subvolume_trigger(struct btree_trans *, struct btree_trigger_op);
 

--- a/fs/snapshots/types.h
+++ b/fs/snapshots/types.h
@@ -2,6 +2,9 @@
 #ifndef _BCACHEFS_SNAPSHOT_TYPES_H
 #define _BCACHEFS_SNAPSHOT_TYPES_H
 
+#include <linux/percpu-rwsem.h>
+#include <linux/rwsem.h>
+
 #include "btree/bbpos_types.h"
 #include "init/progress.h"
 #include "util/darray.h"
@@ -74,10 +77,25 @@ struct snapshot_delete {
 	struct progress_indicator	progress;
 };
 
+/*
+ * Snapshot creation must prevent userspace from dirtying the page cache while
+ * the snapshot is being taken: sync_inodes_sb flushes existing dirty pages
+ * before the snapshot transaction, but if new pages get dirtied in the window
+ * between sync_inodes_sb returning and the snapshot transaction running, those
+ * dirty pages can be partially flushed (e.g. data page flushed but redo log
+ * page not yet) such that the snapshot captures an inconsistent state — the
+ * shape that bit MySQL/InnoDB.
+ *
+ * Page-cache dirtying paths (buffered write_iter and mmap mkdirty) take this
+ * lock as readers; snapshot creation takes it as a writer. O_DIRECT doesn't
+ * need it — direct writes commit as atomic btree transactions, no page cache
+ * staleness window. Buffered writeback is fine too — each writeback insert
+ * is atomic w.r.t. the snapshot transaction.
+ */
 struct bch_fs_snapshots {
 	struct snapshot_table __rcu		*table;
 	struct mutex				table_lock;
-	struct rw_semaphore			create_lock;
+	struct percpu_rw_semaphore		create_lock;
 	struct snapshot_delete			delete;
 	struct work_struct			wait_for_pagecache_and_delete_work;
 	snapshot_id_list			unlinked;

--- a/fs/vfs/buffered.c
+++ b/fs/vfs/buffered.c
@@ -10,6 +10,8 @@
 #include "data/read.h"
 #include "data/write.h"
 
+#include "snapshots/snapshot.h"
+
 #include "vfs/io.h"
 #include "vfs/buffered.h"
 #include "vfs/direct.h"
@@ -1130,6 +1132,7 @@ ssize_t bch2_write_iter(struct kiocb *iocb, struct iov_iter *from)
 {
 	struct file *file = iocb->ki_filp;
 	struct bch_inode_info *inode = file_bch_inode(file);
+	struct bch_fs *c = inode->v.i_sb->s_fs_info;
 	ssize_t ret;
 
 	if (iocb->ki_flags & IOCB_DIRECT) {
@@ -1137,7 +1140,22 @@ ssize_t bch2_write_iter(struct kiocb *iocb, struct iov_iter *from)
 		goto out;
 	}
 
+	/*
+	 * Buffered write: dirties page cache; must be serialized against snapshot
+	 * creation so the snapshot doesn't capture a half-flushed inconsistent
+	 * state. O_DIRECT doesn't need this — btree commits are already atomic
+	 * w.r.t. snapshot — so we take the lock only on this side of the branch.
+	 *
+	 * NB: this assumes buffered writes are synchronous — submit and dirty
+	 * happen in the same task. If async buffered IO is ever added (e.g.
+	 * io_uring buffered writes via worker threads), the up_read here will
+	 * happen in a different task than down_read, which percpu_rwsem's lockdep
+	 * tracking won't tolerate. At that point switch this lock to a plain
+	 * rwsem + down_read_non_owner / up_read_non_owner under CONFIG_LOCKDEP,
+	 * or rethink the model.
+	 */
 	inode_lock(&inode->v);
+	percpu_down_read(&c->snapshots.create_lock);
 
 	ret = generic_write_checks(iocb, from);
 	if (ret <= 0)
@@ -1155,6 +1173,7 @@ ssize_t bch2_write_iter(struct kiocb *iocb, struct iov_iter *from)
 	if (likely(ret > 0))
 		iocb->ki_pos += ret;
 unlock:
+	percpu_up_read(&c->snapshots.create_lock);
 	inode_unlock(&inode->v);
 
 	if (ret > 0)

--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -1141,10 +1141,24 @@ int bch2_setattr_nonsize(struct mnt_idmap *idmap,
 		qid.q[QTYP_GRP] = from_kgid(i_user_ns(&inode->v), kgid);
 	}
 
+	struct bch_qid old_qid = inode->ei_qid;
+
 	try(bch2_fs_quota_transfer(c, inode, qid, ~0, KEY_TYPE_QUOTA_PREALLOC));
 
 	CLASS(btree_trans, trans)(c);
-	return lockrestart_do(trans, bch2_setattr_nonsize_trans(trans, idmap, inode, attr));
+	int ret = lockrestart_do(trans, bch2_setattr_nonsize_trans(trans, idmap, inode, attr));
+	if (unlikely(ret))
+		/*
+		 * Roll back the in-memory quota transfer: the btree commit
+		 * failed, so the inode on disk still has the old qid. Without
+		 * this rollback, in-memory quota counts diverge from what an
+		 * inode scan would compute - generic/270 catches it.
+		 *
+		 * NOCHECK because we're returning to a qid we just came from;
+		 * it had room.
+		 */
+		bch2_fs_quota_transfer(c, inode, old_qid, ~0, KEY_TYPE_QUOTA_NOCHECK);
+	return ret;
 }
 
 static int bch2_getattr(struct mnt_idmap *idmap,

--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -49,23 +49,6 @@
 #include <linux/version.h>
 #include <linux/xattr.h>
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,19,0)
-static inline unsigned inode_state_read(struct inode *inode)
-{
-	return inode->i_state;
-}
-
-static inline unsigned inode_state_read_once(struct inode *inode)
-{
-	return READ_ONCE(inode->i_state);
-}
-
-static inline void inode_state_set_raw(struct inode *inode, unsigned flags)
-{
-	WRITE_ONCE(inode->i_state, inode->i_state|flags);
-}
-#endif
-
 static struct kmem_cache *bch2_inode_cache;
 
 static void bch2_vfs_inode_init(struct btree_trans *, subvol_inum,
@@ -434,8 +417,7 @@ retry:
 
 		inode_sb_list_add(&inode->v);
 
-		scoped_guard(mutex, &c->vfs.inodes_lock)
-			list_add(&inode->ei_vfs_inode_list, &c->vfs.inodes_list);
+		fast_list_set(&c->vfs.inodes, inode->ei_inodes_idx, inode);
 		return inode;
 	}
 }
@@ -462,16 +444,23 @@ static struct bch_inode_info *__bch2_new_inode(struct bch_fs *c, gfp_t gfp)
 	if (!inode)
 		return NULL;
 
+	int idx = fast_list_get_idx(&c->vfs.inodes, gfp);
+	if (idx < 0) {
+		kmem_cache_free(bch2_inode_cache, inode);
+		return NULL;
+	}
+
 	inode_init_once(&inode->v);
 	mutex_init(&inode->ei_update_lock);
 	two_state_lock_init(&inode->ei_pagecache_lock);
-	INIT_LIST_HEAD(&inode->ei_vfs_inode_list);
+	inode->ei_inodes_idx = idx;
 	inode->ei_flags = 0;
 	mutex_init(&inode->ei_quota_lock);
 	memset(&inode->ei_devs_need_flush, 0, sizeof(inode->ei_devs_need_flush));
 	INIT_DELAYED_WORK(&inode->ei_writeback_timer, bch2_vfs_writeback_fn);
 
 	if (unlikely(inode_init_always_gfp(c->vfs_sb, &inode->v, gfp))) {
+		fast_list_put_idx(&c->vfs.inodes, idx);
 		kmem_cache_free(bch2_inode_cache, inode);
 		return NULL;
 	}
@@ -490,6 +479,7 @@ static struct bch_inode_info *bch2_new_inode(struct btree_trans *trans)
 		int ret = drop_locks_do(trans, (inode = __bch2_new_inode(trans->c, GFP_NOFS)) ? 0 : -ENOMEM);
 		if (ret && inode) {
 			__destroy_inode(&inode->v);
+			fast_list_put_idx(&trans->c->vfs.inodes, inode->ei_inodes_idx);
 			kmem_cache_free(bch2_inode_cache, inode);
 		}
 		if (ret)
@@ -1952,8 +1942,8 @@ static void bch2_evict_inode(struct inode *vinode)
 		bch2_inode_hash_remove(c, inode);
 	}
 
-	scoped_guard(mutex, &c->vfs.inodes_lock)
-		list_del_init(&inode->ei_vfs_inode_list);
+	fast_list_remove(&c->vfs.inodes, inode->ei_inodes_idx);
+	inode->ei_inodes_idx = 0;
 }
 
 void bch2_evict_subvolume_inodes(struct bch_fs *c, snapshot_id_list *s)
@@ -1976,8 +1966,9 @@ again:
 	cond_resched();
 	this_pass_clean = true;
 
-	mutex_lock(&c->vfs.inodes_lock);
-	list_for_each_entry(inode, &c->vfs.inodes_list, ei_vfs_inode_list) {
+	rcu_read_lock();
+	struct genradix_iter iter;
+	fast_list_for_each(&c->vfs.inodes, iter, inode) {
 		if (!snapshot_list_has_id(s, inode->ei_inum.subvol))
 			continue;
 
@@ -1996,14 +1987,14 @@ again:
 			wq_head = inode_bit_waitqueue(&wqe, &inode->v, __I_NEW);
 			prepare_to_wait_event(wq_head, &wqe.wq_entry,
 					      TASK_UNINTERRUPTIBLE);
-			mutex_unlock(&c->vfs.inodes_lock);
+			rcu_read_unlock();
 
 			schedule();
 			finish_wait(wq_head, &wqe.wq_entry);
 			goto again;
 		}
 	}
-	mutex_unlock(&c->vfs.inodes_lock);
+	rcu_read_unlock();
 
 	darray_for_each(grabbed, i) {
 		inode = *i;
@@ -2503,13 +2494,13 @@ void bch2_fs_vfs_exit(struct bch_fs *c)
 		rhltable_destroy(&c->vfs.inodes_by_inum_table);
 	if (c->vfs.inodes_table.tbl)
 		rhashtable_destroy(&c->vfs.inodes_table);
+	fast_list_exit(&c->vfs.inodes);
 }
 
 int bch2_fs_vfs_init(struct bch_fs *c)
 {
 	fdm_init(&c->fdm_table);
-	INIT_LIST_HEAD(&c->vfs.inodes_list);
-	mutex_init(&c->vfs.inodes_lock);
+	try(fast_list_init(&c->vfs.inodes));
 
 	try(rhashtable_init(&c->vfs.inodes_table, &bch2_vfs_inodes_params));
 	try(rhltable_init(&c->vfs.inodes_by_inum_table, &bch2_vfs_inodes_by_inum_params));

--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -1949,7 +1949,6 @@ static void bch2_evict_inode(struct inode *vinode)
 void bch2_evict_subvolume_inodes(struct bch_fs *c, snapshot_id_list *s)
 {
 	struct bch_inode_info *inode;
-	DARRAY(struct bch_inode_info *) grabbed;
 	bool clean_pass = false, this_pass_clean;
 
 	/*
@@ -1957,11 +1956,12 @@ void bch2_evict_subvolume_inodes(struct bch_fs *c, snapshot_id_list *s)
 	 * be pruned with d_mark_dontcache().
 	 *
 	 * Once we've had a clean pass where we didn't find any inodes without
-	 * I_DONTCACHE, we wait for them to be freed:
+	 * I_DONTCACHE, we wait for them to be freed.
+	 *
+	 * fast_list_iter tracks position by integer index, so we can drop rcu
+	 * around the dcache work (held safe by our igrab ref) and resume from
+	 * the same slot on the next iteration.
 	 */
-
-	darray_init(&grabbed);
-	darray_make_room(&grabbed, 1024);
 again:
 	cond_resched();
 	this_pass_clean = true;
@@ -1975,11 +1975,13 @@ again:
 		if (!(inode_state_read_once(&inode->v) & (I_DONTCACHE|I_FREEING)) &&
 		    igrab(&inode->v)) {
 			this_pass_clean = false;
+			rcu_read_unlock();
 
-			if (darray_push_gfp(&grabbed, inode, GFP_ATOMIC|__GFP_NOWARN)) {
-				iput(&inode->v);
-				break;
-			}
+			d_mark_dontcache(&inode->v);
+			d_prune_aliases(&inode->v);
+			iput(&inode->v);
+
+			rcu_read_lock();
 		} else if (clean_pass && this_pass_clean) {
 			struct wait_bit_queue_entry wqe;
 			struct wait_queue_head *wq_head;
@@ -1996,20 +1998,10 @@ again:
 	}
 	rcu_read_unlock();
 
-	darray_for_each(grabbed, i) {
-		inode = *i;
-		d_mark_dontcache(&inode->v);
-		d_prune_aliases(&inode->v);
-		iput(&inode->v);
-	}
-	grabbed.nr = 0;
-
 	if (!clean_pass || !this_pass_clean) {
 		clean_pass = this_pass_clean;
 		goto again;
 	}
-
-	darray_exit(&grabbed);
 }
 
 static int bch2_statfs(struct dentry *dentry, struct kstatfs *buf)

--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -1948,9 +1948,6 @@ static void bch2_evict_inode(struct inode *vinode)
 
 void bch2_evict_subvolume_inodes(struct bch_fs *c, snapshot_id_list *s)
 {
-	struct bch_inode_info *inode;
-	bool clean_pass = false, this_pass_clean;
-
 	/*
 	 * Initially, we scan for inodes without I_DONTCACHE, then mark them to
 	 * be pruned with d_mark_dontcache().
@@ -1962,19 +1959,16 @@ void bch2_evict_subvolume_inodes(struct bch_fs *c, snapshot_id_list *s)
 	 * around the dcache work (held safe by our igrab ref) and resume from
 	 * the same slot on the next iteration.
 	 */
-again:
-	cond_resched();
-	this_pass_clean = true;
-
 	rcu_read_lock();
 	struct genradix_iter iter;
+	struct bch_inode_info *inode;
+
 	fast_list_for_each(&c->vfs.inodes, iter, inode) {
 		if (!snapshot_list_has_id(s, inode->ei_inum.subvol))
 			continue;
 
-		if (!(inode_state_read_once(&inode->v) & (I_DONTCACHE|I_FREEING)) &&
+		if (!(inode_state_read_once(&inode->v) & I_DONTCACHE) &&
 		    igrab(&inode->v)) {
-			this_pass_clean = false;
 			rcu_read_unlock();
 
 			d_mark_dontcache(&inode->v);
@@ -1982,26 +1976,31 @@ again:
 			iput(&inode->v);
 
 			rcu_read_lock();
-		} else if (clean_pass && this_pass_clean) {
-			struct wait_bit_queue_entry wqe;
-			struct wait_queue_head *wq_head;
+		}
+	}
 
-			wq_head = inode_bit_waitqueue(&wqe, &inode->v, __I_NEW);
+	bool found = false;
+	do {
+		found = false;
+
+		fast_list_for_each(&c->vfs.inodes, iter, inode) {
+			if (!snapshot_list_has_id(s, inode->ei_inum.subvol))
+				continue;
+
+			found = true;
+
+			struct wait_bit_queue_entry wqe;
+			struct wait_queue_head *wq_head = inode_bit_waitqueue(&wqe, &inode->v, __I_NEW);
 			prepare_to_wait_event(wq_head, &wqe.wq_entry,
 					      TASK_UNINTERRUPTIBLE);
 			rcu_read_unlock();
 
 			schedule();
 			finish_wait(wq_head, &wqe.wq_entry);
-			goto again;
+			rcu_read_lock();
 		}
-	}
+	} while (found);
 	rcu_read_unlock();
-
-	if (!clean_pass || !this_pass_clean) {
-		clean_pass = this_pass_clean;
-		goto again;
-	}
 }
 
 static int bch2_statfs(struct dentry *dentry, struct kstatfs *buf)

--- a/fs/vfs/fs.h
+++ b/fs/vfs/fs.h
@@ -10,6 +10,24 @@
 
 #include <linux/seqlock.h>
 #include <linux/stat.h>
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,19,0)
+static inline unsigned inode_state_read(struct inode *inode)
+{
+	return inode->i_state;
+}
+
+static inline unsigned inode_state_read_once(struct inode *inode)
+{
+	return READ_ONCE(inode->i_state);
+}
+
+static inline void inode_state_set_raw(struct inode *inode, unsigned flags)
+{
+	WRITE_ONCE(inode->i_state, inode->i_state|flags);
+}
+#endif
 
 struct bch_inode_info {
 	struct inode		v;
@@ -17,7 +35,7 @@ struct bch_inode_info {
 	struct rhlist_head	by_inum_hash;
 	subvol_inum		ei_inum;
 
-	struct list_head	ei_vfs_inode_list;
+	unsigned		ei_inodes_idx;
 	unsigned long		ei_flags;
 
 	struct mutex		ei_update_lock;

--- a/fs/vfs/io.c
+++ b/fs/vfs/io.c
@@ -373,12 +373,15 @@ static int __bch2_truncate_folio(struct bch_inode_info *inode,
 	 * writeback - doing an i_size update if necessary - or whether it will
 	 * be responsible for the i_size update.
 	 *
-	 * Note that we shouldn't ever see a folio beyond EOF, but check and
-	 * warn if so. This has been observed by failure to clean up folios
-	 * after a short write and there's still a chance reclaim will fix
-	 * things up.
+	 * We can see a folio wholly above i_size here even with the inode fully
+	 * locked: marking a folio dirty doesn't go through i_rwsem (e.g.
+	 * bio_set_pages_dirty() from a DIO read whose destination buffer is an
+	 * mmap of this file, completing after the file was truncated), so "no
+	 * dirty folios above i_size" isn't an invariant we maintain.
+	 * __bch2_writepage cleans up the per-sector dirty bits when it sees
+	 * above-i_size data; here we just need to not walk off the end of the
+	 * folio when computing end_pos.
 	 */
-	WARN_ON_ONCE(folio_pos(folio) >= inode->v.i_size);
 	end_pos = folio_end_pos(folio);
 	if (inode->v.i_size > folio_pos(folio))
 		end_pos = min_t(u64, inode->v.i_size, end_pos);

--- a/fs/vfs/ioctl.c
+++ b/fs/vfs/ioctl.c
@@ -248,12 +248,6 @@ static long __bch2_ioctl_subvolume_create(struct bch_fs *c, struct file *filp,
 	if (arg.flags & BCH_SUBVOL_SNAPSHOT_RO)
 		create_flags |= BCH_CREATE_SNAPSHOT_RO;
 
-	if (arg.flags & BCH_SUBVOL_SNAPSHOT_CREATE) {
-		/* sync_inodes_sb enforce s_umount is locked */
-		guard(rwsem_read)(&c->vfs_sb->s_umount);
-		sync_inodes_sb(c->vfs_sb);
-	}
-
 	if (arg.src_ptr) {
 		error = user_path_at(arg.dirfd,
 				(const char __user *)(unsigned long)arg.src_ptr,
@@ -319,10 +313,23 @@ static long __bch2_ioctl_subvolume_create(struct bch_fs *c, struct file *filp,
 	    !arg.src_ptr)
 		snapshot_src.subvol = inode_inum(to_bch_ei(dir)).subvol;
 
-	scoped_guard(rwsem_write, &c->snapshots.create_lock)
-		inode = __bch2_create(file_mnt_idmap(filp), to_bch_ei(dir),
-				      dst_dentry, arg.mode|S_IFDIR,
-				      0, snapshot_src, create_flags);
+	/*
+	 * Atomicity: take create_lock as a writer to block new page-cache
+	 * dirtiers (write_iter, page_mkwrite), then flush existing dirty
+	 * pages. Writeback's folio_clear_dirty_for_io path WPs every PTE
+	 * pointing at a dirty folio (via folio_mkclean), so when sync
+	 * returns no writable PTE remains — any subsequent mmap store
+	 * traps to page_mkwrite, which then blocks on the writer.
+	 */
+	percpu_down_write(&c->snapshots.create_lock);
+	if (arg.flags & BCH_SUBVOL_SNAPSHOT_CREATE) {
+		scoped_guard(rwsem_read, &c->vfs_sb->s_umount)
+			sync_inodes_sb(c->vfs_sb);
+	}
+	inode = __bch2_create(file_mnt_idmap(filp), to_bch_ei(dir),
+			      dst_dentry, arg.mode|S_IFDIR,
+			      0, snapshot_src, create_flags);
+	percpu_up_write(&c->snapshots.create_lock);
 	error = PTR_ERR_OR_ZERO(inode);
 	if (error)
 		goto err3;

--- a/fs/vfs/pagecache.c
+++ b/fs/vfs/pagecache.c
@@ -566,15 +566,14 @@ bool bch2_set_folio_dirty(struct bch_fs *c,
 	 * Potentially a nasty performance bug, we'll be dirtying more than
 	 * we're supposed to.
 	 *
-	 * We'd like to be stricter here, we shouldn't be dirtying above i_size,
-	 * but since we're not given the correct range the uncommented warning
-	 * is the best we can do; __bch2_writepage has to fix it up.
-	 *
-	 * WARN_ON((u64) folio_pos(folio) + offset + len >
-	 *	   round_up((u64) i_size_read(&inode->v), block_bytes(c)));
+	 * We may also legitimately be dirtying folios above i_size: truncate_setsize()
+	 * drops i_size before truncate_pagecache() runs, and folios pinned by
+	 * gup (e.g. DIO read destinations into an mmap'd region of this file)
+	 * stay attached to the address_space until the pin drops. The VFS
+	 * truncate path documents this in truncate_cleanup_folio() and handles
+	 * it via folio_cancel_dirty() ordering; __bch2_writepage cleans up the
+	 * sectors_dirty bits we set here.
 	 */
-
-	WARN_ON((u64) folio_pos(folio) >= i_size_read(&inode->v));
 
 	BUG_ON(!s);
 	BUG_ON(!s->uptodate);

--- a/fs/vfs/pagecache.c
+++ b/fs/vfs/pagecache.c
@@ -7,6 +7,7 @@
 
 #include "data/extents.h"
 
+#include "snapshots/snapshot.h"
 #include "snapshots/subvolume.h"
 
 #include "vfs/io.h"
@@ -689,6 +690,7 @@ vm_fault_t bch2_page_mkwrite(struct vm_fault *vmf)
 
 	bch2_folio_reservation_init(c, inode, &res);
 
+	percpu_down_read(&c->snapshots.create_lock);
 	sb_start_pagefault(inode->v.i_sb);
 	file_update_time(file);
 
@@ -730,6 +732,7 @@ vm_fault_t bch2_page_mkwrite(struct vm_fault *vmf)
 	ret = VM_FAULT_LOCKED;
 out:
 	sb_end_pagefault(inode->v.i_sb);
+	percpu_up_read(&c->snapshots.create_lock);
 
 	return ret;
 }

--- a/fs/vfs/types.h
+++ b/fs/vfs/types.h
@@ -4,9 +4,10 @@
 
 #include <linux/mempool.h>
 
+#include "util/fast_list.h"
+
 struct bch_fs_vfs {
-	struct list_head	inodes_list;
-	struct mutex		inodes_lock;
+	struct fast_list	inodes;
 	struct rhashtable	inodes_table;
 	struct rhltable		inodes_by_inum_table;
 

--- a/src/commands/set_option.rs
+++ b/src/commands/set_option.rs
@@ -136,7 +136,7 @@ fn set_option_offline(
 
         if flags & c::opt_flags::OPT_FS as u32 != 0 {
             let ret = unsafe {
-                c::bch2_opt_hook_pre_set(fs.raw, std::ptr::null_mut(), 0, opt_id, val, true)
+                c::bch2_opt_hook_pre_set(fs.raw, std::ptr::null_mut(), 0, opt_id, val, true, std::ptr::null_mut())
             };
             if ret < 0 {
                 eprintln!("Error setting {name}: {ret}");
@@ -162,7 +162,7 @@ fn set_option_offline(
                 }
 
                 let ret = unsafe {
-                    c::bch2_opt_hook_pre_set(fs.raw, ca, 0, opt_id, val, true)
+                    c::bch2_opt_hook_pre_set(fs.raw, ca, 0, opt_id, val, true, std::ptr::null_mut())
                 };
                 if ret < 0 {
                     eprintln!("Error setting {name}: {ret}");

--- a/src/commands/timestats.rs
+++ b/src/commands/timestats.rs
@@ -497,8 +497,6 @@ fn build_frame(snaps: &[FsSnapshot], state: &TuiState, multi: bool) -> (Vec<Stri
 
         let mut first = true;
         for section in snap.sections.iter().filter(|s| s.page == state.page) {
-            if section.entries.is_empty() { continue }
-
             if !first { lines.push(String::new()); }
             first = false;
             lines.push(format!("{}:", section.label));


### PR DESCRIPTION
This pull request introduces a new mechanism for automatically detecting and repairing single-bit errors in data protected by CRC32C checksums in bcachefs. The main change is the addition of a syndrome-based bitflip repair algorithm, which is invoked as a last-resort recovery step after all normal checksum retries have failed. This helps improve data reliability by correcting recoverable single-bit errors without requiring redundant replicas.

Key changes include:

**Single-bit CRC32C error correction:**

* Added a new file, `data/bitflip_repair.c`, which implements syndrome-based single-bit error correction for CRC32C. This includes syndrome table construction, syndrome search, and bit-flip logic, along with integration with the existing checksum framework.
* Introduced a public header, `data/bitflip_repair.h`, declaring the repair function for use elsewhere in the codebase.

**Integration with read path:**

* Modified `data/read.c` to invoke the new bitflip repair logic as a last resort during read error handling, after all standard checksum retries and redundancy mechanisms are exhausted. The code ensures safety by only operating on kernel-owned pages.
* Included the new header in `data/read.c` for access to the repair function.

**Build system updates:**

* Updated `fs/Makefile` to include the new `data/bitflip_repair.o` object in the build.