### PR TITLE
docs: clarify encryption passphrase commands

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -547,9 +547,14 @@ Keyring to add to (default:
 .Cm user )
 .El
 .It Nm Ic set-passphrase Ar devices\ ...
-Change passphrase on an existing (unmounted) filesystem.
+Change passphrase on an existing encrypted (unmounted) filesystem.
+This rewraps the existing filesystem encryption key; it does not enable
+encryption on a filesystem formatted without
+.Fl -encrypted .
 .It Nm Ic remove-passphrase Ar devices\ ...
-Remove passphrase on an existing (unmounted) filesystem.
+Remove passphrase protection from an existing encrypted (unmounted) filesystem.
+This stores the existing filesystem encryption key without passphrase
+protection; it does not decrypt existing data or disable filesystem encryption.
 .El
 .Sh Commands for migration
 .Bl -tag -width Ds

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -149,7 +149,7 @@ unsafe fn set_crypt_key(fs: &Fs, key: c::bch_encrypted_key) {
 // ---- set-passphrase ----
 
 #[derive(Parser, Debug)]
-#[command(about = "Change passphrase on an existing (unmounted) filesystem")]
+#[command(about = "Change passphrase on an existing encrypted (unmounted) filesystem")]
 pub struct SetPassphraseCli {
     /// Devices (colon-separated or multiple arguments)
     #[arg(required = true)]
@@ -176,7 +176,7 @@ fn cmd_set_passphrase(cli: SetPassphraseCli) -> Result<()> {
 // ---- remove-passphrase ----
 
 #[derive(Parser, Debug)]
-#[command(about = "Remove passphrase on an existing (unmounted) filesystem")]
+#[command(about = "Remove passphrase protection from an existing encrypted (unmounted) filesystem")]
 pub struct RemovePassphraseCli {
     /// Devices (colon-separated or multiple arguments)
     #[arg(required = true)]
@@ -193,5 +193,5 @@ fn cmd_remove_passphrase(cli: RemovePassphraseCli) -> Result<()> {
 }
 
 pub const CMD_UNLOCK: super::CmdDef = typed_cmd!("unlock", "Unlock an encrypted filesystem", UnlockCli, cmd_unlock);
-pub const CMD_SET_PASSPHRASE: super::CmdDef = typed_cmd!("set-passphrase", "Set or change passphrase", SetPassphraseCli, cmd_set_passphrase);
-pub const CMD_REMOVE_PASSPHRASE: super::CmdDef = typed_cmd!("remove-passphrase", "Remove passphrase", RemovePassphraseCli, cmd_remove_passphrase);
+pub const CMD_SET_PASSPHRASE: super::CmdDef = typed_cmd!("set-passphrase", "Set or change encryption passphrase", SetPassphraseCli, cmd_set_passphrase);
+pub const CMD_REMOVE_PASSPHRASE: super::CmdDef = typed_cmd!("remove-passphrase", "Remove encryption passphrase", RemovePassphraseCli, cmd_remove_passphrase);


### PR DESCRIPTION
Related to koverstreet/bcachefs#1064. Adjacent to koverstreet/bcachefs#1065, but does not implement per-user or per-subvolume encryption keys.

This clarifies the current encryption command surface:

- `set-passphrase` requires an already-encrypted filesystem and rewraps the existing filesystem encryption key
- `remove-passphrase` removes passphrase protection from that existing key, but does not decrypt existing data or disable filesystem encryption
- neither command enables encryption on a filesystem that was formatted without `--encrypted`

This does not implement background encryption of existing plaintext data or per-user/per-subvolume keys; those remain kernel/on-disk design feature requests. The goal here is to make the current userspace behavior harder to misread while those features are absent.

Validation:
- `git diff --check`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
- `./bcachefs set-passphrase --help`
- `./bcachefs remove-passphrase --help`
