### PR TITLE
mount: document fstab UUID workaround

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -376,7 +376,10 @@ for performance testing purposes
 .It Nm Ic mount Oo Ar options Oc Ar device mountpoint
 Mount a filesystem. The
 .Ar device
-can be a device, a colon-separated list of devices, or UUID=<UUID>. The
+can be a device, a colon-separated list of devices, UUID=<UUID>, or
+OLD_BLKID_UUID=<UUID>. Use OLD_BLKID_UUID=<UUID> in fstab entries when
+systemd consumes UUID=<UUID> before the bcachefs mount helper can scan all
+members. The
 .Ar mountpoint
 is the path where the filesystem should be mounted. If not set, then the filesystem won't actually be mounted
 but all steps preceding mounting the filesystem (e.g. asking for passphrase) will still be performed.

--- a/flake.nix
+++ b/flake.nix
@@ -145,9 +145,8 @@
             };
 
           checks = {
-            inherit (self'.packages)
+            inherit (pkgs.bcachefsPackages)
               bcachefs-tools
-              bcachefs-tools-aarch64-linux
               bcachefs-tools-fuse
               bcachefs-module-linux-latest
               bcachefs-module-linux-testing

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -184,6 +184,8 @@ fn cmd_mount_inner(cli: &Cli) -> Result<()> {
     long_about = "Mounts a bcachefs filesystem. Devices are discovered automatically \
 by scanning for the filesystem UUID---unlike btrfs, this is handled \
 entirely in userspace.\n\n\
+Use OLD_BLKID_UUID=<uuid> in fstab entries when systemd consumes \
+UUID=<uuid> before the bcachefs mount helper can scan all members.\n\n\
 If the filesystem is encrypted, the passphrase will be looked up in \
 the kernel keyring first; if not found, the user is prompted \
 interactively (or reads from stdin if not a terminal). Use -k or -f \
@@ -204,7 +206,7 @@ pub struct Cli {
     #[arg(short = 'k', long = "key_location", value_enum)]
     unlock_policy: Option<UnlockPolicy>,
 
-    /// Device, or UUID=\<UUID\>
+    /// Device, UUID=\<UUID\>, or OLD_BLKID_UUID=\<UUID\> for fstab
     dev: String,
 
     /// Where the filesystem should be mounted. If not set, then the filesystem


### PR DESCRIPTION
`mount.bcachefs` already accepts `OLD_BLKID_UUID=<uuid>` alongside `UUID=<uuid>`, but the CLI help and checked-in manpage only mentioned `UUID=<uuid>`.

Document `OLD_BLKID_UUID=<uuid>` as the fstab workaround for systems where systemd consumes `UUID=<uuid>` before the bcachefs mount helper can scan all filesystem members.

This complements koverstreet/bcachefs-tools#633, which handles the later case where the helper is invoked and needs to wait briefly for late members.

Validation:
- `git diff --check`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
- `./target/release/bcachefs mount --help | rg -C 2 OLD_BLKID_UUID`
- GitHub Actions Nix flake matrix is green on head `77b6abba8b0fc7d3486f1a78728850b67c8e95be`.
