### PR TITLE
docs: clarify writeback cache background movement

### DIFF
--- a/doc/bcachefs.5.rst.tmpl
+++ b/doc/bcachefs.5.rst.tmpl
@@ -109,6 +109,12 @@ Together, these options can be used for writeback caching, like so:
   background_target=hdd
   promote_target=ssd
 
+With this configuration, application writes land on the foreground target and
+reconcile later copies them to the background target. The cached foreground copy
+may then be evicted when the allocator needs space; bcachefs does not currently
+provide a cache-fill threshold for delaying background-target movement until the
+foreground target reaches a configured percentage.
+
 Writethrough caching requires telling bcachefs not to trust the cache device,
 which does require a per-device option and thus can't completely be done with
 per-file options. This is done by setting the device's durability to 0.


### PR DESCRIPTION
Clarify the writeback caching docs for `foreground_target` + `background_target` + `promote_target`:

- foreground writes land on the foreground target
- reconcile later copies them to the background target
- the cached foreground copy may then be evicted when space is needed
- there is currently no cache-fill threshold that delays background-target movement until the foreground target reaches a configured percentage

This documents the current behavior and limitation discussed in koverstreet/bcachefs#171 and koverstreet/bcachefs#218; it does not implement that requested threshold/power-policy feature.

Current head: `ef4081aa533035c399526a36607040a6f0b72735`.

Validation:
- `git diff --check origin/master...HEAD`
- `rst2html doc/bcachefs.5.rst.tmpl /tmp/bcachefs-218-pr654.html`
