### PR TITLE
opts: latch explicit rotational setting

### DIFF
--- a/fs/opts.c
+++ b/fs/opts.c
@@ -977,6 +977,11 @@ bool __bch2_opt_set_sb(struct bch_sb *sb, int dev_idx,
 		struct bch_member *m = bch2_members_v2_get_mut(sb, dev_idx);
 		changed = v != opt->get_member(m);
 		opt->set_member(m, v);
+
+		if (opt == &bch2_opt_table[Opt_rotational]) {
+			changed |= !BCH_MEMBER_ROTATIONAL_SET(m);
+			SET_BCH_MEMBER_ROTATIONAL_SET(m, true);
+		}
 	}
 
 	if (opt->type == BCH_OPT_STR_MEMBER &&

--- a/fs/opts.c
+++ b/fs/opts.c
@@ -928,6 +928,11 @@ bool __bch2_opt_set_sb(struct bch_sb *sb, int dev_idx,
 		struct bch_member *m = bch2_members_v2_get_mut(sb, dev_idx);
 		changed = v != opt->get_member(m);
 		opt->set_member(m, v);
+
+		if (opt == &bch2_opt_table[Opt_rotational]) {
+			changed |= !BCH_MEMBER_ROTATIONAL_SET(m);
+			SET_BCH_MEMBER_ROTATIONAL_SET(m, true);
+		}
 	}
 
 	return changed;


### PR DESCRIPTION
An explicit `bcachefs set-fs-option --rotational=` write silently did nothing when the requested value already matched the member's current value, because `__bch2_opt_set_sb()` only treated the write as a change when the value itself differed. That left `BCH_MEMBER_ROTATIONAL_SET` unset and the option effectively unlatched, so a later automatic rediscovery of the device's rotational status could silently override the user's explicit choice. This tracks `BCH_MEMBER_ROTATIONAL_SET` as its own change condition, so an explicit rotational write always persists to the superblock regardless of whether the value itself changed.

Fixes koverstreet/bcachefs-tools#594.

Built and verified offline against a loop-file superblock (no live device or mount): `bcachefs format --force fs.img`, `bcachefs set-fs-option --rotational=1 fs.img`, then `bcachefs show-super -f all fs.img` shows `Rotational: 1` persisted correctly, including when the requested value already equals the member's current value (the bug's exact precondition). Tracing confirmed `__bch2_opt_set_sb()` reaches the new latch branch on every explicit rotational write; every superblock this offline flow could produce already had `BCH_MEMBER_ROTATIONAL_SET` latched by the pre-existing auto-detect at format/device-add time, so the "explicit write force-latches a previously-unset flag" transition itself was not exercised live and would need a mounted device to test.
