### PR TITLE
device: persist offline evacuating scan intent

### DIFF
--- a/fs/bcachefs.h
+++ b/fs/bcachefs.h
@@ -443,6 +443,7 @@ struct io_count {
 	x(journal_read)					\
 	x(fs_journal_alloc)				\
 	x(fs_resize_on_mount)				\
+	x(member_reconcile_scan)			\
 	x(fs_mi_field_upgrades)				\
 	x(sb_journal_sort)				\
 	x(btree_node_read)				\

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -941,6 +941,40 @@ int bch2_dev_set_state(struct bch_fs *c, struct bch_dev *ca,
 	return __bch2_dev_set_state(c, ca, new_state, flags, err);
 }
 
+int bch2_dev_start_member_reconcile_scans(struct bch_fs *c)
+{
+	int ret = 0;
+
+	for_each_online_member(c, ca, BCH_DEV_READ_REF_member_reconcile_scan) {
+		struct bch_member m;
+
+		scoped_guard(mutex_noio, &c->sb_lock)
+			m = bch2_sb_member_get(c->disk_sb.sb, ca->dev_idx);
+
+		if (!BCH_MEMBER_NEEDS_RECONCILE_SCAN(&m))
+			continue;
+
+		ret = bch2_set_reconcile_needs_scan(c,
+			(struct reconcile_scan) {
+				.type	= RECONCILE_SCAN_device,
+				.dev	= ca->dev_idx,
+			}, true);
+		if (ret)
+			break;
+
+		scoped_guard(mutex_noio, &c->sb_lock) {
+			struct bch_member *member =
+				bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
+			SET_BCH_MEMBER_NEEDS_RECONCILE_SCAN(member, false);
+			ret = bch2_write_super(c);
+		}
+		if (ret)
+			break;
+	}
+
+	return ret;
+}
+
 /* Device add/removal: */
 
 static int __bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca,

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -941,6 +941,46 @@ int bch2_dev_set_state(struct bch_fs *c, struct bch_dev *ca,
 	return __bch2_dev_set_state(c, ca, new_state, flags, err);
 }
 
+int bch2_dev_start_member_reconcile_scans(struct bch_fs *c)
+{
+	/*
+	 * Best effort: a failure to queue or record a scan must not fail the
+	 * read-write transition. The member flag is only cleared after the
+	 * scan is queued, so anything that fails here is retried on the next
+	 * read-write transition.
+	 */
+	for_each_online_member(c, ca, BCH_DEV_READ_REF_member_reconcile_scan) {
+		struct bch_member m;
+
+		scoped_guard(mutex_noio, &c->sb_lock)
+			m = bch2_sb_member_get(c->disk_sb.sb, ca->dev_idx);
+
+		if (!BCH_MEMBER_NEEDS_RECONCILE_SCAN(&m))
+			continue;
+
+		int ret = bch2_set_reconcile_needs_scan(c,
+			(struct reconcile_scan) {
+				.type	= RECONCILE_SCAN_device,
+				.dev	= ca->dev_idx,
+			}, true);
+		if (ret) {
+			bch_err_fn(c, ret);
+			continue;
+		}
+
+		scoped_guard(mutex_noio, &c->sb_lock) {
+			struct bch_member *member =
+				bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
+			SET_BCH_MEMBER_NEEDS_RECONCILE_SCAN(member, false);
+			ret = bch2_write_super(c);
+		}
+		if (ret)
+			bch_err_fn(c, ret);
+	}
+
+	return 0;
+}
+
 /* Device add/removal: */
 
 static int __bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca,

--- a/fs/init/dev.h
+++ b/fs/init/dev.h
@@ -30,6 +30,7 @@ int __bch2_dev_set_state(struct bch_fs *, struct bch_dev *,
 int bch2_dev_set_state(struct bch_fs *, struct bch_dev *,
 		       enum bch_member_state, int,
 		       struct printbuf *);
+int bch2_dev_start_member_reconcile_scans(struct bch_fs *);
 
 int bch2_dev_add_initialize(struct bch_fs *, struct bch_dev *);
 

--- a/fs/init/fs.c
+++ b/fs/init/fs.c
@@ -612,7 +612,8 @@ static int __bch2_fs_read_write(struct bch_fs *c, bool early)
 		  bch2_btree_write_buffer_start(c) ?:
 		  bch2_copygc_start(c) ?:
 		  (!c->opts.read_only
-		   ? bch2_reconcile_start(c)
+		   ? bch2_reconcile_start(c) ?:
+		     bch2_dev_start_member_reconcile_scans(c)
 		   : 0);
 	if (ret) {
 		bch2_fs_read_only(c);

--- a/fs/sb/members.c
+++ b/fs/sb/members.c
@@ -308,6 +308,7 @@ __cold void bch2_member_to_text(struct printbuf *out,
 	prt_printf(out, "Discard:\t%llu\n", BCH_MEMBER_DISCARD(m));
 	prt_printf(out, "Freespace initialized:\t%llu\n", BCH_MEMBER_FREESPACE_INITIALIZED(m));
 	prt_printf(out, "Resize on mount:\t%llu\n", BCH_MEMBER_RESIZE_ON_MOUNT(m));
+	prt_printf(out, "Needs reconcile scan:\t%llu\n", BCH_MEMBER_NEEDS_RECONCILE_SCAN(m));
 
 	prt_printf(out, "Last device name:\t%.*s\n", (int) sizeof(m->device_name), m->device_name);
 	prt_printf(out, "Last device model:\t%.*s\n", (int) sizeof(m->device_model), m->device_model);

--- a/fs/sb/members.h
+++ b/fs/sb/members.h
@@ -424,6 +424,7 @@ static inline struct bch_member_cpu bch2_mi_to_cpu(struct bch_member *mi)
 		.group		= BCH_MEMBER_GROUP(mi),
 		/* .failure_domain is interned in bch2_sb_members_to_cpu() */
 		.state		= BCH_MEMBER_STATE(mi),
+		.needs_reconcile_scan = BCH_MEMBER_NEEDS_RECONCILE_SCAN(mi),
 		.discard	= BCH_MEMBER_DISCARD(mi),
 		.data_allowed	= BCH_MEMBER_DATA_ALLOWED(mi),
 		.durability	= BCH_MEMBER_DURABILITY(mi)

--- a/fs/sb/members.rs
+++ b/fs/sb/members.rs
@@ -171,6 +171,7 @@ pub fn members_v1(sb: &c::bch_sb) -> Option<MembersV1<'_>> {
 bitmask_accessors! {
     bch_member, flags,
         BCH_MEMBER_STATE          => (member_state, set_member_state),
+        BCH_MEMBER_NEEDS_RECONCILE_SCAN => (member_needs_reconcile_scan, set_member_needs_reconcile_scan),
         BCH_MEMBER_GROUP          => (member_group, set_member_group),
         BCH_MEMBER_DATA_ALLOWED   => (member_data_allowed, set_member_data_allowed),
         BCH_MEMBER_RESIZE_ON_MOUNT => (member_resize_on_mount, set_member_resize_on_mount),

--- a/fs/sb/members_format.h
+++ b/fs/sb/members_format.h
@@ -103,7 +103,9 @@ struct bch_member {
 
 LE16_BITMASK(BCH_MEMBER_BUCKET_SIZE,	struct bch_member, bucket_size,  0, 16)
 LE64_BITMASK(BCH_MEMBER_STATE,		struct bch_member, flags,  0,  4)
-/* 4-14 unused, was TIER, HAS_(META)DATA, REPLACEMENT */
+LE64_BITMASK(BCH_MEMBER_NEEDS_RECONCILE_SCAN,
+					struct bch_member, flags,  4,  5)
+/* 5-14 unused, was TIER, HAS_(META)DATA, REPLACEMENT */
 LE64_BITMASK(BCH_MEMBER_DISCARD,	struct bch_member, flags, 14, 15)
 LE64_BITMASK(BCH_MEMBER_DATA_ALLOWED,	struct bch_member, flags, 15, 20)
 LE64_BITMASK(BCH_MEMBER_GROUP,		struct bch_member, flags, 20, 28)

--- a/fs/sb/members_format.h
+++ b/fs/sb/members_format.h
@@ -115,6 +115,9 @@ LE64_BITMASK(BCH_MEMBER_ROTATIONAL,	struct bch_member, flags, 32, 33)
 LE64_BITMASK(BCH_MEMBER_ROTATIONAL_SET,	struct bch_member, flags, 33, 34)
 LE64_BITMASK(BCH_MEMBER_INITIALIZED,	struct bch_member, flags, 34, 38)
 /* 38-46 free, was FAILURE_DOMAIN (now a string, member.failure_domain) */
+LE64_BITMASK(BCH_MEMBER_NEEDS_RECONCILE_SCAN,
+					struct bch_member, flags, 46, 47)
+/* 47-63 unused: never previously assigned */
 
 #if 0
 LE64_BITMASK(BCH_MEMBER_NR_READ_ERRORS,	struct bch_member, flags[1], 0,  20);

--- a/fs/sb/members_types.h
+++ b/fs/sb/members_types.h
@@ -10,6 +10,7 @@ struct bch_member_cpu {
 	u16			group;
 	u16			failure_domain;
 	u8			state;
+	u8			needs_reconcile_scan;
 	u8			discard;
 	u8			data_allowed;
 	u8			durability;

--- a/src/commands/device.rs
+++ b/src/commands/device.rs
@@ -376,7 +376,11 @@ fn set_state_offline(device: &str, new_state: u32) -> Result<()> {
 
     {
         let _lock = fs.sb_lock();
-        unsafe { fs.member_mut(dev_idx) }.set_member_state(new_state as u64);
+        let member = unsafe { fs.member_mut(dev_idx) };
+        member.set_member_state(new_state as u64);
+        member.set_member_needs_reconcile_scan(
+            (new_state == BCH_MEMBER_STATE_evacuating as u32) as u64,
+        );
         fs.write_super_force()
             .map_err(|e| anyhow!("error writing superblock: {}", e))?;
     }


### PR DESCRIPTION
Persists an offline device-evacuation request so the next read-write mount
actually scans and drains that member.

Previously, `bcachefs device set-state --offline --force evacuating` could store
the member state without durable scan intent. The next mount then showed the
device as evacuating while reconcile had no targeted work and user buckets
could remain on it.

The offline state transition now sets a per-member `Needs reconcile scan` bit
(bit 46 of `bch_member.flags`, never previously assigned to any field — unlike
the currently-free bits 4-14 and 38-46, which are free only because the
TIER/HAS_(META)DATA/REPLACEMENT and FAILURE_DOMAIN fields that used to live
there were removed, so their zero-ness on old superblocks isn't guaranteed
the same way). Mount recovery turns that bit into the existing targeted
device scan, and the bit is cleared once the scan intent is durably queued in
the reconcile_scan btree (the queued intent survives crashes). A queueing
failure is logged, leaves the bit set, and is retried on the next
read-write transition instead of failing the transition.

Upgrade/downgrade: this is a new field with an implicit zero default, so
every existing superblock already reads 0 for bit 46 (no scan pending) and
no migration or format bump is needed. A tool/kernel build that predates
this patch does not know about bit 46 and leaves it untouched, exactly as it
already does for every other reserved bit in this field.

Current head: `77e4066ec32843da1638703cbcee5feb76e8ef2f`.

Validation:

- Full `make -j16 bcachefs` build on current `testing`
- `git diff --check origin/testing...HEAD`
- Negative control without this change failed because the offline transition
  did not persist `Needs reconcile scan: 1`.
- Focused VM test on this head verified the bit after offline state change,
  verified that `evacuating` survived remount, drained all source user data,
  cleared the bit, and passed offline fsck. It completed in 10 seconds.
- Companion test: koverstreet/ktest#59
- Current-head GitHub Actions run:
  https://github.com/koverstreet/bcachefs-tools/actions/runs/29125703287
