### PR TITLE
reconcile: skip empty phys workers

### DIFF
--- a/fs/data/reconcile/types.h
+++ b/fs/data/reconcile/types.h
@@ -22,6 +22,9 @@ struct bch_fs_reconcile {
 	struct bbpos			work_pos;
 	struct bch_move_stats		work_stats;
 	struct progress_indicator	progress;
+	u64				phys_workers_considered;
+	u64				phys_workers_started;
+	u64				phys_workers_skipped_empty;
 
 	struct bbpos			scan_start;
 	struct bbpos			scan_end;

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1498,19 +1498,78 @@ static CLOSURE_CALLBACK(do_reconcile_phys_thread)
 	closure_return(cl);
 }
 
+static int reconcile_phys_dev_has_work(struct bch_fs *c, unsigned reconcile_phase,
+				       unsigned dev, bool *has_work)
+{
+	enum btree_id btree = reconcile_phases[reconcile_phase].btree;
+	bool found = false;
+
+	*has_work = false;
+
+	int ret = bch2_trans_do(c, ({
+		found = false;
+
+		CLASS(btree_iter, iter)(trans, btree, POS(dev, 0), BTREE_ITER_prefetch);
+		int ret = 0;
+
+		while (true) {
+			struct bkey_s_c k = bch2_btree_iter_peek(&iter);
+
+			ret = bkey_err(k);
+			if (ret)
+				break;
+
+			if (!k.k || k.k->p.inode != dev)
+				break;
+
+			if (k.k->type == KEY_TYPE_set) {
+				found = true;
+				break;
+			}
+
+			bch2_btree_iter_advance(&iter);
+		}
+
+		ret;
+	}));
+
+	if (!ret)
+		*has_work = found;
+
+	return ret;
+}
+
 static int do_reconcile_phys(struct bch_fs *c, unsigned reconcile_phase)
 {
+	struct bch_fs_reconcile *r = &c->reconcile;
 	CLASS(darray_reconcile_phys_thr, thrs)();
 	CLASS(closure_stack, cl)();
+	u64 considered = 0, started = 0, skipped_empty = 0;
 
-	for_each_member_device(c, ca)
+	for_each_member_device(c, ca) {
+		bool has_work;
+
 		if (ca->mi.rotational &&
-		    bch2_dev_is_online(ca))
+		    bch2_dev_is_online(ca)) {
+			considered++;
+			try(reconcile_phys_dev_has_work(c, reconcile_phase, ca->dev_idx, &has_work));
+			if (!has_work) {
+				skipped_empty++;
+				continue;
+			}
+
 			try(darray_push(&thrs, ((reconcile_phys_thr) {
 						.c			= c,
 						.dev			= ca->dev_idx,
 						.reconcile_phase	= reconcile_phase,
 						})));
+			started++;
+		}
+	}
+
+	WRITE_ONCE(r->phys_workers_considered, considered);
+	WRITE_ONCE(r->phys_workers_started, started);
+	WRITE_ONCE(r->phys_workers_skipped_empty, skipped_empty);
 
 	darray_for_each(thrs, i)
 		closure_call(&i->cl, do_reconcile_phys_thread, system_unbound_wq, &cl);
@@ -1920,6 +1979,11 @@ __cold void bch2_reconcile_status_to_text(struct printbuf *out, struct bch_fs *c
 			}
 		}
 	}
+
+	prt_printf(out, "phys workers last phase: considered %llu started %llu skipped empty %llu\n",
+		   READ_ONCE(r->phys_workers_considered),
+		   READ_ONCE(r->phys_workers_started),
+		   READ_ONCE(r->phys_workers_skipped_empty));
 
 	struct task_struct *t;
 	scoped_guard(rcu) {


### PR DESCRIPTION
Avoids starting one empty physical-reconcile worker for every online rotational
device.

Physical reconcile work is keyed by device. Before allocating and dispatching a
worker, the coordinator now checks whether that device's range contains an
actual set bit in the current physical-work btree. Devices with no work are
counted and skipped; nonempty devices keep the existing worker path.

`reconcile_status` exposes `considered`, `started`, and `skipped empty` counts
for the most recent physical phase so the fanout decision is observable.

Current head: `bbfac4a3ec327358a769cdf0883c117cf3a19744`.

Validation:

- Full `make -j16 bcachefs` build on current `testing`
- `git diff --check origin/testing...HEAD`
- Focused VM test: evacuate 256 MiB from one of eight rotational devices,
  require a nonzero physical worker while the other devices are skipped, and
  require `started + skipped == considered`; source evacuation and offline
  fsck then complete. The test passed in 17 seconds.
- Instrumented negative control without the skip logic observed
  `considered=8 started=8 skipped_empty=0` and failed the same predicate.
- Companion test: koverstreet/ktest#58
- Current-head GitHub Actions run:
  https://github.com/koverstreet/bcachefs-tools/actions/runs/29125701108
