### PR TITLE
list: add JSON inode extent inspection

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -798,6 +798,8 @@ Btree depth to descend to. (
 Start position to list from
 .It Fl e Ar inode Ns Cm \&: Ns Ar offset
 End position
+.It Fl -inode Ar inode
+Limit extents listing to one inode number.
 .It Fl m , Fl -mode ( Cm keys | formats | nodes | nodes-ondisk )
 (default:
 .Cm keys)

--- a/bcachefs.8
+++ b/bcachefs.8
@@ -790,6 +790,8 @@ Btree depth to descend to. (
 Start position to list from
 .It Fl e Ar inode Ns Cm \&: Ns Ar offset
 End position
+.It Fl -inode Ar inode
+Limit extents listing to one inode number.
 .It Fl m , Fl -mode ( Cm keys | formats | nodes | nodes-ondisk )
 (default:
 .Cm keys)

--- a/bcachefs.8
+++ b/bcachefs.8
@@ -792,6 +792,12 @@ Start position to list from
 End position
 .It Fl -inode Ar inode
 Limit extents listing to one inode number.
+.It Fl -inode-start-offset Ar offset
+First bpos offset to list with
+.Fl -inode .
+.It Fl -inode-end-offset Ar offset
+Last bpos offset to list with
+.Fl -inode .
 .It Fl m , Fl -mode ( Cm keys | formats | nodes | nodes-ondisk )
 (default:
 .Cm keys)

--- a/flake.nix
+++ b/flake.nix
@@ -177,9 +177,8 @@
             };
 
           checks = {
-            inherit (self'.packages)
+            inherit (pkgs.bcachefsPackages)
               bcachefs-tools
-              bcachefs-tools-aarch64-linux
               bcachefs-tools-fuse
               bcachefs-module-linux-latest
               bcachefs-module-linux-testing

--- a/fs/data/extents.rs
+++ b/fs/data/extents.rs
@@ -165,6 +165,42 @@ pub fn bkey_ptrs(k: &c::bkey_i) -> ExtentPtrIter<'_> {
     bkey_ptrs_sc(&BkeyValSC::from_bkey_i(k))
 }
 
+/// Read-only access to an entry's `ptr` union field.
+///
+/// The caller must have checked that this entry is a ptr, i.e.
+/// `extent_entry_type(entry) == BCH_EXTENT_ENTRY_ptr`.
+pub fn entry_ptr(entry: &c::bch_extent_entry) -> &c::bch_extent_ptr {
+    unsafe { extent_union_field_ref(&entry.ptr) }
+}
+
+/// Read-only access to an entry's `crc32` union field.
+///
+/// The caller must have checked that this entry is a crc32.
+pub fn entry_crc32(entry: &c::bch_extent_entry) -> &c::bch_extent_crc32 {
+    unsafe { extent_union_field_ref(&entry.crc32) }
+}
+
+/// Read-only access to an entry's `crc64` union field.
+///
+/// The caller must have checked that this entry is a crc64.
+pub fn entry_crc64(entry: &c::bch_extent_entry) -> &c::bch_extent_crc64 {
+    unsafe { extent_union_field_ref(&entry.crc64) }
+}
+
+/// Read-only access to an entry's `crc128` union field.
+///
+/// The caller must have checked that this entry is a crc128.
+pub fn entry_crc128(entry: &c::bch_extent_entry) -> &c::bch_extent_crc128 {
+    unsafe { extent_union_field_ref(&entry.crc128) }
+}
+
+/// Read-only access to an entry's `stripe_ptr` union field.
+///
+/// The caller must have checked that this entry is a stripe_ptr.
+pub fn entry_stripe_ptr(entry: &c::bch_extent_entry) -> &c::bch_extent_stripe_ptr {
+    unsafe { extent_union_field_ref(&entry.stripe_ptr) }
+}
+
 pub struct ExtentEntryIterMut<'a> {
     fs:       &'a Fs,
     cur:      *mut c::bch_extent_entry,

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,7 +1,6 @@
 use std::ops::ControlFlow;
 
 use anyhow::{bail, Result};
-use bcachefs_kernel::{btree_id, c, pos};
 use bcachefs_kernel::btree::bkey::BkeySC;
 use bcachefs_kernel::btree::iter::BtreeIter;
 use bcachefs_kernel::btree::iter::BtreeIterFlags;
@@ -9,18 +8,19 @@ use bcachefs_kernel::btree::iter::BtreeNodeIter;
 use bcachefs_kernel::btree::iter::BtreeTrans;
 use bcachefs_kernel::fs::Fs;
 use bcachefs_kernel::opt_set;
+use bcachefs_kernel::{btree_id, c, pos};
 use bch_bindgen::c::bch_degraded_actions;
 use clap::Parser;
 use std::io::{stdout, IsTerminal};
 
-use crate::logging;
 use crate::device_scan::OpenedFs;
+use crate::logging;
 use crate::wrappers::handle::BcachefsHandle;
 use crate::wrappers::online_iter::{OnlineBtreeIter, OnlineIterFlags};
 
 fn list_keys(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
-    let (btree, start, end) = opt.list_range();
+    let (btree, start, end) = opt.list_range()?;
 
     let mut flags = BtreeIterFlags::PREFETCH;
 
@@ -28,13 +28,7 @@ fn list_keys(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
         flags |= BtreeIterFlags::ALL_SNAPSHOTS;
     }
 
-    let mut iter = BtreeIter::new_level(
-        &trans,
-        btree,
-        start,
-        opt.level,
-        flags,
-    );
+    let mut iter = BtreeIter::new_level(&trans, btree, start, opt.level, flags);
 
     iter.for_each(&trans, |k| {
         if k.k.p > end {
@@ -56,17 +50,10 @@ fn list_keys(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
 
 fn list_btree_formats(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
-    let (btree, start, end) = opt.list_range();
+    let (btree, start, end) = opt.list_range()?;
 
     for level in opt.level..(c::BTREE_MAX_DEPTH as u32) {
-        let mut iter = BtreeNodeIter::new(
-            &trans,
-            btree,
-            start,
-            0,
-            level,
-            BtreeIterFlags::PREFETCH,
-        );
+        let mut iter = BtreeNodeIter::new(&trans, btree, start, 0, level, BtreeIterFlags::PREFETCH);
 
         iter.for_each(&trans, |b| {
             if b.key.k.p > end {
@@ -83,17 +70,10 @@ fn list_btree_formats(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
 
 fn list_btree_nodes(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
-    let (btree, start, end) = opt.list_range();
+    let (btree, start, end) = opt.list_range()?;
 
     for level in opt.level..(c::BTREE_MAX_DEPTH as u32) {
-        let mut iter = BtreeNodeIter::new(
-            &trans,
-            btree,
-            start,
-            0,
-            level,
-            BtreeIterFlags::PREFETCH,
-        );
+        let mut iter = BtreeNodeIter::new(&trans, btree, start, 0, level, BtreeIterFlags::PREFETCH);
 
         iter.for_each(&trans, |b| {
             if b.key.k.p > end {
@@ -110,17 +90,10 @@ fn list_btree_nodes(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
 
 fn list_nodes_ondisk(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
-    let (btree, start, end) = opt.list_range();
+    let (btree, start, end) = opt.list_range()?;
 
     for level in opt.level..(c::BTREE_MAX_DEPTH as u32) {
-        let mut iter = BtreeNodeIter::new(
-            &trans,
-            btree,
-            start,
-            0,
-            level,
-            BtreeIterFlags::PREFETCH,
-        );
+        let mut iter = BtreeNodeIter::new(&trans, btree, start, 0, level, BtreeIterFlags::PREFETCH);
 
         iter.for_each(&trans, |b| {
             if b.key.k.p > end {
@@ -142,7 +115,7 @@ fn list_nodes_ondisk(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
 /// tables, member names, disk groups) comes from the superblock. Output
 /// is identical to the offline path by construction.
 fn list_keys_online(handle: &BcachefsHandle, fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
-    let (btree, start, end) = opt.list_range();
+    let (btree, start, end) = opt.list_range()?;
     let mut flags = OnlineIterFlags::default();
     if start.snapshot == 0 {
         flags = flags | OnlineIterFlags::ALL_SNAPSHOTS;
@@ -150,7 +123,10 @@ fn list_keys_online(handle: &BcachefsHandle, fs: &Fs, opt: &Cli) -> anyhow::Resu
 
     let mut iter = OnlineBtreeIter::new(handle, btree, opt.level, start, end, flags);
 
-    while let Some(k) = iter.next().map_err(|e| anyhow::anyhow!("BCH_IOCTL_QUERY_BTREE_KEYS: {}", e))? {
+    while let Some(k) = iter
+        .next()
+        .map_err(|e| anyhow::anyhow!("BCH_IOCTL_QUERY_BTREE_KEYS: {}", e))?
+    {
         if k.k.p > end {
             break;
         }
@@ -172,7 +148,9 @@ fn list_online(handle: &BcachefsHandle, fs: &Fs, opt: &Cli) -> anyhow::Result<()
         bail!("only 'keys' mode is supported on a mounted filesystem");
     }
     if opt.fsck {
-        bail!("--fsck requires the filesystem to be unmounted; use 'bcachefs fsck' for online fsck");
+        bail!(
+            "--fsck requires the filesystem to be unmounted; use 'bcachefs fsck' for online fsck"
+        );
     }
 
     list_keys_online(handle, fs, opt)
@@ -230,6 +208,14 @@ pub struct Cli {
     #[arg(long)]
     inode: Option<u64>,
 
+    /// First bpos offset to list with --inode
+    #[arg(long, requires = "inode", default_value_t = 0)]
+    inode_start_offset: u64,
+
+    /// Last bpos offset to list with --inode
+    #[arg(long, requires = "inode", default_value_t = u64::MAX)]
+    inode_end_offset: u64,
+
     /// Check (fsck) the filesystem first
     #[arg(short, long)]
     fsck: bool,
@@ -248,23 +234,40 @@ pub struct Cli {
 }
 
 impl Cli {
-    fn list_range(&self) -> (c::btree_id, c::bpos, c::bpos) {
+    fn list_range(&self) -> Result<(c::btree_id, c::bpos, c::bpos)> {
         if let Some(inode) = self.inode {
-            (btree_id::extents, pos(inode, 0), pos(inode, u64::MAX))
+            if self.inode_start_offset > self.inode_end_offset {
+                bail!(
+                    "--inode-start-offset ({}) must be <= --inode-end-offset ({})",
+                    self.inode_start_offset,
+                    self.inode_end_offset
+                );
+            }
+
+            Ok((
+                btree_id::extents,
+                pos(inode, self.inode_start_offset),
+                pos(inode, self.inode_end_offset),
+            ))
         } else {
-            (self.btree, self.start, self.end)
+            Ok((self.btree, self.start, self.end))
         }
     }
 }
 
 fn cmd_list_inner(opt: &Cli) -> anyhow::Result<()> {
+    let _ = opt.list_range()?;
     let mut fs_opts = c::bch_opts::default();
 
     opt_set!(fs_opts, noexcl, 1);
     opt_set!(fs_opts, nochanges, 1);
     opt_set!(fs_opts, read_only, 1);
     opt_set!(fs_opts, norecovery, 1);
-    opt_set!(fs_opts, degraded, bch_degraded_actions::BCH_DEGRADED_very as u8);
+    opt_set!(
+        fs_opts,
+        degraded,
+        bch_degraded_actions::BCH_DEGRADED_very as u8
+    );
     opt_set!(
         fs_opts,
         errors,
@@ -272,11 +275,7 @@ fn cmd_list_inner(opt: &Cli) -> anyhow::Result<()> {
     );
 
     if opt.fsck {
-        opt_set!(
-            fs_opts,
-            fix_errors,
-            c::fsck_err_opts::FSCK_FIX_yes as u8
-        );
+        opt_set!(fs_opts, fix_errors, c::fsck_err_opts::FSCK_FIX_yes as u8);
         opt_set!(fs_opts, norecovery, 0);
     }
 
@@ -295,13 +294,18 @@ fn cmd_list_inner(opt: &Cli) -> anyhow::Result<()> {
             // mount point or UUID, which aren't openable as devices.
             log::info!("filesystem is mounted, listing via the kernel");
 
-            let devs = handle.member_devices()
+            let devs = handle
+                .member_devices()
                 .map_err(|e| anyhow::anyhow!("getting member devices from sysfs: {}", e))?;
 
             opt_set!(fs_opts, nostart, 1);
-            let fs = crate::device_scan::open_scan(&devs, fs_opts)
-                .map_err(|e| anyhow::anyhow!(
-                    "opening {:?} (noexcl/nostart, for formatting keys): {}", devs, e))?;
+            let fs = crate::device_scan::open_scan(&devs, fs_opts).map_err(|e| {
+                anyhow::anyhow!(
+                    "opening {:?} (noexcl/nostart, for formatting keys): {}",
+                    devs,
+                    e
+                )
+            })?;
 
             list_online(&handle, &fs, opt)
         }
@@ -322,3 +326,50 @@ fn list(opt: Cli) -> Result<()> {
 }
 
 pub const CMD: super::CmdDef = typed_cmd!("list", "List filesystem metadata", Cli, list);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_cli() -> Cli {
+        Cli {
+            mode: Mode::Keys,
+            btree: btree_id::extents,
+            bkey_type: None,
+            level: 0,
+            start: pos(0, 0),
+            end: pos(u64::MAX, u64::MAX),
+            inode: None,
+            inode_start_offset: 0,
+            inode_end_offset: u64::MAX,
+            fsck: false,
+            colorize: false,
+            verbose: 0,
+            devices: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn inode_range_uses_inode_relative_offsets() {
+        let mut cli = base_cli();
+        cli.inode = Some(123);
+        cli.inode_start_offset = 10;
+        cli.inode_end_offset = 20;
+
+        let (btree, start, end) = cli.list_range().unwrap();
+
+        assert_eq!(btree, btree_id::extents);
+        assert_eq!(start, pos(123, 10));
+        assert_eq!(end, pos(123, 20));
+    }
+
+    #[test]
+    fn inode_range_rejects_reversed_offsets() {
+        let mut cli = base_cli();
+        cli.inode = Some(123);
+        cli.inode_start_offset = 20;
+        cli.inode_end_offset = 10;
+
+        assert!(cli.list_range().is_err());
+    }
+}

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,7 +1,7 @@
 use std::ops::ControlFlow;
 
 use anyhow::{bail, Result};
-use bcachefs_kernel::{btree_id, c};
+use bcachefs_kernel::{btree_id, c, pos};
 use bcachefs_kernel::btree::bkey::BkeySC;
 use bcachefs_kernel::btree::iter::BtreeIter;
 use bcachefs_kernel::btree::iter::BtreeIterFlags;
@@ -20,23 +20,24 @@ use crate::wrappers::online_iter::{OnlineBtreeIter, OnlineIterFlags};
 
 fn list_keys(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
+    let (btree, start, end) = opt.list_range();
 
     let mut flags = BtreeIterFlags::PREFETCH;
 
-    if opt.start.snapshot == 0 {
+    if start.snapshot == 0 {
         flags |= BtreeIterFlags::ALL_SNAPSHOTS;
     }
 
     let mut iter = BtreeIter::new_level(
         &trans,
-        opt.btree,
-        opt.start,
+        btree,
+        start,
         opt.level,
         flags,
     );
 
     iter.for_each(&trans, |k| {
-        if k.k.p > opt.end {
+        if k.k.p > end {
             return ControlFlow::Break(());
         }
 
@@ -55,18 +56,20 @@ fn list_keys(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
 
 fn list_btree_formats(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
+    let (btree, start, end) = opt.list_range();
+
     for level in opt.level..(c::BTREE_MAX_DEPTH as u32) {
         let mut iter = BtreeNodeIter::new(
             &trans,
-            opt.btree,
-            opt.start,
+            btree,
+            start,
             0,
             level,
             BtreeIterFlags::PREFETCH,
         );
 
         iter.for_each(&trans, |b| {
-            if b.key.k.p > opt.end {
+            if b.key.k.p > end {
                 return ControlFlow::Break(());
             }
 
@@ -80,18 +83,20 @@ fn list_btree_formats(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
 
 fn list_btree_nodes(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
+    let (btree, start, end) = opt.list_range();
+
     for level in opt.level..(c::BTREE_MAX_DEPTH as u32) {
         let mut iter = BtreeNodeIter::new(
             &trans,
-            opt.btree,
-            opt.start,
+            btree,
+            start,
             0,
             level,
             BtreeIterFlags::PREFETCH,
         );
 
         iter.for_each(&trans, |b| {
-            if b.key.k.p > opt.end {
+            if b.key.k.p > end {
                 return ControlFlow::Break(());
             }
 
@@ -105,18 +110,20 @@ fn list_btree_nodes(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
 
 fn list_nodes_ondisk(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
+    let (btree, start, end) = opt.list_range();
+
     for level in opt.level..(c::BTREE_MAX_DEPTH as u32) {
         let mut iter = BtreeNodeIter::new(
             &trans,
-            opt.btree,
-            opt.start,
+            btree,
+            start,
             0,
             level,
             BtreeIterFlags::PREFETCH,
         );
 
         iter.for_each(&trans, |b| {
-            if b.key.k.p > opt.end {
+            if b.key.k.p > end {
                 return ControlFlow::Break(());
             }
 
@@ -135,16 +142,16 @@ fn list_nodes_ondisk(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
 /// tables, member names, disk groups) comes from the superblock. Output
 /// is identical to the offline path by construction.
 fn list_keys_online(handle: &BcachefsHandle, fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
+    let (btree, start, end) = opt.list_range();
     let mut flags = OnlineIterFlags::default();
-    if opt.start.snapshot == 0 {
+    if start.snapshot == 0 {
         flags = flags | OnlineIterFlags::ALL_SNAPSHOTS;
     }
 
-    let mut iter = OnlineBtreeIter::new(handle, opt.btree, opt.level,
-					opt.start, opt.end, flags);
+    let mut iter = OnlineBtreeIter::new(handle, btree, opt.level, start, end, flags);
 
     while let Some(k) = iter.next().map_err(|e| anyhow::anyhow!("BCH_IOCTL_QUERY_BTREE_KEYS: {}", e))? {
-        if k.k.p > opt.end {
+        if k.k.p > end {
             break;
         }
 
@@ -191,7 +198,10 @@ nodes-ondisk shows the raw on-disk representation.\n\n\
 Use -b to select a btree (default: extents), -s/-e for start/end \
 position, -l for btree depth, -k to filter by key type. With -c, \
 runs fsck before listing. Output is used for debugging filesystem \
-state, verifying btree contents, and inspecting on-disk layout.")]
+state, verifying btree contents, and inspecting on-disk layout.\n\n\
+Use --inode with the extents btree to inspect the extent keys for one \
+file inode, including the pointer/device text printed by the bcachefs \
+metadata formatter.")]
 pub struct Cli {
     #[arg(short, long, default_value = "keys")]
     mode: Mode,
@@ -216,6 +226,10 @@ pub struct Cli {
     #[arg(short, long, default_value = "SPOS_MAX")]
     end: c::bpos,
 
+    /// Limit extents listing to one inode number
+    #[arg(long)]
+    inode: Option<u64>,
+
     /// Check (fsck) the filesystem first
     #[arg(short, long)]
     fsck: bool,
@@ -231,6 +245,16 @@ pub struct Cli {
 
     #[arg(required(true))]
     devices: Vec<std::path::PathBuf>,
+}
+
+impl Cli {
+    fn list_range(&self) -> (c::btree_id, c::bpos, c::bpos) {
+        if let Some(inode) = self.inode {
+            (btree_id::extents, pos(inode, 0), pos(inode, u64::MAX))
+        } else {
+            (self.btree, self.start, self.end)
+        }
+    }
 }
 
 fn cmd_list_inner(opt: &Cli) -> anyhow::Result<()> {
@@ -291,7 +315,6 @@ fn cmd_list_inner(opt: &Cli) -> anyhow::Result<()> {
 }
 
 fn list(opt: Cli) -> Result<()> {
-
     // TODO: centralize this on the top level CLI
     logging::setup(opt.verbose, opt.colorize);
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,22 +1,296 @@
 use std::ops::ControlFlow;
 
 use anyhow::{bail, Result};
-use bcachefs_kernel::btree::bkey::BkeySC;
+use bcachefs_kernel::btree::bkey::{BkeySC, BkeyValSC};
 use bcachefs_kernel::btree::iter::BtreeIter;
 use bcachefs_kernel::btree::iter::BtreeIterFlags;
 use bcachefs_kernel::btree::iter::BtreeNodeIter;
 use bcachefs_kernel::btree::iter::BtreeTrans;
+use bcachefs_kernel::data::extents;
 use bcachefs_kernel::fs::Fs;
 use bcachefs_kernel::opt_set;
 use bcachefs_kernel::{btree_id, c, pos};
 use bch_bindgen::c::bch_degraded_actions;
 use clap::Parser;
+use serde_json::{json, Value};
 use std::io::{stdout, IsTerminal};
 
 use crate::device_scan::OpenedFs;
 use crate::logging;
 use crate::wrappers::handle::BcachefsHandle;
 use crate::wrappers::online_iter::{OnlineBtreeIter, OnlineIterFlags};
+
+fn bpos_json(p: c::bpos) -> Value {
+    let inode = unsafe { core::ptr::addr_of!(p.inode).read_unaligned() };
+    let offset = unsafe { core::ptr::addr_of!(p.offset).read_unaligned() };
+    let snapshot = unsafe { core::ptr::addr_of!(p.snapshot).read_unaligned() };
+
+    json!({
+        "inode": inode,
+        "offset": offset,
+        "snapshot": snapshot,
+    })
+}
+
+fn csum_json(lo: u64, hi: u64) -> Value {
+    json!({
+        "lo": lo,
+        "hi": hi,
+        "lo_hex": format!("{lo:016x}"),
+        "hi_hex": format!("{hi:016x}"),
+    })
+}
+
+fn default_crc_json(size: u32) -> Value {
+    json!({
+        "compressed_size": size,
+        "uncompressed_size": size,
+        "live_size": size,
+        "csum_type": 0,
+        "compression_type": 0,
+        "offset": 0,
+        "nonce": 0,
+        "csum": csum_json(0, 0),
+    })
+}
+
+fn crc32_json(k: &c::bkey, crc: &c::bch_extent_crc32) -> Value {
+    json!({
+        "compressed_size": crc._compressed_size() + 1,
+        "uncompressed_size": crc._uncompressed_size() + 1,
+        "live_size": k.size,
+        "csum_type": crc.csum_type(),
+        "compression_type": crc.compression_type(),
+        "offset": crc.offset(),
+        "nonce": 0,
+        "csum": csum_json(crc.csum as u64, 0),
+    })
+}
+
+fn crc64_json(k: &c::bkey, crc: &c::bch_extent_crc64) -> Value {
+    json!({
+        "compressed_size": crc._compressed_size() + 1,
+        "uncompressed_size": crc._uncompressed_size() + 1,
+        "live_size": k.size,
+        "csum_type": crc.csum_type(),
+        "compression_type": crc.compression_type(),
+        "offset": crc.offset(),
+        "nonce": crc.nonce(),
+        "csum": csum_json(crc.csum_lo, crc.csum_hi()),
+    })
+}
+
+fn crc128_json(k: &c::bkey, crc: &c::bch_extent_crc128) -> Value {
+    let csum = unsafe { core::ptr::addr_of!(crc.csum).read_unaligned() };
+    let lo = u64::from_le(csum.lo);
+    let hi = u64::from_le(csum.hi);
+
+    json!({
+        "compressed_size": crc._compressed_size() + 1,
+        "uncompressed_size": crc._uncompressed_size() + 1,
+        "live_size": k.size,
+        "csum_type": crc.csum_type(),
+        "compression_type": crc.compression_type(),
+        "offset": crc.offset(),
+        "nonce": crc.nonce(),
+        "csum": csum_json(lo, hi),
+    })
+}
+
+fn extent_entry_type_name(ty: u32) -> &'static str {
+    match ty {
+        x if x == c::bch_extent_entry_type::BCH_EXTENT_ENTRY_ptr as u32 => "ptr",
+        x if x == c::bch_extent_entry_type::BCH_EXTENT_ENTRY_crc32 as u32 => "crc32",
+        x if x == c::bch_extent_entry_type::BCH_EXTENT_ENTRY_crc64 as u32 => "crc64",
+        x if x == c::bch_extent_entry_type::BCH_EXTENT_ENTRY_crc128 as u32 => "crc128",
+        x if x == c::bch_extent_entry_type::BCH_EXTENT_ENTRY_stripe_ptr as u32 => "stripe_ptr",
+        x if x == c::bch_extent_entry_type::BCH_EXTENT_ENTRY_rebalance_v1 as u32 => "rebalance_v1",
+        x if x == c::bch_extent_entry_type::BCH_EXTENT_ENTRY_flags as u32 => "flags",
+        x if x == c::bch_extent_entry_type::BCH_EXTENT_ENTRY_reconcile as u32 => "reconcile",
+        x if x == c::bch_extent_entry_type::BCH_EXTENT_ENTRY_reconcile_bp as u32 => "reconcile_bp",
+        _ => "unknown",
+    }
+}
+
+fn bkey_type_name(ty: u8) -> &'static str {
+    match ty as u32 {
+        x if x == c::bch_bkey_type::KEY_TYPE_deleted.0 => "deleted",
+        x if x == c::bch_bkey_type::KEY_TYPE_whiteout.0 => "whiteout",
+        x if x == c::bch_bkey_type::KEY_TYPE_error.0 => "error",
+        x if x == c::bch_bkey_type::KEY_TYPE_cookie.0 => "cookie",
+        x if x == c::bch_bkey_type::KEY_TYPE_hash_whiteout.0 => "hash_whiteout",
+        x if x == c::bch_bkey_type::KEY_TYPE_btree_ptr.0 => "btree_ptr",
+        x if x == c::bch_bkey_type::KEY_TYPE_extent.0 => "extent",
+        x if x == c::bch_bkey_type::KEY_TYPE_reservation.0 => "reservation",
+        x if x == c::bch_bkey_type::KEY_TYPE_inode.0 => "inode",
+        x if x == c::bch_bkey_type::KEY_TYPE_inode_generation.0 => "inode_generation",
+        x if x == c::bch_bkey_type::KEY_TYPE_dirent.0 => "dirent",
+        x if x == c::bch_bkey_type::KEY_TYPE_xattr.0 => "xattr",
+        x if x == c::bch_bkey_type::KEY_TYPE_alloc.0 => "alloc",
+        x if x == c::bch_bkey_type::KEY_TYPE_quota.0 => "quota",
+        x if x == c::bch_bkey_type::KEY_TYPE_stripe.0 => "stripe",
+        x if x == c::bch_bkey_type::KEY_TYPE_reflink_p.0 => "reflink_p",
+        x if x == c::bch_bkey_type::KEY_TYPE_reflink_v.0 => "reflink_v",
+        x if x == c::bch_bkey_type::KEY_TYPE_inline_data.0 => "inline_data",
+        x if x == c::bch_bkey_type::KEY_TYPE_btree_ptr_v2.0 => "btree_ptr_v2",
+        x if x == c::bch_bkey_type::KEY_TYPE_indirect_inline_data.0 => "indirect_inline_data",
+        x if x == c::bch_bkey_type::KEY_TYPE_alloc_v2.0 => "alloc_v2",
+        x if x == c::bch_bkey_type::KEY_TYPE_subvolume.0 => "subvolume",
+        x if x == c::bch_bkey_type::KEY_TYPE_snapshot.0 => "snapshot",
+        x if x == c::bch_bkey_type::KEY_TYPE_inode_v2.0 => "inode_v2",
+        x if x == c::bch_bkey_type::KEY_TYPE_alloc_v3.0 => "alloc_v3",
+        x if x == c::bch_bkey_type::KEY_TYPE_set.0 => "set",
+        x if x == c::bch_bkey_type::KEY_TYPE_lru.0 => "lru",
+        x if x == c::bch_bkey_type::KEY_TYPE_alloc_v4.0 => "alloc_v4",
+        x if x == c::bch_bkey_type::KEY_TYPE_backpointer.0 => "backpointer",
+        x if x == c::bch_bkey_type::KEY_TYPE_inode_v3.0 => "inode_v3",
+        x if x == c::bch_bkey_type::KEY_TYPE_bucket_gens.0 => "bucket_gens",
+        x if x == c::bch_bkey_type::KEY_TYPE_snapshot_tree.0 => "snapshot_tree",
+        x if x == c::bch_bkey_type::KEY_TYPE_logged_op_truncate.0 => "logged_op_truncate",
+        x if x == c::bch_bkey_type::KEY_TYPE_logged_op_finsert.0 => "logged_op_finsert",
+        x if x == c::bch_bkey_type::KEY_TYPE_accounting.0 => "accounting",
+        x if x == c::bch_bkey_type::KEY_TYPE_inode_alloc_cursor.0 => "inode_alloc_cursor",
+        x if x == c::bch_bkey_type::KEY_TYPE_extent_whiteout.0 => "extent_whiteout",
+        x if x == c::bch_bkey_type::KEY_TYPE_logged_op_stripe_update.0 => "logged_op_stripe_update",
+        x if x == c::bch_bkey_type::KEY_TYPE_damage.0 => "damage",
+        _ => "unknown",
+    }
+}
+
+fn extent_entries_json(k: BkeySC<'_>) -> Vec<Value> {
+    let mut entries = Vec::new();
+    let mut current_crc = default_crc_json(k.k.size);
+
+    for entry in extents::bkey_extent_entries_sc(&k.v()) {
+        let ty = extents::extent_entry_type(entry);
+        let ty_name = extent_entry_type_name(ty);
+        let mut out = json!({
+            "entry_type": ty,
+            "entry_type_name": ty_name,
+        });
+
+        match ty {
+            x if x == c::bch_extent_entry_type::BCH_EXTENT_ENTRY_ptr as u32 => {
+                let ptr = extents::entry_ptr(entry);
+                out["ptr"] = json!({
+                    "dev": ptr.dev(),
+                    "offset": ptr.offset(),
+                    "generation": ptr.generation(),
+                    "cached": ptr.cached() != 0,
+                    "unwritten": ptr.unwritten() != 0,
+                    "crc": current_crc.clone(),
+                });
+            }
+            x if x == c::bch_extent_entry_type::BCH_EXTENT_ENTRY_crc32 as u32 => {
+                current_crc = crc32_json(k.k, extents::entry_crc32(entry));
+                out["crc"] = current_crc.clone();
+            }
+            x if x == c::bch_extent_entry_type::BCH_EXTENT_ENTRY_crc64 as u32 => {
+                current_crc = crc64_json(k.k, extents::entry_crc64(entry));
+                out["crc"] = current_crc.clone();
+            }
+            x if x == c::bch_extent_entry_type::BCH_EXTENT_ENTRY_crc128 as u32 => {
+                current_crc = crc128_json(k.k, extents::entry_crc128(entry));
+                out["crc"] = current_crc.clone();
+            }
+            x if x == c::bch_extent_entry_type::BCH_EXTENT_ENTRY_stripe_ptr as u32 => {
+                let stripe = extents::entry_stripe_ptr(entry);
+                out["stripe_ptr"] = json!({
+                    "idx": stripe.idx(),
+                    "block": stripe.block(),
+                    "redundancy": stripe.redundancy(),
+                    "crc": current_crc.clone(),
+                });
+            }
+            _ => {}
+        }
+
+        entries.push(out);
+    }
+
+    entries
+}
+
+fn reflink_p_json(v: &c::bch_reflink_p) -> Value {
+    let idx_flags = unsafe { core::ptr::addr_of!(v.idx_flags).read_unaligned() };
+    let idx_flags = u64::from_le(idx_flags);
+    let front_pad = unsafe { core::ptr::addr_of!(v.front_pad).read_unaligned() };
+    let back_pad = unsafe { core::ptr::addr_of!(v.back_pad).read_unaligned() };
+
+    json!({
+        "idx": idx_flags & ((1u64 << 56) - 1),
+        "error": ((idx_flags >> 56) & 1) != 0,
+        "may_update_options": ((idx_flags >> 57) & 1) != 0,
+        "front_pad": u32::from_le(front_pad),
+        "back_pad": u32::from_le(back_pad),
+    })
+}
+
+fn backpointer_json(v: &c::bch_backpointer) -> Value {
+    let flags = unsafe { core::ptr::addr_of!(v.flags).read_unaligned() };
+    let bucket_len = unsafe { core::ptr::addr_of!(v.bucket_len).read_unaligned() };
+    let pos = unsafe { core::ptr::addr_of!(v.pos).read_unaligned() };
+
+    json!({
+        "btree_id": v.btree_id,
+        "level": v.level,
+        "data_type": v.data_type,
+        "bucket_gen": v.bucket_gen,
+        "flags": flags,
+        "bucket_len": bucket_len,
+        "pos": bpos_json(pos),
+    })
+}
+
+fn key_json(fs: &Fs, btree: c::btree_id, level: u32, k: BkeySC<'_>) -> Value {
+    let key_type = k.k.type_;
+    let bversion_lo = unsafe { core::ptr::addr_of!(k.k.bversion.lo).read_unaligned() };
+    let bversion_hi = unsafe { core::ptr::addr_of!(k.k.bversion.hi).read_unaligned() };
+
+    let mut out = json!({
+        "btree": format!("{btree}"),
+        "btree_id": btree as u32,
+        "level": level,
+        "key": {
+            "type": key_type,
+            "type_name": bkey_type_name(key_type),
+            "pos": bpos_json(k.pos()),
+            "start_pos": bpos_json(k.start_pos()),
+            "size": k.size(),
+            "bversion": {
+                "lo": bversion_lo,
+                "hi": bversion_hi,
+            },
+            "deleted": k.is_deleted(),
+        },
+        "text": format!("{}", k.to_text(fs)),
+    });
+
+    let entries = extent_entries_json(k);
+    if !entries.is_empty() {
+        out["extent_entries"] = json!(entries);
+    }
+
+    match k.v() {
+        BkeyValSC::reflink_p(_, v) => out["reflink_p"] = reflink_p_json(v),
+        BkeyValSC::reflink_v(_, v) => {
+            let refcount = unsafe { core::ptr::addr_of!(v.refcount).read_unaligned() };
+            out["reflink_v"] = json!({ "refcount": u64::from_le(refcount) });
+        }
+        BkeyValSC::backpointer(_, v) => out["backpointer"] = backpointer_json(v),
+        _ => {}
+    }
+
+    out
+}
+
+fn print_key(fs: &Fs, opt: &Cli, btree: c::btree_id, k: BkeySC<'_>) {
+    if opt.json {
+        println!("{}", key_json(fs, btree, opt.level, k));
+    } else {
+        println!("{}", k.to_text(fs));
+    }
+}
 
 fn list_keys(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
@@ -41,7 +315,7 @@ fn list_keys(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
             }
         }
 
-        println!("{}", k.to_text(fs));
+        print_key(fs, opt, btree, k);
         ControlFlow::Continue(())
     })?;
 
@@ -137,7 +411,7 @@ fn list_keys_online(handle: &BcachefsHandle, fs: &Fs, opt: &Cli) -> anyhow::Resu
             }
         }
 
-        println!("{}", k.to_text(fs));
+        print_key(fs, opt, btree, k);
     }
 
     Ok(())
@@ -216,6 +490,10 @@ pub struct Cli {
     #[arg(long, requires = "inode", default_value_t = u64::MAX)]
     inode_end_offset: u64,
 
+    /// Emit one JSON object per key
+    #[arg(long)]
+    json: bool,
+
     /// Check (fsck) the filesystem first
     #[arg(short, long)]
     fsck: bool,
@@ -257,6 +535,10 @@ impl Cli {
 
 fn cmd_list_inner(opt: &Cli) -> anyhow::Result<()> {
     let _ = opt.list_range()?;
+    if opt.json && !matches!(opt.mode, Mode::Keys) {
+        bail!("--json is only supported with keys mode");
+    }
+
     let mut fs_opts = c::bch_opts::default();
 
     opt_set!(fs_opts, noexcl, 1);
@@ -342,6 +624,7 @@ mod tests {
             inode: None,
             inode_start_offset: 0,
             inode_end_offset: u64::MAX,
+            json: false,
             fsck: false,
             colorize: false,
             verbose: 0,
@@ -371,5 +654,27 @@ mod tests {
         cli.inode_end_offset = 10;
 
         assert!(cli.list_range().is_err());
+    }
+
+    #[test]
+    fn json_flag_parses_for_keys_mode() {
+        let cli = Cli::parse_from(["list", "--json", "/dev/null"]);
+
+        assert!(cli.json);
+        assert!(matches!(cli.mode, Mode::Keys));
+    }
+
+    #[test]
+    fn json_rejects_non_key_modes_before_opening_devices() {
+        let mut cli = base_cli();
+        cli.json = true;
+        cli.mode = Mode::Nodes;
+        cli.devices.push("/dev/null".into());
+
+        let err = cmd_list_inner(&cli).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("--json is only supported with keys mode"));
     }
 }


### PR DESCRIPTION
References koverstreet/bcachefs-tools#613.

Add `bcachefs list --inode <ino>` as a small tools-side step toward inspecting where file data lives. The flag constrains `list` to the extents-btree range for one inode, so users can inspect existing bcachefs extent key text without manually constructing bpos ranges.

This also adds `--inode-start-offset` and `--inode-end-offset`, letting the inode-scoped listing start and stop at inode-relative bpos offsets. That makes the inspection surface resumable and shardable for tooling that wants to walk one file's extents in bounded chunks.

The latest update adds `--json` for key-listing mode. Each emitted JSON line preserves the existing text formatter output and adds structured key position/type metadata plus decoded extent entries, reflink, and backpointer fields. For extent entries, pointer records include device, offset, generation, cached/unwritten flags, and the attached CRC state when present.

This deliberately uses the metadata formatter rather than FIEMAP: FIEMAP can expose physical offsets and encoded flags, but it cannot reliably answer the multi-device/EC membership question from koverstreet/bcachefs-tools#613 on its own.

This also includes the native-runner CI package check fix from koverstreet/bcachefs-tools#671 so hosted CI does not fail before the Rust build starts.

Refreshed 2026-08-11 to current `origin/master` / `v1.39.1`.

Checks run locally:

- `cargo build --release`
- `cargo test --release commands::list`
- `make -j32 bcachefs`
- `groff -mandoc -Tascii bcachefs.8 >/dev/null` (only pre-existing empty-line warnings)
- `bcachefs list --help` -> shows `--inode`, `--inode-start-offset`, `--inode-end-offset`, and `--json`
- `bcachefs list --inode-start-offset 1 /tmp` -> rejected by clap because `--inode` is required
- `bcachefs list --inode 1 --inode-start-offset 10 --inode-end-offset 5 /tmp` -> rejected before filesystem opening
- `bcachefs format -f --source=<fixture> <image>; bcachefs list --json <image>` -> emitted parseable JSON lines with `extent_entries` containing CRC and pointer records
- `bcachefs list --json -b inodes <image>` -> emitted parseable JSON key records with decoded bkey type names
- `git diff --check origin/master...HEAD`
- generated-tree/scope gate: `git diff --name-only origin/master...HEAD` is exactly `bcachefs.8`, `flake.nix`, `fs/data/extents.rs`, and `src/commands/list.rs`; contains no `build/`, `target/`, object, module, archive, or cache paths

Related to koverstreet/bcachefs#1081.
