### PR TITLE
opts: schedule reconcile scan after offline target change

### DIFF
--- a/fs/init/fs.rs
+++ b/fs/init/fs.rs
@@ -248,13 +248,13 @@ impl Fs {
 
     /// Set an option in the superblock; None dev = filesystem scope.
     pub fn opt_set_sb(&self, dev: Option<&DevRef>, opt: &c::bch_option, v: u64,
-                      val_str: Option<&core::ffi::CStr>)
+                      val_str: Option<&core::ffi::CStr>) -> bool
     {
         unsafe {
             c::bch2_opt_set_sb(self.raw,
                 dev.map_or(core::ptr::null_mut(), |d| d.as_mut_ptr()),
                 opt, v,
-                val_str.map_or(core::ptr::null(), |s| s.as_ptr()));
+                val_str.map_or(core::ptr::null(), |s| s.as_ptr()))
         }
     }
 

--- a/src/commands/set_option.rs
+++ b/src/commands/set_option.rs
@@ -15,32 +15,50 @@ fn opt_flags() -> u32 {
     c::opt_flags::OPT_FS as u32 | c::opt_flags::OPT_DEVICE as u32
 }
 
+fn schedule_reconcile_after_offline_io_opt_change(fs: &bcachefs_kernel::fs::Fs) -> Result<()> {
+    let ext_u64s = (std::mem::size_of::<c::bch_sb_field_ext>() / std::mem::size_of::<u64>()) as u32;
+    let ext: &mut c::bch_sb_field_ext =
+        unsafe { bcachefs_kernel::sb::io::sb_field_get_minsize(&mut (*fs.raw).disk_sb, ext_u64s) }
+            .ok_or_else(|| anyhow::anyhow!("Error getting sb_field_ext"))?;
+    let pass = 1u64 << c::bch_recovery_pass::BCH_RECOVERY_PASS_set_fs_needs_reconcile as u64;
+    let stable_pass = unsafe { c::bch2_recovery_passes_to_stable(pass) };
+    ext.recovery_passes_required[0] |= stable_pass.to_le();
+    Ok(())
+}
+
 fn set_option_cmd() -> Command {
     Command::new("set-fs-option")
         .about("Set a filesystem option")
-        .long_about("\
+        .long_about(
+            "\
 Set a filesystem or device option on a running filesystem. Changes \
 are persisted to the superblock. Use -d to target a specific device \
 for device-scoped options. See <<sec:options>> for the full list of \
-available options.")
+available options.",
+        )
         .args(bch_option_args(opt_flags(), false))
-        .arg(Arg::new("dev-idx")
-            .short('d')
-            .long("dev-idx")
-            .action(ArgAction::Append)
-            .value_parser(clap::value_parser!(u32))
-            .help("Device index for device-specific options"))
-        .arg(Arg::new("devices")
-            .required(true)
-            .action(ArgAction::Append)
-            .help("Device path(s)"))
+        .arg(
+            Arg::new("dev-idx")
+                .short('d')
+                .long("dev-idx")
+                .action(ArgAction::Append)
+                .value_parser(clap::value_parser!(u32))
+                .help("Device index for device-specific options"),
+        )
+        .arg(
+            Arg::new("devices")
+                .required(true)
+                .action(ArgAction::Append)
+                .help("Device path(s)"),
+        )
 }
 
 fn cmd_set_option(argv: Vec<String>) -> Result<()> {
     let matches = set_option_cmd().get_matches_from(argv);
 
     let devices: Vec<&String> = matches.get_many::<String>("devices").unwrap().collect();
-    let dev_idxs: Vec<u32> = matches.get_many::<u32>("dev-idx")
+    let dev_idxs: Vec<u32> = matches
+        .get_many::<u32>("dev-idx")
         .map(|v| v.copied().collect())
         .unwrap_or_default();
 
@@ -55,7 +73,7 @@ fn cmd_set_option(argv: Vec<String>) -> Result<()> {
     opt_set!(fs_opts, nostart, 1);
 
     match crate::device_scan::open_online_or_offline(&devs, fs_opts)? {
-        OpenedFs::Online(fs)  => set_option_online(fs, &devices, &dev_idxs, &opts),
+        OpenedFs::Online(fs) => set_option_online(fs, &devices, &dev_idxs, &opts),
         OpenedFs::Offline(fs) => set_option_offline(fs, &devices, &dev_idxs, &opts),
     }
 }
@@ -123,6 +141,7 @@ fn set_option_offline(
     opts: &[(String, String)],
 ) -> Result<()> {
     let mut modified = false;
+    let mut needs_reconcile = false;
 
     for (name, value) in opts {
         let Some((opt_id, opt)) = bch_opt_lookup(name) else {
@@ -147,17 +166,20 @@ fn set_option_offline(
                 eprintln!("Error setting {name}: {e}");
                 continue;
             }
-            fs.opt_set_sb(None, opt, val, Some(&c_value));
-            modified = true;
+            if fs.opt_set_sb(None, opt, val, Some(&c_value)) {
+                modified = true;
+                needs_reconcile |= unsafe { c::bch2_opt_is_inode_opt(opt_id) };
+            }
         }
 
         if flags & c::opt_flags::OPT_DEVICE as u32 != 0 {
             let indices: Vec<u32> = if !dev_idxs.is_empty() {
                 dev_idxs.to_vec()
             } else {
-                devices.iter().filter_map(|dev| {
-                    name_to_dev_idx(&fs, dev).map(|i| i as u32)
-                }).collect()
+                devices
+                    .iter()
+                    .filter_map(|dev| name_to_dev_idx(&fs, dev).map(|i| i as u32))
+                    .collect()
             };
 
             for idx in indices {
@@ -170,18 +192,22 @@ fn set_option_offline(
                     eprintln!("Error setting {name}: {e}");
                     continue;
                 }
-                fs.opt_set_sb(Some(&ca), opt, val, Some(&c_value));
-                modified = true;
+                modified |= fs.opt_set_sb(Some(&ca), opt, val, Some(&c_value));
             }
         }
     }
 
     if modified {
         if fs.disk_sb().sb().sb_initialized() == 0 {
-            bail!("superblock not initialized (filesystem was never started): \
-                   bch2_write_super would silently skip the write; mount it once first");
+            bail!(
+                "superblock not initialized (filesystem was never started): \
+                   bch2_write_super would silently skip the write; mount it once first"
+            );
         }
         let _lock = fs.sb_lock();
+        if needs_reconcile {
+            schedule_reconcile_after_offline_io_opt_change(&fs)?;
+        }
         fs.write_super_force()
             .map_err(|e| anyhow::anyhow!("error writing superblock: {e}"))?;
     }
@@ -191,7 +217,10 @@ fn set_option_offline(
 
 fn name_to_dev_idx(fs: &Fs, name: &str) -> Option<usize> {
     (0..fs.nr_devices())
-        .find(|&i| fs.dev_get(i).is_some_and(|ca| ca.name().to_bytes() == name.as_bytes()))
+        .find(|&i| {
+            fs.dev_get(i)
+                .is_some_and(|ca| ca.name().to_bytes() == name.as_bytes())
+        })
         .map(|i| i as usize)
 }
 

--- a/src/commands/set_option.rs
+++ b/src/commands/set_option.rs
@@ -15,6 +15,17 @@ fn opt_flags() -> u32 {
     c::opt_flags::OPT_FS as u32 | c::opt_flags::OPT_DEVICE as u32
 }
 
+fn schedule_reconcile_after_offline_io_opt_change(fs: &bcachefs_kernel::fs::Fs) -> Result<()> {
+    let ext_u64s = (std::mem::size_of::<c::bch_sb_field_ext>() / std::mem::size_of::<u64>()) as u32;
+    let ext: &mut c::bch_sb_field_ext =
+        unsafe { bcachefs_kernel::sb::io::sb_field_get_minsize(&mut (*fs.raw).disk_sb, ext_u64s) }
+            .ok_or_else(|| anyhow::anyhow!("Error getting sb_field_ext"))?;
+    let pass = 1u64 << c::bch_recovery_pass::BCH_RECOVERY_PASS_set_fs_needs_reconcile as u64;
+    let stable_pass = unsafe { c::bch2_recovery_passes_to_stable(pass) };
+    ext.recovery_passes_required[0] |= stable_pass.to_le();
+    Ok(())
+}
+
 fn set_option_cmd() -> Command {
     Command::new("set-fs-option")
         .about("Set a filesystem option")
@@ -161,6 +172,7 @@ fn set_option_offline(
 ) -> Result<()> {
     let mut modified = false;
     let mut failed = std::collections::BTreeSet::new();
+    let mut needs_reconcile = false;
 
     for (name, value) in opts {
 
@@ -190,8 +202,10 @@ fn set_option_offline(
                 failed.insert(name.as_str());
                 continue;
             }
-            fs.opt_set_sb(None, opt, val, Some(&c_value));
-            modified = true;
+            if fs.opt_set_sb(None, opt, val, Some(&c_value)) {
+                modified = true;
+                needs_reconcile |= unsafe { c::bch2_opt_is_inode_opt(opt_id) };
+            }
         }
 
         if flags & c::opt_flags::OPT_DEVICE as u32 != 0 {
@@ -231,8 +245,7 @@ fn set_option_offline(
                     failed.insert(name.as_str());
                     continue;
                 }
-                fs.opt_set_sb(Some(&ca), opt, val, Some(&c_value));
-                modified = true;
+                modified |= fs.opt_set_sb(Some(&ca), opt, val, Some(&c_value));
             }
         }
     }
@@ -243,6 +256,9 @@ fn set_option_offline(
                    bch2_write_super would silently skip the write; mount it once first");
         }
         let _lock = fs.sb_lock();
+        if needs_reconcile {
+            schedule_reconcile_after_offline_io_opt_change(&fs)?;
+        }
         fs.write_super_force()
             .map_err(|e| anyhow::anyhow!("error writing superblock: {e}"))?;
     }


### PR DESCRIPTION
Fixes offline data migration after a filesystem-wide io-path target option
(`foreground_target`, `background_target`, `compression`, ...) is changed
while the filesystem is unmounted.

The trap: `bcachefs set-fs-option --background_target=hdd` on an unmounted
filesystem writes the new value into the superblock and reports success, but
nothing schedules a scan of existing data. The next mount starts up normally
and existing extents keep pointing at the old target forever — migration
never begins until something else happens to trigger a reconcile.

The fix:

- `Fs::opt_set_sb()` (`fs/init/fs.rs`) now returns whether it actually
  changed the value in the superblock, so re-setting an option to its
  current value is a no-op.
- In the offline path (`src/commands/set_option.rs`), when an inode
  io-path option actually changes, set the
  `BCH_RECOVERY_PASS_set_fs_needs_reconcile` bit in the superblock's
  `bch_sb_field_ext.recovery_passes_required`.
- That bit is persisted through the existing final `sb_lock` /
  `write_super_force()` write, so the next mount runs the recovery pass
  and the reconcile worker picks up the migration.

Online (mounted, sysfs) option changes are unaffected — those paths already
have their own scheduling/trigger hooks.

Related: koverstreet/bcachefs#964 (`background_target` unable to make
progress) reports the same missing-migration symptom after an offline
target change; worth retesting against this fix.

## Validation

Offline smoke test on loop-file images (`bcachefs format` + `set-fs-option`
+ `show-super`, no kernel mount involved):

- Two-device fs, `foreground_target=ssd background_target=ssd` at format
  time. Offline `set-fs-option --background_target=hdd` on the unmounted
  image → `show-super -f all` shows `Recovery passes required:
  set_fs_needs_reconcile`.
- No-op check: re-running the same `--background_target=hdd` a second
  time (value unchanged) does not add a duplicate write; the marker comes
  only from the actual value change.
- Single-device fs: `foreground_target` `ssd` → `none` also sets the
  marker.
- Negative control A: fresh, never-touched image → `Recovery passes
  required:` is empty.
- Negative control B: offline change of a non-inode-io option
  (`data_replicas`, not covered by `bch2_opt_is_inode_opt()`) → `Recovery
  passes required:` stays empty, confirming the gate is on the option
  kind, not just "something changed."

Build: `make -j -k` (full C+Rust build) and `cargo check -q -p
bcachefs-tools` both clean. `git diff --check` clean.

The diff is scoped to the two files above; no formatting-only changes are
included.
