### PR TITLE
docs: describe qemu direct io alignment

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -28,6 +28,7 @@ At this moment, only a few of these are described here.
    :numbered:
 
    casefolding
+   qemu_direct_io
    errorcodes
 
 Future design

--- a/Documentation/qemu_direct_io.rst
+++ b/Documentation/qemu_direct_io.rst
@@ -1,0 +1,31 @@
+.. SPDX-License-Identifier: GPL-2.0
+
+QEMU cache=none and direct I/O alignment
+========================================
+
+QEMU's ``cache=none`` mode uses ``O_DIRECT`` for image I/O.  On bcachefs,
+direct writes must be aligned to the filesystem block size: both the file
+offset and I/O length have to be multiples of ``block_size``.  The kernel
+advertises this contract through ``statx(STATX_DIOALIGN)``:
+
+* ``stx_dio_mem_align`` is currently 512 bytes.
+* ``stx_dio_offset_align`` is the bcachefs block size.
+
+The common bcachefs block size is 4 KiB.  A virtual disk that exposes 512-byte
+logical sectors can therefore issue guest writes that are valid for the guest
+block device but not valid ``O_DIRECT`` writes to the host image file.  In that
+case the host write is rejected and the guest may report I/O errors such as
+``Invalid field in cdb`` while formatting or using the virtual disk.
+
+For virtual machine image files, use one of these configurations:
+
+* Configure the virtual disk logical and physical block size to match the
+  bcachefs block size when using ``cache=none``.
+* Use a QEMU cache mode that does not require unpadded 512-byte ``O_DIRECT``
+  writes to the image file.
+* If 512-byte direct I/O is required, format the bcachefs filesystem with a
+  512-byte block size.
+
+These errors are rejected I/O, not silent corruption.  Userspace that uses
+``O_DIRECT`` should check ``STATX_DIOALIGN`` and avoid issuing writes that do
+not satisfy the advertised alignment.


### PR DESCRIPTION
## Summary

- Add bcachefs documentation for QEMU `cache=none` and direct-I/O alignment.
- Explain that bcachefs rejects misaligned `O_DIRECT` writes instead of silently corrupting data.
- Point userspace toward `STATX_DIOALIGN` and list practical VM-image configurations.

## Issue

koverstreet/bcachefs#791 reports VM image I/O errors with QEMU `cache=none`; koverstreet/bcachefs#1095 reports the same class of `BLK_STS_INVAL` failures with Proxmox raw VM disks on bcachefs. Current bcachefs already advertises direct-I/O alignment through `STATX_DIOALIGN`: memory alignment is 512 bytes and offset/length alignment is the bcachefs block size. With a common 4 KiB bcachefs block size, a virtual disk exposing 512-byte sectors can issue writes that are valid for the guest block device but invalid as host-file `O_DIRECT`.

References koverstreet/bcachefs#1095.

## Tests

- koverstreet/ktest#67 adds focused coverage for the advertised direct-I/O alignment contract.

## Validation

- `rst2html.py --halt=2 Documentation/qemu_direct_io.rst`
- `git diff --check origin/testing...HEAD`
- Branch rebased on current `origin/testing` and force-pushed from `c52e6c0894ff2ae983b580959e23d97025305114` to `f0966c3dff78c3243d7999df824240b0126f289f`
- GitHub CI: 17/17 visible Nix Flake checks green for refreshed head `f0966c3dff78c3243d7999df824240b0126f289f`
