### PR TITLE
extents: keep foreground cached replicas

### DIFF
--- a/doc/bcachefs.5.rst.tmpl
+++ b/doc/bcachefs.5.rst.tmpl
@@ -97,9 +97,11 @@ The following options control which disks data is written to:
 The foreground_target option is used to direct writes from applications. The
 background_target option, if set, will cause data to be moved to that target in
 the background by the reconcile thread some time after it has been initially
-written - leaving behind the original copy, but marking it cached so that it can
-be discarded by the allocator. The promote_target will cause reads to write
-a cached copy of the data being read to that target, if it doesn't exist.
+written - leaving behind foreground copies, but marking them cached so that they
+can be discarded by the allocator. Cached foreground copies are kept up to the
+configured data_replicas count and devices in that target. The promote_target
+will cause reads to write a cached copy of the data being read to that target,
+if it doesn't exist.
 
 Together, these options can be used for writeback caching, like so:
 

--- a/doc/bcachefs.5.rst.tmpl
+++ b/doc/bcachefs.5.rst.tmpl
@@ -180,9 +180,11 @@ The following options control which disks data is written to:
 The foreground_target option is used to direct writes from applications. The
 background_target option, if set, will cause data to be moved to that target in
 the background by the reconcile thread some time after it has been initially
-written - leaving behind the original copy, but marking it cached so that it can
-be discarded by the allocator. The promote_target will cause reads to write
-a cached copy of the data being read to that target, if it doesn't exist.
+written - leaving behind foreground copies, but marking them cached so that they
+can be discarded by the allocator. Cached foreground copies are kept up to the
+configured data_replicas count and devices in that target. The promote_target
+will cause reads to write a cached copy of the data being read to that target,
+if it doesn't exist.
 
 Together, these options can be used for writeback caching, like so:
 

--- a/fs/data/extents.c
+++ b/fs/data/extents.c
@@ -1491,13 +1491,31 @@ static bool ptr_has_ec(struct bch_fs *c, struct bkey_s k, struct bch_extent_ptr 
 	return false;
 }
 
+static unsigned cached_ptrs_want(struct bch_fs *c, struct bch_inode_opts *opts)
+{
+	unsigned target = opts->promote_target ?: opts->foreground_target;
+	unsigned replicas = max_t(unsigned, opts->data_replicas, 1);
+	const struct bch_devs_mask *devs;
+
+	if (!target)
+		return 1;
+
+	devs = bch2_target_to_mask(c, target);
+	if (!devs)
+		return 1;
+
+	return max_t(unsigned, min(replicas, dev_mask_nr(devs)), 1);
+}
+
 static bool maybe_drop_cached_ptr(struct bch_fs *c, struct bch_inode_opts *opts,
 				  struct bkey_s k,
-				  struct bch_extent_ptr *ptr, bool have_cached_ptr)
+				  struct bch_extent_ptr *ptr,
+				  unsigned cached_ptrs_seen,
+				  unsigned cached_ptrs_want)
 {
 	if (ptr->cached) {
-		if (have_cached_ptr)
-			return drop_cached_pointer_trace(c, k, ptr, "extent already has another cached pointer");
+		if (cached_ptrs_seen >= cached_ptrs_want)
+			return drop_cached_pointer_trace(c, k, ptr, "extent already has enough cached pointers");
 
 		if (ptr_has_ec(c, k, ptr))
 			return drop_cached_pointer_trace(c, k, ptr, "cached ptr incompatible with erasure coding");
@@ -1524,12 +1542,15 @@ void bch2_extent_ptr_set_cached(struct bch_fs *c,
 	unsigned drop_dev = ptr->dev;
 
 	guard(rcu)();
-	bool have_cached_ptr, dropped;
+	unsigned want = cached_ptrs_want(c, opts);
+	unsigned cached_ptrs_seen;
+	bool dropped;
 	do {
 		struct bkey_ptrs ptrs = bch2_bkey_ptrs(k);
 		union bch_extent_entry *entry;
 		struct extent_ptr_decoded p;
-		have_cached_ptr = dropped = false;
+		cached_ptrs_seen = 0;
+		dropped = false;
 
 		bkey_for_each_ptr_decode(k.k, ptrs, p, entry) {
 			/*
@@ -1541,14 +1562,15 @@ void bch2_extent_ptr_set_cached(struct bch_fs *c,
 				return;
 			}
 
-			if (maybe_drop_cached_ptr(c, opts, k, &entry->ptr, have_cached_ptr)) {
+			if (maybe_drop_cached_ptr(c, opts, k, &entry->ptr,
+						  cached_ptrs_seen, want)) {
 				/* @ptr is being invalidated; we'll have to find it again */
 				ptr = NULL;
 				dropped = true;
 				break;
 			}
 
-			have_cached_ptr |= p.ptr.cached;
+			cached_ptrs_seen += p.ptr.cached;
 		}
 	} while (dropped);
 
@@ -1560,7 +1582,7 @@ void bch2_extent_ptr_set_cached(struct bch_fs *c,
 	}
 
 	ptr->cached = true;
-	maybe_drop_cached_ptr(c, opts, k, ptr, have_cached_ptr);
+	maybe_drop_cached_ptr(c, opts, k, ptr, cached_ptrs_seen, want);
 }
 
 static void bch2_bkey_set_ptrs_cached_mask(struct bch_fs *c,
@@ -1641,16 +1663,18 @@ void bch2_bkey_drop_extra_cached_ptrs(struct bch_fs *c,
 
 	do {
 		struct bkey_ptrs ptrs = bch2_bkey_ptrs(k);
-		bool have_cached_ptr = false;
+		unsigned cached_ptrs_seen = 0;
+		unsigned want = cached_ptrs_want(c, opts);
 		dropped = false;
 
 		bkey_for_each_ptr(ptrs, ptr) {
-			if (maybe_drop_cached_ptr(c, opts, k, ptr, have_cached_ptr)) {
+			if (maybe_drop_cached_ptr(c, opts, k, ptr,
+						  cached_ptrs_seen, want)) {
 				dropped = true;
 				break;
 			}
 
-			have_cached_ptr |= ptr->cached;
+			cached_ptrs_seen += ptr->cached;
 		}
 	} while (dropped);
 }

--- a/fs/data/extents.c
+++ b/fs/data/extents.c
@@ -1503,13 +1503,31 @@ static bool ptr_has_ec(struct bch_fs *c, struct bkey_s k, struct bch_extent_ptr 
 	return false;
 }
 
+static unsigned cached_ptrs_want(struct bch_fs *c, struct bch_inode_opts *opts)
+{
+	unsigned target = opts->promote_target ?: opts->foreground_target;
+	unsigned replicas = max_t(unsigned, opts->data_replicas, 1);
+	const struct bch_devs_mask *devs;
+
+	if (!target)
+		return 1;
+
+	devs = bch2_target_to_mask(c, target);
+	if (!devs)
+		return 1;
+
+	return max_t(unsigned, min(replicas, dev_mask_nr(devs)), 1);
+}
+
 static bool maybe_drop_cached_ptr(struct bch_fs *c, struct bch_inode_opts *opts,
 				  struct bkey_s k,
-				  struct bch_extent_ptr *ptr, bool have_cached_ptr)
+				  struct bch_extent_ptr *ptr,
+				  unsigned cached_ptrs_seen,
+				  unsigned cached_ptrs_want)
 {
 	if (ptr->cached) {
-		if (have_cached_ptr)
-			return drop_cached_pointer_trace(c, k, ptr, "extent already has another cached pointer");
+		if (cached_ptrs_seen >= cached_ptrs_want)
+			return drop_cached_pointer_trace(c, k, ptr, "extent already has enough cached pointers");
 
 		if (ptr_has_ec(c, k, ptr))
 			return drop_cached_pointer_trace(c, k, ptr, "cached ptr incompatible with erasure coding");
@@ -1536,12 +1554,15 @@ void bch2_extent_ptr_set_cached(struct bch_fs *c,
 	unsigned drop_dev = ptr->dev;
 
 	guard(rcu)();
-	bool have_cached_ptr, dropped;
+	unsigned want = cached_ptrs_want(c, opts);
+	unsigned cached_ptrs_seen;
+	bool dropped;
 	do {
 		struct bkey_ptrs ptrs = bch2_bkey_ptrs(k);
 		union bch_extent_entry *entry;
 		struct extent_ptr_decoded p;
-		have_cached_ptr = dropped = false;
+		cached_ptrs_seen = 0;
+		dropped = false;
 
 		bkey_for_each_ptr_decode(k.k, ptrs, p, entry) {
 			/*
@@ -1553,14 +1574,15 @@ void bch2_extent_ptr_set_cached(struct bch_fs *c,
 				return;
 			}
 
-			if (maybe_drop_cached_ptr(c, opts, k, &entry->ptr, have_cached_ptr)) {
+			if (maybe_drop_cached_ptr(c, opts, k, &entry->ptr,
+						  cached_ptrs_seen, want)) {
 				/* @ptr is being invalidated; we'll have to find it again */
 				ptr = NULL;
 				dropped = true;
 				break;
 			}
 
-			have_cached_ptr |= p.ptr.cached;
+			cached_ptrs_seen += p.ptr.cached;
 		}
 	} while (dropped);
 
@@ -1572,7 +1594,7 @@ void bch2_extent_ptr_set_cached(struct bch_fs *c,
 	}
 
 	ptr->cached = true;
-	maybe_drop_cached_ptr(c, opts, k, ptr, have_cached_ptr);
+	maybe_drop_cached_ptr(c, opts, k, ptr, cached_ptrs_seen, want);
 }
 
 static void bch2_bkey_set_ptrs_cached_mask(struct bch_fs *c,
@@ -1653,16 +1675,18 @@ void bch2_bkey_drop_extra_cached_ptrs(struct bch_fs *c,
 
 	do {
 		struct bkey_ptrs ptrs = bch2_bkey_ptrs(k);
-		bool have_cached_ptr = false;
+		unsigned cached_ptrs_seen = 0;
+		unsigned want = cached_ptrs_want(c, opts);
 		dropped = false;
 
 		bkey_for_each_ptr(ptrs, ptr) {
-			if (maybe_drop_cached_ptr(c, opts, k, ptr, have_cached_ptr)) {
+			if (maybe_drop_cached_ptr(c, opts, k, ptr,
+						  cached_ptrs_seen, want)) {
 				dropped = true;
 				break;
 			}
 
-			have_cached_ptr |= ptr->cached;
+			cached_ptrs_seen += ptr->cached;
 		}
 	} while (dropped);
 }


### PR DESCRIPTION
## Summary

Fixes koverstreet/bcachefs-tools#574.

When `background_target` moved foreground data to the background target, `bch2_extent_ptr_set_cached()` marked the old foreground pointer cached and then `maybe_drop_cached_ptr()` kept only one cached pointer per extent.

That meant a `data_replicas=2` writeback-cache setup could end up with the intended two durable background replicas, but only one cached foreground replica, even when the foreground/promote target had two devices.

This changes cached-pointer cleanup to keep cached pointers up to:

```
min(data_replicas, nr_devices_in(promote_target ?: foreground_target))
```

while still dropping cached pointers that are stale, incompatible with erasure coding, on evacuating devices, or outside the promote/foreground target.

The manpage wording is updated to describe that background movement leaves foreground cached copies, not just one original cached copy. That wording update is now a separate second commit from the code fix.

Scope note: this preserves foreground replicas left behind by writeback/background movement. Read promotion is still the existing opportunistic single cached-copy path when a promote-target copy does not already exist.

## Validation

- `git diff --check origin/master...HEAD`
- `make generate_version`
- `BINDGEN=$HOME/.cargo/bin/bindgen LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu make -j4 libbcachefs.a`
- `BINDGEN=$HOME/.cargo/bin/bindgen LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu make -j4`
- GitHub CI was green through refreshed head 9649223f3482e1393346edcf7f454fc13e632c13: https://github.com/koverstreet/bcachefs-tools/actions/runs/28424805608 (CI will re-run for the rebased/split head pushed after that).
- Rebased onto fresh upstream master and rebuilt clean (`BINDGEN=$HOME/.cargo/bin/bindgen make -j16 bcachefs`) with no code-content changes from the diff above.
- Non-kernel smoke: `bcachefs format` with the same 2 fg + 2 bg device, `replicas=2`, `foreground_target=fg`, `background_target=bg`, `promote_target=fg` layout qubitnano used above, mounted via the built binary's own FUSE path (`bcachefs fusemount`, no kernel module/mount involved), wrote 100MiB, then let the reconcile mover run and unmounted. Both fg images grew by an equal ~54.5MiB each and both bg images grew by an equal ~104.9MiB each -- the symmetric-across-both-foreground-devices pattern this fix restores, versus the pre-fix single-cached-pointer collapse. `bcachefs fs usage`/`reconcile wait` could not be exercised in this sandbox: those subcommands query live sysfs accounting and only work against a kernel-mounted filesystem, which this sandbox does not have; the on-disk image sizes above are what was checked instead. This is in addition to, not a replacement for, qubitnano's live confirmation and the koverstreet/ktest#79 regression coverage below.
