### PR TITLE
docs: document fs top non-interactive mode

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -443,6 +443,23 @@ Show disk usage.
 .It Fl h , Fl -human-readable
 Print human readable sizes.
 .El
+.It Nm Ic fs Ic top Oo Ar options Oc Op Ar filesystem
+Show live filesystem performance counters.
+When stdout is a terminal, this starts an interactive display.
+When stdout is not a terminal, it prints one sample and exits.
+.Bl -tag -width Ds
+.It Fl h , Fl -human-readable
+Print human readable sizes.
+.It Fl -once
+Print one sample and exit; equivalent to specifying a count of 1.
+.It Fl n , Fl -count Ns = Ns Ar count
+Print
+.Ar count
+samples and exit.
+A count of 0 keeps the interactive display running.
+.It Fl d , Fl -delay Ns = Ns Ar seconds
+Delay between samples, in seconds.
+.El
 .El
 .Sh Commands for managing devices within a running filesystem
 .Bl -tag -width Ds


### PR DESCRIPTION
Document the `bcachefs fs top` non-interactive behavior added for koverstreet/bcachefs-tools#389.

The manpage now lists `--once`, `-n/--count`, `-d/--delay`, human-readable output, and the default one-sample behavior when stdout is not a terminal.

Local validation:
- `git diff --check`
- `groff -man -Tutf8 bcachefs.8 >/tmp/bcachefs.8.rendered`

`mandoc` is not installed in this environment.