### PR TITLE
opts: report inclusive maximum in errors

### DIFF
--- a/fs/opts.c
+++ b/fs/opts.c
@@ -385,7 +385,7 @@ int bch2_opt_validate(const struct bch_option *opt, u64 v, struct printbuf *err)
 	if (opt->max && v >= opt->max) {
 		if (err)
 			prt_printf(err, "%s: too big (max %llu)",
-			       opt->attr.name, opt->max);
+			       opt->attr.name, opt->max - 1);
 		return -BCH_ERR_ERANGE_option_too_big;
 	}
 


### PR DESCRIPTION
## Summary

`bch2_opt_validate()` treats `opt->max` as an exclusive upper bound (`v >= opt->max`). The error message printed that exclusive value directly, which made options such as `metadata_replicas=5` report `too big (max 5)` even though the largest accepted value is 4.

Print `opt->max - 1` in the diagnostic so the message matches the accepted range.

## Validation

- `git diff --check origin/master...HEAD && git diff --check`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
- `./target/release/bcachefs format --metadata_replicas=5` reports `max 4`
- disposable sparse-file format check with `--metadata_replicas=4 --data_replicas=4`, then `show-super` readback confirmed both are 4
- GitHub CI is passing for head `1b68f545ba5e2143168bde89765c0e24233196b8` (17/17 Nix Flake actions jobs green)

The disposable sparse files under `/home/kom/tmp/bcachefs-replicas-test` and temporary `/tmp/bcachefs-replicas-*` outputs were removed after validation.

Fixes: https://github.com/koverstreet/bcachefs-tools/issues/238
