### PR TITLE
docs: clarify device set-state states

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -53,7 +53,7 @@ Take a device offline, without removing it
 .It Ic device evacuate
 Migrate data off of a specific device
 .It Ic device set-state
-Change the state of a device
+Set a device state
 .It Ic device resize
 Resize filesystem on a device
 .It Ic device resize-journal
@@ -480,7 +480,10 @@ Force, if data redundancy will be degraded
 Move data off of a given device
 .It Nm Ic device Ic set-state Oo Ar options Oc Ar new-state Ar device
 .Bl -tag -width Ds
-.It Ar  new-state Ns = Ns ( Ar rw | ro | failed | spare )
+.It Ar  new-state Ns = Ns ( Ar rw | ro | evacuating | spare )
+New member state. Use
+.Ar rw
+to cancel an in-progress evacuation and return the device to normal use.
 .It Fl f , Fl -force
 Force, if data redundancy will be degraded
 .It Fl -force-if-data-lost

--- a/src/commands/device.rs
+++ b/src/commands/device.rs
@@ -313,7 +313,7 @@ fn device_size(dev: &str) -> Result<u64> {
 }
 
 #[derive(Parser, Debug)]
-#[command(about = "Change the state of a device")]
+#[command(about = "Set a device state (rw, ro, evacuating, or spare)")]
 pub struct SetStateCli {
     /// Force if data redundancy will be degraded
     #[arg(short, long)]
@@ -327,7 +327,7 @@ pub struct SetStateCli {
     #[arg(short = 'o', long)]
     offline: bool,
 
-    /// Device state
+    /// New member state: rw, ro, evacuating, or spare
     #[arg(value_enum)]
     new_state: MemberState,
 


### PR DESCRIPTION
Fixes koverstreet/bcachefs-tools#506.

This updates `bcachefs device set-state` help and the manpage to document the implemented member states: `rw`, `ro`, `evacuating`, and `spare`. The old manpage listed `failed`, which is not accepted by the current CLI enum.

It also notes that setting a device back to `rw` returns it from an in-progress evacuation to normal use.

Validation:
- `git diff --check`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
- `./bcachefs device set-state --help`
