### PR TITLE
ci: check native packages on each runner

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -145,9 +145,8 @@
             };
 
           checks = {
-            inherit (self'.packages)
+            inherit (pkgs.bcachefsPackages)
               bcachefs-tools
-              bcachefs-tools-aarch64-linux
               bcachefs-tools-fuse
               bcachefs-module-linux-latest
               bcachefs-module-linux-testing

--- a/flake.nix
+++ b/flake.nix
@@ -177,9 +177,8 @@
             };
 
           checks = {
-            inherit (self'.packages)
+            inherit (pkgs.bcachefsPackages)
               bcachefs-tools
-              bcachefs-tools-aarch64-linux
               bcachefs-tools-fuse
               bcachefs-module-linux-latest
               bcachefs-module-linux-testing


### PR DESCRIPTION
Have each CI runner check its own native package set instead of inheriting self'.packages, which pulled in the x86_64-hosted aarch64 Rust bootstrap job alongside the real native aarch64 checks. Native aarch64 CI already covers the aarch64 build on its own runner, so the cross-hosted duplicate can go.

Tested with git diff --check and a full CI run (all green).
