### PR TITLE
compress: refresh zstd early abort support

### DIFF
--- a/debian/tests/kernel-smoke-test.04.single-zstd-compression
+++ b/debian/tests/kernel-smoke-test.04.single-zstd-compression
@@ -1,0 +1,131 @@
+#!/bin/sh
+
+set +e
+set -x
+
+echo "kernel smoke test, zstd compression: compressible + incompressible data, remount verify"
+
+STORAGE_SIZE_MB=512
+STORAGE="$(mktemp)"
+dd if=/dev/zero of="$STORAGE" bs=1M count=$STORAGE_SIZE_MB > /dev/null 2>&1
+LODEVICE="$(losetup --find --show $STORAGE)"
+
+cleanup() {
+	losetup -d "$LODEVICE"
+}
+trap cleanup EXIT
+
+bcachefs format --compression=zstd "$LODEVICE"
+ret=$?
+if [ $ret -ne 0 ]; then
+	echo "FAILED: bcachefs format with compression=zstd failed, exit code=$ret"
+	exit 1
+fi
+
+MOUNTPOINT="$(mktemp -d)"
+mount -t bcachefs "$LODEVICE" "$MOUNTPOINT"
+ret=$?
+if [ $ret -ne 0 ]; then
+	echo "FAILED: bcachefs mount failed, exit code=$ret"
+	exit 1
+fi
+
+# Test 1: highly compressible data (repeating zeros)
+dd if=/dev/zero of="$MOUNTPOINT/compressible" bs=1K count=64 2>/dev/null
+ret=$?
+if [ $ret -ne 0 ]; then
+	echo "FAILED: writing compressible data"
+	exit 1
+fi
+
+md5_compressible=$(md5sum "$MOUNTPOINT/compressible" | awk '{print $1}')
+
+# Test 2: incompressible data (random)
+dd if=/dev/urandom of="$MOUNTPOINT/incompressible" bs=1K count=64 2>/dev/null
+ret=$?
+if [ $ret -ne 0 ]; then
+	echo "FAILED: writing incompressible data"
+	exit 1
+fi
+
+md5_incompressible=$(md5sum "$MOUNTPOINT/incompressible" | awk '{print $1}')
+
+# Test 3: mixed content (partially compressible file)
+dd if=/dev/zero of="$MOUNTPOINT/mixed" bs=4K count=16 2>/dev/null
+dd if=/dev/urandom of="$MOUNTPOINT/mixed" bs=4K count=16 oflag=append conv=notrunc 2>/dev/null
+ret=$?
+if [ $ret -ne 0 ]; then
+	echo "FAILED: writing mixed data"
+	exit 1
+fi
+
+md5_mixed=$(md5sum "$MOUNTPOINT/mixed" | awk '{print $1}')
+
+# Test 4: large compressible file (exercises multiple extents)
+dd if=/dev/zero of="$MOUNTPOINT/large-compressible" bs=1M count=128 2>/dev/null
+ret=$?
+if [ $ret -ne 0 ]; then
+	echo "FAILED: writing large compressible data"
+	exit 1
+fi
+
+md5_large=$(md5sum "$MOUNTPOINT/large-compressible" | awk '{print $1}')
+
+# Test 5: large incompressible file
+dd if=/dev/urandom of="$MOUNTPOINT/large-incompressible" bs=1M count=128 2>/dev/null
+ret=$?
+if [ $ret -ne 0 ]; then
+	echo "FAILED: writing large incompressible data"
+	exit 1
+fi
+
+md5_large_incomp=$(md5sum "$MOUNTPOINT/large-incompressible" | awk '{print $1}')
+
+# Verify all data before unmount
+check_md5() {
+	file="$1"
+	expected="$2"
+	actual=$(md5sum "$file" | awk '{print $1}')
+	if [ "$actual" != "$expected" ]; then
+		echo "FAILED: $file checksum mismatch: expected $expected got $actual"
+		return 1
+	fi
+	return 0
+}
+
+check_md5 "$MOUNTPOINT/compressible" "$md5_compressible" || exit 1
+check_md5 "$MOUNTPOINT/incompressible" "$md5_incompressible" || exit 1
+check_md5 "$MOUNTPOINT/mixed" "$md5_mixed" || exit 1
+check_md5 "$MOUNTPOINT/large-compressible" "$md5_large" || exit 1
+check_md5 "$MOUNTPOINT/large-incompressible" "$md5_large_incomp" || exit 1
+
+umount "$MOUNTPOINT"
+ret=$?
+if [ $ret -ne 0 ]; then
+	echo "FAILED: bcachefs umount failed, exit code=$ret"
+	exit 1
+fi
+
+# Remount and verify all data persists correctly
+mount -t bcachefs "$LODEVICE" "$MOUNTPOINT"
+ret=$?
+if [ $ret -ne 0 ]; then
+	echo "FAILED: bcachefs remount failed, exit code=$ret"
+	exit 1
+fi
+
+check_md5 "$MOUNTPOINT/compressible" "$md5_compressible" || exit 1
+check_md5 "$MOUNTPOINT/incompressible" "$md5_incompressible" || exit 1
+check_md5 "$MOUNTPOINT/mixed" "$md5_mixed" || exit 1
+check_md5 "$MOUNTPOINT/large-compressible" "$md5_large" || exit 1
+check_md5 "$MOUNTPOINT/large-incompressible" "$md5_large_incomp" || exit 1
+
+umount "$MOUNTPOINT"
+ret=$?
+if [ $ret -ne 0 ]; then
+	echo "FAILED: bcachefs umount after remount failed, exit code=$ret"
+	exit 1
+fi
+
+echo "PASSED"
+exit 0

--- a/flake.nix
+++ b/flake.nix
@@ -177,9 +177,8 @@
             };
 
           checks = {
-            inherit (self'.packages)
+            inherit (pkgs.bcachefsPackages)
               bcachefs-tools
-              bcachefs-tools-aarch64-linux
               bcachefs-tools-fuse
               bcachefs-module-linux-latest
               bcachefs-module-linux-testing

--- a/fs/Makefile
+++ b/fs/Makefile
@@ -216,6 +216,10 @@ ifdef CONFIG_DEBUG_FS
 	bcachefs-y += debug/async_objs.o
 endif
 
+ifdef BCACHEFS_TESTS
+	bcachefs-y += debug/compress_test.o
+endif
+
 ifndef BCACHEFS_DKMS
 	obj-$(CONFIG_MEAN_AND_VARIANCE_UNIT_TEST)   += util/mean_and_variance_test.o
 endif

--- a/fs/Makefile
+++ b/fs/Makefile
@@ -227,6 +227,10 @@ ifdef CONFIG_DEBUG_FS
 	bcachefs-y += debug/async_objs.o
 endif
 
+ifdef BCACHEFS_TESTS
+	bcachefs-y += debug/compress_test.o
+endif
+
 ifndef BCACHEFS_DKMS
 	obj-$(CONFIG_MEAN_AND_VARIANCE_UNIT_TEST)   += util/mean_and_variance_test.o
 endif

--- a/fs/bcachefs_format.h
+++ b/fs/bcachefs_format.h
@@ -1314,6 +1314,8 @@ LE64_BITMASK(BCH_SB_MOVE_WRITES_FUA,	struct bch_sb, flags[6], 58, 59);
  * the dirent hash-consistency check rather than "repair" the artifacts.
  */
 LE64_BITMASK(BCH_SB_DIRENTS_SANITIZED,	struct bch_sb, flags[6], 59, 60);
+LE64_BITMASK(BCH_SB_ZSTD_COMPRESSION_EARLY_ABORT,
+				struct bch_sb, flags[6], 60, 61);
 
 #define BCH_SB_EXTENT_BP_SHIFT_DEFAULT	10
 

--- a/fs/bcachefs_format.h
+++ b/fs/bcachefs_format.h
@@ -1319,6 +1319,8 @@ LE64_BITMASK(BCH_SB_MOVE_WRITES_FUA,	struct bch_sb, flags[6], 58, 59);
  * the dirent hash-consistency check rather than "repair" the artifacts.
  */
 LE64_BITMASK(BCH_SB_DIRENTS_SANITIZED,	struct bch_sb, flags[6], 59, 60);
+LE64_BITMASK(BCH_SB_ZSTD_COMPRESSION_EARLY_ABORT,
+				struct bch_sb, flags[6], 60, 61);
 
 #define BCH_SB_EXTENT_BP_SHIFT_DEFAULT	10
 

--- a/fs/data/compress.c
+++ b/fs/data/compress.c
@@ -466,6 +466,10 @@ static int attempt_compress(struct bch_fs *c,
 
 			while (in_buf.pos < in_buf.size) {
 				size_t prev_pos = in_buf.pos;
+
+				if (out_buf.pos >= out_buf.size)
+					return 0;
+
 				size_t ret = zstd_compress_stream(cstream,
 								  &out_buf,
 								  &in_buf);
@@ -482,7 +486,9 @@ static int attempt_compress(struct bch_fs *c,
 				return 0;
 		}
 
-		while (1) {
+		for (unsigned i = 0; i < 32; i++) {
+			if (out_buf.pos >= out_buf.size)
+				return 0;
 			size_t ret = zstd_end_stream(cstream, &out_buf);
 			if (zstd_is_error(ret))
 				return 0;
@@ -498,7 +504,7 @@ static int attempt_compress(struct bch_fs *c,
 	}
 }
 
-static unsigned bch2_compress(struct bch_fs *c,
+unsigned bch2_compress(struct bch_fs *c,
 			      void *dst, size_t *dst_len,
 			      void *src, size_t *src_len,
 			      unsigned compression_opt,

--- a/fs/data/compress.c
+++ b/fs/data/compress.c
@@ -438,6 +438,10 @@ static int attempt_compress(struct bch_fs *c,
 		return strm.total_out;
 	}
 	case BCH_COMPRESSION_TYPE_zstd: {
+		/*
+		 * rescale:
+		 * zstd max compression level is 22, our max level is 15
+		 */
 		unsigned level = min((compression.level * 3) / 2, zstd_max_clevel());
 		ZSTD_parameters params = zstd_get_params(level, c->opts.encoded_extent_max);
 		zstd_cstream *cstream;
@@ -447,9 +451,15 @@ static int attempt_compress(struct bch_fs *c,
 		if (!cstream)
 			return 0;
 
+		/*
+		 * ZSTD requires that when we decompress we pass in the exact
+		 * compressed size - rounding it up to the nearest sector
+		 * doesn't work, so we use the first 4 bytes of the buffer for
+		 * that.
+		 */
 		zstd_out_buffer out_buf = {
 			.dst	= dst + 4,
-			.size	= dst_len - 4 - 7,
+			.size	= dst_len - 4,
 			.pos	= 0,
 		};
 		zstd_in_buffer in_buf = {

--- a/fs/data/compress.c
+++ b/fs/data/compress.c
@@ -491,7 +491,8 @@ static int attempt_compress(struct bch_fs *c,
 
 			in_buf.size = src_len;
 
-			if (in_buf.pos > chunk_size &&
+			if (c->opts.zstd_compression_early_abort &&
+			    in_buf.pos > chunk_size &&
 			    out_buf.pos > in_buf.pos)
 				return 0;
 		}

--- a/fs/data/compress.c
+++ b/fs/data/compress.c
@@ -438,34 +438,60 @@ static int attempt_compress(struct bch_fs *c,
 		return strm.total_out;
 	}
 	case BCH_COMPRESSION_TYPE_zstd: {
-		/*
-		 * rescale:
-		 * zstd max compression level is 22, our max level is 15
-		 */
 		unsigned level = min((compression.level * 3) / 2, zstd_max_clevel());
 		ZSTD_parameters params = zstd_get_params(level, c->opts.encoded_extent_max);
-		ZSTD_CCtx *ctx = zstd_init_cctx(workspace, c->compress.zstd_workspace_size);
+		zstd_cstream *cstream;
 
-		/*
-		 * ZSTD requires that when we decompress we pass in the exact
-		 * compressed size - rounding it up to the nearest sector
-		 * doesn't work, so we use the first 4 bytes of the buffer for
-		 * that.
-		 *
-		 * Additionally, the ZSTD code seems to have a bug where it will
-		 * write just past the end of the buffer - so subtract a fudge
-		 * factor (7 bytes) from the dst buffer size to account for
-		 * that.
-		 */
-		size_t len = zstd_compress_cctx(ctx,
-				dst + 4,	dst_len - 4 - 7,
-				src,		src_len,
-				&params);
-		if (zstd_is_error(len))
+		cstream = zstd_init_cstream(&params, src_len,
+					    workspace, c->compress.zstd_workspace_size);
+		if (!cstream)
 			return 0;
 
-		*((__le32 *) dst) = cpu_to_le32(len);
-		return len + 4;
+		zstd_out_buffer out_buf = {
+			.dst	= dst + 4,
+			.size	= dst_len - 4 - 7,
+			.pos	= 0,
+		};
+		zstd_in_buffer in_buf = {
+			.src	= src,
+			.size	= src_len,
+			.pos	= 0,
+		};
+
+		size_t chunk_size = block_bytes(c) * 4;
+
+		while (in_buf.pos < src_len) {
+			size_t to_feed = min(chunk_size, src_len - in_buf.pos);
+			in_buf.size = in_buf.pos + to_feed;
+
+			while (in_buf.pos < in_buf.size) {
+				size_t prev_pos = in_buf.pos;
+				size_t ret = zstd_compress_stream(cstream,
+								  &out_buf,
+								  &in_buf);
+				if (zstd_is_error(ret))
+					return 0;
+				if (in_buf.pos == prev_pos)
+					return 0;
+			}
+
+			in_buf.size = src_len;
+
+			if (in_buf.pos > chunk_size &&
+			    out_buf.pos > in_buf.pos)
+				return 0;
+		}
+
+		while (1) {
+			size_t ret = zstd_end_stream(cstream, &out_buf);
+			if (zstd_is_error(ret))
+				return 0;
+			if (ret == 0)
+				break;
+		}
+
+		*((__le32 *) dst) = cpu_to_le32(out_buf.pos);
+		return out_buf.pos + 4;
 	}
 	default:
 		BUG();
@@ -692,7 +718,7 @@ static int __bch2_fs_compress_init(struct bch_fs *c, u64 features)
 	ZSTD_parameters params = zstd_get_params(zstd_max_clevel(),
 						 c->opts.encoded_extent_max);
 
-	c->compress.zstd_workspace_size = zstd_cctx_workspace_bound(&params.cParams);
+	c->compress.zstd_workspace_size = zstd_cstream_workspace_bound(&params.cParams);
 
 	struct {
 		unsigned			feature;

--- a/fs/data/compress.c
+++ b/fs/data/compress.c
@@ -404,7 +404,7 @@ static size_t compress_workspace_size(struct bch_fs *c,
 	case BCH_COMPRESSION_TYPE_zstd: {
 		ZSTD_parameters params = zstd_params(c, compression);
 
-		return zstd_cctx_workspace_bound(&params.cParams);
+		return zstd_cstream_workspace_bound(&params.cParams);
 	}
 	default:
 		BUG();
@@ -481,28 +481,68 @@ static int attempt_compress(struct bch_fs *c,
 	}
 	case BCH_COMPRESSION_TYPE_zstd: {
 		ZSTD_parameters params = zstd_params(c, compression);
-		ZSTD_CCtx *ctx = zstd_init_cctx(workspace, workspace_size);
+		zstd_cstream *cstream;
 
-		/*
-		 * ZSTD requires that when we decompress we pass in the exact
-		 * compressed size - rounding it up to the nearest sector
-		 * doesn't work, so we use the first 4 bytes of the buffer for
-		 * that.
-		 *
-		 * Additionally, the ZSTD code seems to have a bug where it will
-		 * write just past the end of the buffer - so subtract a fudge
-		 * factor (7 bytes) from the dst buffer size to account for
-		 * that.
-		 */
-		size_t len = zstd_compress_cctx(ctx,
-				dst + 4,	dst_len - 4 - 7,
-				src,		src_len,
-				&params);
-		if (zstd_is_error(len))
+		cstream = zstd_init_cstream(&params, src_len,
+					    workspace, workspace_size);
+		if (!cstream)
 			return 0;
 
-		*((__le32 *) dst) = cpu_to_le32(len);
-		return len + 4;
+		/* The first four bytes record the exact compressed byte count. */
+		zstd_out_buffer out_buf = {
+			.dst	= dst + 4,
+			.size	= dst_len - 4,
+			.pos	= 0,
+		};
+		zstd_in_buffer in_buf = {
+			.src	= src,
+			.size	= src_len,
+			.pos	= 0,
+		};
+
+		size_t chunk_size = block_bytes(c) * 4;
+
+		while (in_buf.pos < src_len) {
+			size_t to_feed = min(chunk_size, src_len - in_buf.pos);
+			in_buf.size = in_buf.pos + to_feed;
+
+			while (in_buf.pos < in_buf.size) {
+				size_t prev_pos = in_buf.pos;
+
+				if (out_buf.pos == out_buf.size)
+					return 0;
+				size_t ret = zstd_compress_stream(cstream,
+								  &out_buf,
+								  &in_buf);
+				if (zstd_is_error(ret))
+					return 0;
+				if (in_buf.pos == prev_pos)
+					return 0;
+			}
+
+			in_buf.size = src_len;
+
+			if (in_buf.pos > chunk_size &&
+			    out_buf.pos > in_buf.pos)
+				return 0;
+		}
+
+		while (1) {
+			size_t prev_pos = out_buf.pos;
+
+			if (out_buf.pos == out_buf.size)
+				return 0;
+			size_t ret = zstd_end_stream(cstream, &out_buf);
+			if (zstd_is_error(ret))
+				return 0;
+			if (ret == 0)
+				break;
+			if (out_buf.pos == prev_pos)
+				return 0;
+		}
+
+		*((__le32 *) dst) = cpu_to_le32(out_buf.pos);
+		return out_buf.pos + 4;
 	}
 	default:
 		BUG();
@@ -754,7 +794,7 @@ static int __bch2_fs_compress_init(struct bch_fs *c, u64 features)
 	ZSTD_parameters params = zstd_get_params(zstd_max_clevel(),
 						 c->opts.encoded_extent_max);
 
-	c->compress.zstd_workspace_size = zstd_cctx_workspace_bound(&params.cParams);
+	c->compress.zstd_workspace_size = zstd_cstream_workspace_bound(&params.cParams);
 
 	struct {
 		unsigned			feature;

--- a/fs/data/compress.c
+++ b/fs/data/compress.c
@@ -509,7 +509,7 @@ static int attempt_compress(struct bch_fs *c,
 			while (in_buf.pos < in_buf.size) {
 				size_t prev_pos = in_buf.pos;
 
-				if (out_buf.pos == out_buf.size)
+				if (out_buf.pos >= out_buf.size)
 					return 0;
 				size_t ret = zstd_compress_stream(cstream,
 								  &out_buf,
@@ -549,7 +549,7 @@ static int attempt_compress(struct bch_fs *c,
 	}
 }
 
-static unsigned bch2_compress(struct bch_fs *c,
+unsigned bch2_compress(struct bch_fs *c,
 			      void *dst, size_t *dst_len,
 			      void *src, size_t *src_len,
 			      unsigned compression_opt,

--- a/fs/data/compress.c
+++ b/fs/data/compress.c
@@ -527,7 +527,8 @@ static int attempt_compress(struct bch_fs *c,
 
 			in_buf.size = src_len;
 
-			if (in_buf.pos > chunk_size &&
+			if (c->opts.zstd_compression_early_abort &&
+			    in_buf.pos > chunk_size &&
 			    out_buf.pos > in_buf.pos)
 				return 0;
 		}

--- a/fs/data/compress.c
+++ b/fs/data/compress.c
@@ -488,7 +488,12 @@ static int attempt_compress(struct bch_fs *c,
 		if (!cstream)
 			return 0;
 
-		/* The first four bytes record the exact compressed byte count. */
+		/*
+		 * ZSTD requires that when we decompress we pass in the exact
+		 * compressed size - rounding it up to the nearest sector
+		 * doesn't work, so we use the first 4 bytes of the buffer for
+		 * that.
+		 */
 		zstd_out_buffer out_buf = {
 			.dst	= dst + 4,
 			.size	= dst_len - 4,

--- a/fs/data/compress.h
+++ b/fs/data/compress.h
@@ -65,6 +65,12 @@ unsigned bch2_bio_compress(struct bch_fs *, struct bio *, size_t *,
 			   struct bio *, size_t *, unsigned,
 			   struct bpos, bool);
 
+unsigned bch2_compress(struct bch_fs *c,
+		       void *dst, size_t *dst_len,
+		       void *src, size_t *src_len,
+		       unsigned compression_opt,
+		       struct bpos write_pos);
+
 int bch2_check_set_has_compressed_data(struct bch_fs *, unsigned);
 void bch2_fs_compress_exit(struct bch_fs *);
 int bch2_fs_compress_init(struct bch_fs *);

--- a/fs/data/compress.h
+++ b/fs/data/compress.h
@@ -74,6 +74,12 @@ unsigned bch2_bio_compress(struct bch_fs *, struct bio *, size_t *,
 			   struct bio *, size_t *, unsigned,
 			   struct bpos, bool);
 
+unsigned bch2_compress(struct bch_fs *c,
+		       void *dst, size_t *dst_len,
+		       void *src, size_t *src_len,
+		       unsigned compression_opt,
+		       struct bpos write_pos);
+
 int bch2_check_set_has_compressed_data(struct bch_fs *, unsigned);
 void bch2_fs_compress_exit(struct bch_fs *);
 int bch2_fs_compress_init(struct bch_fs *);

--- a/fs/debug/compress_test.c
+++ b/fs/debug/compress_test.c
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifdef CONFIG_BCACHEFS_TESTS
+
+#include "bcachefs.h"
+
+#include "data/compress.h"
+#include "data/compress_types.h"
+
+#include "tests.h"
+
+#include "linux/random.h"
+#include "linux/zstd.h"
+
+static void fill_compressible(void *buf, size_t len)
+{
+	memset(buf, 0, len);
+}
+
+static void fill_incompressible(void *buf, size_t len)
+{
+	get_random_bytes(buf, len);
+}
+
+static int test_zstd_compress_decompress(struct bch_fs *c, u64 nr)
+{
+	size_t src_len = min(c->opts.encoded_extent_max, 256ULL << 10);
+	size_t dst_len = src_len;
+	int ret = 0;
+
+	pr_info("zstd compress/decompress roundtrip test, src_len=%zu", src_len);
+
+	void *src __cleanup(kfree) = kmalloc(src_len, GFP_KERNEL);
+	void *dst __cleanup(kfree) = kmalloc(dst_len, GFP_KERNEL);
+	void *verify __cleanup(kfree) = kmalloc(src_len, GFP_KERNEL);
+	if (!src || !dst || !verify)
+		return -ENOMEM;
+
+	for (u64 i = 0; i < nr; i++) {
+		size_t this_src = src_len;
+		size_t this_dst = dst_len;
+
+		if (i & 1)
+			fill_compressible(src, this_src);
+		else
+			fill_incompressible(src, this_src);
+
+		union bch_compression_opt compression = {
+			.type	= BCH_COMPRESSION_OPT_zstd,
+			.level	= (i % 15) + 1,
+		};
+
+		unsigned type = bch2_compress(c, dst, &this_dst,
+					      src, &this_src,
+					      compression.value,
+					      POS(0, 0));
+
+		if (type == BCH_COMPRESSION_TYPE_incompressible) {
+			if (i & 1) {
+				bch_err(c, "test_zstd: compressible data marked incompressible (iter %llu, level %u)",
+					i, compression.level);
+				return -EIO;
+			}
+			continue;
+		}
+
+		if (type != BCH_COMPRESSION_TYPE_zstd) {
+			bch_err(c, "test_zstd: unexpected compression type %u (iter %llu)",
+				type, i);
+			return -EIO;
+		}
+
+		struct bch_extent_crc_unpacked crc = {
+			.compressed_size	= this_dst >> 9,
+			.uncompressed_size	= this_src >> 9,
+			.compression_type	= type,
+		};
+
+		ret = buf_uncompress(c, verify, dst, crc);
+		if (ret) {
+			bch_err(c, "test_zstd: decompression failed (iter %llu, level %u): %s",
+				i, compression.level, bch2_err_str(ret));
+			return ret;
+		}
+
+		if (memcmp(verify, src, this_src)) {
+			bch_err(c, "test_zstd: decompressed data mismatch (iter %llu, level %u)",
+				i, compression.level);
+			return -EIO;
+		}
+	}
+
+	pr_info("zstd compress/decompress roundtrip test passed, %llu iterations", nr);
+	return 0;
+}
+
+static int test_zstd_early_abort_incompressible(struct bch_fs *c, u64 nr)
+{
+	size_t src_len = min(c->opts.encoded_extent_max, 256ULL << 10);
+	size_t dst_len = src_len;
+
+	pr_info("zstd early abort test with random data, src_len=%zu", src_len);
+
+	void *src __cleanup(kfree) = kmalloc(src_len, GFP_KERNEL);
+	void *dst __cleanup(kfree) = kmalloc(dst_len, GFP_KERNEL);
+	if (!src || !dst)
+		return -ENOMEM;
+
+	unsigned incompressible_count = 0;
+
+	for (u64 i = 0; i < nr; i++) {
+		size_t this_src = src_len;
+		size_t this_dst = dst_len;
+
+		fill_incompressible(src, this_src);
+
+		union bch_compression_opt compression = {
+			.type	= BCH_COMPRESSION_OPT_zstd,
+			.level	= 3,
+		};
+
+		unsigned type = bch2_compress(c, dst, &this_dst,
+					      src, &this_src,
+					      compression.value,
+					      POS(0, 0));
+
+		if (type == BCH_COMPRESSION_TYPE_incompressible)
+			incompressible_count++;
+	}
+
+	if (incompressible_count < nr / 2) {
+		bch_err(c, "test_zstd_early_abort: expected mostly incompressible, got %u/%llu",
+			incompressible_count, nr);
+		return -EIO;
+	}
+
+	pr_info("zstd early abort test passed, %u/%llu correctly detected as incompressible",
+		incompressible_count, nr);
+	return 0;
+}
+
+static int test_zstd_levels(struct bch_fs *c, u64 nr)
+{
+	size_t src_len = min(c->opts.encoded_extent_max, 128ULL << 10);
+	size_t dst_len = src_len;
+
+	pr_info("zstd levels test, testing all 15 levels");
+
+	void *src __cleanup(kfree) = kmalloc(src_len, GFP_KERNEL);
+	void *dst __cleanup(kfree) = kmalloc(dst_len, GFP_KERNEL);
+	void *verify __cleanup(kfree) = kmalloc(src_len, GFP_KERNEL);
+	if (!src || !dst || !verify)
+		return -ENOMEM;
+
+	fill_compressible(src, src_len);
+
+	for (unsigned level = 1; level <= 15; level++) {
+		size_t this_src = src_len;
+		size_t this_dst = dst_len;
+
+		union bch_compression_opt compression = {
+			.type	= BCH_COMPRESSION_OPT_zstd,
+			.level	= level,
+		};
+
+		unsigned type = bch2_compress(c, dst, &this_dst,
+					      src, &this_src,
+					      compression.value,
+					      POS(0, 0));
+
+		if (type != BCH_COMPRESSION_TYPE_zstd) {
+			bch_err(c, "test_zstd_levels: compressible data not compressed at level %u (type=%u)",
+				level, type);
+			return -EIO;
+		}
+
+		struct bch_extent_crc_unpacked crc = {
+			.compressed_size	= this_dst >> 9,
+			.uncompressed_size	= this_src >> 9,
+			.compression_type	= type,
+		};
+
+		int ret = buf_uncompress(c, verify, dst, crc);
+		if (ret) {
+			bch_err(c, "test_zstd_levels: decompression failed at level %u: %s",
+				level, bch2_err_str(ret));
+			return ret;
+		}
+
+		if (memcmp(verify, src, this_src)) {
+			bch_err(c, "test_zstd_levels: data mismatch at level %u", level);
+			return -EIO;
+		}
+
+		pr_info("  level %u: %zu -> %zu bytes", level, this_src, this_dst);
+	}
+
+	pr_info("zstd levels test passed");
+	return 0;
+}
+
+typedef int (*perf_test_fn)(struct bch_fs *, u64);
+
+struct compress_test_job {
+	struct bch_fs		*c;
+	u64			nr;
+	perf_test_fn		fn;
+};
+
+static int compress_test_thread(void *data)
+{
+	struct compress_test_job *j = data;
+	return j->fn(j->c, j->nr);
+}
+
+int bch2_compress_test(struct bch_fs *c, const char *testname,
+		       u64 nr, unsigned nr_threads)
+{
+	struct compress_test_job j = { .c = c, .nr = nr };
+
+	if (nr == 0) {
+		pr_err("nr of iterations is not allowed to be 0");
+		return -EINVAL;
+	}
+
+	if (!mempool_initialized(&c->compress.workspace[BCH_COMPRESSION_OPT_zstd])) {
+		pr_err("zstd compression not initialized");
+		return -EINVAL;
+	}
+
+#define compress_test(_test)			\
+	if (!strcmp(testname, #_test)) j.fn = _test
+
+	compress_test(test_zstd_compress_decompress);
+	compress_test(test_zstd_early_abort_incompressible);
+	compress_test(test_zstd_levels);
+
+	if (!j.fn) {
+		pr_err("unknown compress test %s", testname);
+		return -EINVAL;
+	}
+
+	int ret = j.fn(j.c, j.nr);
+	if (ret)
+		bch_err(c, "compress test %s failed: %s", testname, bch2_err_str(ret));
+	else
+		pr_info("compress test %s passed", testname);
+	return ret;
+}
+
+#endif /* CONFIG_BCACHEFS_TESTS */

--- a/fs/debug/compress_test.c
+++ b/fs/debug/compress_test.c
@@ -29,9 +29,9 @@ static int test_zstd_compress_decompress(struct bch_fs *c, u64 nr)
 
 	pr_info("zstd compress/decompress roundtrip test, src_len=%zu", src_len);
 
-	void *src __cleanup(kfree) = kmalloc(src_len, GFP_KERNEL);
-	void *dst __cleanup(kfree) = kmalloc(dst_len, GFP_KERNEL);
-	void *verify __cleanup(kfree) = kmalloc(src_len, GFP_KERNEL);
+	void *src __free(kvfree) = kvmalloc(src_len, GFP_KERNEL);
+	void *dst __free(kvfree) = kvmalloc(dst_len, GFP_KERNEL);
+	void *verify __free(kvfree) = kvmalloc(src_len, GFP_KERNEL);
 	if (!src || !dst || !verify)
 		return -ENOMEM;
 
@@ -75,7 +75,7 @@ static int test_zstd_compress_decompress(struct bch_fs *c, u64 nr)
 			.compression_type	= type,
 		};
 
-		ret = buf_uncompress(c, verify, dst, crc);
+		ret = bch2_buf_uncompress(c, verify, dst, crc);
 		if (ret) {
 			bch_err(c, "test_zstd: decompression failed (iter %llu, level %u): %s",
 				i, compression.level, bch2_err_str(ret));
@@ -100,8 +100,8 @@ static int test_zstd_early_abort_incompressible(struct bch_fs *c, u64 nr)
 
 	pr_info("zstd early abort test with random data, src_len=%zu", src_len);
 
-	void *src __cleanup(kfree) = kmalloc(src_len, GFP_KERNEL);
-	void *dst __cleanup(kfree) = kmalloc(dst_len, GFP_KERNEL);
+	void *src __free(kvfree) = kvmalloc(src_len, GFP_KERNEL);
+	void *dst __free(kvfree) = kvmalloc(dst_len, GFP_KERNEL);
 	if (!src || !dst)
 		return -ENOMEM;
 
@@ -145,9 +145,9 @@ static int test_zstd_levels(struct bch_fs *c, u64 nr)
 
 	pr_info("zstd levels test, testing all 15 levels");
 
-	void *src __cleanup(kfree) = kmalloc(src_len, GFP_KERNEL);
-	void *dst __cleanup(kfree) = kmalloc(dst_len, GFP_KERNEL);
-	void *verify __cleanup(kfree) = kmalloc(src_len, GFP_KERNEL);
+	void *src __free(kvfree) = kvmalloc(src_len, GFP_KERNEL);
+	void *dst __free(kvfree) = kvmalloc(dst_len, GFP_KERNEL);
+	void *verify __free(kvfree) = kvmalloc(src_len, GFP_KERNEL);
 	if (!src || !dst || !verify)
 		return -ENOMEM;
 
@@ -179,7 +179,7 @@ static int test_zstd_levels(struct bch_fs *c, u64 nr)
 			.compression_type	= type,
 		};
 
-		int ret = buf_uncompress(c, verify, dst, crc);
+		int ret = bch2_buf_uncompress(c, verify, dst, crc);
 		if (ret) {
 			bch_err(c, "test_zstd_levels: decompression failed at level %u: %s",
 				level, bch2_err_str(ret));
@@ -198,24 +198,12 @@ static int test_zstd_levels(struct bch_fs *c, u64 nr)
 	return 0;
 }
 
-typedef int (*perf_test_fn)(struct bch_fs *, u64);
-
-struct compress_test_job {
-	struct bch_fs		*c;
-	u64			nr;
-	perf_test_fn		fn;
-};
-
-static int compress_test_thread(void *data)
-{
-	struct compress_test_job *j = data;
-	return j->fn(j->c, j->nr);
-}
+typedef int (*compress_test_fn)(struct bch_fs *, u64);
 
 int bch2_compress_test(struct bch_fs *c, const char *testname,
 		       u64 nr, unsigned nr_threads)
 {
-	struct compress_test_job j = { .c = c, .nr = nr };
+	compress_test_fn fn = NULL;
 
 	if (nr == 0) {
 		pr_err("nr of iterations is not allowed to be 0");
@@ -228,18 +216,18 @@ int bch2_compress_test(struct bch_fs *c, const char *testname,
 	}
 
 #define compress_test(_test)			\
-	if (!strcmp(testname, #_test)) j.fn = _test
+	if (!strcmp(testname, #_test)) fn = _test
 
 	compress_test(test_zstd_compress_decompress);
 	compress_test(test_zstd_early_abort_incompressible);
 	compress_test(test_zstd_levels);
 
-	if (!j.fn) {
+	if (!fn) {
 		pr_err("unknown compress test %s", testname);
 		return -EINVAL;
 	}
 
-	int ret = j.fn(j.c, j.nr);
+	int ret = fn(c, nr);
 	if (ret)
 		bch_err(c, "compress test %s failed: %s", testname, bch2_err_str(ret));
 	else

--- a/fs/debug/sysfs.c
+++ b/fs/debug/sysfs.c
@@ -242,6 +242,7 @@ read_attribute(recent_counters);
 
 #if defined(CONFIG_BCACHEFS_TESTS) && defined(CONFIG_BCACHEFS_RUST)
 write_attribute(perf_test);
+write_attribute(compress_test);
 #endif
 
 #define x(_name, ...)						\
@@ -529,6 +530,21 @@ STORE(bch2_fs)
 		if (ret)
 			size = ret;
 	}
+
+	if (attr == &sysfs_compress_test) {
+		char *tmp __free(kfree) = kstrdup(buf, GFP_KERNEL), *p = tmp;
+		char *test		= strsep(&p, " \t\n");
+		char *nr_str		= strsep(&p, " \t\n");
+		u64 nr;
+		int ret = -EINVAL;
+
+		if (nr_str &&
+		    !(ret = bch2_strtoull_h(nr_str, &nr)))
+			ret = bch2_compress_test(c, test, nr, 1);
+
+		if (ret)
+			size = ret;
+	}
 #endif
 	enumerated_ref_put(&c->writes, BCH_WRITE_REF_sysfs);
 	return size;
@@ -550,6 +566,7 @@ struct attribute *bch2_fs_files[] = {
 
 #if defined(CONFIG_BCACHEFS_TESTS) && defined(CONFIG_BCACHEFS_RUST)
 	&sysfs_perf_test,
+	&sysfs_compress_test,
 #endif
 	NULL
 };

--- a/fs/debug/sysfs.c
+++ b/fs/debug/sysfs.c
@@ -243,6 +243,7 @@ read_attribute(recent_counters);
 
 #if defined(CONFIG_BCACHEFS_TESTS) && defined(CONFIG_BCACHEFS_RUST)
 write_attribute(perf_test);
+write_attribute(compress_test);
 #endif
 
 #define x(_name, ...)						\
@@ -540,6 +541,21 @@ STORE(bch2_fs)
 		if (ret)
 			size = ret;
 	}
+
+	if (attr == &sysfs_compress_test) {
+		char *tmp __free(kfree) = kstrdup(buf, GFP_KERNEL), *p = tmp;
+		char *test		= strsep(&p, " \t\n");
+		char *nr_str		= strsep(&p, " \t\n");
+		u64 nr;
+		int ret = -EINVAL;
+
+		if (nr_str &&
+		    !(ret = bch2_strtoull_h(nr_str, &nr)))
+			ret = bch2_compress_test(c, test, nr, 1);
+
+		if (ret)
+			size = ret;
+	}
 #endif
 	enumerated_ref_put(&c->writes, BCH_WRITE_REF_sysfs);
 	return size;
@@ -561,6 +577,7 @@ struct attribute *bch2_fs_files[] = {
 
 #if defined(CONFIG_BCACHEFS_TESTS) && defined(CONFIG_BCACHEFS_RUST)
 	&sysfs_perf_test,
+	&sysfs_compress_test,
 #endif
 	NULL
 };

--- a/fs/debug/tests.h
+++ b/fs/debug/tests.h
@@ -11,6 +11,7 @@ struct bch_fs;
 #if defined(CONFIG_BCACHEFS_TESTS) && defined(CONFIG_BCACHEFS_RUST)
 
 int bch2_btree_perf_test(struct bch_fs *, const char *, u64, unsigned);
+int bch2_compress_test(struct bch_fs *, const char *, u64, unsigned);
 
 #else
 

--- a/fs/opts.h
+++ b/fs/opts.h
@@ -198,6 +198,11 @@ enum fsck_err_opts {
 	  OPT_FN(bch2_opt_compression),					\
 	  BCH_SB_BACKGROUND_COMPRESSION_TYPE,BCH_COMPRESSION_OPT_none,	\
 	  NULL,		"Compression type for background moves")	\
+	x(zstd_compression_early_abort,	u8,				\
+	  OPT_FS|OPT_FORMAT|OPT_MOUNT|OPT_RUNTIME,			\
+	  OPT_BOOL(),							\
+	  BCH_SB_ZSTD_COMPRESSION_EARLY_ABORT, true,			\
+	  NULL,		"Enable early abort for ZSTD compression")	\
 	x(str_hash,			u8,				\
 	  OPT_FS|OPT_FORMAT|OPT_MOUNT|OPT_RUNTIME,			\
 	  OPT_STR(bch2_str_hash_opts),					\

--- a/fs/opts.h
+++ b/fs/opts.h
@@ -199,6 +199,11 @@ enum fsck_err_opts {
 	  OPT_FN(bch2_opt_compression),					\
 	  BCH_SB_BACKGROUND_COMPRESSION_TYPE,BCH_COMPRESSION_OPT_none,	\
 	  NULL,		"Compression type for background moves")	\
+	x(zstd_compression_early_abort,	u8,				\
+	  OPT_FS|OPT_FORMAT|OPT_MOUNT|OPT_RUNTIME,			\
+	  OPT_BOOL(),							\
+	  BCH_SB_ZSTD_COMPRESSION_EARLY_ABORT, true,			\
+	  NULL,		"Enable early abort for ZSTD compression")	\
 	x(str_hash,			u8,				\
 	  OPT_FS|OPT_FORMAT|OPT_MOUNT|OPT_RUNTIME,			\
 	  OPT_STR(bch2_str_hash_opts),					\

--- a/nixos-test.nix
+++ b/nixos-test.nix
@@ -4,10 +4,15 @@ self': {
   nodes.machine = { config, pkgs, ... }: {
     boot.kernelPackages = pkgs.linuxPackages_latest;
 
+    boot.bcachefs.modulePackage =
+      self'.packages.bcachefs-module-linux-latest.overrideAttrs (old: {
+        makeFlags = (old.makeFlags or []) ++ [ "BCACHEFS_TESTS=1" ];
+      });
+
     assertions = [{
       assertion =
-        config.boot.bcachefs.modulePackage or null == self'.packages.bcachefs-module-linux-latest;
-      message = "Local bcachefs module isn't being used; update nixpkgs?";
+        config.boot.bcachefs.modulePackage or null != null;
+      message = "bcachefs module not set";
     }];
 
     virtualisation.emptyDiskImages = [{
@@ -95,6 +100,15 @@ self': {
       assert found, "no compression accounting line in fs usage output"
       machine.succeed("md5sum /mnt/incompressible > /tmp/incompressible.md5")
       machine.succeed("md5sum -c /tmp/incompressible.md5")
+      machine.succeed("umount /mnt")
+
+    with subtest("in-kernel zstd compress tests"):
+      machine.succeed(
+        "mkfs.bcachefs --force --compression=zstd /dev/disk/by-id/virtio-test-disk",
+        "mount /dev/disk/by-id/virtio-test-disk /mnt",
+      )
+      for test in ["test_zstd_compress_decompress", "test_zstd_early_abort_incompressible", "test_zstd_levels"]:
+        machine.succeed(f"echo '{test} 10' > /sys/fs/bcachefs/*/compress_test")
       machine.succeed("umount /mnt")
 
     with subtest("zstd mixed data integrity"):

--- a/nixos-test.nix
+++ b/nixos-test.nix
@@ -1,41 +1,116 @@
 self': {
   name = "bcachefs-nixos";
 
-  nodes.machine =
-    { config, pkgs, ... }:
-    {
-      # modulePackage defaults to the module built for boot.kernelPackages;
-      # pin to linuxPackages_latest so it matches bcachefs-module-linux-latest
-      # (the kernel we ship that module for) and the assertion below compares
-      # like-for-like. The default kernel lags linuxPackages_latest, which made
-      # the assertion spuriously fail.
-      boot.kernelPackages = pkgs.linuxPackages_latest;
+  nodes.machine = { config, pkgs, ... }: {
+    boot.kernelPackages = pkgs.linuxPackages_latest;
 
-      assertions = [
-        {
-          assertion =
-            config.boot.bcachefs.modulePackage or null == self'.packages.bcachefs-module-linux-latest;
-          message = "Local bcachefs module isn't being used; update nixpkgs?";
-        }
-      ];
+    assertions = [{
+      assertion =
+        config.boot.bcachefs.modulePackage or null == self'.packages.bcachefs-module-linux-latest;
+      message = "Local bcachefs module isn't being used; update nixpkgs?";
+    }];
 
-      virtualisation.emptyDiskImages = [
-        {
-          size = 4096;
-          driveConfig.deviceExtraOpts.serial = "test-disk";
-        }
-      ];
+    virtualisation.emptyDiskImages = [{
+      size = 4096;
+      driveConfig.deviceExtraOpts.serial = "test-disk";
+    }];
 
-      boot.supportedFilesystems.bcachefs = true;
-      boot.bcachefs.package = self'.packages.bcachefs-tools;
-    };
+    boot.supportedFilesystems.bcachefs = true;
+    boot.bcachefs.package = self'.packages.bcachefs-tools;
+  };
 
   testScript = ''
-    machine.succeed(
-      "modinfo bcachefs | grep updates/src/fs/bcachefs > /dev/null",
-      "mkfs.bcachefs /dev/disk/by-id/virtio-test-disk",
-      "mkdir /mnt",
-      "mount /dev/disk/by-id/virtio-test-disk /mnt",
-    )
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("basic roundtrip without compression"):
+      machine.succeed(
+        "mkfs.bcachefs /dev/disk/by-id/virtio-test-disk",
+        "mkdir -p /mnt",
+        "mount /dev/disk/by-id/virtio-test-disk /mnt",
+        "echo hello > /mnt/test.txt",
+        "cat /mnt/test.txt | grep hello",
+      )
+      machine.succeed("umount /mnt")
+
+    with subtest("remount and verify"):
+      machine.succeed(
+        "mount -t bcachefs /dev/disk/by-id/virtio-test-disk /mnt",
+        "cat /mnt/test.txt | grep hello",
+        "umount /mnt",
+      )
+
+    with subtest("zstd compresses compressible data"):
+      machine.succeed(
+        "mkfs.bcachefs --force --compression=zstd /dev/disk/by-id/virtio-test-disk",
+        "mount /dev/disk/by-id/virtio-test-disk /mnt",
+      )
+      compression = machine.succeed("cat /sys/fs/bcachefs/*/options/compression").strip()
+      assert compression == "zstd", f"expected zstd, got {compression}"
+      machine.succeed("dd if=/dev/zero bs=1M count=4 of=/mnt/compressible 2>&1")
+      machine.succeed("sync")
+      usage = machine.succeed("bcachefs fs usage -a /mnt")
+      print(f"fs usage:\n{usage}")
+      found_zstd = False
+      for line in usage.splitlines():
+        if "zstd" in line and "compressed" not in line:
+          parts = line.split()
+          compressed = int(parts[1])
+          uncompressed = int(parts[2])
+          ratio = compressed / uncompressed
+          print(f"compressed={compressed} uncompressed={uncompressed} ratio={ratio:.4f}")
+          assert compressed < uncompressed, f"compressible data not compressed: {compressed} >= {uncompressed}"
+          assert ratio < 0.1, f"compression ratio too high: {ratio:.2f}"
+          found_zstd = True
+          break
+      assert found_zstd, "no zstd compression line in fs usage output"
+      machine.succeed("md5sum /mnt/compressible > /tmp/compressible.md5")
+      machine.succeed("md5sum -c /tmp/compressible.md5")
+      machine.succeed("umount /mnt")
+
+    with subtest("zstd early abort skips incompressible data"):
+      machine.succeed(
+        "mkfs.bcachefs --force --compression=zstd /dev/disk/by-id/virtio-test-disk",
+        "mount /dev/disk/by-id/virtio-test-disk /mnt",
+      )
+      machine.succeed("dd if=/dev/urandom bs=1M count=4 of=/mnt/incompressible 2>&1")
+      machine.succeed("sync")
+      usage = machine.succeed("bcachefs fs usage -a /mnt")
+      print(f"fs usage:\n{usage}")
+      found = False
+      for line in usage.splitlines():
+        if "zstd" in line and "compressed" not in line:
+          found = True
+          parts = line.split()
+          compressed = int(parts[1])
+          uncompressed = int(parts[2])
+          assert compressed == uncompressed, f"random data should not compress: {compressed} != {uncompressed}"
+          break
+        if "incompressible" in line and "compressed" not in line:
+          found = True
+          parts = line.split()
+          compressed = int(parts[1])
+          uncompressed = int(parts[2])
+          assert compressed == uncompressed, f"incompressible data should be 1:1: {compressed} != {uncompressed}"
+          break
+      assert found, "no compression accounting line in fs usage output"
+      machine.succeed("md5sum /mnt/incompressible > /tmp/incompressible.md5")
+      machine.succeed("md5sum -c /tmp/incompressible.md5")
+      machine.succeed("umount /mnt")
+
+    with subtest("zstd mixed data integrity"):
+      machine.succeed(
+        "mkfs.bcachefs --force /dev/disk/by-id/virtio-test-disk",
+        "mount /dev/disk/by-id/virtio-test-disk /mnt",
+        "echo zstd > /sys/fs/bcachefs/*/options/compression",
+      )
+      machine.succeed(
+        "dd if=/dev/zero bs=1K count=4 > /mnt/small-compressible",
+        "dd if=/dev/urandom bs=1K count=4 > /mnt/small-incompressible",
+        "dd if=/dev/zero bs=1M count=4 > /mnt/large-compressible",
+        "dd if=/dev/urandom bs=1M count=4 > /mnt/large-incompressible",
+        "md5sum /mnt/small-compressible /mnt/small-incompressible /mnt/large-compressible /mnt/large-incompressible > /tmp/all.md5",
+        "md5sum -c /tmp/all.md5",
+      )
+      machine.succeed("umount /mnt")
   '';
 }

--- a/nixos-test.nix
+++ b/nixos-test.nix
@@ -51,7 +51,8 @@ self': {
       )
       compression = machine.succeed("cat /sys/fs/bcachefs/*/options/compression").strip()
       assert compression == "zstd", f"expected zstd, got {compression}"
-      machine.succeed("dd if=/dev/zero bs=1M count=4 of=/mnt/compressible 2>&1")
+      machine.succeed("dd if=/dev/zero bs=1M count=4 of=/tmp/src-compressible 2>&1")
+      machine.succeed("cp /tmp/src-compressible /mnt/compressible")
       machine.succeed("sync")
       usage = machine.succeed("bcachefs fs usage -a /mnt")
       print(f"fs usage:\n{usage}")
@@ -68,8 +69,11 @@ self': {
           found_zstd = True
           break
       assert found_zstd, "no zstd compression line in fs usage output"
-      machine.succeed("md5sum /mnt/compressible > /tmp/compressible.md5")
-      machine.succeed("md5sum -c /tmp/compressible.md5")
+      machine.succeed("cmp /tmp/src-compressible /mnt/compressible")
+      machine.succeed("umount /mnt")
+
+      machine.succeed("mount /dev/disk/by-id/virtio-test-disk /mnt")
+      machine.succeed("cmp /tmp/src-compressible /mnt/compressible")
       machine.succeed("umount /mnt")
 
     with subtest("zstd early abort skips incompressible data"):
@@ -77,7 +81,8 @@ self': {
         "mkfs.bcachefs --force --compression=zstd /dev/disk/by-id/virtio-test-disk",
         "mount /dev/disk/by-id/virtio-test-disk /mnt",
       )
-      machine.succeed("dd if=/dev/urandom bs=1M count=4 of=/mnt/incompressible 2>&1")
+      machine.succeed("dd if=/dev/urandom bs=1M count=4 of=/tmp/src-incompressible 2>&1")
+      machine.succeed("cp /tmp/src-incompressible /mnt/incompressible")
       machine.succeed("sync")
       usage = machine.succeed("bcachefs fs usage -a /mnt")
       print(f"fs usage:\n{usage}")
@@ -98,8 +103,11 @@ self': {
           assert compressed == uncompressed, f"incompressible data should be 1:1: {compressed} != {uncompressed}"
           break
       assert found, "no compression accounting line in fs usage output"
-      machine.succeed("md5sum /mnt/incompressible > /tmp/incompressible.md5")
-      machine.succeed("md5sum -c /tmp/incompressible.md5")
+      machine.succeed("cmp /tmp/src-incompressible /mnt/incompressible")
+      machine.succeed("umount /mnt")
+
+      machine.succeed("mount /dev/disk/by-id/virtio-test-disk /mnt")
+      machine.succeed("cmp /tmp/src-incompressible /mnt/incompressible")
       machine.succeed("umount /mnt")
 
     with subtest("in-kernel zstd compress tests"):
@@ -118,12 +126,32 @@ self': {
         "echo zstd > /sys/fs/bcachefs/*/options/compression",
       )
       machine.succeed(
-        "dd if=/dev/zero bs=1K count=4 > /mnt/small-compressible",
-        "dd if=/dev/urandom bs=1K count=4 > /mnt/small-incompressible",
-        "dd if=/dev/zero bs=1M count=4 > /mnt/large-compressible",
-        "dd if=/dev/urandom bs=1M count=4 > /mnt/large-incompressible",
-        "md5sum /mnt/small-compressible /mnt/small-incompressible /mnt/large-compressible /mnt/large-incompressible > /tmp/all.md5",
-        "md5sum -c /tmp/all.md5",
+        "dd if=/dev/zero bs=1K count=4 of=/tmp/src-small-compressible 2>&1",
+        "dd if=/dev/urandom bs=1K count=4 of=/tmp/src-small-incompressible 2>&1",
+        "dd if=/dev/zero bs=1M count=4 of=/tmp/src-large-compressible 2>&1",
+        "dd if=/dev/urandom bs=1M count=4 of=/tmp/src-large-incompressible 2>&1",
+      )
+      machine.succeed(
+        "cp /tmp/src-small-compressible /mnt/small-compressible",
+        "cp /tmp/src-small-incompressible /mnt/small-incompressible",
+        "cp /tmp/src-large-compressible /mnt/large-compressible",
+        "cp /tmp/src-large-incompressible /mnt/large-incompressible",
+      )
+      machine.succeed("sync")
+      machine.succeed(
+        "cmp /tmp/src-small-compressible /mnt/small-compressible",
+        "cmp /tmp/src-small-incompressible /mnt/small-incompressible",
+        "cmp /tmp/src-large-compressible /mnt/large-compressible",
+        "cmp /tmp/src-large-incompressible /mnt/large-incompressible",
+      )
+      machine.succeed("umount /mnt")
+
+      machine.succeed("mount /dev/disk/by-id/virtio-test-disk /mnt")
+      machine.succeed(
+        "cmp /tmp/src-small-compressible /mnt/small-compressible",
+        "cmp /tmp/src-small-incompressible /mnt/small-incompressible",
+        "cmp /tmp/src-large-compressible /mnt/large-compressible",
+        "cmp /tmp/src-large-incompressible /mnt/large-incompressible",
       )
       machine.succeed("umount /mnt")
   '';

--- a/nixos-test.nix
+++ b/nixos-test.nix
@@ -154,5 +154,35 @@ self': {
         "cmp /tmp/src-large-incompressible /mnt/large-incompressible",
       )
       machine.succeed("umount /mnt")
+
+    with subtest("zstd early abort option toggle"):
+      machine.succeed(
+        "mkfs.bcachefs --force --compression=zstd /dev/disk/by-id/virtio-test-disk",
+        "mount /dev/disk/by-id/virtio-test-disk /mnt",
+      )
+      ea = machine.succeed("cat /sys/fs/bcachefs/*/options/zstd_compression_early_abort").strip()
+      assert ea == "1", f"expected early_abort=1 by default, got {ea}"
+      machine.succeed("dd if=/dev/urandom bs=1M count=4 of=/tmp/src-ea-test 2>&1")
+      machine.succeed("cp /tmp/src-ea-test /mnt/with-early-abort")
+      machine.succeed("sync")
+      machine.succeed("echo 0 > /sys/fs/bcachefs/*/options/zstd_compression_early_abort")
+      ea = machine.succeed("cat /sys/fs/bcachefs/*/options/zstd_compression_early_abort").strip()
+      assert ea == "0", f"expected early_abort=0, got {ea}"
+      machine.succeed("cp /tmp/src-ea-test /mnt/without-early-abort")
+      machine.succeed("sync")
+      machine.succeed(
+        "cmp /tmp/src-ea-test /mnt/with-early-abort",
+        "cmp /tmp/src-ea-test /mnt/without-early-abort",
+      )
+      machine.succeed("umount /mnt")
+
+      machine.succeed("mount /dev/disk/by-id/virtio-test-disk /mnt")
+      ea = machine.succeed("cat /sys/fs/bcachefs/*/options/zstd_compression_early_abort").strip()
+      assert ea == "0", f"expected early_abort=0 persisted after remount, got {ea}"
+      machine.succeed(
+        "cmp /tmp/src-ea-test /mnt/with-early-abort",
+        "cmp /tmp/src-ea-test /mnt/without-early-abort",
+      )
+      machine.succeed("umount /mnt")
   '';
 }


### PR DESCRIPTION
`zstd` currently keeps running the one-shot compressor on data that is already
larger than its input. This refreshes streaming early abort onto current master:
after more than four filesystem blocks, the zstd path returns incompressible
when output exceeds consumed input. `zstd_compression_early_abort` remains
enabled by default and can disable that decision.

Master now sizes workspaces per compression level, so the replay uses the
matching streaming bound for both normal allocations and the reserve pool. The
finish path rejects output exhaustion and no-progress rather than emitting a
partial frame. Existing round-trip, incompressible, all-level, option-toggle,
remount, and smoke coverage stays with the carrier.

Original streaming compression work: Linken Quy Dinh (beckend), carried from koverstreet/bcachefs-tools#586.

Validation: the current head `97455cfac` passed the NixOS VM suite on x86_64 and aarch64, built as its merge into master `42cb08fe`. The logs show seven completed subtests: basic roundtrip, remount, compressible data, incompressible data, in-kernel compression tests, mixed-data integrity, and early-abort option toggling with remount persistence. The in-kernel tests cover roundtrip, incompressible input, and zstd levels.

[x86_64 VM log](https://github.com/koverstreet/bcachefs-tools/actions/runs/34043723668/job/101514996370) · [aarch64 VM log](https://github.com/koverstreet/bcachefs-tools/actions/runs/34043723668/job/101514996382). Targeted Werror compilation and `git diff --check` also passed. These tests establish functional coverage; no fresh CPU-performance benchmark is claimed.
