### PR TITLE
device: let online resize delegate shrink to kernel

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -489,7 +489,10 @@ Force, if data will be lost
 Set state of an offline device
 .El
 .It Nm Ic device Ic resize Ar device Op Ar size
-Resize filesystem on a device
+Resize filesystem on a device.
+Online shrinking is passed to the mounted filesystem kernel; if that kernel
+does not support shrinking, the resize ioctl fails.  Offline shrinking is still
+unsupported by the bundled userspace filesystem implementation.
 .It Nm Ic device Ic resize-journal Ar device Op Ar size
 Resize journal on a device
 .El

--- a/src/commands/device.rs
+++ b/src/commands/device.rs
@@ -414,14 +414,17 @@ fn cmd_device_resize(cli: ResizeCli) -> Result<()> {
             let usage = handle.dev_usage(dev_idx)
                 .context("querying device usage")?;
             let nbuckets = size_sectors / usage.bucket_size as u64;
-
-            if nbuckets < usage.nr_buckets {
-                return Err(anyhow!("Shrinking not supported yet"));
-            }
+            let shrinking = nbuckets < usage.nr_buckets;
 
             println!("resizing {} to {} buckets", cli.device, nbuckets);
             handle.disk_resize(dev_idx, nbuckets)
-                .context("resizing device")?;
+                .with_context(|| {
+                    if shrinking {
+                        "shrinking device (requires kernel shrink support)"
+                    } else {
+                        "resizing device"
+                    }
+                })?;
         }
         Err(_) if Path::new(&cli.device).exists() => {
             println!("Doing offline resize of {}", cli.device);


### PR DESCRIPTION
This removes the tools-side online shrink precheck from `bcachefs device resize` so mounted filesystems can delegate smaller target sizes to the kernel resize ioctl.

That keeps current kernels honest: if shrink is unsupported, the ioctl still fails, now with shrink-specific context from the CLI.
The offline path still rejects shrinking because the bundled userspace/libbcachefs implementation has not gained the shrink machinery yet.

This is an independent tools-side delegation patch that matches the CLI boundary discussed around koverstreet/bcachefs#1070; it does not import or flatten the older shrink implementation branch. The full tools-targeted shrink stack is carried separately in koverstreet/bcachefs-tools#742 with original Jul Lang / Codex commits preserved where practical and Komzpa tools adaptations split at the tail.

Related to koverstreet/bcachefs-tools#268, koverstreet/bcachefs#781, koverstreet/bcachefs#1070, and koverstreet/bcachefs#1073.
Does not claim full filesystem shrinking support by itself.

Validation:
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32`
- `BINDGEN=/home/kom/.cargo/bin/bindgen cargo check -q`
- `git diff --check`
- `./target/release/bcachefs device resize --help`
- GitHub CI is passing for head `81ee809c6d8922a04c0e5d2cebbb19f7950ad47e`
