### PR TITLE
reconcile wait: fix TUI output indentation in raw mode

### DIFF
--- a/src/commands/reconcile.rs
+++ b/src/commands/reconcile.rs
@@ -209,7 +209,9 @@ fn reconcile_wait_tui(
         let pending = reconcile_status_to_text(&mut out, handle, sysfs_path, types)?;
 
         execute!(stdout, cursor::MoveTo(0, 0), terminal::Clear(ClearType::All))?;
-        write!(stdout, "{}", out)?;
+        for line in out.as_str().lines() {
+            write!(stdout, "{}\r\n", line)?;
+        }
         stdout.flush()?;
 
         if !pending {


### PR DESCRIPTION
Very minor display bugfix for the `bcachefs reconcile wait` subcommand.