### PR TITLE
docs: describe degraded mount recovery path

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -386,7 +386,13 @@ but all steps preceding mounting the filesystem (e.g. asking for passphrase) wil
 Mount options provided as a comma-separated list. See user guide for complete list.
 .Bl -tag -width Ds -compact
 .It Cm degraded
-Allow mounting with data degraded
+Allow mounting with missing devices.
+Use
+.Cm degraded=run
+to allow normal operation with devices missing, and
+.Cm degraded=very
+only when writes are allowed to continue even if the requested replica count
+cannot be maintained.
 .It Cm verbose
 Extra debugging info during mount/recovery
 .It Cm fsck
@@ -519,6 +525,9 @@ Make snapshot read-only
 .It Nm Ic data Ic rereplicate Ar filesystem
 Walks existing data in a filesystem,
 writing additional copies of any degraded data.
+This can be used after a degraded mount or device replacement to restore
+redundancy on the available devices; mounted filesystems may also queue
+reconcile work automatically when degraded extents are detected.
 .It Nm Ic data Ic job Ar job filesystem
 Kick off a data job and report progress
 .sp


### PR DESCRIPTION
## Summary

- document the practical `degraded=run` and `degraded=very` mount modes in the manpage
- clarify that `data rereplicate` can be used after degraded mounts or device replacement to restore redundancy
- mention that mounted filesystems may queue reconcile work automatically when degraded extents are detected

Related source reports:
- koverstreet/bcachefs#820
- koverstreet/bcachefs#1014
- koverstreet/bcachefs#553

## Testing

- `git diff --check origin/master...HEAD`
- `rg -n "degraded=run|degraded=very|data rereplicate|reconcile work automatically" bcachefs.8`
- `groff -mandoc -Tascii bcachefs.8 >/tmp/bcachefs-665.8.rendered`
- GitHub CI is passing for head `15c770a03162ef2386d838478ae10a2c8d4bd440`
