### PR TITLE
opts: honor background target for metadata reconcile

### DIFF
--- a/fs/opts.c
+++ b/fs/opts.c
@@ -1033,7 +1033,9 @@ void bch2_inode_opts_get(struct bch_fs *c, struct bch_inode_opts *ret, bool meta
 	ret->change_cookie = c->opt_change_cookie;
 
 	if (metadata) {
-		ret->background_target	= c->opts.metadata_target ?: c->opts.foreground_target;
+		ret->background_target	= c->opts.metadata_target ?:
+			c->opts.background_target ?:
+			c->opts.foreground_target;
 		ret->data_replicas	= c->opts.metadata_replicas;
 		ret->data_checksum	= c->opts.metadata_checksum;
 		ret->compression	= 0;

--- a/fs/opts.c
+++ b/fs/opts.c
@@ -966,7 +966,9 @@ void bch2_inode_opts_get(struct bch_fs *c, struct bch_inode_opts *ret, bool meta
 	ret->change_cookie = c->opt_change_cookie;
 
 	if (metadata) {
-		ret->background_target	= c->opts.metadata_target ?: c->opts.foreground_target;
+		ret->background_target	= c->opts.metadata_target ?:
+			c->opts.background_target ?:
+			c->opts.foreground_target;
 		ret->data_replicas	= c->opts.metadata_replicas;
 		ret->data_checksum	= c->opts.metadata_checksum;
 		ret->compression	= 0;


### PR DESCRIPTION
Metadata reconcile falls back through `metadata_target` and `foreground_target` but skips `background_target` entirely, so a filesystem that sets `foreground_target` and `background_target` without an explicit `metadata_target` keeps scheduling metadata reconcile at the foreground tier. This matches tracepoint evidence from koverstreet/bcachefs#1006 and koverstreet/bcachefs#1109, where metadata reconcile reported `background_target=ssd` on a filesystem whose configured background target was `hdd`. This patch inserts `background_target` into the fallback chain (`metadata_target -> background_target -> foreground_target`), matching how user data already picks its background target; setups that want metadata pinned to the fast tier while `background_target` is set should set `metadata_target` explicitly. koverstreet/bcachefs#1074's `metadata_target=none` variant is related but not addressed here and may need separate retesting. GitHub CI (nix flake build/test matrix across x86_64 and aarch64) passed on the submitted commit.
