### PR TITLE
docs: replace obsolete data job commands

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -70,10 +70,10 @@ Create a snapshot
 .El
 .Ss Commands for managing filesystem data
 .Bl -tag -width 18n -compact
-.It Ic data rereplicate
-Rereplicate degraded data
-.It Ic data job
-Kick off low level data jobs
+.It Ic reconcile
+Query or wait for background data reconciliation
+.It Ic scrub
+Verify data checksums
 .El
 .Ss Commands for encryption
 .Bl -tag -width 18n -compact
@@ -516,23 +516,25 @@ Make snapshot read-only
 .El
 .Sh Commands for managing filesystem data
 .Bl -tag -width Ds
-.It Nm Ic data Ic rereplicate Ar filesystem
-Walks existing data in a filesystem,
-writing additional copies of any degraded data.
-.It Nm Ic data Ic job Ar job filesystem
-Kick off a data job and report progress
-.sp
-.Ar job
-is one of (
-.Cm scrub | rereplicate | migrate | rewrite_old_nodes
-)
+.It Nm Ic reconcile Ic status Op Fl t Ar type Ns Op , Ns Ar ...
+.Op Ar filesystem
+Show pending background reconciliation work.
 .Bl -tag -width Ds
-.It Fl b Ar btree
-Btree to operate on
-.It Fl s Ar inode Ns Cm \&: Ns Ar offset
-Start position
-.It Fl e Ar inode Ns Cm \&: Ns Ar offset
-End position
+.It Fl t , Fl -types Ar type Ns Op , Ns Ar ...
+Limit output to the selected reconciliation types.
+.El
+.It Nm Ic reconcile Ic wait Op Fl t Ar type Ns Op , Ns Ar ...
+.Op Ar filesystem
+Wait for background reconciliation work to finish.
+.Bl -tag -width Ds
+.It Fl t , Fl -types Ar type Ns Op , Ns Ar ...
+Wait only for the selected reconciliation types.
+.El
+.It Nm Ic scrub Oo Fl m | Fl -metadata Oc Ar filesystem
+Verify checksums and correct errors when possible.
+.Bl -tag -width Ds
+.It Fl m , Fl -metadata
+Check metadata only.
 .El
 .El
 .Sh Commands for encryption

--- a/flake.nix
+++ b/flake.nix
@@ -145,9 +145,8 @@
             };
 
           checks = {
-            inherit (self'.packages)
+            inherit (pkgs.bcachefsPackages)
               bcachefs-tools
-              bcachefs-tools-aarch64-linux
               bcachefs-tools-fuse
               bcachefs-module-linux-latest
               bcachefs-module-linux-testing


### PR DESCRIPTION
Fixes koverstreet/bcachefs-tools#49.

The old `bcachefs data rereplicate` / `bcachefs data job` manpage entries no longer match the CLI. Reconcile obsoleted those commands, and the command registry now exposes filesystem-data commands as `reconcile` and `scrub`.

This updates `bcachefs.8` so the command index and detailed filesystem-data section document the current `reconcile status`, `reconcile wait`, and `scrub` interfaces instead of advertising removed low-level data jobs.

The branch also includes the native-runner CI check fix from koverstreet/bcachefs-tools#671 so this PR is tested against the packages that build on each runner instead of the known broken cross-runner package set.

Checks run:
- `git diff origin/master...HEAD --check`
- `groff -mandoc -Tascii bcachefs.8 >/dev/null` (only pre-existing empty-line warnings)