### PR TITLE
bcachefs: persist refreshed member identity fields

### DIFF
--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -687,8 +687,8 @@ static int read_file_str(const char *path, darray_char *ret)
 }
 
 /*
- * Read a sysfs device attribute (e.g. "model", "serial") into @ret, resolving
- * partitions to their parent disk.
+ * Read a sysfs device file (e.g. "device/model", "device/serial") into @ret,
+ * resolving partitions to their parent disk.
  *
  * device/model and device/serial live under the whole disk, not its partitions.
  * Look the device up by dev_t under /sys/dev/block/<maj>:<min>/ (present for
@@ -696,16 +696,18 @@ static int read_file_str(const char *path, darray_char *ret)
  * fall back to the parent disk via "..". Mirrors fd_to_dev_model() in the
  * userspace tools (src/wrappers/bdev.rs).
  */
-static void read_dev_sysfs_attr(dev_t dev, const char *attr, darray_char *ret)
+static void read_dev_sysfs_file(dev_t dev, const char *file, darray_char *ret)
 {
 	static const char * const fmts[] = {
-		"/sys/dev/block/%u:%u/device/%s",
-		"/sys/dev/block/%u:%u/../device/%s",
+		"/sys/dev/block/%u:%u/%s",
+		"/sys/dev/block/%u:%u/../%s",
 	};
+
+	ret->nr = 0;
 
 	for (unsigned i = 0; i < ARRAY_SIZE(fmts); i++) {
 		CLASS(printbuf, path)();
-		prt_printf(&path, fmts[i], MAJOR(dev), MINOR(dev), attr);
+		prt_printf(&path, fmts[i], MAJOR(dev), MINOR(dev), file);
 
 		read_file_str(path.buf, ret);
 
@@ -714,6 +716,44 @@ static void read_dev_sysfs_attr(dev_t dev, const char *attr, darray_char *ret)
 
 		if (ret->nr)
 			return;
+	}
+}
+
+static void read_dev_sysfs_attr(dev_t dev, const char *attr, darray_char *ret)
+{
+	CLASS(printbuf, file)();
+	prt_printf(&file, "device/%s", attr);
+	read_dev_sysfs_file(dev, file.buf, ret);
+}
+
+void bch2_dev_read_identity(struct block_device *bdev,
+			    char *name, size_t name_size,
+			    char *model, size_t model_size,
+			    char *serial, size_t serial_size)
+{
+	CLASS(printbuf, bdevname)();
+	prt_bdevname(&bdevname, bdev);
+
+	strscpy(name, bdevname.buf, name_size);
+	if (model_size)
+		model[0] = '\0';
+	if (serial_size)
+		serial[0] = '\0';
+
+	CLASS(darray_char, sysfs_model)();
+	if (model_size && !darray_make_room(&sysfs_model, model_size)) {
+		read_dev_sysfs_attr(bdev->bd_dev, "model", &sysfs_model);
+		if (!sysfs_model.nr)
+			read_dev_sysfs_file(bdev->bd_dev, "loop/backing_file", &sysfs_model);
+		if (sysfs_model.nr)
+			strscpy(model, sysfs_model.data, model_size);
+	}
+
+	CLASS(darray_char, sysfs_serial)();
+	if (serial_size && !darray_make_room(&sysfs_serial, serial_size)) {
+		read_dev_sysfs_attr(bdev->bd_dev, "serial", &sysfs_serial);
+		if (sysfs_serial.nr)
+			strscpy(serial, sysfs_serial.data, serial_size);
 	}
 }
 
@@ -744,27 +784,6 @@ static int __bch2_dev_attach_bdev(struct bch_fs *c, struct bch_dev *ca,
 	CLASS(printbuf, name)();
 	prt_bdevname(&name, sb->bdev);
 	strscpy(ca->name, name.buf, sizeof(ca->name));
-
-	CLASS(darray_char, model)();
-	darray_make_room(&model, 128);
-	read_dev_sysfs_attr(sb->bdev->bd_dev, "model", &model);
-
-	CLASS(darray_char, serial)();
-	darray_make_room(&serial, 128);
-	read_dev_sysfs_attr(sb->bdev->bd_dev, "serial", &serial);
-
-	scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
-		guard(mutex)(&c->sb_lock);
-		struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
-
-		strtomem_pad(m->device_name, name.buf, '\0');
-
-		if (model.nr)
-			strtomem_pad(m->device_model, model.data, '\0');
-
-		if (serial.nr)
-			strtomem_pad(m->device_serial, serial.data, '\0');
-	}
 
 	/* Commit: */
 	ca->disk_sb = *sb;

--- a/fs/init/dev.h
+++ b/fs/init/dev.h
@@ -14,6 +14,10 @@ void bch2_dev_unlink(struct bch_dev *);
 void bch2_dev_free(struct bch_dev *);
 void __bch2_dev_offline(struct bch_fs *, struct bch_dev *);
 int bch2_dev_sysfs_online(struct bch_fs *, struct bch_dev *);
+void bch2_dev_read_identity(struct block_device *bdev,
+			    char *name, size_t name_size,
+			    char *model, size_t model_size,
+			    char *serial, size_t serial_size);
 int bch2_dev_alloc(struct bch_fs *, unsigned);
 int bch2_dev_attach_bdev(struct bch_fs *, struct bch_sb_handle *, struct printbuf *);
 
@@ -42,4 +46,3 @@ struct bch_dev *bch2_dev_lookup(struct bch_fs *, const char *);
 extern const struct blk_holder_ops bch2_sb_handle_bdev_ops;
 
 #endif /* _BCACHEFS_INIT_DEV_H */
-

--- a/fs/sb/members.c
+++ b/fs/sb/members.c
@@ -12,6 +12,7 @@
 #include "sb/members.h"
 #include "sb/io.h"
 
+#include "init/dev.h"
 #include "init/error.h"
 #include "init/passes.h"
 #include "init/progress.h"
@@ -863,9 +864,41 @@ void bch2_sb_members_clean_deleted(struct bch_fs *c)
 		bch2_write_super(c);
 }
 
+static void dev_mi_update_str(void *dst, size_t dst_size, const char *src,
+			      bool *write_sb)
+{
+	u8 padded[sizeof(((struct bch_member *)NULL)->device_model)] = {};
+
+	if (!src[0])
+		return;
+
+	if (WARN_ON_ONCE(dst_size > sizeof(padded)))
+		return;
+
+	memcpy_and_pad(padded, dst_size, src, strnlen(src, dst_size), '\0');
+
+	if (memcmp(dst, padded, dst_size)) {
+		memcpy(dst, padded, dst_size);
+		*write_sb = true;
+	}
+}
+
 void __bch2_dev_mi_field_upgrades(struct bch_fs *c, struct bch_dev *ca, bool *write_sb)
 {
 	struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
+
+	char name[sizeof(m->device_name) + 1];
+	char model[sizeof(m->device_model) + 1];
+	char serial[sizeof(m->device_serial) + 1];
+
+	bch2_dev_read_identity(ca->disk_sb.bdev,
+			       name, sizeof(name),
+			       model, sizeof(model),
+			       serial, sizeof(serial));
+
+	dev_mi_update_str(m->device_name, sizeof(m->device_name), name, write_sb);
+	dev_mi_update_str(m->device_model, sizeof(m->device_model), model, write_sb);
+	dev_mi_update_str(m->device_serial, sizeof(m->device_serial), serial, write_sb);
 
 	if (!BCH_MEMBER_ROTATIONAL_SET(m)) {
 		SET_BCH_MEMBER_ROTATIONAL(m, bdev_rot(ca->disk_sb.bdev));


### PR DESCRIPTION
## Summary

`__bch2_dev_attach_bdev()` refreshed `device_name`, `device_model`, and `device_serial` in the in-memory superblock member record, but that path did not own the `write_sb` decision. Unless another member-field upgrade happened to write the superblock, refreshed identity strings could be lost.

Move persistent identity refresh into `__bch2_dev_mi_field_upgrades()`, where rotational already updates through the `write_sb` contract. Attach keeps only the runtime `ca->name` update; mount, online, and device-add now share the same durable refresh path.

This also keeps the current partition-aware sysfs lookup and generalizes it so loop devices can use `loop/backing_file` as a model fallback when no hardware model is available.

## Validation

- `git diff --cached --check`
- `git diff --cached -- fs/init/dev.h fs/init/dev.c fs/sb/members.c | /home/kom/proj/bcachefs-kernel-upstream/scripts/checkpatch.pl --strict --codespell --no-tree --show-types --max-line-length=100 -`
- `make -j32`
- `./target/release/bcachefs version`
- `./target/release/bcachefs --help >/tmp/bcachefs-tools-help-smoke.txt`
