### PR TITLE
docs: describe DKMS-free module builds

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,6 +47,40 @@ dnf install -y @c-development libaio-devel libsodium-devel \
     findutils systemd-devel clang-devel llvm-devel rust cargo
 ```
 
+Building a loadable kernel module without DKMS
+----------------------------------------------
+
+Immutable/rpm-ostree systems such as Fedora CoreOS may not support DKMS in the
+running host, but they can still load a packaged `bcachefs.ko` built elsewhere
+for the exact target kernel and architecture.
+
+To stage the out-of-tree module sources without registering them with DKMS:
+
+```shell
+mkdir build
+make DESTDIR="$PWD/build" DKMSDIR="" install_dkms
+```
+
+Then build the module against a target kernel build tree:
+
+```shell
+KERNEL="$(uname -r)"
+make -C "/usr/lib/modules/${KERNEL}/build" M="$PWD/build" modules
+```
+
+The resulting module is `build/src/fs/bcachefs/bcachefs.ko`. Install it under
+the target system's module tree, for example:
+
+```shell
+install -D -m 0644 build/src/fs/bcachefs/bcachefs.ko \
+    "/lib/modules/${KERNEL}/extra/fs/bcachefs/bcachefs.ko"
+depmod "${KERNEL}"
+```
+
+`Module.symvers` is a build-time artifact for module symbol versioning and for
+other modules that depend on bcachefs symbols; it is not normally needed beside
+the installed `.ko`.
+
 openSUSE: install build dependencies with:
 ```shell
 zypper in -y libaio-devel libsodium-devel libblkid-devel liburcu-devel \


### PR DESCRIPTION
## Summary
- document how immutable/rpm-ostree systems can stage bcachefs module sources without registering DKMS
- show the direct kbuild command for building `bcachefs.ko` against a target kernel
- note where to install the module and why `Module.symvers` is normally not needed at runtime

## Testing
- `git diff --check`
- `make DESTDIR="/home/kom/tmp/bcachefs-fcos-module-docs-verify-192155/build" DKMSDIR="" install_dkms`

References: https://github.com/koverstreet/bcachefs-tools/issues/470

Related to koverstreet/bcachefs#1061 for direct module/build guidance; this PR does not address the repo/channel documentation parts of that issue.
