### PR TITLE
vfs: show UUID for multi-device mount source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -145,9 +145,8 @@
             };
 
           checks = {
-            inherit (self'.packages)
+            inherit (pkgs.bcachefsPackages)
               bcachefs-tools
-              bcachefs-tools-aarch64-linux
               bcachefs-tools-fuse
               bcachefs-module-linux-latest
               bcachefs-module-linux-testing

--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -2258,6 +2258,11 @@ static int bch2_show_devname(struct seq_file *seq, struct dentry *root)
 	struct bch_fs *c = root->d_sb->s_fs_info;
 	bool first = true;
 
+	if (c->sb.multi_device) {
+		seq_printf(seq, "/dev/disk/by-uuid/%pU", c->sb.user_uuid.b);
+		return 0;
+	}
+
 	guard(rcu)();
 	for_each_online_member_rcu(c, ca) {
 		if (!first)


### PR DESCRIPTION
## Summary

For multi-device bcachefs mounts, `df` currently gets a source string containing every member device separated by `:`, which becomes unreadable for large arrays.

This keeps the existing single-device output, but reports multi-device mounts as `/dev/disk/by-uuid/<filesystem UUID>` from `show_devname()`. That gives `df` and `/proc/mounts` a stable, short filesystem source without choosing an arbitrary primary member device, while keeping the source string usable as a path on systems with the usual udev links.

References koverstreet/bcachefs#1041.

## Validation

- `git diff --check origin/master...HEAD`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j16 bcachefs`
- Branch rebased on current `origin/master` and force-pushed from `b2ae40f746eb6704abcc4b2780c57d56663aa5c8` to `487904f235e54f21395be11fe4dcb785f4c20914`
- GitHub CI: 15/15 visible Nix Flake checks green for refreshed head `487904f235e54f21395be11fe4dcb785f4c20914`
