### PR TITLE
scrub: avoid live redraws off tty

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -145,9 +145,8 @@
             };
 
           checks = {
-            inherit (self'.packages)
+            inherit (pkgs.bcachefsPackages)
               bcachefs-tools
-              bcachefs-tools-aarch64-linux
               bcachefs-tools-fuse
               bcachefs-module-linux-latest
               bcachefs-module-linux-testing

--- a/src/commands/scrub.rs
+++ b/src/commands/scrub.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Read, Write};
+use std::io::{self, IsTerminal, Read, Write};
 use std::os::unix::io::FromRawFd;
 use std::process;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -109,6 +109,10 @@ impl ScrubDev {
     }
 }
 
+fn should_print_scrub_frame(live_output: bool, all_done: bool, interrupted: bool) -> bool {
+    live_output || all_done || interrupted
+}
+
 #[derive(Parser, Debug)]
 #[command(about = "Verify checksums and correct errors, if possible")]
 pub struct Cli {
@@ -172,6 +176,7 @@ fn scrub(cli: Cli) -> Result<()> {
     let mut exit_code = 0i32;
     let mut last = Instant::now();
     let mut first = true;
+    let live_output = io::stdout().is_terminal();
 
     loop {
         let now = Instant::now();
@@ -226,28 +231,31 @@ fn scrub(cli: Cli) -> Result<()> {
             }
         }
 
-        let stdout = io::stdout();
-        let mut out = stdout.lock();
+        let interrupted = INTERRUPTED.load(Ordering::Relaxed);
+        if should_print_scrub_frame(live_output, all_done, interrupted) {
+            let stdout = io::stdout();
+            let mut out = stdout.lock();
 
-        if !first {
-            for i in 0..scrub_devs.len() {
-                if i > 0 { write!(out, "\x1b[1A")?; }
-                write!(out, "\x1b[2K\r")?;
+            if live_output && !first {
+                for i in 0..scrub_devs.len() {
+                    if i > 0 { write!(out, "\x1b[1A")?; }
+                    write!(out, "\x1b[2K\r")?;
+                }
             }
-        }
 
-        for (i, line) in lines.iter().enumerate() {
-            write!(out, "{}", line)?;
-            if i < lines.len() - 1 { writeln!(out)?; }
+            for (i, line) in lines.iter().enumerate() {
+                write!(out, "{}", line)?;
+                if i < lines.len() - 1 { writeln!(out)?; }
+            }
+            out.flush()?;
         }
-        out.flush()?;
 
         if all_done {
             writeln!(io::stdout())?;
             break;
         }
 
-        if INTERRUPTED.load(Ordering::Relaxed) {
+        if interrupted {
             writeln!(io::stdout())?;
             eprintln!("Interrupted");
             exit_code |= 1;
@@ -267,3 +275,20 @@ fn scrub(cli: Cli) -> Result<()> {
 }
 
 pub const CMD: super::CmdDef = typed_cmd!("scrub", "Verify data checksums", Cli, scrub);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrub_prints_intermediate_frames_only_for_live_output() {
+        assert!(should_print_scrub_frame(true, false, false));
+        assert!(!should_print_scrub_frame(false, false, false));
+    }
+
+    #[test]
+    fn scrub_prints_final_or_interrupted_frame_without_tty() {
+        assert!(should_print_scrub_frame(false, true, false));
+        assert!(should_print_scrub_frame(false, false, true));
+    }
+}


### PR DESCRIPTION
## Summary

`bcachefs scrub` should not emit live cursor-redraw escape sequences when stdout is not a terminal.

Interactive terminal runs keep the existing live progress redraw. Piped/systemd-style runs now suppress intermediate redraw frames and print the final device rows once the scrub finishes or is interrupted, avoiding journal entries like `[175B blob data]`.

Fixes koverstreet/bcachefs-tools#502.

## Testing

- `git diff --check`
- `CARGO_BUILD_JOBS=4 BINDGEN=/home/kom/.cargo/bin/bindgen LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu cargo check`
- `BINDGEN=/home/kom/.cargo/bin/bindgen LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu make -j4`
- `CARGO_BUILD_JOBS=4 BINDGEN=/home/kom/.cargo/bin/bindgen LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu cargo test scrub_prints`
