### PR TITLE
module-build.nix: find vmlinux on nix

### DIFF
--- a/module-build.nix
+++ b/module-build.nix
@@ -47,6 +47,11 @@ stdenv.mkDerivation {
     "INSTALL_MOD_PATH=${placeholder "out"}"
   ];
 
+  postPatch = ''
+    substituteInPlace src/fs/bcachefs/Makefile \
+      --replace-fail '$(objtree)/vmlinux' '${kernel.dev}/vmlinux'
+  '';
+
   installPhase = ''
     runHook preInstall
     make -C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build M=$(pwd) modules_install "''${makeFlags[@]}" "''${installFlags[@]}"


### PR DESCRIPTION
Fixes: bcachefs: bch2_dirent_init() bcachefs: filldir64 fastpath disabled: struct layout unverified for this kernel