### PR TITLE
module-build.nix: add RUST_LIB_SRC

### DIFF
--- a/module-build.nix
+++ b/module-build.nix
@@ -27,6 +27,7 @@ bcachefs-tools:
   stdenv,
   kernelModuleMakeFlags,
   kernel,
+  rustPlatform
 }:
 
 stdenv.mkDerivation {
@@ -45,6 +46,7 @@ stdenv.mkDerivation {
   makeFlags = kernelModuleMakeFlags ++ [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=${placeholder "out"}"
+    "RUST_LIB_SRC=${rustPlatform.rustLibSrc}"
   ];
 
   postPatch = ''


### PR DESCRIPTION
Fixes autodetecting rust support since 30dd537