### PR TITLE
nix: provide bindgen CLI for crane build

### DIFF
--- a/crane-build.nix
+++ b/crane-build.nix
@@ -7,6 +7,7 @@
   jq,
   pkg-config,
   rustPlatform,
+  rust-bindgen,
   versionCheckHook,
 
   # run time
@@ -40,6 +41,7 @@ let
     strictDeps = true;
 
     env = {
+      BINDGEN = "${rust-bindgen}/bin/bindgen";
       PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
       PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";
     };
@@ -56,6 +58,7 @@ let
       jq
       pkg-config
       rustPlatform.bindgenHook
+      rust-bindgen
     ];
 
     buildInputs = [


### PR DESCRIPTION
The crane build currently includes `rustPlatform.bindgenHook`, which sets up bindgen/libclang-related environment, but it does not by itself provide the `bindgen` CLI executable in the derivation. This can make the `bcachefs-kernel` build script fail with:

```text
run bindgen: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```
Add rust-bindgen to nativeBuildInputs and set BINDGEN explicitly so the codegen step can reliably find the bindgen executable.
