### PR TITLE
mount: place legacy fallback key in session keyring

### DIFF
--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -18,6 +18,8 @@ use crate::{
     logging,
 };
 
+const MOUNT_KEYRING: Keyring = Keyring::Session;
+
 fn mount_inner(
     src: OsString,
     target: &std::path::Path,
@@ -169,14 +171,14 @@ mod tests {
 /// used, then search for the key or ask for it.
 fn handle_unlock(cli: &Cli, sb: &bch_sb_handle) -> Result<KeyHandle> {
     if let Some(policy) = cli.unlock_policy.as_ref() {
-        return policy.apply(sb);
+        return policy.apply(sb, MOUNT_KEYRING);
     }
 
     if let Some(path) = cli.passphrase_file.as_deref() {
         let passphrase_correct = Passphrase::read_from_file(path)?
             .check(sb)
             .ok_or_else(|| anyhow::anyhow!("incorrect passphrase"))?;
-        return KeyHandle::new(&passphrase_correct, Keyring::User);
+        return KeyHandle::new(&passphrase_correct, MOUNT_KEYRING);
     }
 
     let uuid = sb.sb().uuid();
@@ -185,7 +187,7 @@ fn handle_unlock(cli: &Cli, sb: &bch_sb_handle) -> Result<KeyHandle> {
     }
 
     let passphrase_correct = Passphrase::ask_and_check(sb)?;
-    KeyHandle::new(&passphrase_correct, Keyring::User)
+    KeyHandle::new(&passphrase_correct, MOUNT_KEYRING)
 }
 
 fn cmd_mount_inner(cli: &Cli) -> Result<()> {
@@ -251,8 +253,9 @@ entirely in userspace.\n\n\
 Use OLD_BLKID_UUID=<uuid> in fstab entries when systemd consumes \
 UUID=<uuid> before the bcachefs mount helper can scan all members.\n\n\
 If the filesystem is encrypted, the passphrase will be looked up in \
-the kernel keyring first; if not found, the user is prompted \
-interactively (or reads from stdin if not a terminal). Use -k or --passphrase-file \
+the kernel keyrings first; if not found, the user is prompted \
+interactively (or reads from stdin if not a terminal) and the key is \
+added to the session keyring for the mount. Use -k or --passphrase-file \
 to specify alternative unlock methods.")]
 pub struct Cli {
     /// Path to passphrase file

--- a/src/key.rs
+++ b/src/key.rs
@@ -67,7 +67,7 @@ pub enum UnlockPolicy {
 }
 
 impl UnlockPolicy {
-    pub fn apply(&self, sb: &bch_sb_handle) -> Result<KeyHandle> {
+    pub fn apply(&self, sb: &bch_sb_handle, keyring: Keyring) -> Result<KeyHandle> {
         let uuid = sb.sb().uuid();
 
         info!("Using filesystem unlock policy '{self}' on {uuid}");
@@ -80,14 +80,14 @@ impl UnlockPolicy {
                 let passphrase_correct = passphrase
                     .check(sb)
                     .ok_or_else(|| anyhow!("incorrect passphrase"))?;
-                KeyHandle::new(&passphrase_correct, Keyring::User)
+                KeyHandle::new(&passphrase_correct, keyring)
             }
             Self::Stdin => {
                 let passphrase = Passphrase::read_from_stdin()?;
                 let passphrase_correct = passphrase
                     .check(sb)
                     .ok_or_else(|| anyhow!("incorrect passphrase"))?;
-                KeyHandle::new(&passphrase_correct, Keyring::User)
+                KeyHandle::new(&passphrase_correct, keyring)
             }
         }
     }

--- a/src/key.rs
+++ b/src/key.rs
@@ -109,9 +109,13 @@ impl Unlocked {
 
     /// Put it where bch2_request_key() will look, for the mount(2) path - that
     /// has nowhere to carry a parameter, so the keyring is the only channel.
+    ///
+    /// The kernel searches the invoking task's keyring tree. A fresh session
+    /// need not link the user keyring, so this must be the session keyring the
+    /// mount syscall will run under.
     pub fn to_keyring(&self) -> Result<()> {
         match self {
-            Self::Key(k)    => KeyHandle::new(k, Keyring::User).map(|_| ()),
+            Self::Key(k)    => KeyHandle::new(k, Keyring::Session).map(|_| ()),
             Self::InKeyring => Ok(()),
         }
     }


### PR DESCRIPTION
A freshly created session keyring need not link the user keyring. In the legacy mount(2) fallback, placing a prompted or file-derived key only in the user keyring can therefore leave the immediate kernel request_key() unable to find it.

Use the session keyring for keys held by the mount helper when it takes this fallback. The normal fsconfig path continues passing the private user_key parameter directly, and previously unlocked keys are unchanged.

A disposable empty-session keyutils probe reproduced ENOKEY for a user-keyring-only key; adding the same dummy key to the session keyring made request_key() succeed. Both keys were revoked. The userspace build and all 40 package tests passed. No filesystem mount was performed in this probe.

Related: koverstreet/bcachefs#640.
