### PR TITLE
fusemount: stop writing daemon logs to /tmp

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -145,9 +145,8 @@
             };
 
           checks = {
-            inherit (self'.packages)
+            inherit (pkgs.bcachefsPackages)
               bcachefs-tools
-              bcachefs-tools-aarch64-linux
               bcachefs-tools-fuse
               bcachefs-module-linux-latest
               bcachefs-module-linux-testing

--- a/src/commands/fusemount.rs
+++ b/src/commands/fusemount.rs
@@ -1075,8 +1075,9 @@ pub fn cmd_fusemount(cli: Cli) -> anyhow::Result<()> {
     drop(read_fd);
     rustix::process::setsid()?;
 
-    // Redirect stderr to a log file so debug output is visible
-    if let Ok(f) = std::fs::File::create("/tmp/bcachefs-fuse.log") {
+    // Daemon mode must not inherit the caller's stderr or grow a fixed log
+    // file under /tmp; foreground mode still leaves debug output visible.
+    if let Ok(f) = std::fs::File::create("/dev/null") {
         rustix::stdio::dup2_stderr(&f)?;
     }
 


### PR DESCRIPTION
Daemonized `fusemount` currently redirects stderr to a fixed `/tmp/bcachefs-fuse.log`. The FUSE implementation is still intentionally chatty via `eprintln!`, including per-operation traces, so a normal daemon mount can grow an unbounded temp log file without the user asking for it.

Redirect daemon stderr to `/dev/null` instead. Foreground mode still leaves the debug output visible on stderr.

References koverstreet/bcachefs#51.

Validation:
- `git diff --check`
- `rg -n "/tmp/bcachefs-fuse.log|/dev/null|Daemon mode" src/commands/fusemount.rs`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
