### PR TITLE
bcachefs: translate 32-bit readdir dirents

### DIFF
--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -35,6 +35,7 @@
 
 #include <linux/aio.h>
 #include <linux/backing-dev.h>
+#include <linux/compat.h>
 #include <linux/exportfs.h>
 #include <linux/fileattr.h>
 #include <linux/fs_context.h>
@@ -1480,10 +1481,130 @@ static int bch2_mmap(struct file *file, struct vm_area_struct *vma)
 
 /* Directories: */
 
+struct bch_dir_cookie_state {
+	bool		valid;
+	loff_t		cookie;
+	u64		next_pos;
+};
+
+#define BCH2_READDIR_32_FIRST	2
+#define BCH2_READDIR_32_EOF	INT_MAX
+
+static inline bool bch2_dir_32bit_api(void)
+{
+#ifdef CONFIG_COMPAT
+	return in_compat_syscall();
+#else
+	return BITS_PER_LONG == 32;
+#endif
+}
+
+static inline bool bch2_dir_32bit_dirents(struct file *file)
+{
+	return (file->f_mode & FMODE_32BITHASH) ||
+		(!(file->f_mode & FMODE_64BITHASH) && bch2_dir_32bit_api());
+}
+
+static inline unsigned bch2_dir_cookie_shift(const struct bch_hash_info *hash)
+{
+	if (hash->is_31bit)
+		return 0;
+	if (hash->type == BCH_STR_HASH_crc32c)
+		return 1;
+	return 32;
+}
+
+/*
+ * 32-bit readdir ABIs have to round-trip d_off through signed long and d_ino
+ * through unsigned long. Keep bcachefs' internal cursor 64-bit, but hand the
+ * caller values that its dirent layout can represent.
+ */
+static inline loff_t bch2_dir_pos_to_32(const struct bch_hash_info *hash, u64 pos)
+{
+	unsigned shift = bch2_dir_cookie_shift(hash);
+
+	if (pos < BCH2_READDIR_32_FIRST || !shift)
+		return min_t(loff_t, pos, BCH2_READDIR_32_EOF);
+
+	return min_t(loff_t, BCH2_READDIR_32_EOF - 1,
+		     max_t(loff_t, BCH2_READDIR_32_FIRST,
+			   pos >> shift));
+}
+
+static inline u64 bch2_dir_pos_from_32(const struct bch_hash_info *hash, loff_t pos)
+{
+	unsigned shift = bch2_dir_cookie_shift(hash);
+
+	if (pos < BCH2_READDIR_32_FIRST || !shift)
+		return pos;
+	if (pos == BCH2_READDIR_32_FIRST)
+		return BCH2_READDIR_32_FIRST;
+	if (pos >= BCH2_READDIR_32_EOF)
+		return U64_MAX;
+	return (u64) pos << shift;
+}
+
+static inline u32 bch2_dir_ino_to_32(u64 ino)
+{
+	u32 ret = ino;
+
+	return ret ?: 1;
+}
+
+struct bch_readdir_ctx32 {
+	struct dir_context		ctx;
+	struct dir_context		*dst;
+	struct bch_dir_cookie_state	*state;
+	struct bch_hash_info		*hash;
+};
+
+#if defined(__KERNEL__) && LINUX_VERSION_CODE >= KERNEL_VERSION(7,1,0)
+typedef bool bch2_filldir_ret_t;
+#define bch2_filldir_ret_success(_ret)	(_ret)
+#else
+typedef int bch2_filldir_ret_t;
+#define bch2_filldir_ret_success(_ret)	(!(_ret))
+#endif
+
+static bch2_filldir_ret_t bch2_readdir_emit32(struct dir_context *ctx,
+					      const char *name, int namelen,
+					      loff_t offset, u64 ino, unsigned type)
+{
+	struct bch_readdir_ctx32 *src = container_of(ctx, struct bch_readdir_ctx32, ctx);
+	loff_t cookie = bch2_dir_pos_to_32(src->hash, offset);
+	u32 ino32 = bch2_dir_ino_to_32(ino);
+	bch2_filldir_ret_t ret = src->dst->actor(src->dst, name, namelen, cookie, ino32, type);
+
+	if (bch2_filldir_ret_success(ret) && src->state) {
+		src->state->valid = true;
+		src->state->cookie = cookie;
+		src->state->next_pos = offset + 1;
+	}
+
+	return ret;
+}
+
+static int bch2_dir_open(struct inode *vinode, struct file *file)
+{
+	file->private_data = kzalloc(sizeof(struct bch_dir_cookie_state), GFP_KERNEL);
+	return file->private_data ? 0 : -ENOMEM;
+}
+
+static int bch2_dir_release(struct inode *vinode, struct file *file)
+{
+	kfree(file->private_data);
+	return 0;
+}
+
 static loff_t bch2_dir_llseek(struct file *file, loff_t offset, int whence)
 {
-	return generic_file_llseek_size(file, offset, whence,
-					S64_MAX, S64_MAX);
+	struct bch_dir_cookie_state *state = file->private_data;
+	loff_t max = bch2_dir_32bit_dirents(file) ? BCH2_READDIR_32_EOF : S64_MAX;
+
+	if (state)
+		state->valid = false;
+
+	return generic_file_llseek_size(file, offset, whence, max, max);
 }
 
 static int bch2_vfs_readdir(struct file *file, struct dir_context *ctx)
@@ -1494,10 +1615,33 @@ static int bch2_vfs_readdir(struct file *file, struct dir_context *ctx)
 	struct bch_hash_info hash;
 	try(bch2_hash_info_init(c, &inode->ei_inode, &hash));
 
-	if (!dir_emit_dots(file, ctx))
-		return 0;
+	int ret;
 
-	int ret = bch2_readdir(c, inode_inum(inode), &hash, ctx);
+	if (bch2_dir_32bit_dirents(file)) {
+		struct bch_dir_cookie_state *state = file->private_data;
+		u64 start = state && state->valid && state->cookie == ctx->pos
+			? state->next_pos
+			: bch2_dir_pos_from_32(&hash, ctx->pos);
+		struct bch_readdir_ctx32 ctx32 = {
+			.ctx	= { .actor = bch2_readdir_emit32, .pos = start, },
+			.dst	= ctx,
+			.state	= state,
+			.hash	= &hash,
+		};
+
+		if (!dir_emit_dots(file, &ctx32.ctx)) {
+			ctx->pos = bch2_dir_pos_to_32(&hash, ctx32.ctx.pos);
+			return 0;
+		}
+
+		ret = bch2_readdir(c, inode_inum(inode), &hash, &ctx32.ctx);
+		ctx->pos = bch2_dir_pos_to_32(&hash, ctx32.ctx.pos);
+	} else {
+		if (!dir_emit_dots(file, ctx))
+			return 0;
+
+		ret = bch2_readdir(c, inode_inum(inode), &hash, ctx);
+	}
 
 	bch_err_fn(c, ret);
 	return bch2_err_class(ret);
@@ -1718,6 +1862,8 @@ static const struct inode_operations bch_dir_inode_operations = {
 };
 
 static const struct file_operations bch_dir_file_operations = {
+	.open		= bch2_dir_open,
+	.release	= bch2_dir_release,
 	.llseek		= bch2_dir_llseek,
 	.read		= generic_read_dir,
 	.iterate_shared	= bch2_vfs_readdir,


### PR DESCRIPTION
## Summary

- Translate bcachefs directory entries for 32-bit `readdir()` callers, or upper layers requesting `FMODE_32BITHASH`, without changing the on-disk dirent hash format.
- Keep bcachefs' internal directory cursor on the real btree offset while returning 32-bit-representable `d_off` cookies to userspace.
- Take the directory `str_hash` mode into account:
  - `BCH_INODE_31bit_dirent_offset` directories already have representable cookies, so their offsets are left alone;
  - `crc32c` directories use the high 31 bits of the 32-bit hash (`pos >> 1`);
  - 64-bit hash directories use the high 31 bits of the 63-bit positive hash (`pos >> 32`).
- Also translate emitted `d_ino` values for the same 32-bit dirent path, including `.` and `..`, so shallow directories under a default-formatted filesystem do not still fail before normal entries are reached.
- Keep a per-open-directory resume state so linear `getdents()` pagination can continue from the exact real btree position even when several real offsets collapse to the same 32-bit cookie.

## Issue

koverstreet/bcachefs#650 reports 32-bit userspace hitting `EOVERFLOW` from `readdir()` on bcachefs. The visible Steam/Wine style failure is not only a subtree-created-with-`inodes_32bit` problem: a default-formatted filesystem can hand 32-bit userspace directory cookies or inode numbers that its `struct dirent` cannot represent.

The earlier shape of this branch tried to make more directories use `BCH_INODE_31bit_dirent_offset`. That was too narrow. Kent pointed out that ext4 handles the cookie side of this class of problem by translating readdir cookies at runtime instead of changing the on-disk directory format.

## Approach

For 64-bit callers, behaviour is unchanged.

For 32-bit dirent callers, the VFS readdir path wraps the `dir_context` for the whole directory stream:

- `.` and `..` are emitted through the wrapper, so parent inode overflow is handled instead of being left as the first shallow-directory failure;
- ctx positions `0` and `1` remain dot positions, so the wrapper does not skip dot entries;
- ordinary bcachefs dirents are still iterated internally by their real btree positions;
- emitted offsets are translated only when the directory hash format needs it;
- emitted inode numbers are truncated to a nonzero 32-bit value on the same compat path;
- `llseek()` is bounded to the 32-bit cookie space for these callers;
- the per-open state records the real next btree position after successful emits, avoiding loops across `getdents()` calls when translated cookies collide.

This keeps 32-bit `seekdir()` semantics ext4-like: seeks by a collapsed cookie can be inexact, but linear iteration and pagination keep forward progress without changing existing on-disk directories.

## Tests

koverstreet/ktest#66 covers the default-formatted filesystem case directly: it creates a nested `/home/someone/gamesdir` tree without `--inodes_32bit`, fills it with entries, and reads both the mount root and nested game directory from a 32-bit `readdir(3)` caller.

The ktest companion now runs the Steam/Wine-style shape: x86_64 kernel plus `IA32_EMULATION`, with the userspace helper compiled using `gcc -m32`. It also requires `.` and `..` to appear and exercises `--str_hash=crc32c` plus `--inodes_32bit` formatted filesystems.

## Validation

- `git diff --check`
- `cargo check -q -p bcachefs-tools`
- `make -j32 bcachefs`
- `bash -n tests/fs/bcachefs/32bit.ktest`
- GitHub CI on koverstreet/bcachefs-tools#652: 17/17 successful
- Local VM proof: x86_64 ktest kernel built with `IA32_EMULATION=y`, bcachefs DKMS from this branch loaded, and a static i386 `readdir(3)` helper successfully read the default root, nested `/home/someone/gamesdir`, `--str_hash=crc32c`, and `--inodes_32bit` cases with fsck/end checks.

Current heads:

- koverstreet/bcachefs-tools#652: `b4a0a4cbffa67bf1235924de683eb7cf597f9c2c`
- koverstreet/ktest#66: `456a6392b96ecdb909c131cdc35405c8d1376c84`
