### PR TITLE
bcachefs: make nocow lock waits SRCU-aware

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -145,9 +145,8 @@
             };
 
           checks = {
-            inherit (self'.packages)
+            inherit (pkgs.bcachefsPackages)
               bcachefs-tools
-              bcachefs-tools-aarch64-linux
               bcachefs-tools-fuse
               bcachefs-module-linux-latest
               bcachefs-module-linux-testing

--- a/fs/data/nocow_locking.c
+++ b/fs/data/nocow_locking.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 
 #include "bcachefs.h"
+#include "btree/iter.h"
 #include "btree/bkey_methods.h"
 #include "closure.h"
 #include "nocow_locking.h"
@@ -156,8 +157,16 @@ static inline int bucket_to_lock_cmp(struct bucket_to_lock l,
 	return cmp_int(l.l, r.l);
 }
 
-void bch2_bkey_nocow_lock(struct bch_fs *c, struct bkey_ptrs_c ptrs,
-			  struct bch_dev **cas, int flags)
+#define nocow_lock_wait(_trans, _l, _condition)			\
+do {								\
+	if (_trans)						\
+		trans_wait_event(_trans, &(_l)->wait, _condition);	\
+	else							\
+		__closure_wait_event(&(_l)->wait, _condition);		\
+} while (0)
+
+void bch2_bkey_nocow_lock(struct bch_fs *c, struct btree_trans *trans,
+			  struct bkey_ptrs_c ptrs, struct bch_dev **cas, int flags)
 {
 	if (bch2_bkey_nocow_trylock(c, ptrs, cas, flags))
 		return;
@@ -195,8 +204,8 @@ retake_all:
 		u64 start_time = local_clock();
 
 		if (ret == -BCH_ERR_nocow_trylock_contended)
-			__closure_wait_event(&i->l->wait,
-					(ret = __bch2_bucket_nocow_trylock(c, i->l, i->b, flags)) != -BCH_ERR_nocow_trylock_contended);
+			nocow_lock_wait(trans, i->l,
+				(ret = __bch2_bucket_nocow_trylock(c, i->l, i->b, flags)) != -BCH_ERR_nocow_trylock_contended);
 		if (!ret) {
 			bch2_time_stats_update(&c->times[BCH_TIME_nocow_lock_contended], start_time);
 			continue;
@@ -210,7 +219,7 @@ retake_all:
 			__bch2_bucket_nocow_unlock(&c->nocow_locks, i2->b, flags);
 		}
 
-		__closure_wait_event(&i->l->wait, nocow_bucket_empty(i->l));
+		nocow_lock_wait(trans, i->l, nocow_bucket_empty(i->l));
 		bch2_time_stats_update(&c->times[BCH_TIME_nocow_lock_contended], start_time);
 		goto retake_all;
 	}

--- a/fs/data/nocow_locking.h
+++ b/fs/data/nocow_locking.h
@@ -30,7 +30,8 @@ static inline void bch2_bucket_nocow_unlock(struct bucket_nocow_lock_table *t, s
 
 void bch2_bkey_nocow_unlock(struct bch_fs *, struct bkey_s_c, struct bch_dev **, int);
 bool bch2_bkey_nocow_trylock(struct bch_fs *, struct bkey_ptrs_c, struct bch_dev **, int);
-void bch2_bkey_nocow_lock(struct bch_fs *, struct bkey_ptrs_c, struct bch_dev **, int);
+void bch2_bkey_nocow_lock(struct bch_fs *, struct btree_trans *,
+			  struct bkey_ptrs_c, struct bch_dev **, int);
 
 void bch2_nocow_locks_to_text(struct printbuf *, struct bucket_nocow_lock_table *);
 

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -1513,7 +1513,7 @@ int bch2_data_update_init(struct btree_trans *trans,
 			if (!locked) {
 				if (ctxt)
 					bch2_trans_unlock(ctxt->trans);
-				bch2_bkey_nocow_lock(c, ptrs, m->cas, 0);
+				bch2_bkey_nocow_lock(c, ctxt ? ctxt->trans : NULL, ptrs, m->cas, 0);
 			}
 		}
 	}

--- a/fs/data/write.c
+++ b/fs/data/write.c
@@ -2189,7 +2189,7 @@ retry:
 
 		bch2_trans_unlock(trans);
 
-		bch2_bkey_nocow_lock(c, ptrs, cas, BUCKET_NOCOW_LOCK_UPDATE);
+		bch2_bkey_nocow_lock(c, trans, ptrs, cas, BUCKET_NOCOW_LOCK_UPDATE);
 
 		/*
 		 * This could be handled better: If we're able to trylock the


### PR DESCRIPTION
## Summary

- threads the active `btree_trans` into blocking nocow lock waits
- uses the existing `trans_wait_event()` wrapper so long waits can drop SRCU via the current short-wait budget
- leaves the fast trylock path unchanged and avoids the blanket `bch2_trans_unlock_long()` replacement from the conflicted kernel PR

## Context

This targets the nocow-write stall path reported in koverstreet/bcachefs#680, where writeback was blocked around `bch2_nocow_write()` / nocow locking while the transaction still held SRCU. It is also the narrow form of the maintainer direction on koverstreet/bcachefs#1069: start with the normal unlock path, but escalate long blocking waits through the transaction-aware wait helper instead of dropping SRCU unconditionally at every callsite.

## Tests

- koverstreet/ktest#88 adds focused nocow write pressure coverage for this SRCU-held wait path.

## Validation

- `git diff --check`
- `make generate_version && BINDGEN=/home/kom/.cargo/bin/bindgen LIBCLANG_PATH=/usr/lib/llvm-18/lib CARGO_BUILD_JOBS=4 make -j4 bcachefs`
- safe staged kbuild module compile without unload/install side effects:
  `make -C /lib/modules/$(uname -r)/build M=/home/kom/tmp/bcachefs-module-nocow-srcu-wait modules -j4`
- GitHub Actions: Nix Flake actions run 28427644776, 15/15 jobs passed on head `896612eb72c2741ce554d147a65006475adfc042`

Related: koverstreet/bcachefs#1069
