### PR TITLE
label: add filesystem label commands

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -22,6 +22,10 @@ Format one or a list of devices with bcachefs data structures.
 Dump superblock information to stdout.
 .It Ic set-fs-option
 Set a filesystem option
+.It Ic get-label
+Print filesystem label
+.It Ic set-label
+Set filesystem label
 .El
 .Ss Mount commands
 .Bl -tag -width 18n -compact
@@ -370,6 +374,16 @@ move path needed if nocow will ever be in use
 Skip submit_bio() for data reads and writes,
 for performance testing purposes
 .El
+.It Nm Ic get-label Ar target
+Print the filesystem label for a mounted bcachefs filesystem.
+.Ar target
+may be any path on the mounted filesystem.
+.It Nm Ic set-label Ar target Ar label
+Set the filesystem label for a mounted bcachefs filesystem.
+.Ar target
+may be any path on the mounted filesystem.
+.Ar label
+must fit in the bcachefs filesystem label field.
 .El
 .Sh Mount commands
 .Bl -tag -width Ds

--- a/src/commands/label.rs
+++ b/src/commands/label.rs
@@ -1,0 +1,88 @@
+use std::ffi::CStr;
+
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+
+use crate::wrappers::handle::BcachefsHandle;
+
+const FSLABEL_MAX: usize = 256;
+const BCH_SB_LABEL_SIZE: usize = 32;
+
+const IOC_WRITE: u32 = 1;
+const IOC_READ: u32 = 2;
+const FS_IOC_MAGIC: u32 = 0x94;
+const FS_IOC_GETFSLABEL_NR: u32 = 49;
+const FS_IOC_SETFSLABEL_NR: u32 = 50;
+
+const fn fs_ioc<T>(dir: u32, nr: u32) -> libc::Ioctl {
+    ((dir << 30) | ((std::mem::size_of::<T>() as u32) << 16) | (FS_IOC_MAGIC << 8) | nr)
+        as libc::Ioctl
+}
+
+const FS_IOC_GETFSLABEL: libc::Ioctl = fs_ioc::<[u8; FSLABEL_MAX]>(IOC_READ, FS_IOC_GETFSLABEL_NR);
+const FS_IOC_SETFSLABEL: libc::Ioctl = fs_ioc::<[u8; FSLABEL_MAX]>(IOC_WRITE, FS_IOC_SETFSLABEL_NR);
+
+#[derive(Parser, Debug)]
+#[command(about = "Print filesystem label")]
+pub struct GetLabelCli {
+    /// Mounted filesystem path
+    target: String,
+}
+
+#[derive(Parser, Debug)]
+#[command(about = "Set filesystem label")]
+pub struct SetLabelCli {
+    /// Mounted filesystem path
+    target: String,
+
+    /// New filesystem label
+    label: String,
+}
+
+fn get_label(cli: GetLabelCli) -> Result<()> {
+    let handle = BcachefsHandle::open(&cli.target)
+        .with_context(|| format!("opening mounted filesystem '{}'", cli.target))?;
+    let mut label = [0u8; FSLABEL_MAX];
+
+    let ret = unsafe { libc::ioctl(handle.ioctl_fd_raw(), FS_IOC_GETFSLABEL, label.as_mut_ptr()) };
+    if ret < 0 {
+        return Err(std::io::Error::last_os_error()).context("FS_IOC_GETFSLABEL");
+    }
+
+    let label = CStr::from_bytes_until_nul(&label)
+        .context("filesystem label is not nul-terminated")?
+        .to_string_lossy();
+    println!("{label}");
+    Ok(())
+}
+
+fn set_label(cli: SetLabelCli) -> Result<()> {
+    if cli.label.as_bytes().len() >= BCH_SB_LABEL_SIZE {
+        bail!(
+            "filesystem label too long (max {} characters)",
+            BCH_SB_LABEL_SIZE - 1
+        );
+    }
+
+    let handle = BcachefsHandle::open(&cli.target)
+        .with_context(|| format!("opening mounted filesystem '{}'", cli.target))?;
+    let mut label = [0u8; FSLABEL_MAX];
+    label[..cli.label.len()].copy_from_slice(cli.label.as_bytes());
+
+    let ret = unsafe { libc::ioctl(handle.ioctl_fd_raw(), FS_IOC_SETFSLABEL, label.as_ptr()) };
+    if ret < 0 {
+        return Err(std::io::Error::last_os_error()).context("FS_IOC_SETFSLABEL");
+    }
+    Ok(())
+}
+
+pub const CMD_GET_LABEL: super::CmdDef = typed_cmd!(
+    "get-label",
+    "Print filesystem label",
+    aliases: ["label"],
+    GetLabelCli,
+    get_label
+);
+
+pub const CMD_SET_LABEL: super::CmdDef =
+    typed_cmd!("set-label", "Set filesystem label", SetLabelCli, set_label);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -85,6 +85,7 @@ pub mod fusemount;
 pub mod image;
 pub mod key;
 pub mod kill_btree_node;
+pub mod label;
 pub mod journal_rewind_info;
 pub mod list;
 pub mod list_journal;
@@ -203,6 +204,7 @@ pub const COMMAND_GROUPS: &[GroupDef] = &[
     GroupDef { heading: "Superblock commands", commands: &[
         &format::CMD, &super_cmd::CMD, &recover_super::CMD,
         &set_option::CMD, &counters::CMD, &strip_alloc::CMD,
+        &label::CMD_GET_LABEL, &label::CMD_SET_LABEL,
     ]},
     GroupDef { heading: "Images",                   commands: &[&image::CMD] },
     GroupDef { heading: "Mount",                    commands: &[&mount::CMD, &fusemount::CMD, &wait_devices::CMD] },


### PR DESCRIPTION
Adds `get-label` and `set-label` commands for mounted bcachefs filesystems.

The commands use the existing VFS filesystem-label ioctls (`FS_IOC_GETFSLABEL` and `FS_IOC_SETFSLABEL`), so they operate on any path inside the mounted filesystem rather than rewriting a superblock offline.
The setter enforces the current bcachefs filesystem label field limit before issuing the ioctl.
The getter is also exposed through the `label` alias for quick inspection.

Fixes koverstreet/bcachefs#617.
Related to koverstreet/bcachefs#551, koverstreet/bcachefs#1041, and koverstreet/bcachefs-tools#246.
Companion ktest coverage: koverstreet/ktest#86.
Validation:
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32`
- `BINDGEN=/home/kom/.cargo/bin/bindgen cargo check -q`
- `git diff --check`
- `./target/release/bcachefs get-label --help`
- `./target/release/bcachefs set-label --help`
