### PR TITLE
mount: add nofsck recovery option

### DIFF
--- a/Changelog.mdwn
+++ b/Changelog.mdwn
@@ -339,6 +339,9 @@ benchmarks were profiled. Some highlights:
 - bcachefs wait-devices now uses the same superblock filtering logic as mount,
   so stale superblocks from removed devices are ignored consistently.
 
+- Mount now accepts an explicit `nofsck` option for disaster-recovery mounts
+  that need to avoid fsck recovery passes while still using `nochanges`.
+
 ## v1.38.5 - Wed Jun 10 2026
 
 Bugfix release on top of v1.38.4. No on-disk format changes.

--- a/bcachefs.8
+++ b/bcachefs.8
@@ -349,6 +349,8 @@ Maximum Amount of IO to keep in flight by the move path
 Maximum number of IOs to keep in flight by the move path
 .It Fl -fsck
 Run fsck on mount
+.It Fl -nofsck
+Do not run fsck recovery passes on mount
 .It Fl -fix_errors Ns = Ns Ar error
 Fix errors during fsck without asking
 .It Fl -ratelimit_errors
@@ -443,8 +445,14 @@ are available, or assemble the complete filesystem before allowing writes.
 Extra debugging info during mount/recovery
 .It Cm fsck
 Run fsck during mount
+.It Cm nofsck
+Do not run fsck recovery passes during mount
 .It Cm fix_errors
 Fix errors without asking during fsck
+.It Cm nochanges
+Super read only mode: do not issue writes
+.It Cm norecovery
+Exit recovery before journal replay
 .It Cm read_only
 Mount in read only mode
 .It Cm version_upgrade

--- a/fs/init/fs.c
+++ b/fs/init/fs.c
@@ -964,6 +964,20 @@ static int bch2_fs_opt_version_init(struct bch_fs *c, struct printbuf *out)
 	if (c->opts.journal_rewind)
 		c->opts.fsck = true;
 
+	if (c->opts.nofsck) {
+		if (c->opts.journal_rewind) {
+			prt_str(out, "cannot mount with both journal_rewind and nofsck\n");
+			return bch_err_throw(c, mount_option);
+		}
+
+		u64 fsck_passes = bch2_fsck_recovery_passes() &
+			~bch2_recovery_passes_match(PASS_ALWAYS);
+
+		c->opts.fsck = false;
+		c->opts.recovery_passes_exclude |= fsck_passes;
+		bch2_recovery_passes_apply_excludes(c);
+	}
+
 	if (!(c->sb.features & (BIT_ULL(BCH_FEATURE_small_image)|
 			        BIT_ULL(BCH_FEATURE_no_default_sb))) ||
 	    bch2_fs_will_resize_on_mount(c))
@@ -1068,6 +1082,7 @@ static int bch2_fs_opt_version_init(struct bch_fs *c, struct printbuf *out)
 		}
 
 		c->opts.recovery_passes |= bch2_recovery_passes_from_stable(le64_to_cpu(ext->recovery_passes_required[0]));
+		bch2_recovery_passes_apply_excludes(c);
 
 		if (c->sb.version_upgrade_complete < bcachefs_metadata_version_autofix_errors)
 			SET_BCH_SB_ERROR_ACTION(c->disk_sb.sb, BCH_ON_ERROR_fix_safe);

--- a/fs/init/passes.c
+++ b/fs/init/passes.c
@@ -328,6 +328,11 @@ static bool recovery_pass_needs_rewind(struct bch_fs *c,
 		!(r->passes_attempted & BIT_ULL(pass));
 }
 
+static bool recovery_pass_excluded(struct bch_fs *c, enum bch_recovery_pass pass)
+{
+	return c->opts.recovery_passes_exclude & BIT_ULL(pass);
+}
+
 static bool recovery_pass_needs_set(struct bch_fs *c,
 				    enum bch_recovery_pass pass,
 				    enum bch_run_recovery_pass_flags *flags)
@@ -395,6 +400,9 @@ int __bch2_run_explicit_recovery_pass(struct bch_fs *c,
 	bch2_printbuf_make_room(out, 1024);
 	guard(printbuf_atomic)(out);
 	guard(spinlock_irq)(&r->lock);
+
+	if (recovery_pass_excluded(c, pass))
+		return 0;
 
 	if (!recovery_pass_needs_set(c, pass, &flags))
 		return 0;
@@ -541,6 +549,9 @@ int bch2_require_recovery_pass(struct bch_fs *c,
 			       struct printbuf *out,
 			       enum bch_recovery_pass pass)
 {
+	if (recovery_pass_excluded(c, pass))
+		return 0;
+
 	if (test_bit(BCH_FS_running_recovery_passes, &c->flags) &&
 	    c->recovery.passes_complete & BIT_ULL(pass))
 		return 0;
@@ -735,6 +746,7 @@ static void bch2_async_recovery_passes_work(struct work_struct *work)
 		bch2_run_recovery_passes(c,
 			(c->sb.recovery_passes_required |
 			 r->scheduled_passes_ephemeral) &
+			~c->opts.recovery_passes_exclude &
 			~r->passes_ratelimiting &
 			bch2_recovery_passes_match(PASS_ONLINE),
 			false);

--- a/fs/init/passes.h
+++ b/fs/init/passes.h
@@ -12,6 +12,11 @@ u64 bch2_recovery_passes_from_stable(u64 v);
 
 u64 bch2_fsck_recovery_passes(void);
 
+static inline void bch2_recovery_passes_apply_excludes(struct bch_fs *c)
+{
+	c->opts.recovery_passes &= ~c->opts.recovery_passes_exclude;
+}
+
 void bch2_recovery_pass_set_no_ratelimit(struct bch_fs *, enum bch_recovery_pass);
 
 enum bch_run_recovery_pass_flags {

--- a/fs/init/recovery.c
+++ b/fs/init/recovery.c
@@ -225,6 +225,7 @@ static void bch2_reconstruct_alloc(struct bch_fs *c)
 	c->sb.compat &= ~(1ULL << BCH_COMPAT_alloc_info);
 
 	c->opts.recovery_passes |= bch2_recovery_passes_from_stable(le64_to_cpu(ext->recovery_passes_required[0]));
+	bch2_recovery_passes_apply_excludes(c);
 
 	c->disk_sb.sb->features[0] &= ~cpu_to_le64(BIT_ULL(BCH_FEATURE_no_alloc_info));
 
@@ -940,6 +941,11 @@ use_clean:
 			prt_str(&msg.m, ")");
 
 			bch2_journal_log_msg(c, "%s", msg.m.buf);
+			if (c->opts.nofsck) {
+				bch_err(c, "cannot mount with nofsck: journal scrub requires journal rewind and fsck");
+				return bch_err_throw(c, mount_option);
+			}
+
 			c->opts.journal_rewind = rewind_seq;
 			c->opts.fsck = true;
 

--- a/fs/opts.h
+++ b/fs/opts.h
@@ -375,6 +375,11 @@ enum fsck_err_opts {
 	  OPT_BOOL(),							\
 	  BCH2_NO_SB_OPT,		false,				\
 	  NULL,		"Run fsck on mount")				\
+	x(nofsck,			u8,				\
+	  OPT_MOUNT,							\
+	  OPT_BOOL(),							\
+	  BCH2_NO_SB_OPT,		false,				\
+	  NULL,		"Do not run fsck recovery passes on mount")	\
 	x(fsck_memory_usage_percent,	u8,				\
 	  OPT_FS|OPT_MOUNT,						\
 	  OPT_UINT(20, 70),						\


### PR DESCRIPTION
Fixes koverstreet/bcachefs#498.

This adds an explicit mount-only `nofsck` option for disaster-recovery mounts that need `ro,nochanges` semantics without running fsck recovery passes. The option:

- clears the `fsck` mount request and excludes non-`PASS_ALWAYS` fsck recovery passes;
- keeps always-required recovery such as journal replay and snapshot reads available;
- rejects `journal_rewind` plus `nofsck`, including automatic rewind from recent-journal scrub;
- filters later required-pass merges so excluded fsck passes do not force early read-write recovery.

Validation:

- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
- `git diff --check origin/master...HEAD && git diff --check`
- `./bcachefs set-fs-option --help` includes the existing `--fsck`/`--fsck_memory_usage_percent` options and does not expose an accidental persistent `--nofsck`
- `./bcachefs mount -o nofsck,ro,nochanges UUID=00000000-0000-0000-0000-000000000000` accepts the option and reaches the expected missing-device error
- `codex review --base origin/master` reported no discrete correctness issue after the journal-rewind guard was added
