### PR TITLE
doc: add ktest reproducer reporting guidance

### DIFF
--- a/Documentation/SubmittingPatches.rst
+++ b/Documentation/SubmittingPatches.rst
@@ -8,9 +8,10 @@ Submission checklist
 
 Patches must be tested before being submitted, either with the xfstests suite
 [0]_, or the full bcachefs test suite in ktest [1]_, depending on what's being
-touched. Note that ktest wraps xfstests and will be an easier method to running
-it for most users; it includes single-command wrappers for all the mainstream
-in-kernel local filesystems.
+touched. The bcachefs ktests live in the separate ktest repository, under
+``tests/fs/bcachefs/``. Note that ktest wraps xfstests and will be an easier
+method to running it for most users; it includes single-command wrappers for
+all the mainstream in-kernel local filesystems.
 
 Patches will undergo more testing after being merged (including
 lockdep/kasan/preempt/etc. variants), these are not generally required to be

--- a/doc/bcachefs-principles-of-operation.tex
+++ b/doc/bcachefs-principles-of-operation.tex
@@ -1441,6 +1441,32 @@ Valid hash types for string hash tables are:
 \section{Debugging tools}
 \label{sec:debugging}
 
+\subsection{Making a ktest reproducer}
+\label{sec:ktest-reproducer}
+
+When reporting a bug, first collect the facts from the machine that is failing:
+
+\begin{itemize}
+	\item what command or workload triggered it;
+	\item what happened, and what should have happened instead;
+	\item kernel version and \texttt{bcachefs-tools} version;
+	\item mount options and filesystem options;
+	\item relevant \texttt{dmesg}, journal, sysfs, or debugfs output.
+\end{itemize}
+
+A small ktest reproducer is useful even without a patch: maintainers can run it,
+debug it, and keep it as a regression test after the bug is fixed. ktest lives
+in a separate test harness repository\footnote{\url{https://evilpiepirate.org/git/ktest.git/}};
+bcachefs tests are under \texttt{tests/fs/bcachefs/}.
+
+If you hit a bug but are not confident writing filesystem tests yourself, you
+can still help. Codex, Claude, or another coding assistant may be able to turn
+your report into a small ktest reproducer. Give it the real logs and state from
+the failing machine. If you can safely let it inspect that machine, it can also
+act as an interactive debugging assistant: reading sysfs, debugfs, logs, stack
+traces, filesystem options, and command output to find the state that matters.
+Ask for a failing ktest before asking for a fix.
+
 \subsection{Sysfs interface}
 
 Mounted filesystems are available in sysfs at \texttt{/sys/fs/bcachefs/<uuid>/}

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -9,7 +9,12 @@
 
 ## ktest
 
-Tests live in `~/ktest/tests/fs/bcachefs/` (e.g. `subvol.ktest`).
+ktest is a separate test harness repository:
+<https://evilpiepirate.org/git/ktest.git/>. It is also available on GitHub as
+`koverstreet/ktest`.
+
+After checking out ktest locally, bcachefs tests live in
+`~/ktest/tests/fs/bcachefs/` (e.g. `subvol.ktest`).
 
 ```bash
 # Run a test


### PR DESCRIPTION
## Summary

- move the bug-reporting guidance into the Principles of Operation debugging section
- add a hands-on checklist for collecting failing-machine evidence
- explain that ktest lives in the separate ktest repository under `tests/fs/bcachefs/`
- mention Codex, Claude, or another coding assistant as an optional way to turn real machine evidence into a small ktest reproducer

## Context

This follows the IRC suggestion that this belongs in PoO: a user who hits a real bcachefs failure can still help by collecting evidence and, if useful, having an assistant inspect the failing machine/logs and draft a ktest reproducer before any fix.

## Validation

- `git diff --check`
- parsed `Documentation/SubmittingPatches.rst` with `docutils.core.publish_doctree`
- `env BINDGEN=$HOME/.cargo/bin/bindgen make bcachefs-principles-of-operation.pdf` progressed past the new section, then failed later in existing generated content on Unicode `↔` in `doc/generated/btree-node-cache.tex`
