### PR TITLE
mount: wait briefly for late UUID members

### DIFF
--- a/Changelog.mdwn
+++ b/Changelog.mdwn
@@ -568,6 +568,9 @@ unit so systemd doesn't try to mount before all members are visible.
 Ships with a `bcachefs-wait-devices@.service` template unit in the
 Debian package.
 
+`bcachefs wait-devices` now accepts `--timeout` to bound the wait and
+`-v`/`--verbose` to report how many initialized devices have been found.
+
 ### Userspace
 
 `bcachefs fs top` gained live tracepoint drill-down: every counter on the

--- a/Changelog.mdwn
+++ b/Changelog.mdwn
@@ -533,6 +533,9 @@ unit so systemd doesn't try to mount before all members are visible.
 Ships with a `bcachefs-wait-devices@.service` template unit in the
 Debian package.
 
+`bcachefs wait-devices` now accepts `--timeout` to bound the wait and
+`-v`/`--verbose` to report how many initialized devices have been found.
+
 ### Userspace
 
 `bcachefs fs top` gained live tracepoint drill-down: every counter on the

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -1,16 +1,20 @@
 use std::{
+    collections::HashSet,
+    env,
     ffi::{CStr, CString, OsString},
     io::{stdout, IsTerminal},
     os::unix::ffi::OsStringExt,
     path::{Path, PathBuf},
     ptr, str,
+    time::Duration,
 };
 
 use anyhow::{ensure, Context, Result};
 use bcachefs_kernel::c::bch_sb_handle;
+use bcachefs_kernel::opt_get;
 use bcachefs_kernel::path_to_cstr;
 use clap::Parser;
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use crate::device_scan;
 
 use crate::{
@@ -115,6 +119,9 @@ fn mount_fs_context(
 
     Ok(Mounted::Yes)
 }
+
+const DEFAULT_MOUNT_DEVICE_WAIT_SECS: u64 = 10;
+const MOUNT_DEVICE_WAIT_ENV: &str = "BCACHEFS_MOUNT_DEVICE_WAIT_SECS";
 
 fn mount_inner(
     src: OsString,
@@ -320,6 +327,49 @@ fn handle_unlock(cli: &Cli, sb: &bch_sb_handle) -> Result<KeyHandle> {
     KeyHandle::new(&passphrase_correct, Keyring::User)
 }
 
+fn incomplete_device_scan(sbs: &[(PathBuf, bch_sb_handle)]) -> Option<(uuid::Uuid, usize, usize)> {
+    let (_, first) = sbs.first()?;
+    let expected = first.sb().number_of_devices() as usize;
+    if expected <= 1 {
+        return None;
+    }
+
+    let found = sbs
+        .iter()
+        .map(|(_, sb)| sb.sb().dev_idx)
+        .collect::<HashSet<_>>()
+        .len();
+
+    (found < expected).then_some((first.sb().uuid(), found, expected))
+}
+
+fn mount_device_wait_timeout() -> Option<Duration> {
+    let secs = env::var(MOUNT_DEVICE_WAIT_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_MOUNT_DEVICE_WAIT_SECS);
+
+    (secs != 0).then_some(Duration::from_secs(secs))
+}
+
+fn mount_allows_degraded(opts: &bcachefs_kernel::c::bch_opts) -> bool {
+    opt_get!(opts, degraded) != 0
+}
+
+fn mount_should_wait_for_devices(
+    uuid: Option<uuid::Uuid>,
+    opts: &bcachefs_kernel::c::bch_opts,
+    mountflags: libc::c_ulong,
+    sbs: &[(PathBuf, bch_sb_handle)],
+) -> Option<(uuid::Uuid, usize, usize)> {
+    if mountflags & libc::MS_REMOUNT != 0 || mount_allows_degraded(opts) {
+        return None;
+    }
+
+    let uuid = uuid?;
+    incomplete_device_scan(sbs).map(|(_, found, expected)| (uuid, found, expected))
+}
+
 fn cmd_mount_inner(cli: &Cli) -> Result<()> {
     if cli.no_mtab {
         debug!("ignoring -n/--no-mtab; mount.bcachefs does not update /etc/mtab");
@@ -332,7 +382,36 @@ fn cmd_mount_inner(cli: &Cli) -> Result<()> {
     let opts = bcachefs_kernel::opts::parse_mount_opts(None, parsed.fs_opts.as_deref(), true)
         .unwrap_or_default();
 
-    let sbs = device_scan::scan_sbs(&cli.dev, &opts)?;
+    let mut sbs = device_scan::scan_sbs(&cli.dev, &opts)?;
+    let mount_uuid = device_scan::parse_uuid_equals(&cli.dev)?;
+
+    if let Some((uuid, found, expected)) =
+        mount_should_wait_for_devices(mount_uuid, &opts, parsed.flags, &sbs)
+    {
+        if let Some(timeout) = mount_device_wait_timeout() {
+            info!(
+                "found {found}/{expected} devices for UUID={uuid}; waiting up to {}s for late devices",
+                timeout.as_secs()
+            );
+
+            match super::wait_devices::wait_for_devices(uuid, Some(timeout), &opts) {
+                Ok(true) => {
+                    info!("all devices appeared for UUID={uuid}; rescanning before mount");
+                }
+                Ok(false) => {
+                    warn!(
+                        "timed out waiting for all devices for UUID={uuid}; rescanning before mount"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        "error while waiting for all devices for UUID={uuid}: {e}; rescanning before mount"
+                    );
+                }
+            }
+            sbs = device_scan::scan_sbs(&cli.dev, &opts)?;
+        }
+    }
 
     ensure!(!sbs.is_empty(), "No device(s) to mount specified");
 

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -1,22 +1,29 @@
 use std::{
+    collections::HashSet,
+    env,
     ffi::{CString, OsString},
     io::{stdout, IsTerminal},
     os::unix::ffi::OsStringExt,
     path::{Path, PathBuf},
     ptr, str,
+    time::Duration,
 };
 
 use anyhow::{ensure, Result};
 use bcachefs_kernel::c::bch_sb_handle;
+use bcachefs_kernel::opt_get;
 use bcachefs_kernel::path_to_cstr;
 use clap::Parser;
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use crate::device_scan;
 
 use crate::{
     key::{KeyHandle, Keyring, Passphrase, UnlockPolicy},
     logging,
 };
+
+const DEFAULT_MOUNT_DEVICE_WAIT_SECS: u64 = 10;
+const MOUNT_DEVICE_WAIT_ENV: &str = "BCACHEFS_MOUNT_DEVICE_WAIT_SECS";
 
 fn mount_inner(
     src: OsString,
@@ -188,6 +195,49 @@ fn handle_unlock(cli: &Cli, sb: &bch_sb_handle) -> Result<KeyHandle> {
     KeyHandle::new(&passphrase_correct, Keyring::User)
 }
 
+fn incomplete_device_scan(sbs: &[(PathBuf, bch_sb_handle)]) -> Option<(uuid::Uuid, usize, usize)> {
+    let (_, first) = sbs.first()?;
+    let expected = first.sb().number_of_devices() as usize;
+    if expected <= 1 {
+        return None;
+    }
+
+    let found = sbs
+        .iter()
+        .map(|(_, sb)| sb.sb().dev_idx)
+        .collect::<HashSet<_>>()
+        .len();
+
+    (found < expected).then_some((first.sb().uuid(), found, expected))
+}
+
+fn mount_device_wait_timeout() -> Option<Duration> {
+    let secs = env::var(MOUNT_DEVICE_WAIT_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_MOUNT_DEVICE_WAIT_SECS);
+
+    (secs != 0).then_some(Duration::from_secs(secs))
+}
+
+fn mount_allows_degraded(opts: &bcachefs_kernel::c::bch_opts) -> bool {
+    opt_get!(opts, degraded) != 0
+}
+
+fn mount_should_wait_for_devices(
+    uuid: Option<uuid::Uuid>,
+    opts: &bcachefs_kernel::c::bch_opts,
+    mountflags: libc::c_ulong,
+    sbs: &[(PathBuf, bch_sb_handle)],
+) -> Option<(uuid::Uuid, usize, usize)> {
+    if mountflags & libc::MS_REMOUNT != 0 || mount_allows_degraded(opts) {
+        return None;
+    }
+
+    let uuid = uuid?;
+    incomplete_device_scan(sbs).map(|(_, found, expected)| (uuid, found, expected))
+}
+
 fn cmd_mount_inner(cli: &Cli) -> Result<()> {
     if cli.no_mtab {
         debug!("ignoring -n/--no-mtab; mount.bcachefs does not update /etc/mtab");
@@ -200,7 +250,36 @@ fn cmd_mount_inner(cli: &Cli) -> Result<()> {
     let opts = bcachefs_kernel::opts::parse_mount_opts(None, parsed.fs_opts.as_deref(), true)
         .unwrap_or_default();
 
-    let sbs = device_scan::scan_sbs(&cli.dev, &opts)?;
+    let mut sbs = device_scan::scan_sbs(&cli.dev, &opts)?;
+    let mount_uuid = device_scan::parse_uuid_equals(&cli.dev)?;
+
+    if let Some((uuid, found, expected)) =
+        mount_should_wait_for_devices(mount_uuid, &opts, parsed.flags, &sbs)
+    {
+        if let Some(timeout) = mount_device_wait_timeout() {
+            info!(
+                "found {found}/{expected} devices for UUID={uuid}; waiting up to {}s for late devices",
+                timeout.as_secs()
+            );
+
+            match super::wait_devices::wait_for_devices(uuid, Some(timeout), &opts) {
+                Ok(true) => {
+                    info!("all devices appeared for UUID={uuid}; rescanning before mount");
+                }
+                Ok(false) => {
+                    warn!(
+                        "timed out waiting for all devices for UUID={uuid}; rescanning before mount"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        "error while waiting for all devices for UUID={uuid}: {e}; rescanning before mount"
+                    );
+                }
+            }
+            sbs = device_scan::scan_sbs(&cli.dev, &opts)?;
+        }
+    }
 
     ensure!(!sbs.is_empty(), "No device(s) to mount specified");
 

--- a/src/commands/wait_devices.rs
+++ b/src/commands/wait_devices.rs
@@ -10,11 +10,11 @@ use anyhow::bail;
 use bcachefs_kernel::c;
 use c::bch_sb_handle;
 use clap::Parser;
-use log::{debug, warn};
+use log::{debug, info, warn};
 use rustix::event::{poll, PollFd, PollFlags, Timespec};
 use uuid::Uuid;
 
-use crate::device_scan;
+use crate::{device_scan, logging};
 
 /// Waits until every device in a filesystem is initialized.
 #[derive(Parser, Debug)]
@@ -32,9 +32,15 @@ pub struct Cli {
     /// Maximum seconds to wait. The default is to wait forever.
     #[arg(long)]
     timeout: Option<u64>,
+
+    /// Be verbose. Can be specified more than once.
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
 }
 
 fn cmd_wait_devices(cli: Cli) -> anyhow::Result<()> {
+    logging::setup(cli.verbose, false);
+
     let Some(uuid) = device_scan::parse_uuid_equals(&cli.device)? else {
         bail!("invalid device string: {}", cli.device);
     };
@@ -109,7 +115,7 @@ fn duration_to_timespec(duration: Duration) -> Timespec {
 struct WaitInitialized {
     uuid: Uuid,
     opts: c::bch_opts,
-    sbs:  Vec<(PathBuf, bch_sb_handle)>,
+    sbs: Vec<(PathBuf, bch_sb_handle)>,
     started_at: Instant,
 }
 
@@ -118,7 +124,7 @@ impl WaitInitialized {
         WaitInitialized {
             uuid,
             opts,
-	    sbs: Vec::new(),
+            sbs: Vec::new(),
             started_at: Instant::now(),
         }
     }
@@ -164,14 +170,14 @@ impl WaitInitialized {
             "adding device at {} with index {dev_idx}",
             devnode.display()
         );
-	self.sbs.push((devnode.to_path_buf(), sb_handle));
+        self.sbs.push((devnode.to_path_buf(), sb_handle));
         Ok(())
     }
 
     fn remove(&mut self, devnode: &Path) {
-	if let Some(i) = self.sbs.iter().position(|(dev, _)| dev == devnode) {
-	    let dev_idx = self.sbs[i].1.sb().dev_idx;
-	    self.sbs.remove(i);
+        if let Some(i) = self.sbs.iter().position(|(dev, _)| dev == devnode) {
+            let dev_idx = self.sbs[i].1.sb().dev_idx;
+            self.sbs.remove(i);
             debug!(
                 "removing device at {} with index {dev_idx}",
                 devnode.display()
@@ -199,21 +205,30 @@ impl WaitInitialized {
     }
 
     fn every_device_is_initialized(&mut self) -> anyhow::Result<bool> {
-	self.sbs = device_scan::filter_current_sbs(std::mem::take(&mut self.sbs), &self.opts)?;
+        self.sbs = device_scan::filter_current_sbs(std::mem::take(&mut self.sbs), &self.opts)?;
 
-	let Some((_, best)) = self.sbs.first() else {
-	    return Ok(false);
+        let Some((_, best)) = self.sbs.first() else {
+            return Ok(false);
         };
 
-	let number_of_devices = best.sb().number_of_devices() as usize;
-	let unique_dev_indices: HashSet<u8> = self.sbs
-	    .iter()
-	    .map(|(_, sb)| sb.sb().dev_idx)
-	    .collect();
+        let number_of_devices = best.sb().number_of_devices() as usize;
+        let unique_dev_indices: HashSet<u8> =
+            self.sbs.iter().map(|(_, sb)| sb.sb().dev_idx).collect();
 
-	Ok(unique_dev_indices.len() == number_of_devices)
+        info!(
+            "found {}/{} initialized devices for UUID={}",
+            unique_dev_indices.len(),
+            number_of_devices,
+            self.uuid
+        );
+
+        Ok(unique_dev_indices.len() == number_of_devices)
     }
 }
 
-pub const CMD: super::CmdDef =
-    typed_cmd!("wait-devices", "Wait until every device in a filesystem is initialized", Cli, cmd_wait_devices);
+pub const CMD: super::CmdDef = typed_cmd!(
+    "wait-devices",
+    "Wait until every device in a filesystem is initialized",
+    Cli,
+    cmd_wait_devices
+);

--- a/src/commands/wait_devices.rs
+++ b/src/commands/wait_devices.rs
@@ -3,6 +3,7 @@ use std::{
     ffi::OsStr,
     os::fd::{AsRawFd, BorrowedFd},
     path::{Path, PathBuf},
+    time::{Duration, Instant},
 };
 
 use anyhow::bail;
@@ -10,7 +11,7 @@ use bcachefs_kernel::c;
 use c::bch_sb_handle;
 use clap::Parser;
 use log::{debug, warn};
-use rustix::event::{poll, PollFd, PollFlags};
+use rustix::event::{poll, PollFd, PollFlags, Timespec};
 use uuid::Uuid;
 
 use crate::device_scan;
@@ -27,6 +28,10 @@ exit status means that an error was encountered."
 pub struct Cli {
     /// A device string in the UUID=\<UUID\> format.
     device: String,
+
+    /// Maximum seconds to wait. The default is to wait forever.
+    #[arg(long)]
+    timeout: Option<u64>,
 }
 
 fn cmd_wait_devices(cli: Cli) -> anyhow::Result<()> {
@@ -34,7 +39,20 @@ fn cmd_wait_devices(cli: Cli) -> anyhow::Result<()> {
         bail!("invalid device string: {}", cli.device);
     };
 
-    let mut wait_initialized = WaitInitialized::new(uuid);
+    let opts = c::bch_opts::default();
+    if !wait_for_devices(uuid, cli.timeout.map(Duration::from_secs), &opts)? {
+        bail!("timed out waiting for all devices for UUID={uuid}");
+    }
+
+    Ok(())
+}
+
+pub fn wait_for_devices(
+    uuid: Uuid,
+    timeout: Option<Duration>,
+    opts: &c::bch_opts,
+) -> anyhow::Result<bool> {
+    let mut wait_initialized = WaitInitialized::new(uuid, *opts);
 
     let socket = udev::MonitorBuilder::new()?
         .match_subsystem("block")?
@@ -53,10 +71,20 @@ fn cmd_wait_devices(cli: Cli) -> anyhow::Result<()> {
     }
 
     while !wait_initialized.every_device_is_initialized()? {
+        let poll_timeout = timeout
+            .and_then(|timeout| deadline_remaining(wait_initialized.started_at, timeout))
+            .map(duration_to_timespec);
+        if timeout.is_some() && poll_timeout.is_none() {
+            return Ok(false);
+        }
+
         let socket_fd = unsafe { BorrowedFd::borrow_raw(socket.as_raw_fd()) };
 
         let mut fds = [PollFd::new(&socket_fd, PollFlags::IN)];
-        poll(&mut fds, None)?;
+        let event_count = poll(&mut fds, poll_timeout.as_ref())?;
+        if event_count == 0 {
+            return Ok(false);
+        }
         if fds.iter().any(|fd| fd.revents().contains(PollFlags::ERR)) {
             bail!("error on udev socket fd");
         }
@@ -64,19 +92,34 @@ fn cmd_wait_devices(cli: Cli) -> anyhow::Result<()> {
         wait_initialized.process_events(&socket)?;
     }
 
-    Ok(())
+    Ok(true)
+}
+
+fn deadline_remaining(started_at: Instant, timeout: Duration) -> Option<Duration> {
+    timeout.checked_sub(started_at.elapsed())
+}
+
+fn duration_to_timespec(duration: Duration) -> Timespec {
+    Timespec {
+        tv_sec: duration.as_secs().try_into().unwrap_or(i64::MAX),
+        tv_nsec: duration.subsec_nanos().into(),
+    }
 }
 
 struct WaitInitialized {
     uuid: Uuid,
+    opts: c::bch_opts,
     sbs:  Vec<(PathBuf, bch_sb_handle)>,
+    started_at: Instant,
 }
 
 impl WaitInitialized {
-    fn new(uuid: Uuid) -> Self {
+    fn new(uuid: Uuid, opts: c::bch_opts) -> Self {
         WaitInitialized {
             uuid,
+            opts,
 	    sbs: Vec::new(),
+            started_at: Instant::now(),
         }
     }
 
@@ -96,8 +139,7 @@ impl WaitInitialized {
         if device_scan::should_skip_multipath_component(device) {
             return Ok(());
         }
-	let opts = c::bch_opts::default();
-        let sb_handle = match device_scan::read_super_silent(devnode, opts) {
+        let sb_handle = match device_scan::read_super_silent(devnode, self.opts) {
             Ok(handle) => handle,
             Err(err) if err.raw() == libc::ENOENT => return Ok(()),
             Err(err) => return Err(err.into()),
@@ -157,8 +199,7 @@ impl WaitInitialized {
     }
 
     fn every_device_is_initialized(&mut self) -> anyhow::Result<bool> {
-	let opts = c::bch_opts::default();
-	self.sbs = device_scan::filter_current_sbs(std::mem::take(&mut self.sbs), &opts)?;
+	self.sbs = device_scan::filter_current_sbs(std::mem::take(&mut self.sbs), &self.opts)?;
 
 	let Some((_, best)) = self.sbs.first() else {
 	    return Ok(false);


### PR DESCRIPTION
## Summary

Multi-device filesystems mounted as `UUID=...` can be attempted before udev
has finished tagging every member device during boot. When that happens the
mount helper's device scan is short: it sees fewer devices than the
superblock says exist, and the mount either fails outright or comes up
degraded even though every member is present and about to show up a moment
later. This race has been reported repeatedly, on different distros and
different udev timings: koverstreet/bcachefs-tools#308,
koverstreet/bcachefs-tools#44, koverstreet/bcachefs-tools#174,
koverstreet/bcachefs-tools#571, koverstreet/bcachefs#930,
koverstreet/bcachefs#975.

This PR makes `UUID=...` mounts wait briefly for the rest of the members
before giving up. When a plain UUID mount (not a remount, not an explicit
degraded mount) finds an incomplete device set, it waits up to a bounded
timeout for the missing members to appear and then rescans before mounting.
Explicit device-path and colon-list mounts are unchanged; only `UUID=`
mounts pay this cost, and only when the first scan is actually short.

- Default wait is 10s, overridable (including disabling it, with `0`) via
  `BCACHEFS_MOUNT_DEVICE_WAIT_SECS`.
- `bcachefs wait-devices` gains a matching `--timeout` so callers get a
  bounded wait instead of the previous wait-forever loop, and `-v`/
  `--verbose` progress logging so a stuck wait can show how many of the
  expected devices have been seen so far. `mount` reuses this same
  `wait_for_devices()` helper internally.

## Testing

- `git diff --check`
- `rustfmt --edition 2021 --check src/commands/wait_devices.rs` (`mount.rs`
  is left out of the rustfmt check: it currently wants to reformat existing
  untouched code in that file, unrelated to this change)
- `make generate_version && BINDGEN=$(command -v bindgen) cargo build --release --locked`
- Loop-device smoke test of `wait-devices` itself (this does not exercise
  the kernel mount path — see the note below): formatted a 2-device
  filesystem across two loop devices, detached the loop device for the
  second member to simulate it being late/missing, then ran
  `bcachefs wait-devices UUID=<uuid> --timeout 10 -v` in the background.
  - Positive case: reattached the second loop device 3s in. `wait-devices`
    exited 0 about 0.12s after the device reappeared (3.12s total, well
    under the 10s timeout), confirming it wakes on the device appearing
    rather than sleeping to the timeout.
  - Negative control: same setup, but the second device was kept detached
    for the whole run. `wait-devices` exited non-zero at ~10.11s, i.e. at
    the timeout, confirming it doesn't return early or hang past the bound
    when the device never shows up.

Honest gap: the above proves `wait-devices`'s own wait/timeout/rescan
behavior against loop devices, not the actual boot-time `mount -U <uuid>`
path with a real kernel mount racing real udev events. That full
kernel-mount scenario is queued separately for a VM test batch and isn't
covered by this local smoke test.
