### PR TITLE
opts: allow runtime encoded_extent_max changes

### DIFF
--- a/fs/opts.h
+++ b/fs/opts.h
@@ -166,7 +166,7 @@ enum fsck_err_opts {
 	  BCH_SB_DATA_REPLICAS_WANT,	1,				\
 	  "#",		"Number of data replicas")			\
 	x(encoded_extent_max,		u32,				\
-	  OPT_FS|OPT_FORMAT|						\
+	  OPT_FS|OPT_FORMAT|OPT_RUNTIME|				\
 	  OPT_HUMAN_READABLE|OPT_MUST_BE_POW_2|OPT_SB_FIELD_SECTORS|OPT_SB_FIELD_ILOG2,\
 	  OPT_UINT(4096, 2U << 20),					\
 	  BCH_SB_ENCODED_EXTENT_MAX_BITS, 256 << 10,			\


### PR DESCRIPTION
## Summary

Expose `encoded_extent_max` as a runtime filesystem option so it can be tuned through the existing sysfs options directory, e.g. `/sys/fs/bcachefs/<uuid>/options/encoded_extent_max`.

The option already has the required parser, validation, superblock encoding, and sysfs store plumbing. Adding `OPT_RUNTIME` makes the existing options machinery create a writable sysfs attribute and update both the in-memory option and superblock for new writes.

Fixes koverstreet/bcachefs-tools#603.
Related to koverstreet/bcachefs#1150.

## Testing

- `git diff --check origin/master...HEAD`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j16 bcachefs`
- `./target/release/bcachefs format --help | rg -n "encoded_extent_max|Maximum size"`

Current head: `d23a289b8a3ae81c25e9024930c7e64b56ab847f`
