### PR TITLE
copygc: prioritize and diagnose pressure copygc

### DIFF
--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -786,7 +786,7 @@ again:
 			copygc_can_make_progress = bch2_copygc_can_make_progress(ca);
 		if (copygc_can_make_progress) {
 			req->copygc_can_make_progress = true;
-			bch2_copygc_wakeup(c);
+			bch2_copygc_wakeup_for_pressure(c);
 		}
 
 		track_event_change(&c->times[BCH_TIME_blocked_allocate], true);
@@ -2174,7 +2174,7 @@ static bool alloc_wait_advanced(struct bch_fs *c, struct alloc_request *req)
 			    !bch2_copygc_can_make_progress(ca))
 				return true;
 
-			bch2_copygc_wakeup(c);
+			bch2_copygc_wakeup_for_pressure(c);
 		}
 	}
 	BUG_ON(!found);

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -800,7 +800,7 @@ again:
 			copygc_can_make_progress = bch2_copygc_can_make_progress(ca);
 		if (copygc_can_make_progress) {
 			req->copygc_can_make_progress = true;
-			bch2_copygc_wakeup(c);
+			bch2_copygc_wakeup_for_pressure(c);
 		}
 
 		track_event_change(&c->times[BCH_TIME_blocked_allocate], true);
@@ -2322,7 +2322,7 @@ static bool alloc_wait_advanced(struct bch_fs *c, struct alloc_request *req)
 			    !bch2_copygc_can_make_progress(ca))
 				return true;
 
-			bch2_copygc_wakeup(c);
+			bch2_copygc_wakeup_for_pressure(c);
 		}
 	}
 	BUG_ON(!found);

--- a/fs/data/copygc.c
+++ b/fs/data/copygc.c
@@ -51,6 +51,7 @@
 #include "util/clock.h"
 
 #include <linux/freezer.h>
+#include <linux/ioprio.h>
 #include <linux/kthread.h>
 #include <linux/math64.h>
 #include <linux/sched/task.h>
@@ -471,6 +472,7 @@ noinline
 static int bch2_copygc(struct moving_context *ctxt,
 		       struct buckets_in_flight *buckets_in_flight,
 		       darray_copygc_dev *devs,
+		       bool pressure,
 		       bool *did_work)
 {
 	struct btree_trans *trans = ctxt->trans;
@@ -478,6 +480,9 @@ static int bch2_copygc(struct moving_context *ctxt,
 	struct data_update_opts data_opts = {
 		.type		= BCH_DATA_UPDATE_copygc,
 		.commit_flags	= (unsigned) BCH_WATERMARK_copygc,
+		.ioprio		= pressure
+			? IOPRIO_PRIO_VALUE(IOPRIO_CLASS_BE, 7)
+			: 0,
 	};
 	u64 sectors_seen	= atomic64_read(&ctxt->stats->sectors_seen);
 	u64 sectors_moved	= atomic64_read(&ctxt->stats->sectors_moved);
@@ -605,8 +610,12 @@ s64 bch2_copygc_dev_wait_amount(struct bch_dev *ca)
 __cold void bch2_copygc_wait_to_text(struct printbuf *out, struct bch_fs *c)
 {
 	printbuf_tabstop_push(out, 32);
-	prt_printf(out, "running:\t%u\n",		c->copygc.running);
-	prt_printf(out, "run count:\t%u\n",		c->copygc.run_count);
+	prt_printf(out, "running:\t%u\n",		READ_ONCE(c->copygc.running));
+	prt_printf(out, "pressure pending:\t%u\n", READ_ONCE(c->copygc.pressure_pending));
+	prt_printf(out, "current run pressure:\t%u\n", READ_ONCE(c->copygc.current_run_pressure));
+	prt_printf(out, "last run pressure:\t%u\n", READ_ONCE(c->copygc.last_run_pressure));
+	prt_printf(out, "pressure run count:\t%u\n", READ_ONCE(c->copygc.pressure_run_count));
+	prt_printf(out, "run count:\t%u\n",		READ_ONCE(c->copygc.run_count));
 	prt_printf(out, "copygc_wait:\t%llu\n",		c->copygc.wait);
 	prt_printf(out, "copygc_wait_at:\t%llu\n",	c->copygc.wait_at);
 
@@ -726,11 +735,18 @@ static int bch2_copygc_thread(void *arg)
 
 		kick = READ_ONCE(c->copygc.kick_count);
 		c->copygc.wait = 0;
+		bool pressure = xchg(&c->copygc.pressure_pending, false);
+		if (pressure)
+			WRITE_ONCE(c->copygc.pressure_run_count,
+				   READ_ONCE(c->copygc.pressure_run_count) + 1);
 
-		c->copygc.running = true;
-		ret = bch2_copygc(&ctxt, &buckets, &devs, &did_work);
-		c->copygc.running = false;
-		c->copygc.run_count++;
+		WRITE_ONCE(c->copygc.current_run_pressure, pressure);
+		WRITE_ONCE(c->copygc.running, true);
+		ret = bch2_copygc(&ctxt, &buckets, &devs, pressure, &did_work);
+		WRITE_ONCE(c->copygc.running, false);
+		WRITE_ONCE(c->copygc.last_run_pressure, pressure);
+		WRITE_ONCE(c->copygc.current_run_pressure, false);
+		WRITE_ONCE(c->copygc.run_count, READ_ONCE(c->copygc.run_count) + 1);
 
 		wake_up(&c->copygc.running_wq);
 

--- a/fs/data/copygc.c
+++ b/fs/data/copygc.c
@@ -51,6 +51,7 @@
 #include "util/clock.h"
 
 #include <linux/freezer.h>
+#include <linux/ioprio.h>
 #include <linux/kthread.h>
 #include <linux/math64.h>
 #include <linux/sched/task.h>
@@ -471,6 +472,7 @@ noinline
 static int bch2_copygc(struct moving_context *ctxt,
 		       struct buckets_in_flight *buckets_in_flight,
 		       darray_copygc_dev *devs,
+		       bool pressure,
 		       bool *did_work)
 {
 	struct btree_trans *trans = ctxt->trans;
@@ -478,6 +480,9 @@ static int bch2_copygc(struct moving_context *ctxt,
 	struct data_update_opts data_opts = {
 		.type		= BCH_DATA_UPDATE_copygc,
 		.commit_flags	= (unsigned) BCH_WATERMARK_copygc,
+		.ioprio		= pressure
+			? IOPRIO_PRIO_VALUE(IOPRIO_CLASS_BE, 7)
+			: 0,
 	};
 	u64 sectors_seen	= atomic64_read(&ctxt->stats->sectors_seen);
 	u64 sectors_moved	= atomic64_read(&ctxt->stats->sectors_moved);
@@ -622,6 +627,10 @@ __cold void bch2_copygc_wait_to_text(struct printbuf *out, struct bch_fs *c)
 {
 	printbuf_tabstop_push(out, 32);
 	prt_printf(out, "running:\t%u\n",		READ_ONCE(c->copygc.running));
+	prt_printf(out, "pressure pending:\t%u\n", READ_ONCE(c->copygc.pressure_pending));
+	prt_printf(out, "current run pressure:\t%u\n", READ_ONCE(c->copygc.current_run_pressure));
+	prt_printf(out, "last run pressure:\t%u\n", READ_ONCE(c->copygc.last_run_pressure));
+	prt_printf(out, "pressure run count:\t%u\n", READ_ONCE(c->copygc.pressure_run_count));
 	prt_printf(out, "run count:\t%u\n",		READ_ONCE(c->copygc.run_count));
 	prt_printf(out, "copygc_wait:\t%llu\n",		c->copygc.wait);
 	prt_printf(out, "copygc_wait_at:\t%llu\n",	c->copygc.wait_at);
@@ -742,10 +751,17 @@ static int bch2_copygc_thread(void *arg)
 
 		kick = READ_ONCE(c->copygc.kick_count);
 		c->copygc.wait = 0;
+		bool pressure = xchg(&c->copygc.pressure_pending, false);
+		if (pressure)
+			WRITE_ONCE(c->copygc.pressure_run_count,
+				   READ_ONCE(c->copygc.pressure_run_count) + 1);
 
+		WRITE_ONCE(c->copygc.current_run_pressure, pressure);
 		WRITE_ONCE(c->copygc.running, true);
-		ret = bch2_copygc(&ctxt, &buckets, &devs, &did_work);
+		ret = bch2_copygc(&ctxt, &buckets, &devs, pressure, &did_work);
 		WRITE_ONCE(c->copygc.running, false);
+		WRITE_ONCE(c->copygc.last_run_pressure, pressure);
+		WRITE_ONCE(c->copygc.current_run_pressure, false);
 		WRITE_ONCE(c->copygc.run_count, READ_ONCE(c->copygc.run_count) + 1);
 
 		wake_up(&c->copygc.running_wq);

--- a/fs/data/copygc.c
+++ b/fs/data/copygc.c
@@ -621,8 +621,8 @@ s64 bch2_copygc_dev_wait_amount(struct bch_dev *ca)
 __cold void bch2_copygc_wait_to_text(struct printbuf *out, struct bch_fs *c)
 {
 	printbuf_tabstop_push(out, 32);
-	prt_printf(out, "running:\t%u\n",		c->copygc.running);
-	prt_printf(out, "run count:\t%u\n",		c->copygc.run_count);
+	prt_printf(out, "running:\t%u\n",		READ_ONCE(c->copygc.running));
+	prt_printf(out, "run count:\t%u\n",		READ_ONCE(c->copygc.run_count));
 	prt_printf(out, "copygc_wait:\t%llu\n",		c->copygc.wait);
 	prt_printf(out, "copygc_wait_at:\t%llu\n",	c->copygc.wait_at);
 
@@ -743,10 +743,10 @@ static int bch2_copygc_thread(void *arg)
 		kick = READ_ONCE(c->copygc.kick_count);
 		c->copygc.wait = 0;
 
-		c->copygc.running = true;
+		WRITE_ONCE(c->copygc.running, true);
 		ret = bch2_copygc(&ctxt, &buckets, &devs, &did_work);
-		c->copygc.running = false;
-		c->copygc.run_count++;
+		WRITE_ONCE(c->copygc.running, false);
+		WRITE_ONCE(c->copygc.run_count, READ_ONCE(c->copygc.run_count) + 1);
 
 		wake_up(&c->copygc.running_wq);
 

--- a/fs/data/copygc.h
+++ b/fs/data/copygc.h
@@ -16,6 +16,12 @@ static inline void bch2_copygc_wakeup(struct bch_fs *c)
 		wake_up_process(p);
 }
 
+static inline void bch2_copygc_wakeup_for_pressure(struct bch_fs *c)
+{
+	WRITE_ONCE(c->copygc.pressure_pending, true);
+	bch2_copygc_wakeup(c);
+}
+
 void bch2_copygc_stop(struct bch_fs *);
 int bch2_copygc_start(struct bch_fs *);
 

--- a/fs/data/copygc_types.h
+++ b/fs/data/copygc_types.h
@@ -8,6 +8,10 @@ struct bch_fs_copygc {
 	s64			wait_at;
 	s64			wait;
 	bool			running;
+	bool			pressure_pending;
+	bool			current_run_pressure;
+	bool			last_run_pressure;
+	u32			pressure_run_count;
 	u32			run_count;
 	u32			kick_count;
 	wait_queue_head_t	running_wq;
@@ -17,4 +21,3 @@ struct bch_fs_copygc {
 };
 
 #endif /* _BCACHEFS_COPYGC_TYPES_H */
-

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -39,6 +39,11 @@
 #include <linux/ioprio.h>
 #include <linux/kthread.h>
 
+static inline u16 bch2_move_ioprio(struct data_update_opts *opts)
+{
+	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+}
+
 const char * const bch2_data_ops_strs[] = {
 #define x(t, n, ...) [n] = #t,
 	BCH_DATA_OPS()
@@ -253,7 +258,7 @@ static int __bch2_move_extent(struct moving_context *ctxt,
 
 	u->op.end_io		= move_write_done;
 	u->rbio.bio.bi_end_io	= move_read_endio;
-	u->rbio.bio.bi_ioprio	= IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+	u->rbio.bio.bi_ioprio	= bch2_move_ioprio(data_opts);
 
 	u32 size = k.k->size;
 
@@ -464,10 +469,10 @@ int bch2_move_ratelimit(struct moving_context *ctxt)
 	bool is_kthread = current->flags & PF_KTHREAD;
 	u64 delay;
 
-	if (ctxt->wait_on_copygc && c->copygc.running) {
+	if (ctxt->wait_on_copygc && READ_ONCE(c->copygc.running)) {
 		bch2_moving_ctxt_flush_all(ctxt);
 		wait_event_freezable(c->copygc.running_wq,
-				    !c->copygc.running ||
+				    !READ_ONCE(c->copygc.running) ||
 				    (is_kthread && kthread_should_stop()));
 	}
 
@@ -1244,6 +1249,25 @@ __cold void bch2_move_stats_to_text(struct printbuf *out, struct bch_move_stats 
 	prt_newline(out);
 }
 
+static const char *bch2_moving_ctxt_wait_reason(struct bch_fs *c,
+						struct moving_context *ctxt)
+{
+	u32 sectors_limit = c->opts.move_bytes_in_flight >> 9;
+
+	if (ctxt->wait_on_copygc && READ_ONCE(c->copygc.running))
+		return "copygc running";
+	if (atomic_read(&ctxt->write_ios) >= c->opts.move_ios_in_flight)
+		return "write ios in flight";
+	if (atomic_read(&ctxt->read_ios) >= c->opts.move_ios_in_flight)
+		return "read ios in flight";
+	if (atomic_read(&ctxt->write_sectors) >= sectors_limit)
+		return "write bytes in flight";
+	if (atomic_read(&ctxt->read_sectors) >= sectors_limit)
+		return "read bytes in flight";
+
+	return "none";
+}
+
 static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs *c, struct moving_context *ctxt)
 {
 	if (!out->nr_tabstops)
@@ -1251,6 +1275,9 @@ static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs 
 
 	bch2_move_stats_to_text(out, ctxt->stats);
 	guard(printbuf_indent)(out);
+
+	prt_printf(out, "wait reason:\t%s\n", bch2_moving_ctxt_wait_reason(c, ctxt));
+	prt_printf(out, "wait on copygc:\t%u\n", ctxt->wait_on_copygc);
 
 	prt_printf(out, "reads: ios %u/%u sectors %u/%u\n",
 		   atomic_read(&ctxt->read_ios),

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -39,6 +39,11 @@
 #include <linux/ioprio.h>
 #include <linux/kthread.h>
 
+static inline u16 bch2_move_ioprio(struct data_update_opts *opts)
+{
+	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+}
+
 const char * const bch2_data_ops_strs[] = {
 #define x(t, n, ...) [n] = #t,
 	BCH_DATA_OPS()
@@ -253,7 +258,7 @@ static int __bch2_move_extent(struct moving_context *ctxt,
 
 	u->op.end_io		= move_write_done;
 	u->rbio.bio.bi_end_io	= move_read_endio;
-	u->rbio.bio.bi_ioprio	= IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+	u->rbio.bio.bi_ioprio	= bch2_move_ioprio(data_opts);
 
 	u32 size = k.k->size;
 
@@ -1257,6 +1262,25 @@ __cold void bch2_move_stats_to_text(struct printbuf *out, struct bch_move_stats 
 	prt_newline(out);
 }
 
+static const char *bch2_moving_ctxt_wait_reason(struct bch_fs *c,
+						struct moving_context *ctxt)
+{
+	u32 sectors_limit = c->opts.move_bytes_in_flight >> 9;
+
+	if (ctxt->wait_on_copygc && READ_ONCE(c->copygc.running))
+		return "copygc running";
+	if (atomic_read(&ctxt->write_ios) >= c->opts.move_ios_in_flight)
+		return "write ios in flight";
+	if (atomic_read(&ctxt->read_ios) >= c->opts.move_ios_in_flight)
+		return "read ios in flight";
+	if (atomic_read(&ctxt->write_sectors) >= sectors_limit)
+		return "write bytes in flight";
+	if (atomic_read(&ctxt->read_sectors) >= sectors_limit)
+		return "read bytes in flight";
+
+	return "none";
+}
+
 static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs *c, struct moving_context *ctxt)
 {
 	if (!out->nr_tabstops)
@@ -1264,6 +1288,9 @@ static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs 
 
 	bch2_move_stats_to_text(out, ctxt->stats);
 	guard(printbuf_indent)(out);
+
+	prt_printf(out, "wait reason:\t%s\n", bch2_moving_ctxt_wait_reason(c, ctxt));
+	prt_printf(out, "wait on copygc:\t%u\n", ctxt->wait_on_copygc);
 
 	prt_printf(out, "reads: ios %u/%u sectors %u/%u\n",
 		   atomic_read(&ctxt->read_ios),

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -464,10 +464,10 @@ int bch2_move_ratelimit(struct moving_context *ctxt)
 	bool is_kthread = current->flags & PF_KTHREAD;
 	u64 delay;
 
-	if (ctxt->wait_on_copygc && c->copygc.running) {
+	if (ctxt->wait_on_copygc && READ_ONCE(c->copygc.running)) {
 		bch2_moving_ctxt_flush_all(ctxt);
 		wait_event_freezable(c->copygc.running_wq,
-				    !c->copygc.running ||
+				    !READ_ONCE(c->copygc.running) ||
 				    (is_kthread && kthread_should_stop()));
 	}
 

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1649,11 +1649,11 @@ static int do_reconcile_phase_iter(struct reconcile_pass *p, u32 kick,
 
 		if (bch2_err_matches(ret, BCH_ERR_data_update_fail_need_copygc)) {
 			bch2_trans_unlock_long(trans);
-			bch2_copygc_wakeup(c);
+			bch2_copygc_wakeup_for_pressure(c);
 			wait_event(c->copygc.running_wq,
-				   c->copygc.run_count != *p->copygc_run_count ||
+				   READ_ONCE(c->copygc.run_count) != *p->copygc_run_count ||
 				   kthread_should_stop());
-			*p->copygc_run_count = c->copygc.run_count;
+			*p->copygc_run_count = READ_ONCE(c->copygc.run_count);
 			ret = 0;
 			continue;
 		}
@@ -1721,7 +1721,7 @@ static int do_reconcile(struct moving_context *ctxt)
 	struct bch_fs_reconcile *r = &c->reconcile;
 	u64 sectors_scanned = 0;
 	u32 kick = r->kick;
-	u32 copygc_run_count = c->copygc.run_count;
+	u32 copygc_run_count = READ_ONCE(c->copygc.run_count);
 	int ret = 0;
 
 	CLASS(darray_reconcile_work, work)();

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1676,7 +1676,7 @@ static int do_reconcile_phase_iter(struct reconcile_pass *p, u32 kick,
 
 		if (bch2_err_matches(ret, BCH_ERR_data_update_fail_need_copygc)) {
 			bch2_trans_unlock_long(trans);
-			bch2_copygc_wakeup(c);
+			bch2_copygc_wakeup_for_pressure(c);
 			wait_event(c->copygc.running_wq,
 				   READ_ONCE(c->copygc.run_count) != *p->copygc_run_count ||
 				   kthread_should_stop());

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1678,9 +1678,9 @@ static int do_reconcile_phase_iter(struct reconcile_pass *p, u32 kick,
 			bch2_trans_unlock_long(trans);
 			bch2_copygc_wakeup(c);
 			wait_event(c->copygc.running_wq,
-				   c->copygc.run_count != *p->copygc_run_count ||
+				   READ_ONCE(c->copygc.run_count) != *p->copygc_run_count ||
 				   kthread_should_stop());
-			*p->copygc_run_count = c->copygc.run_count;
+			*p->copygc_run_count = READ_ONCE(c->copygc.run_count);
 			ret = 0;
 			continue;
 		}
@@ -1748,7 +1748,7 @@ static int do_reconcile(struct moving_context *ctxt)
 	struct bch_fs_reconcile *r = &c->reconcile;
 	u64 sectors_scanned = 0;
 	u32 kick = r->kick;
-	u32 copygc_run_count = c->copygc.run_count;
+	u32 copygc_run_count = READ_ONCE(c->copygc.run_count);
 	int ret = 0;
 
 	CLASS(darray_reconcile_work, work)();

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -48,6 +48,27 @@ static const struct rhashtable_params bch_update_params = {
 	.automatic_shrinking	= true,
 };
 
+static inline u16 bch2_move_ioprio(struct data_update_opts *opts)
+{
+	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+}
+
+static const char *bch2_ioprio_class_str(u16 ioprio)
+{
+	switch (IOPRIO_PRIO_CLASS(ioprio)) {
+	case IOPRIO_CLASS_NONE:
+		return "none";
+	case IOPRIO_CLASS_RT:
+		return "realtime";
+	case IOPRIO_CLASS_BE:
+		return "best-effort";
+	case IOPRIO_CLASS_IDLE:
+		return "idle";
+	default:
+		return "unknown";
+	}
+}
+
 bool bch2_data_update_in_flight(struct bch_fs *c, struct bbpos *pos,
 				enum bch_data_update_types type)
 {
@@ -905,6 +926,10 @@ __cold void bch2_data_update_opts_to_text(struct printbuf *out, struct bch_fs *c
 
 	prt_printf(out, "read_dev:\t%i\n", data_opts->read_dev);
 	prt_printf(out, "checksum_paranoia:\t%i\n", data_opts->checksum_paranoia);
+	u16 ioprio = bch2_move_ioprio(data_opts);
+	prt_printf(out, "ioprio:\t%s:%u\n",
+		   bch2_ioprio_class_str(ioprio),
+		   (unsigned) IOPRIO_PRIO_DATA(ioprio));
 
 	prt_str(out, "io path options:\t");
 	bch2_inode_opts_to_text(out, c, *io_opts);
@@ -1006,7 +1031,7 @@ static int bch2_data_update_bios_init(struct data_update *m, struct bch_fs *c,
 	m->rbio.data_update		= true;
 	m->rbio.bio.bi_iter.bi_size	= buf_bytes;
 	m->rbio.bio.bi_iter.bi_sector	= bkey_start_offset(&m->k.k->k);
-	m->op.wbio.bio.bi_ioprio	= IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+	m->op.wbio.bio.bi_ioprio	= bch2_move_ioprio(&m->opts);
 	return 0;
 }
 
@@ -1047,7 +1072,7 @@ static unsigned durability_available_on_target(struct bch_fs *c,
 			durability += (write_flags & BCH_WRITE_cached) ? 1 : ca->mi.durability;
 		else if (bch2_copygc_can_make_progress(ca)) {
 			*need_copygc = true;
-			bch2_copygc_wakeup(c);
+			bch2_copygc_wakeup_for_pressure(c);
 		}
 
 		if (trace)

--- a/fs/data/update.h
+++ b/fs/data/update.h
@@ -39,6 +39,7 @@ struct data_update_opts {
 	enum bch_read_flags		read_flags;
 	enum bch_write_flags		write_flags;
 	enum bch_trans_commit_flags	commit_flags;
+	u16				ioprio;
 };
 
 struct data_update {


### PR DESCRIPTION
## Summary

Copygc runs triggered by allocation pressure are required for forward progress, but ran at idle IO priority like any other background move, so they could stall behind unrelated idle IO instead of relieving the pressure that triggered them. Give pressure-triggered copygc runs `best-effort:7` and expose the trigger through pressure counters and a wait-reason string so it's visible from sysfs, not just inferred. Normal (non-pressure) copygc keeps idle priority.

Companion test: koverstreet/ktest#62.

## Scope

Two commits on bcachefs-tools `testing`, rebased onto current tip:

1. `copygc: use READ_ONCE/WRITE_ONCE for copygc.running/run_count` -- correctness only, no behavior change. `c->copygc.running` and `c->copygc.run_count` are read without a lock from the move-ratelimit and reconcile paths while the copygc kthread writes them; this makes every access explicit.
2. `copygc: prioritize and diagnose pressure copygc` -- the actual priority flip described above, plus the pressure counters and wait-reason diagnostic.

## Validation

- `git diff --check` on both commits
- full bcachefs-tools build (rebased onto current `testing`)
- offline smoke, no kernel mount: FUSE-mounted a loop-file filesystem, filled it to 100% capacity to force `bch2_copygc_wakeup_for_pressure()` off the allocation-pressure path, deleted/overwrote files to fragment it, then `fusermount -u` and `fsck -y`. Clean unmount, no WARN/BUG in the fuse log, no crash. Ran the identical workload against unpatched `testing` as a negative control: both runs produced the same `deleted_inode_but_clean` fsck fixups (a pre-existing FUSE-unmount inode-reclaim quirk, unrelated to this change) and nothing else -- this smoke does not distinguish the two, it only rules out a crash/deadlock regression from the READ_ONCE/WRITE_ONCE conversion and the priority flip
- from an earlier VM pass on this same code (unchanged by the commit split -- diff is byte-identical before and after): the focused koverstreet/ktest#62 pressure-copygc test observed an increased pressure-run counter and an event-local `copygc` plus `best-effort:7`, completed offline fsck, and reported `TEST SUCCESS` in 11 seconds; the same test against unpatched `testing` failed because pressure-run accounting was absent

## Proof still needed before ready

This remains a draft. The VM pass proves trigger selection and IO priority, but raising priority under pressure has a foreground scheduling tradeoff that still needs the performance packet Kent requested.

Before marking it ready, compare current `testing` and this head with the same near-full workload and report copygc progress, pressure counters, and foreground latency or throughput.
