### PR TITLE
alloc: avoid busy devices for move allocations

### DIFF
--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -52,6 +52,14 @@
 #include <linux/rcupdate.h>
 #include <linux/sched/signal.h>
 
+/*
+ * Move allocation uses congestion to steer background relocation away from
+ * devices that are already slow. Rotational devices can stay throughput-limited
+ * for seconds after a bad write/flush sample, so use a slower decay here than
+ * the read path's target-congestion check.
+ */
+#define MOVE_ALLOC_CONGESTION_DECAY_SHIFT	24
+
 static void bch2_trans_mutex_lock_norelock(struct btree_trans *trans,
 					   struct mutex *lock)
 {
@@ -1044,7 +1052,7 @@ static u32 move_alloc_dev_congested(struct bch_dev *ca, u64 now)
 	u64 last = READ_ONCE(ca->congested_last);
 
 	if (time_after64(now, last))
-		congested -= (now - last) >> 20;
+		congested -= (now - last) >> MOVE_ALLOC_CONGESTION_DECAY_SHIFT;
 
 	return clamp(congested, 0LL, CONGESTED_MAX);
 }

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -1037,6 +1037,38 @@ static unsigned move_alloc_dev_busy(struct bch_fs *c,
 	return busy;
 }
 
+#ifndef CONFIG_BCACHEFS_NO_LATENCY_ACCT
+static u32 move_alloc_dev_congested(struct bch_dev *ca, u64 now)
+{
+	s64 congested = atomic_read(&ca->congested);
+	u64 last = READ_ONCE(ca->congested_last);
+
+	if (time_after64(now, last))
+		congested -= (now - last) >> 12;
+
+	return clamp(congested, 0LL, CONGESTED_MAX);
+}
+#else
+static u32 move_alloc_dev_congested(struct bch_dev *ca, u64 now)
+{
+	return 0;
+}
+#endif
+
+static u32 move_alloc_dev_pressure(struct bch_fs *c,
+				   struct alloc_request *req,
+				   unsigned dev, u64 now)
+{
+	guard(rcu)();
+	struct bch_dev *ca = bch2_dev_rcu_noerror(c, dev);
+
+	if (!ca)
+		return U32_MAX;
+
+	return move_alloc_dev_congested(ca, now) +
+		move_alloc_dev_busy(c, req, dev);
+}
+
 static void move_alloc_avoid_busy_devs(struct bch_fs *c,
 				       struct alloc_request *req)
 {
@@ -1045,21 +1077,26 @@ static void move_alloc_avoid_busy_devs(struct bch_fs *c,
 	    req->devs_sorted.nr <= 1)
 		return;
 
-	unsigned busy[BCH_SB_MEMBERS_MAX];
+	u32 pressure[BCH_SB_MEMBERS_MAX];
+	u64 now = local_clock();
+
 	for (unsigned i = 0; i < req->devs_sorted.nr; i++)
-		busy[i] = move_alloc_dev_busy(c, req, req->devs_sorted.data[i]);
+		pressure[i] = move_alloc_dev_pressure(c, req,
+						      req->devs_sorted.data[i],
+						      now);
 
 	/*
 	 * Background moves can otherwise pick the same emptiest device that
-	 * foreground writepoints or other movers are already filling. Keep all
-	 * candidates as fallbacks, but try quieter devices first.
+	 * foreground writepoints or other movers are already filling, or a
+	 * device that is currently congested from unrelated IO. Keep the
+	 * free-space weighted allocator order primary; only let contention
+	 * break adjacent ties, so we do not defeat free-space balancing.
 	 */
-	for (unsigned i = 0; i + 1 < req->devs_sorted.nr; i++)
-		for (unsigned j = 0; j + 1 < req->devs_sorted.nr - i; j++)
-			if (busy[j] > busy[j + 1]) {
-				swap(req->devs_sorted.data[j], req->devs_sorted.data[j + 1]);
-				swap(busy[j], busy[j + 1]);
-			}
+	for (unsigned j = 0; j + 1 < req->devs_sorted.nr; j++)
+		if (pressure[j] > pressure[j + 1]) {
+			swap(req->devs_sorted.data[j], req->devs_sorted.data[j + 1]);
+			swap(pressure[j], pressure[j + 1]);
+		}
 }
 
 static const u64 stripe_clock_hand_rescale	= 1ULL << 62; /* trigger rescale at */

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -59,7 +59,7 @@
  * the read path's target-congestion check.
  */
 #define MOVE_ALLOC_CONGESTION_DECAY_SHIFT	24
-#define MOVE_ALLOC_STALLED_THRESHOLD		(CONGESTED_MAX >> 1)
+#define MOVE_ALLOC_STALLED_THRESHOLD		(CONGESTED_MAX >> 3)
 #define MOVE_ALLOC_BUSY_BUCKET_WEIGHT		(CONGESTED_MAX >> 1)
 
 static void bch2_trans_mutex_lock_norelock(struct btree_trans *trans,
@@ -1145,9 +1145,10 @@ static void move_alloc_avoid_busy_devs(struct bch_fs *c,
 	 * write/flush path is already far slower than its recent norm.
 	 *
 	 * Keep the free-space weighted allocator order primary while devices are
-	 * only mildly busy. Once a device is clearly stalled, sink it behind less
-	 * stalled choices; otherwise a much larger, mostly empty disk can keep
-	 * winning move allocations while it is already saturated.
+	 * not congested. Once a device is visibly falling behind, sink it behind
+	 * less stalled choices; otherwise a much larger, mostly empty disk can keep
+	 * winning move allocations until it is saturated hard enough to leave move
+	 * writes stuck in the block layer.
 	 */
 	for (unsigned j = 1; j < req->devs_sorted.nr; j++)
 		for (unsigned i = j; i &&

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -1048,8 +1048,36 @@ static u32 move_alloc_dev_congested(struct bch_dev *ca, u64 now)
 
 	return clamp(congested, 0LL, CONGESTED_MAX);
 }
+
+static u32 move_alloc_dev_write_congested(struct bch_dev *ca)
+{
+	struct bch2_time_stats *stats = &ca->io_latency[WRITE].stats;
+	u64 latency = atomic64_read(&ca->cur_latency[WRITE]);
+	s64 typical = mean_and_variance_get_median(stats->duration_stats_weighted);
+	u64 threshold;
+	u64 over;
+	u32 max_pressure = max_t(u32, CONGESTED_MAX >> 3, 1);
+
+	if (stats->duration_stats.n < 32 || typical <= 0)
+		return 0;
+
+	threshold = (u64) typical << 3;
+	if (!threshold || latency <= threshold)
+		return 0;
+
+	over = latency - threshold;
+	if (over >= threshold)
+		return max_pressure;
+
+	return max_t(u32, div64_u64(over * max_pressure, threshold), 1);
+}
 #else
 static u32 move_alloc_dev_congested(struct bch_dev *ca, u64 now)
+{
+	return 0;
+}
+
+static u32 move_alloc_dev_write_congested(struct bch_dev *ca)
 {
 	return 0;
 }
@@ -1065,7 +1093,10 @@ static u32 move_alloc_dev_pressure(struct bch_fs *c,
 	if (!ca)
 		return U32_MAX;
 
-	return move_alloc_dev_congested(ca, now) +
+	return min_t(u32,
+		     move_alloc_dev_congested(ca, now) +
+		     move_alloc_dev_write_congested(ca),
+		     CONGESTED_MAX) +
 		move_alloc_dev_busy(c, req, dev);
 }
 
@@ -1088,9 +1119,14 @@ static void move_alloc_avoid_busy_devs(struct bch_fs *c,
 	/*
 	 * Background moves can otherwise pick the same emptiest device that
 	 * foreground writepoints or other movers are already filling, or a
-	 * device that is currently congested from unrelated IO. Keep the
-	 * free-space weighted allocator order primary; only let contention
-	 * break adjacent ties, so we do not defeat free-space balancing.
+	 * device that is currently congested from unrelated IO. Include a small
+	 * write-latency term here too: the global congestion counter is
+	 * read-oriented, but moving data should avoid a destination whose
+	 * write/flush path is already far slower than its recent norm.
+	 *
+	 * Keep the free-space weighted allocator order primary; only let
+	 * contention break adjacent ties, so we do not defeat free-space
+	 * balancing.
 	 */
 	for (unsigned j = 0; j + 1 < req->devs_sorted.nr; j++)
 		if (pressure[j] > pressure[j + 1]) {

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -52,6 +52,16 @@
 #include <linux/rcupdate.h>
 #include <linux/sched/signal.h>
 
+/*
+ * Move allocation uses congestion to steer background relocation away from
+ * devices that are already slow. Rotational devices can stay throughput-limited
+ * for seconds after a bad write/flush sample, so use a slower decay here than
+ * the read path's target-congestion check.
+ */
+#define MOVE_ALLOC_CONGESTION_DECAY_SHIFT	24
+#define MOVE_ALLOC_STALLED_THRESHOLD		(CONGESTED_MAX >> 3)
+#define MOVE_ALLOC_BUSY_BUCKET_WEIGHT		(CONGESTED_MAX >> 1)
+
 static void bch2_trans_mutex_lock_norelock(struct btree_trans *trans,
 					   struct mutex *lock)
 {
@@ -1005,6 +1015,161 @@ void bch2_dev_alloc_list(struct bch_fs *c,
 			 req->domain_keys, &req->devs_sorted);
 }
 
+static bool open_bucket_is_on_writepoint(struct bch_fs *c,
+					 struct write_point *wp,
+					 struct open_bucket *ob)
+{
+	struct open_bucket *wp_ob;
+	unsigned i;
+
+	open_bucket_for_each(c, &wp->ptrs, wp_ob, i)
+		if (wp_ob == ob)
+			return true;
+
+	return false;
+}
+
+static u32 move_alloc_dev_busy(struct bch_fs *c,
+			       struct alloc_request *req,
+			       unsigned dev)
+{
+	struct bch_fs_allocator *a = &c->allocator;
+	unsigned busy = 0;
+
+	for (struct open_bucket *ob = a->open_buckets;
+	     ob < a->open_buckets + ARRAY_SIZE(a->open_buckets);
+	     ob++) {
+		guard(spinlock)(&ob->lock);
+
+		if (!ob->valid ||
+		    ob->dev != dev ||
+		    ob->data_type != BCH_DATA_user ||
+		    open_bucket_is_on_writepoint(c, req->wp, ob))
+			continue;
+
+		busy++;
+	}
+
+	return min_t(u32, busy, 2) * MOVE_ALLOC_BUSY_BUCKET_WEIGHT;
+}
+
+#ifndef CONFIG_BCACHEFS_NO_LATENCY_ACCT
+static u32 move_alloc_dev_congested(struct bch_dev *ca, u64 now)
+{
+	s64 congested = atomic_read(&ca->congested);
+	u64 last = READ_ONCE(ca->congested_last);
+
+	if (time_after64(now, last))
+		congested -= (now - last) >> MOVE_ALLOC_CONGESTION_DECAY_SHIFT;
+
+	return clamp(congested, 0LL, CONGESTED_MAX);
+}
+
+static u32 move_alloc_dev_write_congested(struct bch_dev *ca)
+{
+	struct bch2_time_stats *stats = &ca->io_latency[WRITE].stats;
+	u64 latency = atomic64_read(&ca->cur_latency[WRITE]);
+	s64 typical = mean_and_variance_get_median(stats->duration_stats_weighted);
+	u64 threshold;
+	u64 over;
+	u32 max_pressure = max_t(u32, CONGESTED_MAX >> 3, 1);
+
+	if (stats->duration_stats.n < 32 || typical <= 0)
+		return 0;
+
+	threshold = (u64) typical << 3;
+	if (!threshold || latency <= threshold)
+		return 0;
+
+	over = latency - threshold;
+	if (over >= threshold)
+		return max_pressure;
+
+	return max_t(u32, div64_u64(over * max_pressure, threshold), 1);
+}
+#else
+static u32 move_alloc_dev_congested(struct bch_dev *ca, u64 now)
+{
+	return 0;
+}
+
+static u32 move_alloc_dev_write_congested(struct bch_dev *ca)
+{
+	return 0;
+}
+#endif
+
+static u32 move_alloc_dev_pressure(struct bch_fs *c,
+				   struct alloc_request *req,
+				   unsigned dev, u64 now)
+{
+	guard(rcu)();
+	struct bch_dev *ca = bch2_dev_rcu_noerror(c, dev);
+
+	if (!ca)
+		return U32_MAX;
+
+	return min_t(u32,
+		     move_alloc_dev_congested(ca, now) +
+		     move_alloc_dev_write_congested(ca),
+		     CONGESTED_MAX) +
+		move_alloc_dev_busy(c, req, dev);
+}
+
+static bool move_alloc_dev_stalled(struct bch_fs *c,
+				   struct alloc_request *req,
+				   unsigned dev, u64 now)
+{
+	return (req->flags & BCH_WRITE_move) &&
+		req->data_type == BCH_DATA_user &&
+		move_alloc_dev_pressure(c, req, dev, now) >=
+		MOVE_ALLOC_STALLED_THRESHOLD;
+}
+
+static void move_alloc_avoid_busy_devs(struct bch_fs *c,
+				       struct alloc_request *req)
+{
+	if (!(req->flags & BCH_WRITE_move) ||
+	    req->data_type != BCH_DATA_user ||
+	    req->devs_sorted.nr <= 1)
+		return;
+
+	/*
+	 * devs_sorted.nr can be up to BCH_SB_MEMBERS_MAX; keep this off the
+	 * (btree transaction path) stack and carry it on @req instead, same
+	 * as domain_keys above.
+	 */
+	u32 *pressure = req->move_pressure;
+	u64 now = local_clock();
+
+	for (unsigned i = 0; i < req->devs_sorted.nr; i++)
+		pressure[i] = move_alloc_dev_pressure(c, req,
+						      req->devs_sorted.data[i],
+						      now);
+
+	/*
+	 * Background moves can otherwise pick the same emptiest device that
+	 * foreground writepoints or other movers are already filling, or a
+	 * device that is currently congested from unrelated IO. Include a small
+	 * write-latency term here too: the global congestion counter is
+	 * read-oriented, but moving data should avoid a destination whose
+	 * write/flush path is already far slower than its recent norm.
+	 *
+	 * Keep the free-space weighted allocator order primary while devices are
+	 * not congested. Once a device is visibly falling behind, sink it behind
+	 * less stalled choices; otherwise a much larger, mostly empty disk can keep
+	 * winning move allocations until it is saturated hard enough to leave move
+	 * writes stuck in the block layer.
+	 */
+	for (unsigned j = 1; j < req->devs_sorted.nr; j++)
+		for (unsigned i = j; i &&
+		     pressure[i - 1] >= MOVE_ALLOC_STALLED_THRESHOLD &&
+		     pressure[i - 1] > pressure[i]; i--) {
+			swap(req->devs_sorted.data[i - 1], req->devs_sorted.data[i]);
+			swap(pressure[i - 1], pressure[i]);
+		}
+}
+
 static const u64 stripe_clock_hand_rescale	= 1ULL << 62; /* trigger rescale at */
 static const u64 stripe_clock_hand_max		= 1ULL << 56; /* max after rescale */
 static const u64 stripe_clock_hand_inv		= 1ULL << 52; /* max increment, if a device is empty */
@@ -1107,6 +1272,7 @@ int bch2_bucket_alloc_set_trans(struct btree_trans *trans,
 	BUG_ON(req->nr_effective >= req->nr_replicas);
 
 	bch2_dev_alloc_list(c, stripe, req);
+	move_alloc_avoid_busy_devs(c, req);
 
 	/*
 	 * Evaluated once, on the full candidate list: this classifies the
@@ -1218,6 +1384,9 @@ static bool want_bucket(struct bch_fs *c,
 		return false;
 
 	if (req->ec != (ob->ec != NULL))
+		return false;
+
+	if (move_alloc_dev_stalled(c, req, ob->dev, local_clock()))
 		return false;
 
 	return true;

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -999,6 +999,69 @@ void bch2_dev_alloc_list(struct bch_fs *c,
 			 req->domain_keys, &req->devs_sorted);
 }
 
+static bool open_bucket_is_on_writepoint(struct bch_fs *c,
+					 struct write_point *wp,
+					 struct open_bucket *ob)
+{
+	struct open_bucket *wp_ob;
+	unsigned i;
+
+	open_bucket_for_each(c, &wp->ptrs, wp_ob, i)
+		if (wp_ob == ob)
+			return true;
+
+	return false;
+}
+
+static unsigned move_alloc_dev_busy(struct bch_fs *c,
+				    struct alloc_request *req,
+				    unsigned dev)
+{
+	struct bch_fs_allocator *a = &c->allocator;
+	unsigned busy = 0;
+
+	for (struct open_bucket *ob = a->open_buckets;
+	     ob < a->open_buckets + ARRAY_SIZE(a->open_buckets);
+	     ob++) {
+		guard(spinlock)(&ob->lock);
+
+		if (!ob->valid ||
+		    ob->dev != dev ||
+		    ob->data_type != BCH_DATA_user ||
+		    open_bucket_is_on_writepoint(c, req->wp, ob))
+			continue;
+
+		busy++;
+	}
+
+	return busy;
+}
+
+static void move_alloc_avoid_busy_devs(struct bch_fs *c,
+				       struct alloc_request *req)
+{
+	if (!(req->flags & BCH_WRITE_move) ||
+	    req->data_type != BCH_DATA_user ||
+	    req->devs_sorted.nr <= 1)
+		return;
+
+	unsigned busy[BCH_SB_MEMBERS_MAX];
+	for (unsigned i = 0; i < req->devs_sorted.nr; i++)
+		busy[i] = move_alloc_dev_busy(c, req, req->devs_sorted.data[i]);
+
+	/*
+	 * Background moves can otherwise pick the same emptiest device that
+	 * foreground writepoints or other movers are already filling. Keep all
+	 * candidates as fallbacks, but try quieter devices first.
+	 */
+	for (unsigned i = 0; i + 1 < req->devs_sorted.nr; i++)
+		for (unsigned j = 0; j + 1 < req->devs_sorted.nr - i; j++)
+			if (busy[j] > busy[j + 1]) {
+				swap(req->devs_sorted.data[j], req->devs_sorted.data[j + 1]);
+				swap(busy[j], busy[j + 1]);
+			}
+}
+
 static const u64 stripe_clock_hand_rescale	= 1ULL << 62; /* trigger rescale at */
 static const u64 stripe_clock_hand_max		= 1ULL << 56; /* max after rescale */
 static const u64 stripe_clock_hand_inv		= 1ULL << 52; /* max increment, if a device is empty */
@@ -1101,6 +1164,7 @@ int bch2_bucket_alloc_set_trans(struct btree_trans *trans,
 	BUG_ON(req->nr_effective >= req->nr_replicas);
 
 	bch2_dev_alloc_list(c, stripe, req);
+	move_alloc_avoid_busy_devs(c, req);
 
 	/*
 	 * Evaluated once, on the full candidate list: this classifies the

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -1044,7 +1044,7 @@ static u32 move_alloc_dev_congested(struct bch_dev *ca, u64 now)
 	u64 last = READ_ONCE(ca->congested_last);
 
 	if (time_after64(now, last))
-		congested -= (now - last) >> 12;
+		congested -= (now - last) >> 20;
 
 	return clamp(congested, 0LL, CONGESTED_MAX);
 }

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -59,6 +59,8 @@
  * the read path's target-congestion check.
  */
 #define MOVE_ALLOC_CONGESTION_DECAY_SHIFT	24
+#define MOVE_ALLOC_STALLED_THRESHOLD		(CONGESTED_MAX >> 1)
+#define MOVE_ALLOC_BUSY_BUCKET_WEIGHT		(CONGESTED_MAX >> 1)
 
 static void bch2_trans_mutex_lock_norelock(struct btree_trans *trans,
 					   struct mutex *lock)
@@ -1021,9 +1023,9 @@ static bool open_bucket_is_on_writepoint(struct bch_fs *c,
 	return false;
 }
 
-static unsigned move_alloc_dev_busy(struct bch_fs *c,
-				    struct alloc_request *req,
-				    unsigned dev)
+static u32 move_alloc_dev_busy(struct bch_fs *c,
+			       struct alloc_request *req,
+			       unsigned dev)
 {
 	struct bch_fs_allocator *a = &c->allocator;
 	unsigned busy = 0;
@@ -1042,7 +1044,7 @@ static unsigned move_alloc_dev_busy(struct bch_fs *c,
 		busy++;
 	}
 
-	return busy;
+	return min_t(u32, busy, 2) * MOVE_ALLOC_BUSY_BUCKET_WEIGHT;
 }
 
 #ifndef CONFIG_BCACHEFS_NO_LATENCY_ACCT
@@ -1108,6 +1110,16 @@ static u32 move_alloc_dev_pressure(struct bch_fs *c,
 		move_alloc_dev_busy(c, req, dev);
 }
 
+static bool move_alloc_dev_stalled(struct bch_fs *c,
+				   struct alloc_request *req,
+				   unsigned dev, u64 now)
+{
+	return (req->flags & BCH_WRITE_move) &&
+		req->data_type == BCH_DATA_user &&
+		move_alloc_dev_pressure(c, req, dev, now) >=
+		MOVE_ALLOC_STALLED_THRESHOLD;
+}
+
 static void move_alloc_avoid_busy_devs(struct bch_fs *c,
 				       struct alloc_request *req)
 {
@@ -1132,14 +1144,17 @@ static void move_alloc_avoid_busy_devs(struct bch_fs *c,
 	 * read-oriented, but moving data should avoid a destination whose
 	 * write/flush path is already far slower than its recent norm.
 	 *
-	 * Keep the free-space weighted allocator order primary; only let
-	 * contention break adjacent ties, so we do not defeat free-space
-	 * balancing.
+	 * Keep the free-space weighted allocator order primary while devices are
+	 * only mildly busy. Once a device is clearly stalled, sink it behind less
+	 * stalled choices; otherwise a much larger, mostly empty disk can keep
+	 * winning move allocations while it is already saturated.
 	 */
-	for (unsigned j = 0; j + 1 < req->devs_sorted.nr; j++)
-		if (pressure[j] > pressure[j + 1]) {
-			swap(req->devs_sorted.data[j], req->devs_sorted.data[j + 1]);
-			swap(pressure[j], pressure[j + 1]);
+	for (unsigned j = 1; j < req->devs_sorted.nr; j++)
+		for (unsigned i = j; i &&
+		     pressure[i - 1] >= MOVE_ALLOC_STALLED_THRESHOLD &&
+		     pressure[i - 1] > pressure[i]; i--) {
+			swap(req->devs_sorted.data[i - 1], req->devs_sorted.data[i]);
+			swap(pressure[i - 1], pressure[i]);
 		}
 }
 
@@ -1357,6 +1372,9 @@ static bool want_bucket(struct bch_fs *c,
 		return false;
 
 	if (req->ec != (ob->ec != NULL))
+		return false;
+
+	if (move_alloc_dev_stalled(c, req, ob->dev, local_clock()))
 		return false;
 
 	return true;

--- a/fs/alloc/foreground.h
+++ b/fs/alloc/foreground.h
@@ -76,6 +76,8 @@ struct alloc_request {
 	/* bch2_bucket_alloc_set_trans(): */
 	struct dev_alloc_list	devs_sorted;
 	u64			domain_keys[BCH_SB_MEMBERS_MAX];
+	/* scratch for move_alloc_avoid_busy_devs(), same lifetime as devs_sorted above */
+	u32			move_pressure[BCH_SB_MEMBERS_MAX];
 	struct bch_dev_usage	usage;
 
 	/* bch2_bucket_alloc_trans(): */

--- a/fs/btree/read.c
+++ b/fs/btree/read.c
@@ -1101,7 +1101,7 @@ void bch2_btree_node_read(struct btree_trans *trans, struct btree *b,
 
 		if (sync) {
 			submit_bio_wait(bio);
-			bch2_latency_acct(ca, rb->start_time, READ);
+			bch2_latency_acct(ca, rb->start_time, READ, true);
 			btree_node_read_work(&rb->work);
 		} else {
 			submit_bio(bio);

--- a/fs/btree/read.c
+++ b/fs/btree/read.c
@@ -1111,7 +1111,7 @@ void bch2_btree_node_read(struct btree_trans *trans, struct btree *b,
 
 		if (sync) {
 			submit_bio_wait(bio);
-			bch2_latency_acct(ca, rb->start_time, READ);
+			bch2_latency_acct(ca, rb->start_time, READ, true);
 			btree_node_read_work(&rb->work);
 		} else {
 			submit_bio(bio);

--- a/fs/data/read.c
+++ b/fs/data/read.c
@@ -82,7 +82,7 @@ static inline u32 bch2_dev_congested_read(struct bch_dev *ca, u64 now)
 	s64 congested = atomic_read(&ca->congested);
 	u64 last = READ_ONCE(ca->congested_last);
 	if (time_after64(now, last))
-		congested -= (now - last) >> 12;
+		congested -= (now - last) >> 20;
 
 	return clamp(congested, 0LL, CONGESTED_MAX);
 }

--- a/fs/data/write.c
+++ b/fs/data/write.c
@@ -779,7 +779,8 @@ static inline void bch2_congested_acct(struct bch_dev *ca, u64 io_latency,
 	}
 }
 
-void bch2_latency_acct(struct bch_dev *ca, u64 submit_time, int rw)
+void bch2_latency_acct(struct bch_dev *ca, u64 submit_time, int rw,
+		       bool account_congestion)
 {
 	atomic64_t *latency = &ca->cur_latency[rw];
 	u64 now = local_clock();
@@ -804,9 +805,10 @@ void bch2_latency_acct(struct bch_dev *ca, u64 submit_time, int rw)
 
 	/*
 	 * Only track read latency for congestion accounting: writes are subject
-	 * to heavy queuing delays from page cache writeback:
+	 * to heavy queuing delays from page cache writeback. Internal move
+	 * writes opt in because their latency is used to steer more move IO.
 	 */
-	if (rw == READ)
+	if (rw == READ || account_congestion)
 		bch2_congested_acct(ca, io_latency, now, rw);
 
 	__bch2_time_stats_update(&ca->io_latency[rw].stats, submit_time, now);
@@ -1520,8 +1522,15 @@ static void bch2_write_endio(struct bio *bio)
 	struct bch_fs *c		= wbio->c;
 	struct bch_dev *ca		= wbio->ca;
 
-	bch2_account_io_completion(ca, BCH_MEMBER_ERROR_write,
-				   wbio->submit_time, !bio->bi_status);
+	if (op->flags & BCH_WRITE_move) {
+		if (ca)
+			bch2_latency_acct(ca, wbio->submit_time, WRITE, true);
+		bch2_account_io_success_fail(ca, BCH_MEMBER_ERROR_write,
+					     !bio->bi_status);
+	} else {
+		bch2_account_io_completion(ca, BCH_MEMBER_ERROR_write,
+					   wbio->submit_time, !bio->bi_status);
+	}
 
 	if (unlikely(bio->bi_status)) {
 		guard(spinlock_irqsave)(&c->write_error_lock);

--- a/fs/init/error.h
+++ b/fs/init/error.h
@@ -299,9 +299,10 @@ void bch2_io_error_work(struct work_struct *);
 void bch2_io_error(struct bch_dev *, enum bch_member_error_type);
 
 #ifndef CONFIG_BCACHEFS_NO_LATENCY_ACCT
-void bch2_latency_acct(struct bch_dev *, u64, int);
+void bch2_latency_acct(struct bch_dev *, u64, int, bool);
 #else
-static inline void bch2_latency_acct(struct bch_dev *ca, u64 submit_time, int rw) {}
+static inline void bch2_latency_acct(struct bch_dev *ca, u64 submit_time, int rw,
+				     bool account_congestion) {}
 #endif
 
 static inline void bch2_account_io_success_fail(struct bch_dev *ca,
@@ -325,7 +326,7 @@ static inline void bch2_account_io_completion(struct bch_dev *ca,
 		return;
 
 	if (type != BCH_MEMBER_ERROR_checksum)
-		bch2_latency_acct(ca, submit_time, type);
+		bch2_latency_acct(ca, submit_time, type, type == BCH_MEMBER_ERROR_read);
 
 	bch2_account_io_success_fail(ca, type, success);
 }


### PR DESCRIPTION
## Problem

Background data moves (copygc, rebalance/reconcile) use their own writepoints,
but device selection for a move write still starts from the same free-space
biased order as normal foreground allocation. Under a foreground-heavy or
device-congested workload, that means a move write can keep choosing a
destination that is technically the free-space winner but is currently a bad
place to add more internal IO: it can pile onto a device that already has
several foreground open buckets, or onto one whose write/flush latency has
fallen far behind its own recent norm, while a less-loaded candidate device
sits right next to it in the sorted list.

## What this does

For `BCH_WRITE_move` user-data allocations only, this adds a small per-device
pressure hint built from:

- the existing read-congestion counter (`ca->congested`), which move writes
  now also feed into (previously only reads updated it, since foreground
  writes go through page-cache writeback and are too noisy for this signal)
- active foreign user open buckets on the same device, so a move doesn't pile
  onto a device foreground writepoints are already filling
- a bounded write-latency term that only engages once a device's current
  write/flush latency is far above its own recent weighted median

The free-space weighted allocator order stays primary: the hint only swaps
adjacent candidates once a device's pressure crosses a stalled threshold, and
`want_bucket()` applies the same threshold when refilling from an existing
writepoint. Busy, congested, or write-stalled devices remain valid candidates
and fallbacks; nothing is excluded outright, so a move still makes progress
when only slow targets are left.

Split into two commits: the first teaches the write-completion path to feed
move-write latency into the per-device congestion counter (plumbing only,
nothing consumes it yet), the second adds the actual allocation-ordering
policy that uses it.

## Validation

Honest state: this has been built, not yet benchmarked on this exact series.

- `make -j$(nproc) build/fs/alloc/foreground.o build/fs/data/write.o build/fs/btree/read.o build/fs/data/read.o` — clean, no warnings
- `git diff --check` — clean

Perf numbers are pending. A proper run needs the VM/ktest batch (the
`evacuate_perf.ktest` busy-destination fixture from koverstreet/ktest#74) to
show move throughput with and without the hint under a contended-destination
workload; that wasn't re-run against this exact rebased/squashed series yet
and I don't want to attach older numbers from a different diff and imply
they still apply. I'll follow up with a run against this head before asking
for a merge decision.

The wider question of how to separate background/foreground IO scheduling
more generally (CoDel-style queueing signals, Kyber-style per-class latency
targets, wbt-style throttling) is being discussed separately, since it's a
bigger design question than this one allocator-ordering hint.
