### PR TITLE
bcachefs: restore rw state after failed device remove

### DIFF
--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -939,7 +939,8 @@ static int __bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca,
 			     struct printbuf *err)
 {
 	unsigned data;
-	int ret;
+	bool was_rw = ca->mi.state == BCH_MEMBER_STATE_rw;
+	int ret, ret2;
 
 	lockdep_assert_held(&c->state_lock);
 
@@ -1073,6 +1074,16 @@ static int __bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca,
 err:
 	/* The device is staying; allow new references to it again: */
 	WRITE_ONCE(ca->removing, false);
+
+	if (test_bit(BCH_FS_rw, &c->flags) &&
+	    was_rw &&
+	    ca->mi.state == BCH_MEMBER_STATE_evacuating &&
+	    !enumerated_ref_is_zero(&ca->io_ref[READ])) {
+		prt_str(err, "Remove failed, restoring device state to rw\n");
+		ret2 = __bch2_dev_set_state(c, ca, BCH_MEMBER_STATE_rw, flags, err);
+		if (ret2)
+			prt_printf(err, "Error restoring device state: %s\n", bch2_err_str(ret2));
+	}
 
 	if (test_bit(BCH_FS_rw, &c->flags) &&
 	    ca->mi.state == BCH_MEMBER_STATE_rw &&


### PR DESCRIPTION
## Summary

`__bch2_dev_remove()` temporarily switches an online `rw` member to `evacuating` before dropping that member's data.

If the remove attempt fails before the device is taken offline, for example because the member still has data and removal returns `-EBUSY`, the error path currently only clears `ca->removing`. The member state can remain `evacuating`, leaving a still-present device stuck out of normal service after the failed remove.

Record whether the device was `rw` before the remove attempt and restore it to `rw` on the online early-error path when the device is still present.

This only fixes cleanup after a failed remove attempt; it does not change the data/metadata migration decision that made removal fail.

Related: https://github.com/koverstreet/bcachefs/issues/988
Related: https://github.com/koverstreet/bcachefs/issues/1140

## Validation

Rebased onto current `testing` (`4bd1010e06665c20ebe227105e480b51ce77ca23`) and pushed head `51ab6fe2be80ebbbcba347be2663cc69c3330cb8`.

- `git diff --check origin/testing..HEAD`
- `make generate_version`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 fs/init/dev.o`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32`

The full build completed successfully. It still reports pre-existing warnings in unrelated files, including `linux/blkdev.c`, `linux/semaphore.c`, `src/commands/list_journal.rs`, and `src/commands/scrub.rs`.

The previous body mentioned `scripts/checkpatch.pl`; that helper is not present in the current tree, so the refreshed validation uses the build and diff checks above.

