### PR TITLE
bcachefs: flush moved data through journal

### DIFF
--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -468,10 +468,14 @@ static int data_update_index_update_key(struct btree_trans *trans,
 	try(bch2_trans_update(trans, iter, insert,
 			      BTREE_UPDATE_internal_snapshot_node|
 			      BTREE_TRIGGER_set_needs_reconcile_done));
-	try(bch2_trans_commit(trans, &u->op.res, NULL,
-			      BCH_TRANS_COMMIT_no_check_rw|
-			      BCH_TRANS_COMMIT_no_enospc|
-			      u->opts.commit_flags));
+	bool flush = (u->op.flags & BCH_WRITE_flush) &&
+		bkey_next(insert) == u->op.insert_keys.top;
+
+	try(bch2_trans_commit_flush(trans, &u->op.res, NULL,
+				    flush ? &u->op.cl : NULL,
+				    BCH_TRANS_COMMIT_no_check_rw|
+				    BCH_TRANS_COMMIT_no_enospc|
+				    u->opts.commit_flags));
 
 	bch2_btree_iter_set_pos(iter, next_pos);
 
@@ -1351,6 +1355,7 @@ int bch2_data_update_init(struct btree_trans *trans,
 		BCH_WRITE_pages_owned|
 		BCH_WRITE_data_encoded|
 		BCH_WRITE_move|
+		BCH_WRITE_flush|
 		m->opts.write_flags;
 	m->op.compression_opt	= io_opts->background_compression;
 	m->op.watermark		= max(m->opts.commit_flags & BCH_WATERMARK_MASK,

--- a/fs/data/write.c
+++ b/fs/data/write.c
@@ -2407,10 +2407,12 @@ err:
 		bio->bi_private	= &op->cl;
 		bio->bi_opf |= REQ_OP_WRITE;
 
-		/* If it's an internal move, do FUA writes so the journal
-		 * doesn't have to flush them:
+		/* If it's an internal move, either do FUA writes so the journal
+		 * doesn't have to flush them, or have the data update path flush
+		 * the journal commit that indexes the moved data:
 		 */
-		if (op->flags & BCH_WRITE_move)
+		if ((op->flags & BCH_WRITE_move) &&
+		    !(op->flags & BCH_WRITE_flush))
 			bio->bi_opf |= REQ_FUA;
 
 		closure_get(bio->bi_private);


### PR DESCRIPTION
## Summary

Internal data-update moves currently force `REQ_FUA` on every moved-data bio so the journal does not need to flush those writes. That is safe, but it can make evacuation/reconcile painfully slow on disks where per-bio FUA serializes throughput.

This changes data-update move writes to use the normal journal durability boundary instead:

- mark data-update moves with `BCH_WRITE_flush`
- have the final index update commit call `bch2_trans_commit_flush()` with the move closure
- skip per-bio `REQ_FUA` for move writes only when that journal flush path is active

The old behavior is still preserved for other internal move writes that do not set `BCH_WRITE_flush`.

Companion ktest proof:

https://github.com/koverstreet/ktest/pull/71

## Validation

- `git diff --check`
- `make -j32 fs/data/update.o fs/data/write.o`
- Staged DKMS module build against kernel `7.1-amd64` completed on this focused branch:
  - `make install_dkms DESTDIR=/home/kom/tmp/bcachefs-pr684-focused-build-20260628T190846 DKMSDIR=/bcachefs-module`
  - `make -C /lib/modules/$(uname -r)/build M=/home/kom/tmp/bcachefs-pr684-focused-build-20260628T190846/bcachefs-module modules -j8 V=0`
- ktest positive control on an integration branch containing this fs/data diff plus the PR645 ktest/DKMS prerequisites:
  - `tests/fs/bcachefs/move_write_journal_flush.ktest` reported `TEST SUCCESS`
  - host trace checks reported `flushmove=yes`, `large_nonfua=yes`, `large_fua=no`
- ktest negative control on PR645 baseline `1c6139610efe831f3777d2d9ea6dcdc0b9d693f3`:
  - same test failed with `did not observe move write op marked for journal flush`
  - host trace checks reported `flushmove=no`, `large_fua=yes`

References koverstreet/bcachefs#646.