### PR TITLE
fs usage: tolerate offline devices

### DIFF
--- a/src/commands/fs_usage.rs
+++ b/src/commands/fs_usage.rs
@@ -76,7 +76,7 @@ fn fs_usage(cli: Cli) -> Result<()> {
 
 struct DevContext {
     info: DevInfo,
-    usage: DevUsage,
+    usage: Option<DevUsage>,
     leaving: u64,
 }
 
@@ -495,8 +495,12 @@ fn devs_usage_to_text(
 
     let mut dev_ctxs: Vec<DevContext> = Vec::new();
     for dev in devs {
-        let usage = handle.dev_usage(dev.idx)
-            .map_err(|e| anyhow!("getting usage for device {}: {}", dev.idx, e))?;
+        let usage = if dev.online {
+            Some(handle.dev_usage(dev.idx)
+                .map_err(|e| anyhow!("getting usage for device {}: {}", dev.idx, e))?)
+        } else {
+            None
+        };
         let leaving = dev_leaving_sectors(&dev_leaving_map, dev.idx);
         dev_ctxs.push(DevContext { info: dev.clone(), usage, leaving });
     }
@@ -527,20 +531,31 @@ fn devs_usage_to_text(
             sub.newline();
 
             for d in &dev_ctxs {
-                let hidden = d.usage.hidden_sectors();
-                let capacity = d.usage.capacity_sectors() - hidden;
-                let used = d.usage.used_sectors() - hidden;
                 let label = d.info.label.as_deref().unwrap_or("(no label)");
-                let state = bcachefs_kernel::sb::members::member_state_str(d.usage.state);
+                write!(sub, "{} (device {}):\t{}\t", label, d.info.idx, d.info.dev).unwrap();
 
-                write!(sub, "{} (device {}):\t{}\t{}\t", label, d.info.idx, d.info.dev, state).unwrap();
+                let Some(usage) = &d.usage else {
+                    write!(sub, "offline\t-\r-\r-\r").unwrap();
+                    if has_leaving {
+                        write!(sub, "\r").unwrap();
+                    }
+                    sub.newline();
+                    continue;
+                };
+
+                let hidden = usage.hidden_sectors();
+                let capacity = usage.capacity_sectors() - hidden;
+                let used = usage.used_sectors() - hidden;
+                let state = bcachefs_kernel::sb::members::member_state_str(usage.state);
+
+                write!(sub, "{}\t", state).unwrap();
 
                 sub.units_sectors(capacity);
                 write!(sub, "\r").unwrap();
                 sub.units_sectors(used);
 
-                let pct = if d.usage.nr_buckets > 0 {
-                    d.usage.used_buckets() * 100 / d.usage.nr_buckets
+                let pct = if usage.nr_buckets > 0 {
+                    usage.used_buckets() * 100 / usage.nr_buckets
                 } else { 0 };
                 write!(sub, "\r{:>2}%\r", pct).unwrap();
 
@@ -558,9 +573,14 @@ fn devs_usage_to_text(
 }
 
 fn dev_usage_full_to_text(out: &mut Printbuf, d: &DevContext) {
-    let u = &d.usage;
-
     let label = d.info.label.as_deref().unwrap_or("(no label)");
+    let Some(u) = &d.usage else {
+        out.aligned(|sub| {
+            writeln!(sub, "{} (device {}):\t{}\toffline\tusage unavailable", label, d.info.idx, d.info.dev).unwrap();
+        });
+        return;
+    };
+
     let state = bcachefs_kernel::sb::members::member_state_str(u.state);
     let pct = if u.nr_buckets > 0 { u.used_buckets() * 100 / u.nr_buckets } else { 0 };
 

--- a/src/wrappers/sysfs.rs
+++ b/src/wrappers/sysfs.rs
@@ -107,6 +107,7 @@ pub struct DevInfo {
     pub dev:        String,
     pub label:      Option<String>,
     pub durability: u32,
+    pub online:     bool,
 }
 
 /// Enumerate devices for a mounted filesystem from its sysfs directory.
@@ -127,6 +128,7 @@ pub fn fs_get_devices(sysfs_path: &Path) -> Result<Vec<DevInfo>> {
         };
 
         let dev_path = entry.path();
+        let online = fs::symlink_metadata(dev_path.join("block")).is_ok();
         let dev = dev_name_from_sysfs(&dev_path);
 
         let label = fs::read_to_string(dev_path.join("label"))
@@ -137,8 +139,42 @@ pub fn fs_get_devices(sysfs_path: &Path) -> Result<Vec<DevInfo>> {
         let durability = read_sysfs_u64(&dev_path.join("durability"))
             .unwrap_or(1) as u32;
 
-        devs.push(DevInfo { idx, dev, label, durability });
+        devs.push(DevInfo { idx, dev, label, durability, online });
     }
     devs.sort_by_key(|d| d.idx);
     Ok(devs)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::symlink;
+
+    use super::*;
+
+    #[test]
+    fn fs_get_devices_marks_missing_block_symlink_offline() {
+        let root = std::env::temp_dir().join(format!(
+            "bcachefs-tools-sysfs-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+
+        fs::create_dir(&root).unwrap();
+        let dev0 = root.join("dev-0");
+        let dev1 = root.join("dev-1");
+        fs::create_dir(&dev0).unwrap();
+        fs::create_dir(&dev1).unwrap();
+        symlink("../sda", dev0.join("block")).unwrap();
+        fs::write(dev0.join("durability"), "1\n").unwrap();
+        fs::write(dev1.join("durability"), "1\n").unwrap();
+
+        let devs = fs_get_devices(&root).unwrap();
+        fs::remove_dir_all(&root).unwrap();
+
+        assert_eq!(devs.len(), 2);
+        assert_eq!(devs[0].dev, "sda");
+        assert!(devs[0].online);
+        assert_eq!(devs[1].dev, "dev-1");
+        assert!(!devs[1].online);
+    }
 }


### PR DESCRIPTION
## Summary

`bcachefs fs usage` should still print filesystem usage when one member device is offline or otherwise lacks a live block-device sysfs link.

The command already enumerates offline members from `dev-N/` directories, but it then called the per-device usage ioctl for every member and treated one failed offline-device ioctl as a fatal command error. That matches the failure reported in koverstreet/bcachefs-tools#522: the useful filesystem accounting output is lost because one device cannot answer `dev_usage`.

This keeps the overall accounting output and online-device usage rows, while marking offline members as `offline` with unavailable per-device usage fields.

Fixes koverstreet/bcachefs-tools#522.

## Testing

- `git diff --check origin/master...HEAD`
- `make generate_version`
- `CARGO_BUILD_JOBS=4 BINDGEN=/home/kom/.cargo/bin/bindgen LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu cargo check -q -p bcachefs-tools`
- `BINDGEN=/home/kom/.cargo/bin/bindgen LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu make -j4 libbcachefs.a`
- `CARGO_BUILD_JOBS=4 BINDGEN=/home/kom/.cargo/bin/bindgen LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu cargo test fs_get_devices_marks_missing_block_symlink_offline`
- `BINDGEN=/home/kom/.cargo/bin/bindgen LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu make -j4`
- GitHub CI is passing for refreshed head 53b73cd1718f5765fb1d4c3acd6609f4473f2176: https://github.com/koverstreet/bcachefs-tools/actions/runs/28423468700
