### PR TITLE
multipath: prefer mapper paths and share display option

### DIFF
--- a/src/commands/fs_usage.rs
+++ b/src/commands/fs_usage.rs
@@ -4,6 +4,7 @@ use anyhow::{anyhow, Result};
 use bch_bindgen::c;
 use clap::Parser;
 
+use crate::commands::DeviceNameArgs;
 use crate::wrappers::accounting::{
     AccountingEntry, DiskAccountingKind, data_type, data_type_is_empty, disk_accounting_type,
 };
@@ -11,7 +12,7 @@ use crate::wrappers::handle::{BcachefsHandle, DevUsage};
 use bcachefs_kernel::{btree, metadata_version};
 use bcachefs_kernel::opts::{prt_data_type, prt_compression_type, prt_reconcile_type};
 use bcachefs_kernel::util::printbuf::Printbuf;
-use crate::wrappers::sysfs::{self, DevInfo, bcachefs_kernel_version};
+use crate::wrappers::sysfs::{self, DeviceNameMode, DevInfo, bcachefs_kernel_version};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
 #[clap(rename_all = "snake_case")]
@@ -48,6 +49,9 @@ pub struct Cli {
     #[arg(short = 'h', long = "human-readable")]
     human_readable: bool,
 
+    #[command(flatten)]
+    device_names: DeviceNameArgs,
+
     /// Filesystem mountpoints
     #[arg(default_value = ".")]
     mountpoints: Vec<String>,
@@ -67,7 +71,8 @@ fn fs_usage(cli: Cli) -> Result<()> {
     for path in &cli.mountpoints {
         let mut out = Printbuf::new();
         out.set_human_readable(cli.human_readable);
-        fs_usage_to_text(&mut out, path, &fields)?;
+        let name_mode = cli.device_names.name_mode();
+        fs_usage_to_text(&mut out, path, &fields, name_mode)?;
         print!("{}", out);
     }
 
@@ -80,12 +85,17 @@ struct DevContext {
     leaving: u64,
 }
 
-fn fs_usage_to_text(out: &mut Printbuf, path: &str, fields: &[Field]) -> Result<()> {
+fn fs_usage_to_text(
+    out: &mut Printbuf,
+    path: &str,
+    fields: &[Field],
+    name_mode: DeviceNameMode,
+) -> Result<()> {
     let handle = BcachefsHandle::open(path)
         .map_err(|e| anyhow!("opening filesystem '{}': {}", path, e))?;
 
     let sysfs_path = sysfs::sysfs_path_from_fd(handle.sysfs_fd())?;
-    let devs = sysfs::fs_get_devices(&sysfs_path)?;
+    let devs = sysfs::fs_get_devices(&sysfs_path, name_mode)?;
 
     fs_usage_v1_to_text(out, &handle, &devs, fields)
         .map_err(|e| anyhow!("query_accounting ioctl failed (kernel too old?): {}", e))?;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,8 @@
 
 use std::process::ExitCode;
 
+use crate::wrappers::sysfs::DeviceNameMode;
+
 // ── Command table types (must precede mod declarations for macro access) ──
 
 pub struct CmdDef {
@@ -30,6 +32,19 @@ pub enum CmdKind {
 pub struct GroupDef {
     pub heading:  &'static str,
     pub commands: &'static [&'static CmdDef],
+}
+
+#[derive(clap::Args, Clone, Copy, Debug, Default)]
+pub struct DeviceNameArgs {
+    /// Show mapper names for dm-multipath devices when available
+    #[arg(long = "mapper-names")]
+    pub mapper_names: bool,
+}
+
+impl DeviceNameArgs {
+    pub fn name_mode(self) -> DeviceNameMode {
+        DeviceNameMode::from_mapper_names(self.mapper_names)
+    }
 }
 
 /// Define a typed command (clap-parsed args).

--- a/src/commands/scrub.rs
+++ b/src/commands/scrub.rs
@@ -13,6 +13,7 @@ use bch_bindgen::c::{
 use bch_bindgen::accounting::data_type;
 use clap::Parser;
 
+use crate::commands::DeviceNameArgs;
 use crate::util::{fmt_bytes_human, fmt_sectors_human};
 use crate::wrappers::handle::BcachefsHandle;
 use crate::wrappers::ioctl::bch_ioc_w;
@@ -116,6 +117,9 @@ pub struct Cli {
     #[arg(short, long)]
     metadata: bool,
 
+    #[command(flatten)]
+    device_names: DeviceNameArgs,
+
     /// Filesystem path or device
     filesystem: String,
 }
@@ -134,7 +138,8 @@ fn scrub(cli: Cli) -> Result<()> {
         .with_context(|| format!("opening filesystem '{}'", cli.filesystem))?;
 
     let sysfs_path = sysfs_path_from_fd(handle.sysfs_fd())?;
-    let devices = fs_get_devices(&sysfs_path)?;
+    let name_mode = cli.device_names.name_mode();
+    let devices = fs_get_devices(&sysfs_path, name_mode)?;
 
     let ioctl_fd = handle.ioctl_fd_raw();
     let dev_idx = handle.dev_idx();

--- a/src/commands/timestats.rs
+++ b/src/commands/timestats.rs
@@ -15,9 +15,10 @@ use crossterm::{
 use owo_colors::OwoColorize;
 use serde::{Deserialize, Serialize};
 
+use crate::commands::DeviceNameArgs;
 use crate::util::run_tui;
 use crate::wrappers::handle::BcachefsHandle;
-use crate::wrappers::sysfs::{dev_name_from_sysfs, sysfs_path_from_fd};
+use crate::wrappers::sysfs::{DeviceNameMode, dev_display_name_from_sysfs, sysfs_path_from_fd};
 
 const SYSFS_BASE: &str = "/sys/fs/bcachefs";
 
@@ -246,7 +247,10 @@ fn read_time_stats(sysfs_path: &Path) -> Result<Vec<StatEntry>> {
     Ok(entries)
 }
 
-fn read_device_latency_stats(sysfs_path: &Path) -> Result<Vec<StatEntry>> {
+fn read_device_latency_stats(
+    sysfs_path: &Path,
+    name_mode: DeviceNameMode,
+) -> Result<Vec<StatEntry>> {
     let mut entries = Vec::new();
     let Ok(dir) = fs::read_dir(sysfs_path) else { return Ok(entries) };
 
@@ -256,7 +260,7 @@ fn read_device_latency_stats(sysfs_path: &Path) -> Result<Vec<StatEntry>> {
         if !dirname.starts_with("dev-") { continue }
 
         let dev_path = entry.path();
-        let dev_name = dev_name_from_sysfs(&dev_path);
+        let dev_name = dev_display_name_from_sysfs(&dev_path, name_mode);
 
         for (suffix, label) in [("io_latency_stats_read_json", "read"),
                                  ("io_latency_stats_write_json", "write")] {
@@ -293,7 +297,11 @@ fn read_btree_trans_stats(sysfs_path: &Path) -> Result<Vec<StatEntry>> {
 
 // Data collection
 
-fn collect_stats(sysfs_paths: &[PathBuf], show_devices: bool) -> Result<Vec<FsSnapshot>> {
+fn collect_stats(
+    sysfs_paths: &[PathBuf],
+    show_devices: bool,
+    name_mode: DeviceNameMode,
+) -> Result<Vec<FsSnapshot>> {
     let mut snaps = Vec::new();
     for path in sysfs_paths {
         let stats = read_time_stats(path)?;
@@ -315,7 +323,7 @@ fn collect_stats(sysfs_paths: &[PathBuf], show_devices: bool) -> Result<Vec<FsSn
             sections.push(Section {
                 label:   "Per-device IO latency",
                 page:    Page::Devices,
-                entries: read_device_latency_stats(path)?,
+                entries: read_device_latency_stats(path, name_mode)?,
             });
         }
 
@@ -391,6 +399,9 @@ pub struct Cli {
     /// Skip per-device IO latency stats
     #[arg(long)]
     no_device_stats: bool,
+
+    #[command(flatten)]
+    device_names: DeviceNameArgs,
 
     /// One-shot output (no interactive TUI)
     #[arg(long)]
@@ -602,7 +613,8 @@ fn run_interactive(cli: Cli, sysfs_paths: Vec<PathBuf>) -> Result<()> {
         /* Only collect per-device stats when we're actually on the devices page —
          * skips the 63-device sysfs read cost on the other pages. */
         let want_devices = state.show_devices && state.page == Page::Devices;
-        let mut snaps = collect_stats(&sysfs_paths, want_devices)
+        let name_mode = cli.device_names.name_mode();
+        let mut snaps = collect_stats(&sysfs_paths, want_devices, name_mode)
             .unwrap_or_default();
         for snap in &mut snaps {
             for section in &mut snap.sections {
@@ -648,10 +660,12 @@ fn timestats(cli: Cli) -> Result<()> {
         find_all_sysfs_dirs()?
     };
 
+    let name_mode = cli.device_names.name_mode();
+
     if cli.json {
-        print_json(&collect_stats(&sysfs_paths, !cli.no_device_stats)?)
+        print_json(&collect_stats(&sysfs_paths, !cli.no_device_stats, name_mode)?)
     } else if cli.once || !io::stdout().is_terminal() {
-        display_stats(collect_stats(&sysfs_paths, !cli.no_device_stats)?, &cli)
+        display_stats(collect_stats(&sysfs_paths, !cli.no_device_stats, name_mode)?, &cli)
     } else {
         run_interactive(cli, sysfs_paths)
     }

--- a/src/commands/top.rs
+++ b/src/commands/top.rs
@@ -20,10 +20,11 @@ use crossterm::{
 use owo_colors::OwoColorize;
 use serde::Deserialize;
 
+use crate::commands::DeviceNameArgs;
 use crate::util::{fmt_bytes_human, fmt_num_human, run_tui};
 use crate::wrappers::handle::BcachefsHandle;
 use crate::wrappers::ioctl::bch_ioc_w;
-use crate::wrappers::sysfs::{dev_name_from_sysfs, sysfs_path_from_fd};
+use crate::wrappers::sysfs::{DeviceNameMode, dev_display_name_from_sysfs, sysfs_path_from_fd};
 
 // ioctl constants
 
@@ -68,7 +69,7 @@ struct DevIoEntry {
     write_bytes: u64,
 }
 
-fn read_device_io(sysfs_path: &Path) -> Vec<DevIoEntry> {
+fn read_device_io(sysfs_path: &Path, name_mode: DeviceNameMode) -> Vec<DevIoEntry> {
     let mut entries = Vec::new();
     let Ok(dir) = fs::read_dir(sysfs_path) else { return entries };
 
@@ -77,7 +78,7 @@ fn read_device_io(sysfs_path: &Path) -> Vec<DevIoEntry> {
         if !dirname.starts_with("dev-") { continue }
 
         let dev_path = entry.path();
-        let dev_name = dev_name_from_sysfs(&dev_path);
+        let dev_name = dev_display_name_from_sysfs(&dev_path, name_mode);
 
         let io_done_path = dev_path.join("io_done");
         let Ok(content) = fs::read_to_string(&io_done_path) else { continue };
@@ -290,6 +291,9 @@ pub struct Cli {
     #[arg(short = 'd', long, default_value = "1")]
     delay: u32,
 
+    #[command(flatten)]
+    device_names: DeviceNameArgs,
+
     /// Filesystem path, device, or UUID (default: current directory)
     filesystem: Option<String>,
 }
@@ -328,6 +332,7 @@ struct TopState {
     prev_vals:      Vec<u64>,
     prev_dev_io:    HashMap<String, (u64, u64)>,    // label -> (read, write)
     human_readable: bool,
+    name_mode:      DeviceNameMode,
     sysfs_path:     PathBuf,
     interval_secs:  u32,
     page:           Page,
@@ -339,7 +344,11 @@ struct TopState {
 }
 
 impl TopState {
-    fn new(handle: &BcachefsHandle, human_readable: bool) -> Result<Self> {
+    fn new(
+        handle: &BcachefsHandle,
+        human_readable: bool,
+        name_mode: DeviceNameMode,
+    ) -> Result<Self> {
         let ioctl_fd = handle.ioctl_fd_raw();
         let nr_stable = COUNTERS.iter().map(|c| c.stable_id).max().unwrap_or(0) + 1;
 
@@ -357,6 +366,7 @@ impl TopState {
             mount_vals, start_vals, prev_vals,
             prev_dev_io: HashMap::new(),
             human_readable,
+            name_mode,
             sysfs_path, interval_secs: 1,
             page: Page::Base,
             cursor: 0,
@@ -569,8 +579,11 @@ fn print_frame(
  * sleep `delay` seconds, take a fresh sample, and print rates against the
  * previous sample. Total samples taken = count + 1; total frames printed = count. */
 fn run_non_interactive(
-    handle: &BcachefsHandle, human_readable: bool,
-    count: u32, delay: u32,
+    handle: &BcachefsHandle,
+    human_readable: bool,
+    count: u32,
+    delay: u32,
+    name_mode: DeviceNameMode,
 ) -> Result<()> {
     let ioctl_fd   = handle.ioctl_fd_raw();
     let nr_stable  = COUNTERS.iter().map(|c| c.stable_id).max().unwrap_or(0) + 1;
@@ -578,7 +591,7 @@ fn run_non_interactive(
     let sysfs_path = sysfs_path_from_fd(handle.sysfs_fd())?;
 
     let mut prev_vals   = read_counters(ioctl_fd, 0, nr_stable)?;
-    let mut prev_dev_io: HashMap<String, (u64, u64)> = read_device_io(&sysfs_path)
+    let mut prev_dev_io: HashMap<String, (u64, u64)> = read_device_io(&sysfs_path, name_mode)
         .into_iter()
         .map(|d| (d.label, (d.read_bytes, d.write_bytes)))
         .collect();
@@ -586,7 +599,7 @@ fn run_non_interactive(
     for i in 0..count {
         std::thread::sleep(Duration::from_secs(delay as u64));
         let curr   = read_counters(ioctl_fd, 0, nr_stable)?;
-        let dev_io = read_device_io(&sysfs_path);
+        let dev_io = read_device_io(&sysfs_path, name_mode);
 
         if i > 0 { println!(); }
         print_frame(&curr, &prev_vals, &mount_vals, &dev_io, &prev_dev_io, delay, human_readable);
@@ -599,8 +612,13 @@ fn run_non_interactive(
     Ok(())
 }
 
-fn run_interactive(handle: BcachefsHandle, human_readable: bool, delay: u32) -> Result<()> {
-    let mut state = TopState::new(&handle, human_readable)?;
+fn run_interactive(
+    handle: BcachefsHandle,
+    human_readable: bool,
+    delay: u32,
+    name_mode: DeviceNameMode,
+) -> Result<()> {
+    let mut state = TopState::new(&handle, human_readable, name_mode)?;
     state.interval_secs = delay.max(1);
 
     /* Sample once up front; prev == curr so the first frame shows zero rates.
@@ -610,7 +628,7 @@ fn run_interactive(handle: BcachefsHandle, human_readable: bool, delay: u32) -> 
      * rate column. */
     let mut curr = read_counters(state.ioctl_fd, 0, state.nr_stable)?;
     state.prev_vals = curr.clone();
-    let mut dev_io = read_device_io(&state.sysfs_path);
+    let mut dev_io = read_device_io(&state.sysfs_path, state.name_mode);
     state.prev_dev_io = dev_io.iter()
         .map(|d| (d.label.clone(), (d.read_bytes, d.write_bytes)))
         .collect();
@@ -713,7 +731,7 @@ fn run_interactive(handle: BcachefsHandle, human_readable: bool, delay: u32) -> 
                 .map(|d| (d.label, (d.read_bytes, d.write_bytes)))
                 .collect();
             curr = read_counters(state.ioctl_fd, 0, state.nr_stable)?;
-            dev_io = read_device_io(&state.sysfs_path);
+            dev_io = read_device_io(&state.sysfs_path, state.name_mode);
         }
     })
 }
@@ -734,10 +752,12 @@ fn top(cli: Cli) -> Result<()> {
                 else if !io::stdout().is_terminal() { 1 }
                 else { 0 };
 
+    let name_mode = cli.device_names.name_mode();
+
     if count > 0 {
-        run_non_interactive(&handle, cli.human_readable, count, delay)
+        run_non_interactive(&handle, cli.human_readable, count, delay, name_mode)
     } else {
-        run_interactive(handle, cli.human_readable, delay)
+        run_interactive(handle, cli.human_readable, delay, name_mode)
     }
 }
 

--- a/src/device_multipath.rs
+++ b/src/device_multipath.rs
@@ -2,8 +2,10 @@
 
 //! Helpers for detecting device-mapper multipath relationships.
 //!
-//! The core entrypoint is [`find_multipath_holder()`], which walks sysfs
-//! holders to determine whether a block device sits under a dm-multipath map.
+//! The core entrypoints are [`find_multipath_holder()`], which walks sysfs
+//! holders to determine whether a block device sits under a dm-multipath map,
+//! and [`preferred_multipath_devnode()`], which normalizes dm-multipath devices
+//! to their `/dev/mapper/` path when that path exists.
 //! Both top-level maps (`mpath-...`) and partition maps
 //! (`part<N>-mpath-...`, including nested partition prefixes) are treated as
 //! multipath.
@@ -64,6 +66,60 @@ fn is_multipath_dm_uuid(uuid: &str) -> bool {
 /// Returns the topmost multipath holder for a device, if any.
 pub fn find_multipath_holder(path: &Path) -> Option<PathBuf> {
     find_multipath_holder_inner(path, 0)
+}
+
+/// Returns the `/dev/mapper/` path for a dm-multipath block device, if one exists.
+pub fn preferred_multipath_devnode(path: &Path) -> Option<PathBuf> {
+    let metadata = match fs::metadata(path) {
+        Ok(m) => m,
+        Err(e) => {
+            debug!("Failed to stat {}: {}", path.display(), e);
+            return None;
+        }
+    };
+
+    if !metadata.file_type().is_block_device() {
+        debug!("Skipping non-block device {}", path.display());
+        return None;
+    }
+
+    let dev = metadata.rdev();
+    if dev == 0 {
+        return None;
+    }
+
+    preferred_multipath_devnode_from_sysfs(&sysfs_path_for_dev(dev))
+}
+
+/// Returns the `/dev/mapper/` path for a dm-multipath sysfs block name, if one exists.
+pub fn preferred_multipath_devnode_for_block_name(name: &str) -> Option<PathBuf> {
+    if !name.starts_with("dm-") {
+        return None;
+    }
+
+    let sysfs = PathBuf::from(format!("/sys/block/{}", name));
+    preferred_multipath_devnode_from_sysfs(&sysfs)
+}
+
+fn multipath_dm_name_from_sysfs(block_sysfs: &Path) -> Option<String> {
+    let dm_path = block_sysfs.join("dm");
+
+    let uuid = read_sysfs_attr(&dm_path, "uuid")?;
+    if !is_multipath_dm_uuid(&uuid) {
+        return None;
+    }
+
+    read_sysfs_attr(&dm_path, "name")
+}
+
+fn mapper_path_if_exists(dm_name: &str) -> Option<PathBuf> {
+    let mapper_path = PathBuf::from(format!("/dev/mapper/{}", dm_name));
+    mapper_path.exists().then_some(mapper_path)
+}
+
+fn preferred_multipath_devnode_from_sysfs(block_sysfs: &Path) -> Option<PathBuf> {
+    let dm_name = multipath_dm_name_from_sysfs(block_sysfs)?;
+    mapper_path_if_exists(&dm_name)
 }
 
 pub fn warn_multipath_component(path: &Path, mpath_dev: &Path) {
@@ -133,24 +189,13 @@ fn find_multipath_holder_inner(path: &Path, depth: u32) -> Option<PathBuf> {
         }
 
         let holder_sysfs = PathBuf::from(format!("/sys/block/{}", name));
-        let dm_path = holder_sysfs.join("dm");
 
-        // Check if this is a multipath dm UUID (map or map partition)
-        let uuid = read_sysfs_attr(&dm_path, "uuid").unwrap_or_default();
-        if !is_multipath_dm_uuid(&uuid) {
+        let Some(dm_name) = multipath_dm_name_from_sysfs(&holder_sysfs) else {
             continue;
-        }
-
-        let mpath_dev = if let Some(dm_name) = read_sysfs_attr(&dm_path, "name") {
-            let mapper_path = PathBuf::from(format!("/dev/mapper/{}", dm_name));
-            if mapper_path.exists() {
-                mapper_path
-            } else {
-                PathBuf::from(format!("/dev/{}", name))
-            }
-        } else {
-            PathBuf::from(format!("/dev/{}", name))
         };
+
+        let mpath_dev = mapper_path_if_exists(&dm_name)
+            .unwrap_or_else(|| PathBuf::from(format!("/dev/{}", name)));
 
         if let Some(higher) = find_multipath_holder_inner(&mpath_dev, depth + 1) {
             debug!(
@@ -259,5 +304,10 @@ mod tests {
         assert!(!is_multipath_dm_uuid("part1-"));
         assert!(!is_multipath_dm_uuid("part1-crypt-foo"));
         assert!(!is_multipath_dm_uuid("foo-mpath-bar"));
+    }
+
+    #[test]
+    fn preferred_devnode_for_non_dm_block_name_returns_none() {
+        assert!(preferred_multipath_devnode_for_block_name("sda").is_none());
     }
 }

--- a/src/device_scan.rs
+++ b/src/device_scan.rs
@@ -40,7 +40,9 @@ use c::bch_opts;
 use uuid::Uuid;
 use log::debug;
 
-use crate::device_multipath::{find_multipath_holder, warn_multipath_component};
+use crate::device_multipath::{
+    find_multipath_holder, preferred_multipath_devnode, warn_multipath_component,
+};
 
 pub fn read_super_silent(path: impl AsRef<Path>, mut opts: bch_opts) -> Result<bch_sb_handle, BchError> {
     opt_set!(opts, noexcl, 1);
@@ -163,7 +165,10 @@ fn read_sbs_matching_uuid(
 		.filter_map(|dev| {
 			read_super_silent(dev, *opts)
 				.ok()
-				.map(|sb| (PathBuf::from(dev), sb))
+				.map(|sb| {
+					let path = preferred_multipath_devnode(dev).unwrap_or_else(|| dev.to_path_buf());
+					(path, sb)
+				})
 		})
 		.filter(|(_, sb)| sb.sb().uuid() == uuid)
 		.collect::<Vec<_>>();
@@ -202,7 +207,9 @@ pub fn filter_current_sbs(
 	let handles = handles.into_vec();
 	let mut filtered = Vec::with_capacity(handles.len());
 	for sb in handles {
-		filtered.push((sb_handle_path(&sb), sb));
+		let path = sb_handle_path(&sb);
+		let path = preferred_multipath_devnode(&path).unwrap_or(path);
+		filtered.push((path, sb));
 	}
 
 	Ok(filtered)

--- a/src/wrappers/sysfs.rs
+++ b/src/wrappers/sysfs.rs
@@ -6,6 +6,28 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
+use crate::device_multipath::preferred_multipath_devnode_for_block_name;
+
+/// Selects how mounted device names are rendered in human-facing output.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DeviceNameMode {
+    /// Show the raw kernel block name from sysfs, such as `dm-0` or `sda`.
+    Raw,
+    /// Show the mapper basename for dm-multipath devices when available.
+    Mapper,
+}
+
+impl DeviceNameMode {
+    /// Convert the command-line `--mapper-names` boolean into a display mode.
+    pub fn from_mapper_names(mapper_names: bool) -> Self {
+        if mapper_names {
+            Self::Mapper
+        } else {
+            Self::Raw
+        }
+    }
+}
+
 /// Resolve the block device name for a bcachefs sysfs device directory.
 ///
 /// Reads the `block` symlink at `dev_sysfs_path/block` (e.g.
@@ -21,6 +43,26 @@ pub fn dev_name_from_sysfs(dev_sysfs_path: &Path) -> String {
     dev_sysfs_path.file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_default()
+}
+
+/// Resolve the block device display name for a bcachefs sysfs device directory.
+///
+/// Returns the raw kernel name by default, or the mapper basename for
+/// dm-multipath devices when requested and available. This is intended for
+/// human output, not for opening devices.
+pub fn dev_display_name_from_sysfs(dev_sysfs_path: &Path, mode: DeviceNameMode) -> String {
+    let name = dev_name_from_sysfs(dev_sysfs_path);
+    if mode == DeviceNameMode::Raw {
+        return name;
+    }
+
+    if let Some(path) = preferred_multipath_devnode_for_block_name(&name) {
+        path.file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or(name)
+    } else {
+        name
+    }
 }
 
 pub fn sysfs_path_from_fd(fd: BorrowedFd) -> Result<PathBuf> {
@@ -104,6 +146,7 @@ pub fn sysfs_write_str(sysfs_fd: BorrowedFd, path: &str, value: &str) {
 #[derive(Clone)]
 pub struct DevInfo {
     pub idx:        u32,
+    /// Human-facing device name selected by [`DeviceNameMode`].
     pub dev:        String,
     pub label:      Option<String>,
     pub durability: u32,
@@ -111,9 +154,12 @@ pub struct DevInfo {
 
 /// Enumerate devices for a mounted filesystem from its sysfs directory.
 ///
-/// Reads `dev-N/` subdirectories under `sysfs_path`, extracting the block
-/// device name (from the `block` symlink) for each.
-pub fn fs_get_devices(sysfs_path: &Path) -> Result<Vec<DevInfo>> {
+/// Reads `dev-N/` subdirectories under `sysfs_path`, extracting the display
+/// device name for each.
+pub fn fs_get_devices(
+    sysfs_path: &Path,
+    name_mode: DeviceNameMode,
+) -> Result<Vec<DevInfo>> {
     let mut devs = Vec::new();
     for entry in fs::read_dir(sysfs_path)
         .with_context(|| format!("reading sysfs dir {}", sysfs_path.display()))?
@@ -127,7 +173,7 @@ pub fn fs_get_devices(sysfs_path: &Path) -> Result<Vec<DevInfo>> {
         };
 
         let dev_path = entry.path();
-        let dev = dev_name_from_sysfs(&dev_path);
+        let dev = dev_display_name_from_sysfs(&dev_path, name_mode);
 
         let label = fs::read_to_string(dev_path.join("label"))
             .ok()


### PR DESCRIPTION
Prefer /dev/mapper paths for dm-multipath discovery when available, with fallback to the kernel device path.

Keep raw device names as the display default, and share the opt-in --mapper-names flag across usage, scrub, top, and timestats.


Slightly usability improvement with multipath systems:

- Prefer mapper names as they are human readable, user-configurable, and stable.
- Create a new `-mapper-names` argument to display mapper names instead of raw device mapper names (current behavior).

