### PR TITLE
move: use best-effort IO for hipri reconcile moves

### DIFF
--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -39,6 +39,11 @@
 #include <linux/ioprio.h>
 #include <linux/kthread.h>
 
+static inline u16 bch2_move_ioprio(struct data_update_opts *opts)
+{
+	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+}
+
 const char * const bch2_data_ops_strs[] = {
 #define x(t, n, ...) [n] = #t,
 	BCH_DATA_OPS()
@@ -253,7 +258,7 @@ static int __bch2_move_extent(struct moving_context *ctxt,
 
 	u->op.end_io		= move_write_done;
 	u->rbio.bio.bi_end_io	= move_read_endio;
-	u->rbio.bio.bi_ioprio	= IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+	u->rbio.bio.bi_ioprio	= bch2_move_ioprio(data_opts);
 
 	u32 size = k.k->size;
 

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -36,7 +36,6 @@
 
 #include "snapshots/snapshot.h"
 
-#include <linux/ioprio.h>
 #include <linux/kthread.h>
 
 const char * const bch2_data_ops_strs[] = {
@@ -253,7 +252,7 @@ static int __bch2_move_extent(struct moving_context *ctxt,
 
 	u->op.end_io		= move_write_done;
 	u->rbio.bio.bi_end_io	= move_read_endio;
-	u->rbio.bio.bi_ioprio	= IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+	u->rbio.bio.bi_ioprio	= bch2_move_ioprio(data_opts);
 
 	u32 size = k.k->size;
 

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -33,6 +33,7 @@
 #include "util/clock.h"
 
 #include <linux/freezer.h>
+#include <linux/ioprio.h>
 #include <linux/kthread.h>
 #include <linux/sched/cputime.h>
 
@@ -434,6 +435,8 @@ static int reconcile_set_data_opts(struct btree_trans *trans,
 
 	data_opts->type			= BCH_DATA_UPDATE_reconcile;
 	data_opts->target		= r->background_target;
+	if (r->hipri)
+		data_opts->ioprio	= IOPRIO_PRIO_VALUE(IOPRIO_CLASS_BE, 7);
 
 	/*
 	 * Never wait on the allocator mid-write: a blocked data update holds a

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -48,6 +48,27 @@ static const struct rhashtable_params bch_update_params = {
 	.automatic_shrinking	= true,
 };
 
+static inline u16 bch2_move_ioprio(struct data_update_opts *opts)
+{
+	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+}
+
+static const char *bch2_ioprio_class_str(u16 ioprio)
+{
+	switch (IOPRIO_PRIO_CLASS(ioprio)) {
+	case IOPRIO_CLASS_NONE:
+		return "none";
+	case IOPRIO_CLASS_RT:
+		return "realtime";
+	case IOPRIO_CLASS_BE:
+		return "best-effort";
+	case IOPRIO_CLASS_IDLE:
+		return "idle";
+	default:
+		return "unknown";
+	}
+}
+
 bool bch2_data_update_in_flight(struct bch_fs *c, struct bbpos *pos,
 				enum bch_data_update_types type)
 {
@@ -905,6 +926,10 @@ __cold void bch2_data_update_opts_to_text(struct printbuf *out, struct bch_fs *c
 
 	prt_printf(out, "read_dev:\t%i\n", data_opts->read_dev);
 	prt_printf(out, "checksum_paranoia:\t%i\n", data_opts->checksum_paranoia);
+	u16 ioprio = bch2_move_ioprio(data_opts);
+	prt_printf(out, "ioprio:\t%s:%u\n",
+		   bch2_ioprio_class_str(ioprio),
+		   (unsigned) IOPRIO_PRIO_DATA(ioprio));
 
 	prt_str(out, "io path options:\t");
 	bch2_inode_opts_to_text(out, c, *io_opts);
@@ -1006,7 +1031,7 @@ static int bch2_data_update_bios_init(struct data_update *m, struct bch_fs *c,
 	m->rbio.data_update		= true;
 	m->rbio.bio.bi_iter.bi_size	= buf_bytes;
 	m->rbio.bio.bi_iter.bi_sector	= bkey_start_offset(&m->k.k->k);
-	m->op.wbio.bio.bi_ioprio	= IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+	m->op.wbio.bio.bi_ioprio	= bch2_move_ioprio(&m->opts);
 	return 0;
 }
 

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -48,6 +48,22 @@ static const struct rhashtable_params bch_update_params = {
 	.automatic_shrinking	= true,
 };
 
+static const char *bch2_ioprio_class_str(u16 ioprio)
+{
+	switch (IOPRIO_PRIO_CLASS(ioprio)) {
+	case IOPRIO_CLASS_NONE:
+		return "none";
+	case IOPRIO_CLASS_RT:
+		return "realtime";
+	case IOPRIO_CLASS_BE:
+		return "best-effort";
+	case IOPRIO_CLASS_IDLE:
+		return "idle";
+	default:
+		return "unknown";
+	}
+}
+
 bool bch2_data_update_in_flight(struct bch_fs *c, struct bbpos *pos,
 				enum bch_data_update_types type)
 {
@@ -905,6 +921,10 @@ __cold void bch2_data_update_opts_to_text(struct printbuf *out, struct bch_fs *c
 
 	prt_printf(out, "read_dev:\t%i\n", data_opts->read_dev);
 	prt_printf(out, "checksum_paranoia:\t%i\n", data_opts->checksum_paranoia);
+	u16 ioprio = bch2_move_ioprio(data_opts);
+	prt_printf(out, "ioprio:\t%s:%u\n",
+		   bch2_ioprio_class_str(ioprio),
+		   (unsigned) IOPRIO_PRIO_DATA(ioprio));
 
 	prt_str(out, "io path options:\t");
 	bch2_inode_opts_to_text(out, c, *io_opts);
@@ -1006,7 +1026,7 @@ static int bch2_data_update_bios_init(struct data_update *m, struct bch_fs *c,
 	m->rbio.data_update		= true;
 	m->rbio.bio.bi_iter.bi_size	= buf_bytes;
 	m->rbio.bio.bi_iter.bi_sector	= bkey_start_offset(&m->k.k->k);
-	m->op.wbio.bio.bi_ioprio	= IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+	m->op.wbio.bio.bi_ioprio	= bch2_move_ioprio(&m->opts);
 	return 0;
 }
 

--- a/fs/data/update.h
+++ b/fs/data/update.h
@@ -39,6 +39,7 @@ struct data_update_opts {
 	enum bch_read_flags		read_flags;
 	enum bch_write_flags		write_flags;
 	enum bch_trans_commit_flags	commit_flags;
+	u16				ioprio;
 };
 
 struct data_update {

--- a/fs/data/update.h
+++ b/fs/data/update.h
@@ -8,6 +8,8 @@
 #include "data/read.h"
 #include "data/write_types.h"
 
+#include <linux/ioprio.h>
+
 struct moving_context;
 
 #define BCH_DATA_UPDATE_TYPES()	\
@@ -39,7 +41,13 @@ struct data_update_opts {
 	enum bch_read_flags		read_flags;
 	enum bch_write_flags		write_flags;
 	enum bch_trans_commit_flags	commit_flags;
+	u16				ioprio;
 };
+
+static inline u16 bch2_move_ioprio(struct data_update_opts *opts)
+{
+	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+}
 
 struct data_update {
 	struct rcu_head		rcu;


### PR DESCRIPTION
## Summary

High-priority reconcile work still submitted move reads and writes at idle IO priority. This change adds an explicit IO priority to `data_update_opts`, preserves idle priority as the normal default, and assigns `best-effort:7` only to high-priority reconcile work.

The data-update trace text now prints that event's selected IO priority. This lets the companion test correlate `reconcile` and `best-effort:7` within the same multiline trace event instead of relying on a global trace grep or a timing threshold.

The IO priority lookup (`bch2_move_ioprio()`) is now a single shared inline in `fs/data/update.h`, used by both `move.c` and `update.c`, instead of two identical copies.

Companion test: koverstreet/ktest#62.

Current head: `591698ed232b754d125d20c076dae5edc6cd4448`.

## Scope

This is one commit, rebased onto bcachefs-tools `testing` at `498fa59b2ff206c6db08a6a7fda071e205fffcb2`. It does not change normal reconcile or copygc priority.

## Validation

- `git diff --check HEAD^..HEAD`
- full bcachefs-tools build (`BINDGEN=$HOME/.cargo/bin/bindgen make -j16 bcachefs`) at the current head, clean, no new warnings
- `nm` on the built binary confirms a single `bch2_move_ioprio` instantiation (no duplicate-definition symbol from the two former copies)
- patched-head VM (prior head, same logic): the focused koverstreet/ktest#62 reconcile test observed an event-local `reconcile` plus `best-effort:7`, drained user data from the evacuating source, completed offline fsck, and reported `TEST SUCCESS` in 10 seconds
- negative control on unpatched `testing`: the same workload performed reconcile updates but emitted no event IO priority and failed with `did not observe high-priority reconcile data_update at best-effort:7`
- the dedupe itself (`bch2_move_ioprio()` moved into `update.h`) has not been re-run through the VM test above; it is a mechanical refactor with no behavior change and is covered by the build + symbol check

## Proof still needed before ready

This remains a draft. The focused VM run proves that this patch selects the intended priority on the intended operation; it does not yet quantify the scheduling tradeoff Kent requested.

Before marking it ready, the remaining performance packet should compare current `testing` and this head under the same reconcile or evacuation workload, including foreground latency or throughput and `internal/moving_ctxts` or equivalent progress evidence.
