### PR TITLE
bcachefs: rewrite btree nodes before dropping device metadata ptrs

### DIFF
--- a/fs/bcachefs.h
+++ b/fs/bcachefs.h
@@ -739,6 +739,13 @@ struct bch_fs {
 
 	unsigned short		block_bits;	/* ilog2(block_size) */
 
+	/*
+	 * shard → preferred CPU mapping for wake_cpu hinting from
+	 * bch2_trans_begin(): each shard's worth of btree-node working set
+	 * gravitates to a fixed CPU's L1/L2.
+	 */
+	u16			inode_shard_cpu[256];
+
 	struct delayed_work	maybe_schedule_btree_bitmap_gc;
 
 	struct bch_fs_counters	counters;

--- a/fs/bcachefs.h
+++ b/fs/bcachefs.h
@@ -662,6 +662,7 @@ struct journal_seq_blacklist_table {
 	x(invalidate)							\
 	x(delete_dead_snapshots)					\
 	x(gc_gens)							\
+	x(presplit_shard_boundaries)					\
 	x(snapshot_delete_pagecache)					\
 	x(sysfs)							\
 	x(btree_write_buffer)						\

--- a/fs/btree/check.c
+++ b/fs/btree/check.c
@@ -1347,6 +1347,86 @@ int bch2_merge_btree_nodes(struct bch_fs *c)
 	return 0;
 }
 
+/*
+ * For each shard boundary in each shard-aware btree, look up the leaf
+ * containing it; if the leaf spans the boundary, rewrite it (which forces
+ * a split at the boundary, since bch2_btree_node_alloc_replacement honors
+ * the "leaves don't cross shard boundaries" constraint).
+ */
+static int presplit_shard_boundary_one(struct btree_trans *trans,
+				       enum btree_id btree, struct bpos pos,
+				       u64 *split_count)
+{
+	struct bch_fs *c = trans->c;
+	CLASS(btree_node_iter, iter)(trans, btree, pos, 0, 0, 0);
+	try(bch2_btree_iter_traverse(&iter));
+
+	struct btree *b = path_l(btree_iter_path(trans, &iter))->b;
+
+	struct bpos pivot = bch2_btree_node_shard_pivot(c, b);
+	if (bpos_eq(pivot, POS_MIN) || bpos_eq(pivot, b->key.k.p))
+		return 1;
+
+	int ret = bch2_btree_split_leaf(trans, iter.path, 0, 0);
+	(*split_count) += !ret;
+	return ret;
+}
+
+int bch2_presplit_shard_boundaries(struct bch_fs *c)
+{
+	if (!c->opts.shard_inode_numbers_bits)
+		return 0;
+
+	if (!enumerated_ref_tryget(&c->writes, BCH_WRITE_REF_presplit_shard_boundaries))
+		return 0;
+
+	static const enum btree_id sharded_btrees[] = {
+		BTREE_ID_inodes,
+		BTREE_ID_extents,
+		BTREE_ID_dirents,
+		BTREE_ID_xattrs,
+	};
+
+	unsigned shard_bits = c->opts.shard_inode_numbers_bits;
+	unsigned bits = 63 - shard_bits;
+	unsigned n_shards = 1U << shard_bits;
+	int ret = 0;
+
+	CLASS(btree_trans, trans)(c);
+
+	for (unsigned i = 0; i < ARRAY_SIZE(sharded_btrees); i++) {
+		u64 split_count = 0;
+		enum btree_id btree = sharded_btrees[i];
+
+		for (unsigned shard = 1; shard < n_shards; shard++) {
+			u64 boundary = (u64) shard << bits;
+			struct bpos pos = btree == BTREE_ID_inodes
+				? SPOS(0, boundary, 0)
+				: SPOS(boundary, 0, 0);
+			do {
+				ret = lockrestart_do(trans,
+					presplit_shard_boundary_one(trans, btree, pos, &split_count));
+			} while (!ret);
+
+			if (ret < 0) {
+				if (bch2_err_matches(ret, ENOSPC))
+					ret = 0;
+				break;
+			}
+			ret = 0;
+		}
+
+		if (split_count) {
+			CLASS(bch_log_msg_level, msg)(c, LOGLEVEL_info);
+			prt_printf(&msg.m, "presplit_shard_boundaries: %llu splits in btree ", split_count);
+			bch2_btree_id_to_text(&msg.m, btree);
+		}
+	}
+
+	enumerated_ref_put(&c->writes, BCH_WRITE_REF_presplit_shard_boundaries);
+	return ret;
+}
+
 void bch2_fs_btree_gc_init_early(struct bch_fs *c)
 {
 	seqcount_init(&c->gc.pos_lock);

--- a/fs/btree/check.h
+++ b/fs/btree/check.h
@@ -84,6 +84,7 @@ int bch2_gc_gens(struct bch_fs *);
 void bch2_gc_gens_async(struct bch_fs *);
 
 int bch2_merge_btree_nodes(struct bch_fs *c);
+int bch2_presplit_shard_boundaries(struct bch_fs *c);
 
 void bch2_fs_btree_gc_init_early(struct bch_fs *);
 

--- a/fs/btree/interior.c
+++ b/fs/btree/interior.c
@@ -61,6 +61,117 @@ void bch2_push_whiteout(struct btree *b, struct bpos pos)
 	bkey_p_copy(unwritten_whiteouts_start(b), &k.k);
 }
 
+/*
+ * Inode-number sharding (shard_inode_numbers_bits) splits concurrent
+ * allocators across disjoint ranges of three btrees so they don't fight
+ * for the same nodes:
+ *
+ *   inodes:  SPOS(0,    inum, snap)   — shard field is offset
+ *   extents: SPOS(inum, offset, snap) — shard field is inode
+ *   dirents: SPOS(inum, hash, snap)   — shard field is inode
+ *   xattrs:  SPOS(inum, hash, snap)   — shard field is inode
+ *
+ * Shard boundaries on inum sit at multiples of
+ * (1 << (63 - shard_inode_numbers_bits)).
+ *
+ * The helpers below let the splitter force a split at a shard boundary
+ * and the merger refuse a merge that would straddle one — keeping the
+ * leaf level shard-aligned over normal growth, no separate pre-split
+ * pass needed.
+ */
+
+/*
+ * Return the greatest shard-boundary pivot bpos strictly less than @key.
+ * POS_MIN if none (non-shard btree, sharding disabled, or @key already
+ * in shard 0) — pivots by definition separate intervals, so POS_MIN is
+ * a safe not-found sentinel.
+ */
+static struct bpos bch2_btree_shard_pivot_below(struct bch_fs *c,
+						enum btree_id id,
+						struct bpos key)
+{
+	unsigned shard_bits = c->opts.shard_inode_numbers_bits;
+	if (!shard_bits)
+		return POS_MIN;
+
+	unsigned bits = 63 - shard_bits;
+	u64 field;
+
+	switch (id) {
+	case BTREE_ID_inodes:
+		field = key.offset;
+		break;
+	case BTREE_ID_extents:
+	case BTREE_ID_dirents:
+	case BTREE_ID_xattrs:
+		field = key.inode;
+		break;
+	default:
+		return POS_MIN;
+	}
+
+	u64 shard = field >> bits;
+	if (!shard)
+		return POS_MIN;
+
+	/*
+	 * Clamp to the largest valid shard. Callers may pass SPOS_MAX (or
+	 * field values above the shard-encoded range) when looking up the
+	 * pivot for an unbounded leaf; without the clamp @shard would
+	 * point to a nonexistent boundary, and @boundary << bits could
+	 * overflow u64 for large shard_bits.
+	 */
+	u64 max_shard = (1ULL << shard_bits) - 1;
+	shard = min(shard, max_shard);
+	--shard;
+	if (!shard)
+		return POS_MIN;
+
+	return id == BTREE_ID_inodes
+		? SPOS(0, shard << bits, U32_MAX)
+		: SPOS(shard << bits, U64_MAX, U32_MAX);
+}
+
+/*
+ * Return the shard-boundary pivot strictly inside (b->min_key, b->max_key)
+ * — the rightmost boundary strictly above min_key and strictly below
+ * max_key. POS_MIN if none, or if @b isn't a leaf.
+ *
+ * Passing max_key to pivot_below already enforces the pivot < max_key
+ * half; a right-edge-aligned leaf still finds the next-smaller boundary
+ * inside, so successive rewrites converge toward full shard alignment.
+ */
+static inline struct bpos bch2_btree_node_shard_pivot(struct bch_fs *c,
+						      const struct btree *b)
+{
+	if (b->c.level)
+		return POS_MIN;
+
+	struct bpos p = bch2_btree_shard_pivot_below(c, b->c.btree_id,
+						     b->data->max_key);
+	return bpos_gt(p, b->data->min_key) ? p : POS_MIN;
+}
+
+/*
+ * True iff @key is at the start of a shard — the key immediately
+ * before @key is in a different shard. Used at both ends of a node:
+ *
+ *   bch2_key_is_shard_boundary(c, id, b->data->min_key)
+ *       — prev sib is in a different shard.
+ *   bch2_key_is_shard_boundary(c, id, bpos_successor(b->data->max_key))
+ *       — next sib is in a different shard.
+ *
+ * The POS_MIN guard avoids a phantom match at SPOS(0,0,1) when
+ * pivot_below returns POS_MIN for shard 0.
+ */
+static inline bool bch2_key_is_shard_boundary(struct bch_fs *c,
+					      enum btree_id id,
+					      struct bpos key)
+{
+	struct bpos p = bch2_btree_shard_pivot_below(c, id, key);
+	return !bpos_eq(p, POS_MIN) && bpos_eq(key, bpos_successor(p));
+}
+
 static const char * const bch2_btree_update_modes[] = {
 #define x(t) #t,
 	BTREE_UPDATE_MODES()
@@ -1748,8 +1859,6 @@ static void btree_pack_into_dsts(struct btree_update *as,
 
 		bsets[i]->u64s = cpu_to_le16((u64 *) out[i] - bsets[i]->_data);
 
-		BUG_ON(!bsets[i]->u64s);
-
 		set_btree_bset_end(n, n->set);
 
 		btree_node_reset_sib_u64s(n);
@@ -1885,7 +1994,16 @@ static int btree_split(struct btree_update *as, struct btree_trans *trans,
 		: as->new_key_u64s &&
 		  !bch2_btree_node_compact_fits(c, b, as->new_key_u64s);
 
-	if (must_split || b->nr.live_u64s > BTREE_SPLIT_THRESHOLD(c)) {
+	/*
+	 * Also split (vs compact) if a shard boundary lies inside this
+	 * leaf — compact would preserve the cross-shard layout that the
+	 * pid-hash inode sharding is trying to escape. Splitting drives
+	 * leaves toward shard-alignment automatically over normal growth;
+	 * no separate pre-split pass needed.
+	 */
+	if (must_split ||
+	    b->nr.live_u64s > BTREE_SPLIT_THRESHOLD(c) ||
+	    !bpos_eq(bch2_btree_node_shard_pivot(c, b), POS_MIN)) {
 		struct btree_merge_node split_src = { .trans = trans, .b = b };
 		darray_merge_node split_srcs = {
 			.data = &split_src, .nr = 1, .size = 1,
@@ -2598,7 +2716,23 @@ static bool find_balanced_split(struct btree_trans *trans,
 	struct split_layout best = {};
 	bool have_best = false;
 
-	if (n1_target_u64s) {
+	struct bpos shard_pivot = bch2_btree_node_shard_pivot(trans->c, srcs->data[0].b);
+
+	if (!bpos_eq(shard_pivot, POS_MIN)) {
+		/*
+		 * Shard pivot takes priority over size balance: force the
+		 * split at the boundary to keep the leaf level shard-aligned,
+		 * which is what gives concurrent inode/dirent/xattr allocators
+		 * their disjoint-btree-node separation. An uneven layout is
+		 * fine — must_split is recursive, so an overflowing side gets
+		 * another shot. Mergers never reach this branch in practice:
+		 * sib_u64s is poisoned at shard boundaries (bch2_foreground_
+		 * maybe_merge), so srcs[0]'s shard_pivot is POS_MIN whenever
+		 * a merger reaches find_balanced_split.
+		 */
+		predict_split(trans, srcs, insert_keys, 0, shard_pivot, &best);
+		have_best = true;
+	} else if (n1_target_u64s) {
 		predict_split(trans, srcs, insert_keys, n1_target_u64s, POS_MIN, &best);
 		have_best = true;
 	} else {
@@ -2804,9 +2938,13 @@ int __bch2_foreground_maybe_merge(struct btree_trans *trans,
 
 	struct btree *b = trans->paths[path].l[level].b;
 
-	if (bpos_eq(b->data->min_key, POS_MIN))
+	if (bpos_eq(b->data->min_key, POS_MIN) ||
+	    (!b->c.level &&
+	     bch2_key_is_shard_boundary(c, btree, b->data->min_key)))
 		b->sib_u64s[btree_prev_sib] = U16_MAX;
-	if (bpos_eq(b->data->max_key, SPOS_MAX))
+	if (bpos_eq(b->data->max_key, SPOS_MAX) ||
+	    (!b->c.level &&
+	     bch2_key_is_shard_boundary(c, btree, bpos_successor(b->data->max_key))))
 		b->sib_u64s[btree_next_sib] = U16_MAX;
 
 	/*

--- a/fs/btree/interior.c
+++ b/fs/btree/interior.c
@@ -141,8 +141,7 @@ static struct bpos bch2_btree_shard_pivot_below(struct bch_fs *c,
  * half; a right-edge-aligned leaf still finds the next-smaller boundary
  * inside, so successive rewrites converge toward full shard alignment.
  */
-static inline struct bpos bch2_btree_node_shard_pivot(struct bch_fs *c,
-						      const struct btree *b)
+struct bpos bch2_btree_node_shard_pivot(struct bch_fs *c, const struct btree *b)
 {
 	if (b->c.level)
 		return POS_MIN;

--- a/fs/btree/interior.h
+++ b/fs/btree/interior.h
@@ -161,6 +161,8 @@ struct btree *__bch2_btree_node_alloc_replacement(struct btree_update *,
 int bch2_btree_split_leaf(struct btree_trans *, btree_path_idx_t,
 			  unsigned, enum bch_trans_commit_flags);
 
+struct bpos bch2_btree_node_shard_pivot(struct bch_fs *, const struct btree *);
+
 int bch2_btree_increase_depth(struct btree_trans *, btree_path_idx_t, unsigned);
 
 int __bch2_foreground_maybe_merge(struct btree_trans *, btree_path_idx_t,

--- a/fs/btree/interior.h
+++ b/fs/btree/interior.h
@@ -163,6 +163,28 @@ int bch2_btree_split_leaf(struct btree_trans *, btree_path_idx_t,
 
 struct bpos bch2_btree_node_shard_pivot(struct bch_fs *, const struct btree *);
 
+static inline int btree_node_shard(struct bch_fs *c, struct btree *b)
+{
+	if (!c->opts.shard_inode_numbers_bits)
+		return -1;
+
+	u64 field;
+	switch (b->c.btree_id) {
+	case BTREE_ID_inodes:
+		field = b->key.k.p.offset;
+		break;
+	case BTREE_ID_extents:
+	case BTREE_ID_dirents:
+	case BTREE_ID_xattrs:
+		field = b->key.k.p.inode;
+		break;
+	default:
+		return -1;
+	}
+
+	return (field << 1) >> (64 - c->opts.shard_inode_numbers_bits);
+}
+
 int bch2_btree_increase_depth(struct btree_trans *, btree_path_idx_t, unsigned);
 
 int __bch2_foreground_maybe_merge(struct btree_trans *, btree_path_idx_t,

--- a/fs/btree/iter.c
+++ b/fs/btree/iter.c
@@ -1207,7 +1207,6 @@ retry_all:
 	btree_trans_sort_paths(trans);
 
 	bch2_trans_unlock(trans);
-	cond_resched();
 	trans_set_locked(trans, false);
 
 	if (unlikely(trans->memory_allocation_failure)) {
@@ -3703,14 +3702,6 @@ u32 bch2_trans_begin(struct btree_trans *trans)
 		     time_after(jiffies, trans->srcu_lock_time + msecs_to_jiffies(10))))
 		bch2_trans_unlock_long(trans);
 
-	if (need_resched() ||
-	    time_after64(now, trans->locking_wait.trans_start_time +
-			 BTREE_TRANS_MAX_LOCK_HOLD_TIME_NS)) {
-		bch2_trans_unlock(trans);
-		cond_resched();
-		now = local_clock();
-	}
-
 	if (!trans->restarted)
 		trans->locking_wait.trans_start_time = now;
 	trans->last_begin_time = now;
@@ -3729,12 +3720,19 @@ u32 bch2_trans_begin(struct btree_trans *trans)
 	trans->trans_kmalloc_trace.nr = 0;
 #endif
 
-	trans_set_locked(trans, false);
-
 	if (trans->restarted) {
+		/* restart is hot — skip the resched check */
 		bch2_btree_path_traverse_all(trans);
 		trans->notrace_relock_fail = false;
+	} else if (need_resched() ||
+		   time_after64(now, trans->locking_wait.trans_start_time +
+				BTREE_TRANS_MAX_LOCK_HOLD_TIME_NS)) {
+		bch2_trans_unlock(trans);
+		cond_resched();
+		now = local_clock();
 	}
+
+	trans_set_locked(trans, false);
 
 	bch2_trans_verify_not_unlocked_or_in_restart(trans);
 	return trans->restart_count;
@@ -3819,6 +3817,9 @@ struct btree_trans *__bch2_trans_get(struct bch_fs *c, unsigned fn_idx)
 		prefetch((const char *) c->btree.cache.roots_b + i);
 
 	trans->c		= c;
+	trans->shard_cpu	= c->opts.shard_inode_numbers_bits
+		? bch2_inode_shard_cpu(c)
+		: -1;
 	trans->fn_idx		= fn_idx;
 	trans->locking_wait.task = current;
 	trans->journal_replay_not_finished =

--- a/fs/btree/locking.c
+++ b/fs/btree/locking.c
@@ -636,6 +636,20 @@ int bch2_six_check_for_deadlock(struct six_lock *lock, struct six_lock_waiter *w
 	if (b && node_reuse_race(trans, b))
 		return bch_err_throw(trans->c, no_btree_node_reused);
 
+#ifdef __KERNEL__
+	/*
+	 * Wake-CPU hint, set at the moment of sleep: nudge the scheduler
+	 * toward the CPU whose L1/L2 owns this task's shard's btree-node
+	 * working set. Soft — sched is free to override under load; writes
+	 * nothing when already matched. Placed here (vs. trans_begin)
+	 * because select_task_rq_fair() consults wake_cpu only at wakeup,
+	 * so the hint has to survive from the schedule() that follows.
+	 */
+	if (trans->shard_cpu >= 0 &&
+	    trans->shard_cpu != raw_smp_processor_id())
+		WRITE_ONCE(current->wake_cpu, trans->shard_cpu);
+#endif
+
 	return bch2_check_for_deadlock(trans, NULL);
 }
 
@@ -1208,6 +1222,7 @@ void bch2_trans_unlock(struct btree_trans *trans)
 void bch2_trans_unlock_long(struct btree_trans *trans)
 {
 	bch2_trans_unlock(trans);
+	trans_enable_migrate(trans);
 
 	if (trans->srcu_held) {
 		struct bch_fs *c = trans->c;

--- a/fs/btree/locking.h
+++ b/fs/btree/locking.h
@@ -41,40 +41,78 @@ static inline struct btree_transaction_stats *btree_trans_stats(struct btree_tra
 
 /* trans locked state */
 
+static inline void trans_maybe_disable_migrate(struct btree_trans *trans)
+{
+	/*
+	 * Pin to CPU while btree locks are held: keeps cache footprint
+	 * hot, and per-CPU cursors (e.g. inode allocation) stable
+	 * across transaction restarts. Released in trans_set_unlocked,
+	 * so any wait that goes through bch2_trans_unlock(_long)
+	 * happens with migration enabled - including the cond_resched
+	 * in bch2_trans_begin and the freezer-visible window during
+	 * suspend.
+	 */
+	if (!trans->migrate_disabled &&
+	    trans->shard_cpu >= 0 &&
+	    trans->shard_cpu == raw_smp_processor_id()) {
+		trans->migrate_disabled = true;
+		migrate_disable();
+	}
+}
+
+static inline void trans_enable_migrate(struct btree_trans *trans)
+{
+	if (trans->migrate_disabled) {
+		trans->migrate_disabled = false;
+		migrate_enable();
+	}
+}
+
 static inline void trans_set_locked(struct btree_trans *trans, bool try)
 {
 	if (!trans->locked) {
-		/*
-		 * Pin to CPU while btree locks are held: keeps cache footprint
-		 * hot, and per-CPU cursors (e.g. inode allocation) stable
-		 * across transaction restarts. Released in trans_set_unlocked,
-		 * so any wait that goes through bch2_trans_unlock(_long)
-		 * happens with migration enabled - including the cond_resched
-		 * in bch2_trans_begin and the freezer-visible window during
-		 * suspend.
-		 */
-		migrate_disable();
-		lock_acquire_exclusive(&trans->dep_map, 0, try, NULL, _THIS_IP_);
 		trans->locked = true;
 		trans->last_unlock_ip = 0;
+		lock_acquire_exclusive(&trans->dep_map, 0, try, NULL, _THIS_IP_);
 
 		trans->pf_memalloc_nofs = (current->flags & PF_MEMALLOC_NOFS) != 0;
 		current->flags |= PF_MEMALLOC_NOFS;
+
+		trans_maybe_disable_migrate(trans);
 	}
 }
 
 static inline void trans_set_unlocked(struct btree_trans *trans)
 {
 	if (trans->locked) {
-		lock_release(&trans->dep_map, _THIS_IP_);
 		trans->locked = false;
 		trans->last_unlock_ip = _RET_IP_;
+		lock_release(&trans->dep_map, _THIS_IP_);
 
 		if (!trans->pf_memalloc_nofs)
 			current->flags &= ~PF_MEMALLOC_NOFS;
-
-		migrate_enable();
 	}
+}
+
+/*
+ * Shard index for inode-number allocation. We used to use the current CPU id,
+ * but threads migrate across CPUs and the win from per-CPU allocator
+ * separation evaporates — concurrent allocators end up sharing shards (and
+ * fighting on the same alloc_cursor btree node) any time the scheduler
+ * shuffles them onto the same core. Hashing the task's pid is stable per
+ * thread, so concurrent allocators in different threads keep their separation
+ * regardless of which CPU they're currently running on.
+ */
+static inline u64 bch2_inode_shard_idx(struct bch_fs *c)
+{
+	return c->opts.shard_inode_numbers_bits
+		? hash_64((u64) current->pid, c->opts.shard_inode_numbers_bits)
+		: 0;
+}
+
+static inline unsigned bch2_inode_shard_cpu(struct bch_fs *c)
+{
+	return c->inode_shard_cpu[bch2_inode_shard_idx(c)];
 }
 
 /* path lock state */
@@ -294,6 +332,8 @@ static inline int btree_node_lock_nopath(struct btree_trans *trans,
 		ret = btree_trans_restart(trans, BCH_ERR_transaction_restart_lock_waitlist_alloc);
 
 	WRITE_ONCE(trans->locking, NULL);
+
+	trans_maybe_disable_migrate(trans);
 
 #ifdef CONFIG_BCACHEFS_DEBUG
 	event_trace(trans->c, btree_path_lock, buf,

--- a/fs/btree/types.h
+++ b/fs/btree/types.h
@@ -657,10 +657,12 @@ struct btree_trans {
 	btree_path_idx_t	nr_paths;
 	btree_path_idx_t	nr_paths_max;
 	btree_path_idx_t	nr_updates;
+	s16			shard_cpu;
 	u8			fn_idx;
 	u8			lock_must_abort;
 	bool			lock_may_not_fail:1;
 	bool			locked:1;
+	bool			migrate_disabled:1;
 	bool			write_locked:1;
 	bool			srcu_held:1;
 	bool			btree_cache_cannibalize_locked:1;

--- a/fs/btree/write.c
+++ b/fs/btree/write.c
@@ -6,6 +6,8 @@
 #include "btree/sort.h"
 #include "btree/write.h"
 
+#include "fs/inode.h"
+
 #include "data/reconcile/trigger.h"
 #include "data/write.h"
 
@@ -127,6 +129,9 @@ static void btree_node_write_work(struct work_struct *work)
 	struct btree *b		= wbio->wbio.bio.bi_private;
 
 	CLASS(btree_trans, trans)(c);
+	int shard = btree_node_shard(c, b);
+	if (shard >= 0)
+		trans->shard_cpu = c->inode_shard_cpu[shard];
 
 	/*
 	 * btree_node_write_update_key commits through the journal; on a dead
@@ -228,7 +233,14 @@ static void btree_node_write_endio(struct bio *bio)
 	smp_mb__after_atomic();
 	wake_up_bit(&b->flags, BTREE_NODE_write_in_flight_inner);
 	INIT_WORK(&wb->work, btree_node_write_work);
-	queue_work(c->btree.write_complete_wq, &wb->work);
+#ifdef __KERNEL__
+	int shard = btree_node_shard(c, b);
+	if (shard >= 0)
+		queue_work_on(c->inode_shard_cpu[shard],
+			      c->btree.write_complete_wq, &wb->work);
+	else
+#endif
+		queue_work(c->btree.write_complete_wq, &wb->work);
 }
 
 static int validate_bset_for_write(struct bch_fs *c, struct btree *b,

--- a/fs/data/migrate.c
+++ b/fs/data/migrate.c
@@ -7,6 +7,7 @@
 
 #include "alloc/backpointers.h"
 #include "alloc/buckets.h"
+#include "alloc/disk_groups.h"
 #include "alloc/replicas.h"
 
 #include "btree/bkey_buf.h"
@@ -89,6 +90,51 @@ static int drop_btree_ptrs(struct btree_trans *trans, struct btree_iter *iter,
 	return bch2_btree_node_update_key(trans, iter, b, n, 0, false);
 }
 
+static unsigned int btree_ptr_rewrite_target(struct bch_fs *c)
+{
+	if (c->opts.metadata_target &&
+	    bch2_target_accepts_data(c, BCH_DATA_btree, c->opts.metadata_target))
+		return c->opts.metadata_target;
+
+	if (c->opts.foreground_target &&
+	    bch2_target_accepts_data(c, BCH_DATA_btree, c->opts.foreground_target))
+		return c->opts.foreground_target;
+
+	return 0;
+}
+
+static int drop_or_rewrite_btree_ptrs(struct btree_trans *trans,
+				      struct btree_iter *iter,
+				      struct btree *b, unsigned int dev_idx,
+				      unsigned int flags, struct printbuf *err)
+{
+	struct printbuf drop_err = PRINTBUF;
+	int ret = drop_btree_ptrs(trans, iter, b, dev_idx, flags, &drop_err);
+	bool drop_would_degrade = bch2_err_matches(ret, BCH_ERR_remove_would_lose_data);
+
+	if (drop_would_degrade)
+		ret = bch2_btree_node_rewrite_pos(trans, iter->btree_id,
+						  b->c.level + 1, b->key.k.p,
+						  btree_ptr_rewrite_target(trans->c),
+						  BCH_TRANS_COMMIT_no_enospc, 0);
+
+	if (bch2_err_matches(ret, BCH_ERR_transaction_restart))
+		goto out;
+
+	if (ret && drop_would_degrade) {
+		prt_printf(err,
+			   "cannot drop device metadata ptr without degrading metadata; "
+			   "btree node rewrite failed: %s\n  ",
+			   bch2_err_str(ret));
+		prt_str(err, bch2_printbuf_str(&drop_err));
+	} else if (ret) {
+		prt_str(err, bch2_printbuf_str(&drop_err));
+	}
+out:
+	printbuf_exit(&drop_err);
+	return ret;
+}
+
 static int bch2_dev_usrdata_drop_key(struct btree_trans *trans,
 				     struct btree_iter *iter,
 				     struct bkey_s_c k,
@@ -122,7 +168,7 @@ static int bch2_dev_btree_drop_key(struct btree_trans *trans,
 	if (ret)
 		return ret == -BCH_ERR_backpointer_to_overwritten_btree_node ? 0 : ret;
 
-	return drop_btree_ptrs(trans, &iter, b, dev_idx, flags, err);
+	return drop_or_rewrite_btree_ptrs(trans, &iter, b, dev_idx, flags, err);
 }
 
 static int bch2_dev_usrdata_drop(struct bch_fs *c,
@@ -169,7 +215,7 @@ static int bch2_dev_metadata_drop(struct bch_fs *c,
 		for (unsigned level = 0; level < BTREE_MAX_DEPTH; level++)
 			try(for_each_btree_node(trans, iter, btree, POS_MIN, level, 0, b, ({
 				bch2_progress_update_iter(trans, progress, &iter) ?:
-				drop_btree_ptrs(trans, &iter, b, dev_idx, flags, err);
+				drop_or_rewrite_btree_ptrs(trans, &iter, b, dev_idx, flags, err);
 			})));
 
 	bch2_trans_unlock(trans);
@@ -271,6 +317,9 @@ int bch2_dev_data_drop_by_backpointers(struct bch_fs *c, struct bch_dev *ca,
 				     &had_open_stripe) ?:
 			bch2_trans_commit(trans, &res.r, NULL, BCH_TRANS_COMMIT_no_enospc);
 		})));
+
+		bch2_trans_unlock_long(trans);
+		bch2_btree_interior_updates_flush(c);
 
 		u64 data_buckets = dev_data_buckets(ca);
 		if (!data_buckets)

--- a/fs/debug/tests.c
+++ b/fs/debug/tests.c
@@ -3,10 +3,13 @@
 
 #include "bcachefs.h"
 
+#include "alloc/backpointers.h"
 #include "alloc/buckets.h"
 
 #include "btree/interior.h"
 #include "btree/update.h"
+
+#include "data/extents.h"
 
 #include "journal/reclaim.h"
 
@@ -546,6 +549,60 @@ static int test_btree_ptr_stale_dirty(struct bch_fs *c, u64 nr)
 	return lockrestart_do(trans, test_btree_ptr_stale_dirty_level(trans, 1));
 }
 
+static int test_btree_ptr_missing_backpointer_dev_once(struct btree_trans *trans,
+						       unsigned int dev)
+{
+	struct bch_fs *c = trans->c;
+
+	for (unsigned int btree = 0; btree < btree_id_nr_alive(c); btree++)
+		for (unsigned int level = 0; level < BTREE_MAX_DEPTH; level++)
+			try(for_each_btree_node(trans, iter, btree, POS_MIN, level, 0, b, ({
+				struct bkey_s_c k = bkey_i_to_s_c(&b->key);
+				struct bkey_ptrs_c ptrs = bch2_bkey_ptrs_c(k);
+				const union bch_extent_entry *entry;
+				struct extent_ptr_decoded p;
+
+				bkey_for_each_ptr_decode(k.k, ptrs, p, entry) {
+					if (p.ptr.dev != dev)
+						continue;
+
+					unsigned int node_l = b->c.level + 1;
+					struct bkey_i_backpointer bp;
+
+					bch2_extent_ptr_to_bp(c, btree, node_l, k, p, entry, &bp);
+
+					bch_info(c, "%s: deleting backpointer for btree %s level %u node %llu:%llu:%u dev %u offset %llu gen %u",
+						 __func__, bch2_btree_id_str(btree), b->c.level,
+						 k.k->p.inode, k.k->p.offset, k.k->p.snapshot,
+						 p.ptr.dev, (u64)p.ptr.offset, p.ptr.gen);
+
+					return bch2_bucket_backpointer_mod(trans, k, &bp, false) ?:
+					       bch2_trans_commit(trans, NULL, NULL,
+								 BCH_TRANS_COMMIT_no_enospc) ?: 1;
+				}
+				0;
+			})));
+
+	return 0;
+}
+
+static int test_btree_ptr_missing_backpointer_dev(struct bch_fs *c, u64 dev_plus_one)
+{
+	if (!dev_plus_one)
+		return -EINVAL;
+
+	u64 dev = dev_plus_one - 1;
+
+	if (dev >= c->sb.nr_devices)
+		return -EINVAL;
+
+	CLASS(btree_trans, trans)(c);
+	int ret = lockrestart_do(trans,
+		test_btree_ptr_missing_backpointer_dev_once(trans, dev));
+
+	return ret <= 0 ? ret ?: -ENOENT : 0;
+}
+
 /* snapshot unit tests */
 
 /* Test skipping over keys in unrelated snapshots: */
@@ -871,6 +928,7 @@ int bch2_btree_perf_test(struct bch_fs *c, const char *testname,
 	perf_test(test_extent_create_overlapping);
 	perf_test(test_extent_create_dup);
 	perf_test(test_btree_ptr_stale_dirty);
+	perf_test(test_btree_ptr_missing_backpointer_dev);
 
 	perf_test(test_snapshots);
 

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -133,7 +133,6 @@ static int create_lostfound(struct btree_trans *trans, u32 snapshot_tree,
 	prt_printf(&msg.m, "/lost+found in subvol %llu snapshot %u", root_inum.subvol, snapshot);
 
 	u64 now = bch2_current_time(c);
-	u64 cpu = raw_smp_processor_id();
 
 	bch2_inode_init_early(c, lostfound);
 	bch2_inode_init_late(c, lostfound, now, 0, 0, S_IFDIR|0700, 0, root_inode);
@@ -143,7 +142,7 @@ static int create_lostfound(struct btree_trans *trans, u32 snapshot_tree,
 	root_inode->bi_nlink++;
 
 	CLASS(btree_iter_uninit, lostfound_iter)(trans);
-	try(bch2_inode_create(trans, &lostfound_iter, lostfound, snapshot, cpu,
+	try(bch2_inode_create(trans, &lostfound_iter, lostfound, snapshot,
 			      inode_opt_get(c, root_inode, inodes_32bit)));
 
 	bch2_btree_iter_set_snapshot(&lostfound_iter, snapshot);
@@ -434,14 +433,13 @@ static int reconstruct_subvol(struct btree_trans *trans, u32 snapshotid, u32 sub
 	if (!inum) {
 		CLASS(btree_iter_uninit, inode_iter)(trans);
 		struct bch_inode_unpacked new_inode;
-		u64 cpu = raw_smp_processor_id();
 
 		bch2_inode_init_early(c, &new_inode);
 		bch2_inode_init_late(c, &new_inode, bch2_current_time(c), 0, 0, S_IFDIR|0755, 0, NULL);
 
 		new_inode.bi_subvol = subvolid;
 
-		try(bch2_inode_create(trans, &inode_iter, &new_inode, snapshotid, cpu, false));
+		try(bch2_inode_create(trans, &inode_iter, &new_inode, snapshotid, false));
 		try(bch2_btree_iter_traverse(&inode_iter));
 		try(bch2_inode_write(trans, &inode_iter, &new_inode));
 

--- a/fs/fs/inode.c
+++ b/fs/fs/inode.c
@@ -907,29 +907,6 @@ __cold void bch2_inode_generation_to_text(struct printbuf *out, struct bch_fs *c
 	prt_printf(out, "generation: %u", le32_to_cpu(gen.v->bi_generation));
 }
 
-int bch2_inode_alloc_cursor_validate(struct bch_fs *c, struct bkey_s_c k,
-				   const struct bkey_validate_context *from)
-{
-	int ret = 0;
-
-	bkey_fsck_err_on(k.k->p.inode != LOGGED_OPS_INUM_inode_cursors,
-			 c, inode_alloc_cursor_inode_bad,
-			 "k.p.inode bad");
-fsck_err:
-	return ret;
-}
-
-__cold
-void bch2_inode_alloc_cursor_to_text(struct printbuf *out, struct bch_fs *c,
-				     struct bkey_s_c k)
-{
-	struct bkey_s_c_inode_alloc_cursor i = bkey_s_c_to_inode_alloc_cursor(k);
-
-	prt_printf(out, "idx %llu generation %llu",
-		   le64_to_cpu(i.v->idx),
-		   le64_to_cpu(i.v->gen));
-}
-
 void bch2_inode_init_early(struct bch_fs *c,
 			   struct bch_inode_unpacked *inode_u)
 {
@@ -984,6 +961,46 @@ void bch2_inode_init(struct bch_fs *c, struct bch_inode_unpacked *inode_u,
 			     uid, gid, mode, rdev, parent);
 }
 
+int bch2_inode_alloc_cursor_validate(struct bch_fs *c, struct bkey_s_c k,
+				   const struct bkey_validate_context *from)
+{
+	int ret = 0;
+
+	bkey_fsck_err_on(k.k->p.inode != LOGGED_OPS_INUM_inode_cursors,
+			 c, inode_alloc_cursor_inode_bad,
+			 "k.p.inode bad");
+fsck_err:
+	return ret;
+}
+
+static inline void cursor_idx_min_max(struct bch_fs *c, unsigned idx,
+				      u64 *min, u64 *max)
+{
+	if (!idx) {
+		*min = BLOCKDEV_INODE_MAX;
+		*max = INT_MAX;
+	} else {
+		u64 shard = idx - 1;
+		unsigned bits = 63 - c->opts.shard_inode_numbers_bits;
+
+		*min = max(shard << bits, (u64) INT_MAX + 1);
+		*max = (shard << bits) | ~(ULLONG_MAX << bits);
+	}
+}
+
+__cold
+void bch2_inode_alloc_cursor_to_text(struct printbuf *out, struct bch_fs *c,
+				     struct bkey_s_c k)
+{
+	struct bkey_s_c_inode_alloc_cursor i = bkey_s_c_to_inode_alloc_cursor(k);
+
+	u64 min, max, idx = le64_to_cpu(i.v->idx);
+	cursor_idx_min_max(c, k.k->p.offset, &min, &max);
+
+	prt_printf(out, "min %llu max %llu consumed %llu idx %llu generation %llu",
+		   min, max, idx - min, idx, le64_to_cpu(i.v->gen));
+}
+
 static struct bkey_i_inode_alloc_cursor *
 bch2_inode_alloc_cursor_get(struct btree_trans *trans, u64 cpu, u64 *min, u64 *max,
 			    bool is_32bit)
@@ -992,7 +1009,7 @@ bch2_inode_alloc_cursor_get(struct btree_trans *trans, u64 cpu, u64 *min, u64 *m
 
 	u64 cursor_idx = is_32bit ? 0 : cpu + 1;
 
-	cursor_idx &= ~(~0ULL << c->opts.shard_inode_numbers_bits);
+	cursor_idx_min_max(c, cursor_idx, min, max);
 
 	CLASS(btree_iter, iter)(trans, BTREE_ID_logged_ops,
 				POS(LOGGED_OPS_INUM_inode_cursors, cursor_idx),
@@ -1009,19 +1026,9 @@ bch2_inode_alloc_cursor_get(struct btree_trans *trans, u64 cpu, u64 *min, u64 *m
 	if (IS_ERR(cursor))
 		return cursor;
 
-	if (is_32bit) {
-		*min = BLOCKDEV_INODE_MAX;
-		*max = INT_MAX;
-	} else {
-		cursor->v.bits = c->opts.shard_inode_numbers_bits;
+	cursor->v.bits = c->opts.shard_inode_numbers_bits;
 
-		unsigned bits = 63 - c->opts.shard_inode_numbers_bits;
-
-		*min = max(cpu << bits, (u64) INT_MAX + 1);
-		*max = (cpu << bits) | ~(ULLONG_MAX << bits);
-	}
-
-	if (le64_to_cpu(cursor->v.idx)  < *min)
+	if (le64_to_cpu(cursor->v.idx) < *min)
 		cursor->v.idx = cpu_to_le64(*min);
 
 	if (le64_to_cpu(cursor->v.idx) >= *max) {

--- a/fs/fs/inode.c
+++ b/fs/fs/inode.c
@@ -1002,12 +1002,12 @@ void bch2_inode_alloc_cursor_to_text(struct printbuf *out, struct bch_fs *c,
 }
 
 static struct bkey_i_inode_alloc_cursor *
-bch2_inode_alloc_cursor_get(struct btree_trans *trans, u64 cpu, u64 *min, u64 *max,
+bch2_inode_alloc_cursor_get(struct btree_trans *trans, u64 *min, u64 *max,
 			    bool is_32bit)
 {
 	struct bch_fs *c = trans->c;
 
-	u64 cursor_idx = is_32bit ? 0 : cpu + 1;
+	u64 cursor_idx = is_32bit ? 0 : bch2_inode_shard_idx(c) + 1;
 
 	cursor_idx_min_max(c, cursor_idx, min, max);
 
@@ -1045,11 +1045,11 @@ bch2_inode_alloc_cursor_get(struct btree_trans *trans, u64 cpu, u64 *min, u64 *m
 int bch2_inode_create(struct btree_trans *trans,
 		      struct btree_iter *iter,
 		      struct bch_inode_unpacked *inode_u,
-		      u32 snapshot, u64 cpu, bool is_32bit)
+		      u32 snapshot, bool is_32bit)
 {
 	u64 min, max;
 	struct bkey_i_inode_alloc_cursor *cursor =
-		errptr_try(bch2_inode_alloc_cursor_get(trans, cpu, &min, &max, is_32bit));
+		errptr_try(bch2_inode_alloc_cursor_get(trans, &min, &max, is_32bit));
 
 	u64 start = le64_to_cpu(cursor->v.idx);
 	u64 pos = start;

--- a/fs/fs/inode.c
+++ b/fs/fs/inode.c
@@ -997,6 +997,35 @@ void bch2_fs_inode_shard_cpu_init(struct bch_fs *c)
 #endif
 }
 
+/*
+ * Default for shard_inode_numbers_bits when the user didn't set it.
+ *
+ * Scales with nr_cpus (x2, for thread-oversubscription headroom), capped so the
+ * pre-split shard-boundary metadata (4 sharded btrees, one node per shard)
+ * stays under 1% of the filesystem, and clamped to [0, 8] - the range the
+ * option and the inode_shard_cpu[] array support.
+ *
+ * Shared so the format-time default (userspace) and the kernel sb_validate
+ * rewrite of legacy bits=0 filesystems pick the same value from one place.
+ */
+unsigned bch2_shard_inode_numbers_bits_default(unsigned nr_cpus,
+					       u64 fs_size,
+					       u64 btree_node_bytes)
+{
+	unsigned cpu_bits = ilog2(roundup_pow_of_two(max(nr_cpus, 1U) * 2));
+
+	/*
+	 * 2^bits * 4 * btree_node_bytes <= fs_size / 100
+	 *   =>  2^bits <= fs_size / (400 * btree_node_bytes)
+	 */
+	u64 denom = 400ULL * btree_node_bytes;
+	unsigned size_bits = btree_node_bytes && fs_size >= denom
+		? ilog2(fs_size / denom)
+		: 0;
+
+	return min(min(cpu_bits, size_bits), 8U);
+}
+
 static inline void cursor_idx_min_max(struct bch_fs *c, unsigned idx,
 				      u64 *min, u64 *max)
 {

--- a/fs/fs/inode.c
+++ b/fs/fs/inode.c
@@ -6,6 +6,7 @@
 #include "alloc/buckets.h"
 
 #include "btree/key_cache.h"
+#include "btree/locking.h"
 #include "btree/write_buffer.h"
 #include "btree/bkey_methods.h"
 #include "btree/update.h"
@@ -971,6 +972,29 @@ int bch2_inode_alloc_cursor_validate(struct bch_fs *c, struct bkey_s_c k,
 			 "k.p.inode bad");
 fsck_err:
 	return ret;
+}
+
+/*
+ * Populate inode_shard_cpu[]: each shard gets a preferred CPU,
+ * spread across online CPUs with NUMA topology awareness.
+ * bch2_trans_cpu_hint() reads this on every trans_begin to nudge the
+ * scheduler toward the CPU that owns the task's shard's working set.
+ */
+void bch2_fs_inode_shard_cpu_init(struct bch_fs *c)
+{
+#ifdef __KERNEL__
+	unsigned bits = c->opts.shard_inode_numbers_bits;
+	if (!bits)
+		return;
+
+	unsigned nr_shards = 1U << bits;
+	BUG_ON(nr_shards > ARRAY_SIZE(c->inode_shard_cpu));
+
+	for (unsigned shard = 0; shard < nr_shards; shard++) {
+		unsigned cpu = cpumask_local_spread(shard, NUMA_NO_NODE);
+		c->inode_shard_cpu[shard] = cpu < nr_cpu_ids ? cpu : 0;
+	}
+#endif
 }
 
 static inline void cursor_idx_min_max(struct bch_fs *c, unsigned idx,

--- a/fs/fs/inode.h
+++ b/fs/fs/inode.h
@@ -190,6 +190,7 @@ int bch2_inode_create(struct btree_trans *, struct btree_iter *,
 		      struct bch_inode_unpacked *, u32, bool);
 
 void bch2_fs_inode_shard_cpu_init(struct bch_fs *);
+unsigned bch2_shard_inode_numbers_bits_default(unsigned nr_cpus, u64 fs_size, u64 btree_node_bytes);
 
 int bch2_inode_rm(struct bch_fs *, subvol_inum);
 

--- a/fs/fs/inode.h
+++ b/fs/fs/inode.h
@@ -6,6 +6,9 @@
 #include "btree/bkey_methods.h"
 #include "snapshots/snapshot.h"
 
+#include <linux/hash.h>
+#include <linux/sched.h>
+
 extern const char * const bch2_inode_opts[];
 
 int bch2_inode_validate(struct bch_fs *, struct bkey_s_c,
@@ -184,7 +187,23 @@ void bch2_inode_init(struct bch_fs *, struct bch_inode_unpacked *,
 		     struct bch_inode_unpacked *);
 
 int bch2_inode_create(struct btree_trans *, struct btree_iter *,
-		      struct bch_inode_unpacked *, u32, u64, bool);
+		      struct bch_inode_unpacked *, u32, bool);
+
+/*
+ * Shard index for inode-number allocation. We used to use the current CPU id,
+ * but threads migrate across CPUs and the win from per-CPU allocator
+ * separation evaporates — concurrent allocators end up sharing shards (and
+ * fighting on the same alloc_cursor btree node) any time the scheduler
+ * shuffles them onto the same core. Hashing the task's pid is stable per
+ * thread, so concurrent allocators in different threads keep their separation
+ * regardless of which CPU they're currently running on.
+ */
+static inline u64 bch2_inode_shard_idx(struct bch_fs *c)
+{
+	return c->opts.shard_inode_numbers_bits
+		? hash_64((u64) current->pid, c->opts.shard_inode_numbers_bits)
+		: 0;
+}
 
 int bch2_inode_rm(struct bch_fs *, subvol_inum);
 

--- a/fs/fs/inode.h
+++ b/fs/fs/inode.h
@@ -189,21 +189,7 @@ void bch2_inode_init(struct bch_fs *, struct bch_inode_unpacked *,
 int bch2_inode_create(struct btree_trans *, struct btree_iter *,
 		      struct bch_inode_unpacked *, u32, bool);
 
-/*
- * Shard index for inode-number allocation. We used to use the current CPU id,
- * but threads migrate across CPUs and the win from per-CPU allocator
- * separation evaporates — concurrent allocators end up sharing shards (and
- * fighting on the same alloc_cursor btree node) any time the scheduler
- * shuffles them onto the same core. Hashing the task's pid is stable per
- * thread, so concurrent allocators in different threads keep their separation
- * regardless of which CPU they're currently running on.
- */
-static inline u64 bch2_inode_shard_idx(struct bch_fs *c)
-{
-	return c->opts.shard_inode_numbers_bits
-		? hash_64((u64) current->pid, c->opts.shard_inode_numbers_bits)
-		: 0;
-}
+void bch2_fs_inode_shard_cpu_init(struct bch_fs *);
 
 int bch2_inode_rm(struct bch_fs *, subvol_inum);
 

--- a/fs/fs/namei.c
+++ b/fs/fs/namei.c
@@ -46,7 +46,6 @@ int bch2_create_trans(struct btree_trans *trans,
 	CLASS(btree_iter_uninit, inode_iter)(trans);
 	subvol_inum new_inum = dir;
 	u64 now = bch2_current_time(c);
-	u64 cpu = raw_smp_processor_id();
 	u64 dir_target;
 	unsigned dir_type = mode_to_type(mode);
 
@@ -68,7 +67,7 @@ int bch2_create_trans(struct btree_trans *trans,
 		if (flags & BCH_CREATE_TMPFILE)
 			new_inode->bi_flags |= BCH_INODE_unlinked;
 
-		try(bch2_inode_create(trans, &inode_iter, new_inode, dir_snapshot, cpu,
+		try(bch2_inode_create(trans, &inode_iter, new_inode, dir_snapshot,
 				      inode_opt_get(c, dir_u, inodes_32bit)));
 
 		snapshot_src = (subvol_inum) { 0 };

--- a/fs/init/fs.c
+++ b/fs/init/fs.c
@@ -1284,6 +1284,8 @@ static int bch2_fs_init(struct bch_fs *c, struct bch_sb *sb,
 
 	c->block_bits		= ilog2(block_sectors(c));
 
+	bch2_fs_inode_shard_cpu_init(c);
+
 	if (bch2_fs_init_fault("fs_alloc")) {
 		prt_printf(out, "fs_alloc fault injected\n");
 		return -EFAULT;

--- a/fs/init/passes_format.h
+++ b/fs/init/passes_format.h
@@ -73,6 +73,12 @@
 	x(merge_btree_nodes,			45, PASS_ONLINE,			0,	\
 	  "Merge adjacent underfull btree nodes to reclaim "					\
 	  "wasted space")									\
+	x(presplit_shard_boundaries,		48, PASS_ALWAYS,				\
+	  BIT_ULL(BCH_RECOVERY_PASS_journal_replay),						\
+	  "Split btree leaves spanning inode-allocator shard "					\
+	  "boundaries so each shard's keys live in dedicated "					\
+	  "nodes (cache locality for sharded inode/dirent/"					\
+	  "extent/xattr access)")								\
 	x(check_alloc_info,			10, PASS_ONLINE|PASS_FSCK_ALLOC,		\
 	  BIT_ULL(BCH_RECOVERY_PASS_check_allocations),						\
 	  "Cross-check alloc btree against freespace, "						\

--- a/fs/init/recovery.c
+++ b/fs/init/recovery.c
@@ -8,6 +8,7 @@
 #include "alloc/replicas.h"
 
 #include "btree/bkey_buf.h"
+#include "btree/check.h"
 #include "btree/interior.h"
 #include "btree/journal_overlay.h"
 #include "btree/node_scan.h"
@@ -1066,6 +1067,7 @@ int bch2_fs_initialize(struct bch_fs *c)
 	try(bch2_journal_replay(c));
 	try(bch2_initialize_subvolumes(c));
 	try(bch2_snapshots_read(c));
+	try(bch2_presplit_shard_boundaries(c));
 
 	bch2_inode_init(c, &root_inode, 0, 0, S_IFDIR|0755, 0, NULL);
 	root_inode.bi_inum	= BCACHEFS_ROOT_INO;

--- a/fs/sb/io.c
+++ b/fs/sb/io.c
@@ -12,6 +12,7 @@
 #include "journal/sb.h"
 #include "journal/seq_blacklist.h"
 
+#include "fs/inode.h"
 #include "fs/quota.h"
 
 #include "init/dev.h"
@@ -610,8 +611,17 @@ int bch2_sb_validate(struct bch_sb *sb, struct bch_opts *opts, u64 read_offset,
 		SET_BCH_SB_MULTI_DEVICE(sb, true);
 
 #ifdef __KERNEL__
-	if (!BCH_SB_SHARD_INUMS_NBITS(sb))
-		SET_BCH_SB_SHARD_INUMS_NBITS(sb, ilog2(roundup_pow_of_two(num_online_cpus())));
+	if (!BCH_SB_SHARD_INUMS_NBITS(sb)) {
+		u64 fs_size = 0;
+		for (unsigned i = 0; i < bch2_sb_nr_devices(sb); i++) {
+			struct bch_member m = bch2_sb_member_get(sb, i);
+			fs_size += le64_to_cpu(m.nbuckets) * le16_to_cpu(m.bucket_size);
+		}
+
+		SET_BCH_SB_SHARD_INUMS_NBITS(sb,
+			bch2_shard_inode_numbers_bits_default(num_online_cpus(),
+				fs_size << 9, (u64) BCH_SB_BTREE_NODE_SIZE(sb) << 9));
+	}
 #endif
 
 	/* validate layout */

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -490,6 +490,43 @@ fn cmd_format(argv: Vec<String>) -> Result<()> {
         })?;
     }
 
+    // Default shard_inode_numbers_bits if the user didn't set it. The policy
+    // (cpu-scaled, fs-size-capped, clamped to [0, 8]) lives in C —
+    // bch2_shard_inode_numbers_bits_default() — so the format-time default and
+    // the kernel sb_validate rewrite of legacy bits=0 filesystems can't diverge.
+    if !bch_bindgen::opts::opt_defined_by_id(&cfg.fs_opts, c::bch_opt_id::Opt_shard_inode_numbers_bits) {
+        let nr_cpus = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1) as u32;
+
+        // Total fs size in bytes, populating per-device sizes from fd if the
+        // user didn't specify them.
+        let total_fs_size: u64 = devices.iter_mut().map(|d| {
+            if d.fs_size == 0 {
+                d.fs_size = crate::wrappers::bdev::get_size(d.fd);
+            }
+            d.fs_size
+        }).sum();
+
+        // btree_node_size in bytes; 0 here if the user didn't override (the
+        // default isn't materialized until later), so fall back to the same
+        // 256K default the format path picks.
+        let btree_node_bytes = if cfg.fs_opts.btree_node_size != 0 {
+            cfg.fs_opts.btree_node_size as u64
+        } else {
+            256 << 10
+        };
+
+        let bits = unsafe {
+            c::bch2_shard_inode_numbers_bits_default(nr_cpus, total_fs_size, btree_node_bytes)
+        } as u64;
+        bch_bindgen::opts::opt_set_by_id(
+            &mut cfg.fs_opts,
+            c::bch_opt_id::Opt_shard_inode_numbers_bits,
+            bits,
+        );
+    }
+
     let sb = crate::commands::format_util::format(fs_opt_strs, cfg.fs_opts, fmt_opts, &mut devices);
     if sb.is_null() {
         bail!("format returned null");


### PR DESCRIPTION
Historical note: this PR is closed and superseded by `koverstreet/bcachefs-tools#601`, with companion coverage in `koverstreet/ktest#55`.

GitHub may still show upstream `testing` commits by Kent Overstreet / Proof of Concept in this compare range because the branch was based on a refreshed tools history. Those commits keep their original authorship. The proposed PR-specific change here was the tail commit `bcachefs: rewrite btree nodes before dropping device metadata ptrs`; the active review/merge artifact is now `koverstreet/bcachefs-tools#601`.

---

## Summary

This ports and updates the btree-metadata part of `koverstreet/bcachefs#1142` for the current `bcachefs-tools` `testing` branch.

Device removal can still find btree-node metadata that points at the member being removed. Directly dropping that pointer may under-replicate metadata, so the remove path reports `remove_would_lose_data` and leaves `BCH_DATA_btree` buckets behind.

When dropping a btree pointer would degrade metadata, this rewrites the btree node first and lets the old node be freed. The fallback is used from both the backpointer-driven path and the slower direct metadata scan.

It also flushes btree interior updates after each backpointer scan before checking whether the device still has data, so the removal loop can observe rewrite progress.

## Notes

This is separate from `koverstreet/bcachefs-tools#596`, which only restores `rw` state after a failed remove attempt. This patch is the forward-progress part for btree-only leftover device metadata after evacuation/backpointer repair has not cleared the member.

This does not try to make `device evacuate` itself repair missing backpointers. The simulated coverage is for the direct `device remove` path after the online backpointer fsck pass, matching the field report where `check_extents_to_backpointers` had already completed but remove still failed with only btree buckets left.

The debug test hook takes `dev + 1` as its numeric argument so `0` remains rejected as an invalid perf-test count by the shared perf-test runner.

## Validation

Local validation after rebasing onto current `testing` head `74d6f0552` and PR head `5175c8e86`:

- `git diff --check origin/testing...HEAD`
- `make -j16 libbcachefs.a`
- `make -j32`

The full build completed successfully. It still reports pre-existing warnings in unrelated files:

- `linux/blkdev.c`: discarded const qualifier in `bdev_file_open_by_path`
- `src/commands/list_journal.rs`: two unused assignment warnings
- `src/commands/scrub.rs`: function item cast warning

Companion simulation coverage is in `koverstreet/ktest#55`. With `koverstreet/ktest#55` head `e148948df7d310c68831ea225d9a71bb2859af2c` and the earlier `koverstreet/bcachefs-tools#599` head loaded via DKMS module `v1.38.5-191-g5f17ca4607f3`, one VM run passed both removal paths:

- `fast_backpointer_device_removal` passed in 8s on the current default format.
- `legacy_scan_device_removal` passed in 6s on `--version=1.26`.

The VM run injected a missing btree-pointer backpointer for device 0, ran the online backpointer fsck pass, completed direct `bcachefs device remove`, passed offline fsck on the remaining members, and ended with `TEST SUCCESS`.
