### PR TITLE
cmd: test online device option routing

### DIFF
--- a/src/commands/set_option.rs
+++ b/src/commands/set_option.rs
@@ -13,6 +13,14 @@ fn opt_flags() -> u32 {
     c::opt_flags::OPT_FS as u32 | c::opt_flags::OPT_DEVICE as u32
 }
 
+fn has_flag(flags: u32, flag: c::opt_flags) -> bool {
+    flags & flag as u32 != 0
+}
+
+fn write_online_fs_option(flags: u32) -> bool {
+    has_flag(flags, c::opt_flags::OPT_FS) && !has_flag(flags, c::opt_flags::OPT_DEVICE)
+}
+
 fn set_option_cmd() -> Command {
     Command::new("set-fs-option")
         .about("Set a filesystem option")
@@ -82,14 +90,11 @@ fn set_option_online(
             continue;
         }
 
-        let is_fs_opt = flags & c::opt_flags::OPT_FS as u32 != 0;
-        let is_device_opt = flags & c::opt_flags::OPT_DEVICE as u32 != 0;
-
-        if is_fs_opt && !is_device_opt {
+        if write_online_fs_option(flags) {
             sysfs::sysfs_write_str(fs.sysfs_fd(), &format!("options/{name}"), value);
         }
 
-        if is_device_opt {
+        if has_flag(flags, c::opt_flags::OPT_DEVICE) {
             if !dev_idxs.is_empty() {
                 for dev_idx in dev_idxs {
                     sysfs::sysfs_write_str(fs.sysfs_fd(), &format!("dev-{dev_idx}/{name}"), value);
@@ -147,7 +152,7 @@ fn set_option_offline(
             continue;
         }
 
-        if flags & c::opt_flags::OPT_FS as u32 != 0 {
+        if has_flag(flags, c::opt_flags::OPT_FS) {
             let ret = unsafe {
                 c::bch2_opt_hook_pre_set(fs.raw, std::ptr::null_mut(), 0, opt_id, val, true, std::ptr::null_mut())
             };
@@ -158,7 +163,7 @@ fn set_option_offline(
             unsafe { c::bch2_opt_set_sb(fs.raw, std::ptr::null_mut(), opt, val); }
         }
 
-        if flags & c::opt_flags::OPT_DEVICE as u32 != 0 {
+        if has_flag(flags, c::opt_flags::OPT_DEVICE) {
             let indices: Vec<u32> = if !dev_idxs.is_empty() {
                 dev_idxs.to_vec()
             } else {
@@ -211,3 +216,18 @@ fn name_to_dev_idx(c: *mut c::bch_fs, name: &str) -> Option<usize> {
 }
 
 pub const CMD: super::CmdDef = raw_cmd!("set-fs-option", "Set filesystem options", cmd_set_option);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn online_sysfs_path_skips_fs_entry_for_device_scoped_options() {
+        let fs = c::opt_flags::OPT_FS as u32;
+        let dev = c::opt_flags::OPT_DEVICE as u32;
+
+        assert!(write_online_fs_option(fs));
+        assert!(!write_online_fs_option(dev));
+        assert!(!write_online_fs_option(fs | dev));
+    }
+}


### PR DESCRIPTION
## Summary

This PR is reworked after the original behavior fix was already applied upstream as `e8bae6a87` (`set-fs-option: route online device options by device`).

Current branch scope is now only a small cleanup/test around that upstreamed behavior:

- keeps the online routing rule in a helper: write `options/<name>` only for FS-only options;
- keeps `OPT_DEVICE` and `OPT_FS|OPT_DEVICE` options on the per-device `dev-N/<name>` path;
- adds a unit test for the `OPT_FS`, `OPT_DEVICE`, and `OPT_FS|OPT_DEVICE` routing cases.

The original issue was that `set-fs-option --discard <device>` should not try the filesystem-level sysfs option path when the option is also device-scoped. Current master already has the behavior fix, so this PR no longer claims to be the primary fix for koverstreet/bcachefs-tools#218.

## Validation

Current head `0636f2d28`:

- `git diff --check origin/master..HEAD`
- `make generate_version`
- `BINDGEN=/home/kom/.cargo/bin/bindgen LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu make -j32 libbcachefs.a`
- `BINDGEN=/home/kom/.cargo/bin/bindgen LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu cargo test --locked online_sysfs_path_skips_fs_entry_for_device_scoped_options`

The focused cargo test passed with 1 matching test. The build emitted pre-existing warnings in unrelated code paths (`list_journal.rs`, `scrub.rs`, C warnings while building `libbcachefs.a`).
