### PR TITLE
bcachefs: raise default move IO depth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ endif
 BCACHEFS_DKMS_FORWARD := BCACHEFS_DEBUG \
                         BCACHEFS_TESTS \
                         BCACHEFS_INJECT_TRANSACTION_RESTARTS \
-                        BCACHEFS_RUST
+                        BCACHEFS_RUST \
+                        CC
 
 # Vars persisted into the *local* build.vars across invocations - a
 # superset of BCACHEFS_DKMS_FORWARD that also covers MAKE_DEBUG, the

--- a/dkms/Makefile
+++ b/dkms/Makefile
@@ -6,7 +6,7 @@ export BCACHEFS_DKMS=1
 # ifdefs in fs/Makefile. Empty / missing file is fine - unset names
 # export as no-ops.
 -include $(CURDIR)/build.vars
-export BCACHEFS_DEBUG BCACHEFS_TESTS BCACHEFS_INJECT_TRANSACTION_RESTARTS BCACHEFS_RUST
+export BCACHEFS_DEBUG BCACHEFS_TESTS BCACHEFS_INJECT_TRANSACTION_RESTARTS BCACHEFS_RUST CC
 
 ifneq (${KERNELRELEASE},)
 ccflags-y := -I$(src)/include

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -645,7 +645,7 @@ again:
 		if (bch2_copygc_can_make_progress(ca)) {
 			copygc_can_make_progress = true;
 			req->copygc_can_make_progress = true;
-			bch2_copygc_wakeup(c);
+			bch2_copygc_wakeup_for_pressure(c);
 		}
 
 		track_event_change(&c->times[BCH_TIME_blocked_allocate], true);
@@ -1945,7 +1945,7 @@ static bool alloc_wait_advanced(struct bch_fs *c, struct alloc_request *req)
 			    !bch2_copygc_can_make_progress(ca))
 				return true;
 
-			bch2_copygc_wakeup(c);
+			bch2_copygc_wakeup_for_pressure(c);
 		}
 	}
 	BUG_ON(!found);

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -768,6 +768,69 @@ void bch2_dev_alloc_list(struct bch_fs *c,
 	bubble_sort(ret->data, ret->nr, dev_stripe_cmp);
 }
 
+static bool open_bucket_is_on_writepoint(struct bch_fs *c,
+					 struct write_point *wp,
+					 struct open_bucket *ob)
+{
+	struct open_bucket *wp_ob;
+	unsigned i;
+
+	open_bucket_for_each(c, &wp->ptrs, wp_ob, i)
+		if (wp_ob == ob)
+			return true;
+
+	return false;
+}
+
+static unsigned move_alloc_dev_busy(struct bch_fs *c,
+				    struct alloc_request *req,
+				    unsigned dev)
+{
+	struct bch_fs_allocator *a = &c->allocator;
+	unsigned busy = 0;
+
+	for (struct open_bucket *ob = a->open_buckets;
+	     ob < a->open_buckets + ARRAY_SIZE(a->open_buckets);
+	     ob++) {
+		guard(spinlock)(&ob->lock);
+
+		if (!ob->valid ||
+		    ob->dev != dev ||
+		    ob->data_type != BCH_DATA_user ||
+		    open_bucket_is_on_writepoint(c, req->wp, ob))
+			continue;
+
+		busy++;
+	}
+
+	return busy;
+}
+
+static void move_alloc_avoid_busy_devs(struct bch_fs *c,
+				       struct alloc_request *req)
+{
+	if (!(req->flags & BCH_WRITE_move) ||
+	    req->data_type != BCH_DATA_user ||
+	    req->devs_sorted.nr <= 1)
+		return;
+
+	unsigned busy[BCH_SB_MEMBERS_MAX];
+	for (unsigned i = 0; i < req->devs_sorted.nr; i++)
+		busy[i] = move_alloc_dev_busy(c, req, req->devs_sorted.data[i]);
+
+	/*
+	 * Background moves can otherwise pick the same emptiest device that
+	 * foreground writepoints or other movers are already filling. Keep all
+	 * candidates as fallbacks, but try quieter devices first.
+	 */
+	for (unsigned i = 0; i + 1 < req->devs_sorted.nr; i++)
+		for (unsigned j = 0; j + 1 < req->devs_sorted.nr - i; j++)
+			if (busy[j] > busy[j + 1]) {
+				swap(req->devs_sorted.data[j], req->devs_sorted.data[j + 1]);
+				swap(busy[j], busy[j + 1]);
+			}
+}
+
 static const u64 stripe_clock_hand_rescale	= 1ULL << 62; /* trigger rescale at */
 static const u64 stripe_clock_hand_max		= 1ULL << 56; /* max after rescale */
 static const u64 stripe_clock_hand_inv		= 1ULL << 52; /* max increment, if a device is empty */
@@ -866,6 +929,7 @@ int bch2_bucket_alloc_set_trans(struct btree_trans *trans,
 	BUG_ON(req->nr_effective >= req->nr_replicas);
 
 	bch2_dev_alloc_list(c, stripe, &req->devs_may_alloc, &req->devs_sorted);
+	move_alloc_avoid_busy_devs(c, req);
 
 	if (req->devs_sorted.nr <= 1)
 		req->will_retry_target_devices = false;

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -572,12 +572,13 @@ static bool req_dev_sizes_mismatched(struct bch_fs *c, struct alloc_request *req
 /*
  * Decide whether an alloc that came up empty-handed on the current candidate
  * device should bail (committing the request with whatever replicas it
- * already has) instead of waiting on freelist_wait. Bails iff the request
- * has at least one replica's worth to commit AND any of:
+ * already has) instead of waiting on freelist_wait. Bails iff any of:
  *
  *  - copygc_can_make_progress is false: the per-device check (set above by
  *    the caller from bch2_copygc_can_make_progress(ca)) says copygc can't
- *    free buckets here. No reason to wait — copygc isn't going to help.
+ *    free buckets here. No reason to wait — copygc isn't going to help. If the
+ *    caller still has target/all-device retries available, those retries run
+ *    before this check is reached.
  *
  *  - watermark == copygc and data_type != btree: the request itself is
  *    issued at copygc watermark, i.e. it IS the thing trying to free
@@ -596,11 +597,6 @@ static bool req_dev_sizes_mismatched(struct bch_fs *c, struct alloc_request *req
  */
 static bool req_alloc_should_bail(struct bch_fs *c, struct alloc_request *req)
 {
-	bool have_replicas = req->nr_effective ||
-		(req->devs_have && req->devs_have->nr);
-	if (!have_replicas)
-		return false;
-
 	return !req->copygc_can_make_progress ||
 	       (req->watermark == BCH_WATERMARK_copygc &&
 		req->data_type != BCH_DATA_btree) ||

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -806,6 +806,38 @@ static unsigned move_alloc_dev_busy(struct bch_fs *c,
 	return busy;
 }
 
+#ifndef CONFIG_BCACHEFS_NO_LATENCY_ACCT
+static u32 move_alloc_dev_congested(struct bch_dev *ca, u64 now)
+{
+	s64 congested = atomic_read(&ca->congested);
+	u64 last = READ_ONCE(ca->congested_last);
+
+	if (time_after64(now, last))
+		congested -= (now - last) >> 12;
+
+	return clamp(congested, 0LL, CONGESTED_MAX);
+}
+#else
+static u32 move_alloc_dev_congested(struct bch_dev *ca, u64 now)
+{
+	return 0;
+}
+#endif
+
+static u32 move_alloc_dev_pressure(struct bch_fs *c,
+				   struct alloc_request *req,
+				   unsigned dev, u64 now)
+{
+	guard(rcu)();
+	struct bch_dev *ca = bch2_dev_rcu_noerror(c, dev);
+
+	if (!ca)
+		return U32_MAX;
+
+	return move_alloc_dev_congested(ca, now) +
+		move_alloc_dev_busy(c, req, dev);
+}
+
 static void move_alloc_avoid_busy_devs(struct bch_fs *c,
 				       struct alloc_request *req)
 {
@@ -814,21 +846,26 @@ static void move_alloc_avoid_busy_devs(struct bch_fs *c,
 	    req->devs_sorted.nr <= 1)
 		return;
 
-	unsigned busy[BCH_SB_MEMBERS_MAX];
+	u32 pressure[BCH_SB_MEMBERS_MAX];
+	u64 now = local_clock();
+
 	for (unsigned i = 0; i < req->devs_sorted.nr; i++)
-		busy[i] = move_alloc_dev_busy(c, req, req->devs_sorted.data[i]);
+		pressure[i] = move_alloc_dev_pressure(c, req,
+						      req->devs_sorted.data[i],
+						      now);
 
 	/*
 	 * Background moves can otherwise pick the same emptiest device that
-	 * foreground writepoints or other movers are already filling. Keep all
-	 * candidates as fallbacks, but try quieter devices first.
+	 * foreground writepoints or other movers are already filling, or a
+	 * device that is currently congested from unrelated IO. Keep the
+	 * free-space weighted allocator order primary; only let contention
+	 * break adjacent ties, so we do not defeat free-space balancing.
 	 */
-	for (unsigned i = 0; i + 1 < req->devs_sorted.nr; i++)
-		for (unsigned j = 0; j + 1 < req->devs_sorted.nr - i; j++)
-			if (busy[j] > busy[j + 1]) {
-				swap(req->devs_sorted.data[j], req->devs_sorted.data[j + 1]);
-				swap(busy[j], busy[j + 1]);
-			}
+	for (unsigned j = 0; j + 1 < req->devs_sorted.nr; j++)
+		if (pressure[j] > pressure[j + 1]) {
+			swap(req->devs_sorted.data[j], req->devs_sorted.data[j + 1]);
+			swap(pressure[j], pressure[j + 1]);
+		}
 }
 
 static const u64 stripe_clock_hand_rescale	= 1ULL << 62; /* trigger rescale at */

--- a/fs/bcachefs.h
+++ b/fs/bcachefs.h
@@ -430,6 +430,7 @@ struct io_count {
 	x(journal_read)					\
 	x(fs_journal_alloc)				\
 	x(fs_resize_on_mount)				\
+	x(evacuating_startup_scan)			\
 	x(fs_mi_field_upgrades)				\
 	x(sb_journal_sort)				\
 	x(btree_node_read)				\

--- a/fs/data/copygc.c
+++ b/fs/data/copygc.c
@@ -470,6 +470,10 @@ __cold void bch2_copygc_wait_to_text(struct printbuf *out, struct bch_fs *c)
 	printbuf_tabstop_push(out, 32);
 	prt_printf(out, "running:\t%u\n",		c->copygc.running);
 	prt_printf(out, "pressure pending:\t%u\n",	READ_ONCE(c->copygc.pressure_pending));
+	prt_printf(out, "current run pressure:\t%u\n",	READ_ONCE(c->copygc.current_run_pressure));
+	prt_printf(out, "last run pressure:\t%u\n",	READ_ONCE(c->copygc.last_run_pressure));
+	prt_printf(out, "pressure run count:\t%u\n",	READ_ONCE(c->copygc.pressure_run_count));
+	prt_printf(out, "last pressure run:\t%u\n",	READ_ONCE(c->copygc.last_pressure_run));
 	prt_printf(out, "run count:\t%u\n",		c->copygc.run_count);
 	prt_printf(out, "copygc_wait:\t%llu\n",		c->copygc.wait);
 	prt_printf(out, "copygc_wait_at:\t%llu\n",	c->copygc.wait_at);
@@ -576,10 +580,19 @@ static int bch2_copygc_thread(void *arg)
 		kick = READ_ONCE(c->copygc.kick_count);
 		c->copygc.wait = 0;
 		bool pressure = xchg(&c->copygc.pressure_pending, false);
+		u32 run = READ_ONCE(c->copygc.run_count) + 1;
+		if (pressure) {
+			WRITE_ONCE(c->copygc.pressure_run_count,
+				   READ_ONCE(c->copygc.pressure_run_count) + 1);
+			WRITE_ONCE(c->copygc.last_pressure_run, run);
+		}
 
+		WRITE_ONCE(c->copygc.current_run_pressure, pressure);
 		c->copygc.running = true;
 		ret = bch2_copygc(&ctxt, &buckets, pressure, &did_work);
 		c->copygc.running = false;
+		WRITE_ONCE(c->copygc.last_run_pressure, pressure);
+		WRITE_ONCE(c->copygc.current_run_pressure, false);
 		c->copygc.run_count++;
 
 		wake_up(&c->copygc.running_wq);

--- a/fs/data/copygc.c
+++ b/fs/data/copygc.c
@@ -50,6 +50,7 @@
 #include "util/clock.h"
 
 #include <linux/freezer.h>
+#include <linux/ioprio.h>
 #include <linux/kthread.h>
 #include <linux/math64.h>
 #include <linux/sched/task.h>
@@ -326,6 +327,7 @@ err:
 noinline
 static int bch2_copygc(struct moving_context *ctxt,
 		       struct buckets_in_flight *buckets_in_flight,
+		       bool pressure,
 		       bool *did_work)
 {
 	struct btree_trans *trans = ctxt->trans;
@@ -333,6 +335,9 @@ static int bch2_copygc(struct moving_context *ctxt,
 	struct data_update_opts data_opts = {
 		.type		= BCH_DATA_UPDATE_copygc,
 		.commit_flags	= (unsigned) BCH_WATERMARK_copygc,
+		.ioprio		= pressure
+			? IOPRIO_PRIO_VALUE(IOPRIO_CLASS_BE, 7)
+			: 0,
 	};
 	u64 sectors_seen	= atomic64_read(&ctxt->stats->sectors_seen);
 	u64 sectors_moved	= atomic64_read(&ctxt->stats->sectors_moved);
@@ -464,6 +469,7 @@ __cold void bch2_copygc_wait_to_text(struct printbuf *out, struct bch_fs *c)
 {
 	printbuf_tabstop_push(out, 32);
 	prt_printf(out, "running:\t%u\n",		c->copygc.running);
+	prt_printf(out, "pressure pending:\t%u\n",	READ_ONCE(c->copygc.pressure_pending));
 	prt_printf(out, "run count:\t%u\n",		c->copygc.run_count);
 	prt_printf(out, "copygc_wait:\t%llu\n",		c->copygc.wait);
 	prt_printf(out, "copygc_wait_at:\t%llu\n",	c->copygc.wait_at);
@@ -569,9 +575,10 @@ static int bch2_copygc_thread(void *arg)
 
 		kick = READ_ONCE(c->copygc.kick_count);
 		c->copygc.wait = 0;
+		bool pressure = xchg(&c->copygc.pressure_pending, false);
 
 		c->copygc.running = true;
-		ret = bch2_copygc(&ctxt, &buckets, &did_work);
+		ret = bch2_copygc(&ctxt, &buckets, pressure, &did_work);
 		c->copygc.running = false;
 		c->copygc.run_count++;
 

--- a/fs/data/copygc.h
+++ b/fs/data/copygc.h
@@ -17,6 +17,12 @@ static inline void bch2_copygc_wakeup(struct bch_fs *c)
 		wake_up_process(p);
 }
 
+static inline void bch2_copygc_wakeup_for_pressure(struct bch_fs *c)
+{
+	WRITE_ONCE(c->copygc.pressure_pending, true);
+	bch2_copygc_wakeup(c);
+}
+
 void bch2_copygc_stop(struct bch_fs *);
 int bch2_copygc_start(struct bch_fs *);
 

--- a/fs/data/copygc_types.h
+++ b/fs/data/copygc_types.h
@@ -8,6 +8,7 @@ struct bch_fs_copygc {
 	s64			wait_at;
 	s64			wait;
 	bool			running;
+	bool			pressure_pending;
 	u32			run_count;
 	u32			kick_count;
 	wait_queue_head_t	running_wq;
@@ -17,4 +18,3 @@ struct bch_fs_copygc {
 };
 
 #endif /* _BCACHEFS_COPYGC_TYPES_H */
-

--- a/fs/data/copygc_types.h
+++ b/fs/data/copygc_types.h
@@ -9,6 +9,10 @@ struct bch_fs_copygc {
 	s64			wait;
 	bool			running;
 	bool			pressure_pending;
+	bool			current_run_pressure;
+	bool			last_run_pressure;
+	u32			pressure_run_count;
+	u32			last_pressure_run;
 	u32			run_count;
 	u32			kick_count;
 	wait_queue_head_t	running_wq;

--- a/fs/data/migrate.c
+++ b/fs/data/migrate.c
@@ -7,6 +7,7 @@
 
 #include "alloc/backpointers.h"
 #include "alloc/buckets.h"
+#include "alloc/disk_groups.h"
 #include "alloc/replicas.h"
 
 #include "btree/bkey_buf.h"
@@ -27,6 +28,14 @@
 #include "sb/io.h"
 
 #include "init/progress.h"
+
+struct btree_ptr_location {
+	enum btree_id		btree;
+	unsigned int		rewrite_level;
+	struct bpos		pos;
+};
+
+DEFINE_DARRAY_NAMED(darray_btree_ptr_location, struct btree_ptr_location);
 
 static struct bkey_i *drop_dev_ptrs(struct btree_trans *trans, struct bkey_s_c k, unsigned dev_idx,
 				    unsigned flags, struct printbuf *err)
@@ -89,6 +98,102 @@ static int drop_btree_ptrs(struct btree_trans *trans, struct btree_iter *iter,
 	return bch2_btree_node_update_key(trans, iter, b, n, 0, false);
 }
 
+static unsigned int btree_ptr_rewrite_target(struct bch_fs *c)
+{
+	if (c->opts.metadata_target &&
+	    bch2_target_accepts_data(c, BCH_DATA_btree, c->opts.metadata_target))
+		return c->opts.metadata_target;
+
+	if (c->opts.foreground_target &&
+	    bch2_target_accepts_data(c, BCH_DATA_btree, c->opts.foreground_target))
+		return c->opts.foreground_target;
+
+	return 0;
+}
+
+static int drop_or_rewrite_btree_ptrs(struct btree_trans *trans,
+				      struct btree_iter *iter,
+				      struct btree *b, unsigned int dev_idx,
+				      unsigned int flags, struct printbuf *err)
+{
+	struct printbuf drop_err = PRINTBUF;
+	int ret = drop_btree_ptrs(trans, iter, b, dev_idx, flags, &drop_err);
+	bool drop_would_degrade = bch2_err_matches(ret, BCH_ERR_remove_would_lose_data);
+
+	if (drop_would_degrade)
+		ret = bch2_btree_node_rewrite_pos(trans, iter->btree_id,
+						  b->c.level + 1, b->key.k.p,
+						  btree_ptr_rewrite_target(trans->c),
+						  BCH_TRANS_COMMIT_no_enospc, 0);
+
+	if (bch2_err_matches(ret, BCH_ERR_transaction_restart))
+		goto out;
+
+	if (ret && drop_would_degrade) {
+		prt_printf(err,
+			   "cannot drop device metadata ptr without degrading metadata; "
+			   "btree node rewrite failed: %s\n  ",
+			   bch2_err_str(ret));
+		prt_str(err, bch2_printbuf_str(&drop_err));
+	} else if (ret) {
+		prt_str(err, bch2_printbuf_str(&drop_err));
+	}
+out:
+	printbuf_exit(&drop_err);
+	return ret;
+}
+
+static int btree_ptr_locations_collect(struct btree_trans *trans,
+				       struct progress_indicator *progress,
+				       unsigned int dev_idx,
+				       darray_btree_ptr_location *locations)
+{
+	struct bch_fs *c = trans->c;
+	size_t limit = (system_totalram_bytes() / 16) /
+		sizeof(struct btree_ptr_location);
+
+	for (unsigned btree = 0; btree < btree_id_nr_alive(c); btree++)
+		for (unsigned level = 0; level < BTREE_MAX_DEPTH; level++)
+			try(for_each_btree_node(trans, iter, btree, POS_MIN, level, 0, b, ({
+				int ret = bch2_progress_update_iter(trans, progress, &iter);
+				if (!ret &&
+				    bch2_bkey_has_device_c(c, bkey_i_to_s_c(&b->key), dev_idx)) {
+					struct btree_ptr_location loc = {
+						.btree		= btree,
+						.rewrite_level	= b->c.level + 1,
+						.pos		= b->key.k.p,
+					};
+
+					ret = locations->nr >= limit
+						? -ENOMEM
+						: darray_push_gfp(locations, loc, GFP_KERNEL|__GFP_NOWARN);
+				}
+				ret;
+			})));
+
+	return 0;
+}
+
+static int btree_ptr_location_drop_or_rewrite(struct btree_trans *trans,
+					      struct btree_ptr_location *loc,
+					      unsigned int dev_idx,
+					      unsigned int flags,
+					      struct printbuf *err)
+{
+	CLASS(btree_node_iter, iter)(trans, loc->btree, loc->pos, 0, loc->rewrite_level - 1, 0);
+	struct btree *b = bch2_btree_iter_peek_node(&iter);
+	int ret = PTR_ERR_OR_ZERO(b);
+
+	if (ret == -ENOENT)
+		return 0;
+	if (ret)
+		return ret;
+	if (!b)
+		return 0;
+
+	return drop_or_rewrite_btree_ptrs(trans, &iter, b, dev_idx, flags, err);
+}
+
 static int bch2_dev_usrdata_drop_key(struct btree_trans *trans,
 				     struct btree_iter *iter,
 				     struct bkey_s_c k,
@@ -122,7 +227,7 @@ static int bch2_dev_btree_drop_key(struct btree_trans *trans,
 	if (ret)
 		return ret == -BCH_ERR_backpointer_to_overwritten_btree_node ? 0 : ret;
 
-	return drop_btree_ptrs(trans, &iter, b, dev_idx, flags, err);
+	return drop_or_rewrite_btree_ptrs(trans, &iter, b, dev_idx, flags, err);
 }
 
 static int bch2_dev_usrdata_drop(struct bch_fs *c,
@@ -164,13 +269,13 @@ static int bch2_dev_metadata_drop(struct bch_fs *c,
 		return bch_err_throw(c, remove_with_metadata_missing_unimplemented);
 
 	CLASS(btree_trans, trans)(c);
+	CLASS(darray_btree_ptr_location, locations)();
 
-	for (unsigned btree = 0; btree < btree_id_nr_alive(c); btree++)
-		for (unsigned level = 0; level < BTREE_MAX_DEPTH; level++)
-			try(for_each_btree_node(trans, iter, btree, POS_MIN, level, 0, b, ({
-				bch2_progress_update_iter(trans, progress, &iter) ?:
-				drop_btree_ptrs(trans, &iter, b, dev_idx, flags, err);
-			})));
+	try(btree_ptr_locations_collect(trans, progress, dev_idx, &locations));
+
+	darray_for_each(locations, loc)
+		try(lockrestart_do(trans,
+			btree_ptr_location_drop_or_rewrite(trans, loc, dev_idx, flags, err)));
 
 	bch2_trans_unlock(trans);
 	bch2_btree_interior_updates_flush(c);
@@ -207,15 +312,31 @@ static int data_drop_bp(struct btree_trans *trans, unsigned dev_idx,
 		return bch2_dev_usrdata_drop_key(trans, &iter, k, dev_idx, flags, err);
 }
 
-static u64 dev_data_buckets(struct bch_dev *ca)
+static u64 dev_data_buckets_from_usage(struct bch_dev_usage usage)
 {
-	struct bch_dev_usage usage = bch2_dev_usage_read(ca);
 	u64 nr = 0;
 	for (unsigned i = 0; i < BCH_DATA_NR; i++)
 		if (!data_type_is_empty(i) && !data_type_is_hidden(i))
 			nr += usage.buckets[i];
 
 	return nr;
+}
+
+static u64 dev_data_buckets(struct bch_dev *ca)
+{
+	return dev_data_buckets_from_usage(bch2_dev_usage_read(ca));
+}
+
+static bool dev_only_has_btree_buckets(struct bch_dev_usage usage)
+{
+	for (unsigned i = 0; i < BCH_DATA_NR; i++)
+		if (!data_type_is_empty(i) &&
+		    !data_type_is_hidden(i) &&
+		    i != BCH_DATA_btree &&
+		    usage.buckets[i])
+			return false;
+
+	return usage.buckets[BCH_DATA_btree] != 0;
 }
 
 int bch2_dev_data_drop_by_backpointers(struct bch_fs *c, struct bch_dev *ca,
@@ -272,9 +393,30 @@ int bch2_dev_data_drop_by_backpointers(struct bch_fs *c, struct bch_dev *ca,
 			bch2_trans_commit(trans, &res.r, NULL, BCH_TRANS_COMMIT_no_enospc);
 		})));
 
-		u64 data_buckets = dev_data_buckets(ca);
+		bch2_trans_unlock_long(trans);
+		bch2_btree_interior_updates_flush(c);
+
+		struct bch_dev_usage usage = bch2_dev_usage_read(ca);
+		u64 data_buckets = dev_data_buckets_from_usage(usage);
 		if (!data_buckets)
 			return 0;
+
+		if (dev_only_has_btree_buckets(usage)) {
+			u64 old_data_buckets = data_buckets;
+
+			bch2_progress_init(&progress, "dropping metadata", c, ~0ULL, ~0ULL);
+			try(bch2_dev_metadata_drop(c, &progress, dev_idx, flags, err));
+
+			data_buckets = dev_data_buckets(ca);
+			if (!data_buckets)
+				return 0;
+
+			if (data_buckets >= old_data_buckets) {
+				prt_printf(err, "%s(): no progress dropping btree metadata, %llu data buckets remain\n",
+					   __func__, data_buckets);
+				return bch_err_throw(c, remove_by_backpointer_did_not_terminate);
+			}
+		}
 
 		if (data_buckets < min_data_buckets) {
 			min_data_buckets = data_buckets;

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -41,7 +41,7 @@
 
 static inline u16 bch2_move_ioprio(struct data_update_opts *opts)
 {
-	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_BE, 7);
 }
 
 const char * const bch2_data_ops_strs[] = {

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -1201,6 +1201,25 @@ __cold void bch2_move_stats_to_text(struct printbuf *out, struct bch_move_stats 
 	prt_newline(out);
 }
 
+static const char *bch2_moving_ctxt_wait_reason(struct bch_fs *c,
+						struct moving_context *ctxt)
+{
+	u32 sectors_limit = c->opts.move_bytes_in_flight >> 9;
+
+	if (ctxt->wait_on_copygc && READ_ONCE(c->copygc.running))
+		return "copygc running";
+	if (atomic_read(&ctxt->write_ios) >= c->opts.move_ios_in_flight)
+		return "write ios in flight";
+	if (atomic_read(&ctxt->read_ios) >= c->opts.move_ios_in_flight)
+		return "read ios in flight";
+	if (atomic_read(&ctxt->write_sectors) >= sectors_limit)
+		return "write bytes in flight";
+	if (atomic_read(&ctxt->read_sectors) >= sectors_limit)
+		return "read bytes in flight";
+
+	return "none";
+}
+
 static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs *c, struct moving_context *ctxt)
 {
 	if (!out->nr_tabstops)
@@ -1208,6 +1227,9 @@ static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs 
 
 	bch2_move_stats_to_text(out, ctxt->stats);
 	guard(printbuf_indent)(out);
+
+	prt_printf(out, "wait reason:\t%s\n", bch2_moving_ctxt_wait_reason(c, ctxt));
+	prt_printf(out, "wait on copygc:\t%u\n", ctxt->wait_on_copygc);
 
 	prt_printf(out, "reads: ios %u/%u sectors %u/%u\n",
 		   atomic_read(&ctxt->read_ios),

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -39,6 +39,11 @@
 #include <linux/ioprio.h>
 #include <linux/kthread.h>
 
+static inline u16 bch2_move_ioprio(struct data_update_opts *opts)
+{
+	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+}
+
 const char * const bch2_data_ops_strs[] = {
 #define x(t, n, ...) [n] = #t,
 	BCH_DATA_OPS()
@@ -253,7 +258,7 @@ static int __bch2_move_extent(struct moving_context *ctxt,
 
 	u->op.end_io		= move_write_done;
 	u->rbio.bio.bi_end_io	= move_read_endio;
-	u->rbio.bio.bi_ioprio	= IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+	u->rbio.bio.bi_ioprio	= bch2_move_ioprio(data_opts);
 
 	u32 size = k.k->size;
 

--- a/fs/data/reconcile/trigger.c
+++ b/fs/data/reconcile/trigger.c
@@ -934,8 +934,24 @@ int bch2_update_reconcile_opts(struct btree_trans *trans,
 	struct bch_extent_reconcile new;
 
 	int ret = bch2_bkey_needs_reconcile(trans, k, opts, &need_update_invalid_devs, &new);
-	if (ret <= 0)
+	if (ret < 0)
 		return ret;
+	if (!ret) {
+		/*
+		 * A scan may be replaying after the reconcile work indexes were
+		 * lost or never created. If the extent's reconcile opts already
+		 * match, the trigger path won't fire; make the work bit match the
+		 * extent metadata here.
+		 */
+		if (!level) {
+			enum reconcile_work_id w = bch2_bkey_reconcile_work_id(c, k);
+
+			if (w)
+				return bch2_btree_bit_mod_buffered(trans, reconcile_work_btree[w],
+						data_to_rb_work_pos(iter->btree_id, k.k->p), true);
+		}
+		return 0;
+	}
 
 	if (!level) {
 		unsigned buf_u64s = k.k->u64s + 1 + BCH_REPLICAS_MAX;

--- a/fs/data/reconcile/types.h
+++ b/fs/data/reconcile/types.h
@@ -22,6 +22,9 @@ struct bch_fs_reconcile {
 	struct bbpos			work_pos;
 	struct bch_move_stats		work_stats;
 	struct progress_indicator	progress;
+	u64				phys_workers_considered;
+	u64				phys_workers_started;
+	u64				phys_workers_skipped_empty;
 
 	struct bbpos			scan_start;
 	struct bbpos			scan_end;

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1696,7 +1696,7 @@ static int do_reconcile_phase_iter(struct reconcile_pass *p, u32 kick,
 
 		if (bch2_err_matches(ret, BCH_ERR_data_update_fail_need_copygc)) {
 			bch2_trans_unlock_long(trans);
-			bch2_copygc_wakeup(c);
+			bch2_copygc_wakeup_for_pressure(c);
 			wait_event(c->copygc.running_wq,
 				   c->copygc.run_count != *p->copygc_run_count ||
 				   kthread_should_stop());

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -33,6 +33,7 @@
 #include "util/clock.h"
 
 #include <linux/freezer.h>
+#include <linux/ioprio.h>
 #include <linux/kthread.h>
 #include <linux/sched/cputime.h>
 
@@ -434,6 +435,8 @@ static int reconcile_set_data_opts(struct btree_trans *trans,
 
 	data_opts->type			= BCH_DATA_UPDATE_reconcile;
 	data_opts->target		= r->background_target;
+	if (r->hipri)
+		data_opts->ioprio	= IOPRIO_PRIO_VALUE(IOPRIO_CLASS_BE, 7);
 
 	/*
 	 * we can't add/drop replicas from btree nodes incrementally, we always

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1483,19 +1483,78 @@ static CLOSURE_CALLBACK(do_reconcile_phys_thread)
 	closure_return(cl);
 }
 
+static int reconcile_phys_dev_has_work(struct bch_fs *c, unsigned reconcile_phase,
+				       unsigned dev, bool *has_work)
+{
+	enum btree_id btree = reconcile_phases[reconcile_phase].btree;
+	bool found = false;
+
+	*has_work = false;
+
+	int ret = bch2_trans_do(c, ({
+		found = false;
+
+		CLASS(btree_iter, iter)(trans, btree, POS(dev, 0), BTREE_ITER_prefetch);
+		int ret = 0;
+
+		while (true) {
+			struct bkey_s_c k = bch2_btree_iter_peek(&iter);
+
+			ret = bkey_err(k);
+			if (ret)
+				break;
+
+			if (!k.k || k.k->p.inode != dev)
+				break;
+
+			if (k.k->type == KEY_TYPE_set) {
+				found = true;
+				break;
+			}
+
+			bch2_btree_iter_advance(&iter);
+		}
+
+		ret;
+	}));
+
+	if (!ret)
+		*has_work = found;
+
+	return ret;
+}
+
 static int do_reconcile_phys(struct bch_fs *c, unsigned reconcile_phase)
 {
+	struct bch_fs_reconcile *r = &c->reconcile;
 	CLASS(darray_reconcile_phys_thr, thrs)();
 	CLASS(closure_stack, cl)();
+	u64 considered = 0, started = 0, skipped_empty = 0;
 
-	for_each_member_device(c, ca)
+	for_each_member_device(c, ca) {
+		bool has_work;
+
 		if (ca->mi.rotational &&
-		    bch2_dev_is_online(ca))
+		    bch2_dev_is_online(ca)) {
+			considered++;
+			try(reconcile_phys_dev_has_work(c, reconcile_phase, ca->dev_idx, &has_work));
+			if (!has_work) {
+				skipped_empty++;
+				continue;
+			}
+
 			try(darray_push(&thrs, ((reconcile_phys_thr) {
 						.c			= c,
 						.dev			= ca->dev_idx,
 						.reconcile_phase	= reconcile_phase,
 						})));
+			started++;
+		}
+	}
+
+	WRITE_ONCE(r->phys_workers_considered, considered);
+	WRITE_ONCE(r->phys_workers_started, started);
+	WRITE_ONCE(r->phys_workers_skipped_empty, skipped_empty);
 
 	darray_for_each(thrs, i)
 		closure_call(&i->cl, do_reconcile_phys_thread, system_unbound_wq, &cl);
@@ -1905,6 +1964,11 @@ __cold void bch2_reconcile_status_to_text(struct printbuf *out, struct bch_fs *c
 			}
 		}
 	}
+
+	prt_printf(out, "phys workers last phase: considered %llu started %llu skipped empty %llu\n",
+		   READ_ONCE(r->phys_workers_considered),
+		   READ_ONCE(r->phys_workers_started),
+		   READ_ONCE(r->phys_workers_skipped_empty));
 
 	struct task_struct *t;
 	scoped_guard(rcu) {

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1331,6 +1331,8 @@ static void reconcile_wait(struct bch_fs *c)
 	struct io_clock *clock = &c->io_clock[WRITE];
 	u64 now = atomic64_read(&clock->now);
 	u64 min_member_capacity = bch2_min_rw_member_capacity(c);
+	/* WRITE io_clock may not advance while the fs is idle. */
+	unsigned long wallclock_timeout = 5 * HZ;
 
 	if (reconcile_hipri_work_pending(c)) {
 		cond_resched();
@@ -1348,7 +1350,7 @@ static void reconcile_wait(struct bch_fs *c)
 		r->running		= false;
 	}
 
-	bch2_kthread_io_clock_wait_once(clock, r->wait_iotime_end, MAX_SCHEDULE_TIMEOUT);
+	bch2_kthread_io_clock_wait_once(clock, r->wait_iotime_end, wallclock_timeout);
 }
 
 struct reconcile_phase {

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -50,7 +50,7 @@ static const struct rhashtable_params bch_update_params = {
 
 static inline u16 bch2_move_ioprio(struct data_update_opts *opts)
 {
-	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_BE, 7);
 }
 
 static const char *bch2_ioprio_class_str(u16 ioprio)

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -48,6 +48,27 @@ static const struct rhashtable_params bch_update_params = {
 	.automatic_shrinking	= true,
 };
 
+static inline u16 bch2_move_ioprio(struct data_update_opts *opts)
+{
+	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+}
+
+static const char *bch2_ioprio_class_str(u16 ioprio)
+{
+	switch (IOPRIO_PRIO_CLASS(ioprio)) {
+	case IOPRIO_CLASS_NONE:
+		return "none";
+	case IOPRIO_CLASS_RT:
+		return "realtime";
+	case IOPRIO_CLASS_BE:
+		return "best-effort";
+	case IOPRIO_CLASS_IDLE:
+		return "idle";
+	default:
+		return "unknown";
+	}
+}
+
 bool bch2_data_update_in_flight(struct bch_fs *c, struct bbpos *pos,
 				enum bch_data_update_types type)
 {
@@ -894,6 +915,10 @@ __cold void bch2_data_update_opts_to_text(struct printbuf *out, struct bch_fs *c
 
 	prt_printf(out, "read_dev:\t%i\n", data_opts->read_dev);
 	prt_printf(out, "checksum_paranoia:\t%i\n", data_opts->checksum_paranoia);
+	u16 ioprio = bch2_move_ioprio(data_opts);
+	prt_printf(out, "ioprio:\t%s:%u\n",
+		   bch2_ioprio_class_str(ioprio),
+		   (unsigned) IOPRIO_PRIO_DATA(ioprio));
 
 	prt_str(out, "io path options:\t");
 	bch2_inode_opts_to_text(out, c, *io_opts);
@@ -995,7 +1020,7 @@ static int bch2_data_update_bios_init(struct data_update *m, struct bch_fs *c,
 	m->rbio.data_update		= true;
 	m->rbio.bio.bi_iter.bi_size	= buf_bytes;
 	m->rbio.bio.bi_iter.bi_sector	= bkey_start_offset(&m->k.k->k);
-	m->op.wbio.bio.bi_ioprio	= IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+	m->op.wbio.bio.bi_ioprio	= bch2_move_ioprio(&m->opts);
 	return 0;
 }
 

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -489,10 +489,14 @@ static int data_update_index_update_key(struct btree_trans *trans,
 	try(bch2_trans_update(trans, iter, insert,
 			      BTREE_UPDATE_internal_snapshot_node|
 			      BTREE_TRIGGER_set_needs_reconcile_done));
-	try(bch2_trans_commit(trans, &u->op.res, NULL,
-			      BCH_TRANS_COMMIT_no_check_rw|
-			      BCH_TRANS_COMMIT_no_enospc|
-			      u->opts.commit_flags));
+	bool flush = (u->op.flags & BCH_WRITE_flush) &&
+		bkey_next(insert) == u->op.insert_keys.top;
+
+	try(bch2_trans_commit_flush(trans, &u->op.res, NULL,
+				    flush ? &u->op.cl : NULL,
+				    BCH_TRANS_COMMIT_no_check_rw|
+				    BCH_TRANS_COMMIT_no_enospc|
+				    u->opts.commit_flags));
 
 	bch2_btree_iter_set_pos(iter, next_pos);
 
@@ -1376,6 +1380,7 @@ int bch2_data_update_init(struct btree_trans *trans,
 		BCH_WRITE_pages_owned|
 		BCH_WRITE_data_encoded|
 		BCH_WRITE_move|
+		BCH_WRITE_flush|
 		m->opts.write_flags;
 	m->op.compression_opt	= io_opts->background_compression;
 	m->op.watermark		= max(m->opts.commit_flags & BCH_WATERMARK_MASK,

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -1059,7 +1059,7 @@ static unsigned durability_available_on_target(struct bch_fs *c,
 			durability += (write_flags & BCH_WRITE_cached) ? 1 : ca->mi.durability;
 		else if (bch2_copygc_can_make_progress(ca)) {
 			*need_copygc = true;
-			bch2_copygc_wakeup(c);
+			bch2_copygc_wakeup_for_pressure(c);
 		}
 
 		if (trace)

--- a/fs/data/update.h
+++ b/fs/data/update.h
@@ -39,6 +39,7 @@ struct data_update_opts {
 	enum bch_read_flags		read_flags;
 	enum bch_write_flags		write_flags;
 	enum bch_trans_commit_flags	commit_flags;
+	u16				ioprio;
 };
 
 struct data_update {

--- a/fs/data/write.c
+++ b/fs/data/write.c
@@ -2407,10 +2407,12 @@ err:
 		bio->bi_private	= &op->cl;
 		bio->bi_opf |= REQ_OP_WRITE;
 
-		/* If it's an internal move, do FUA writes so the journal
-		 * doesn't have to flush them:
+		/* If it's an internal move, either do FUA writes so the journal
+		 * doesn't have to flush them, or have the data update path flush
+		 * the journal commit that indexes the moved data:
 		 */
-		if (op->flags & BCH_WRITE_move)
+		if ((op->flags & BCH_WRITE_move) &&
+		    !(op->flags & BCH_WRITE_flush))
 			bio->bi_opf |= REQ_FUA;
 
 		closure_get(bio->bi_private);

--- a/fs/debug/sysfs.c
+++ b/fs/debug/sysfs.c
@@ -831,10 +831,20 @@ static ssize_t sysfs_opt_store(struct bch_fs *c,
 			BUG();
 		}
 
-		if (changed) {
+		/*
+		 * Re-writing a filesystem-wide inode/IO option is an explicit
+		 * request to make existing data converge to that policy.  This
+		 * matters when the superblock already has e.g. background_target
+		 * set, but older extents were never scanned under that policy.
+		 */
+		bool reconcile = !ca && (opt->flags & OPT_FS) && bch2_opt_is_inode_opt(id);
+
+		if (changed || reconcile) {
 			if (!ca) {
-				bch2_opt_set_by_id(&c->opts, id, v);
-				clear_bit(id, c->mount_opts.d);
+				if (changed) {
+					bch2_opt_set_by_id(&c->opts, id, v);
+					clear_bit(id, c->mount_opts.d);
+				}
 			}
 
 			bch2_opt_hook_post_set(c, ca, 0, id, v);

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -932,6 +932,26 @@ int bch2_dev_set_state(struct bch_fs *c, struct bch_dev *ca,
 	return __bch2_dev_set_state(c, ca, new_state, flags, err);
 }
 
+int bch2_dev_evacuating_startup_scan(struct bch_fs *c)
+{
+	int ret = 0;
+
+	for_each_online_member(c, ca, BCH_DEV_READ_REF_evacuating_startup_scan) {
+		if (ca->mi.state != BCH_MEMBER_STATE_evacuating)
+			continue;
+
+		ret = bch2_set_reconcile_needs_scan(c,
+			(struct reconcile_scan) {
+				.type	= RECONCILE_SCAN_device,
+				.dev	= ca->dev_idx,
+			}, true);
+		if (ret)
+			break;
+	}
+
+	return ret;
+}
+
 /* Device add/removal: */
 
 static int __bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca,

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -939,7 +939,8 @@ static int __bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca,
 			     struct printbuf *err)
 {
 	unsigned data;
-	int ret;
+	bool was_rw = ca->mi.state == BCH_MEMBER_STATE_rw;
+	int ret, ret2;
 
 	lockdep_assert_held(&c->state_lock);
 
@@ -1073,6 +1074,16 @@ static int __bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca,
 err:
 	/* The device is staying; allow new references to it again: */
 	WRITE_ONCE(ca->removing, false);
+
+	if (test_bit(BCH_FS_rw, &c->flags) &&
+	    was_rw &&
+	    ca->mi.state == BCH_MEMBER_STATE_evacuating &&
+	    !enumerated_ref_is_zero(&ca->io_ref[READ])) {
+		prt_str(err, "Remove failed, restoring device state to rw\n");
+		ret2 = __bch2_dev_set_state(c, ca, BCH_MEMBER_STATE_rw, flags, err);
+		if (ret2)
+			prt_printf(err, "Error restoring device state: %s\n", bch2_err_str(ret2));
+	}
 
 	if (test_bit(BCH_FS_rw, &c->flags) &&
 	    ca->mi.state == BCH_MEMBER_STATE_rw &&

--- a/fs/init/dev.h
+++ b/fs/init/dev.h
@@ -30,6 +30,7 @@ int __bch2_dev_set_state(struct bch_fs *, struct bch_dev *,
 int bch2_dev_set_state(struct bch_fs *, struct bch_dev *,
 		       enum bch_member_state, int,
 		       struct printbuf *);
+int bch2_dev_evacuating_startup_scan(struct bch_fs *);
 
 int bch2_dev_add_initialize(struct bch_fs *, struct bch_dev *);
 

--- a/fs/init/fs.c
+++ b/fs/init/fs.c
@@ -618,6 +618,8 @@ static int __bch2_fs_read_write(struct bch_fs *c, bool early)
 		ret = bch2_set_fs_needs_reconcile(c);
 	if (!ret && !c->opts.read_only)
 		ret = bch2_reconcile_start(c);
+	if (!ret && !c->opts.read_only)
+		ret = bch2_dev_evacuating_startup_scan(c);
 	if (ret) {
 		bch2_fs_read_only(c);
 		return ret;

--- a/fs/init/fs.c
+++ b/fs/init/fs.c
@@ -613,7 +613,8 @@ static int __bch2_fs_read_write(struct bch_fs *c, bool early)
 	int ret = bch2_journal_reclaim_start(&c->journal) ?:
 		  bch2_btree_write_buffer_start(c) ?:
 		  bch2_copygc_start(c);
-	if (!ret && c->opts.background_target)
+	if (!ret && c->opts.background_target &&
+	    c->opts.background_target != c->opts.foreground_target)
 		ret = bch2_set_fs_needs_reconcile(c);
 	if (!ret && !c->opts.read_only)
 		ret = bch2_reconcile_start(c);

--- a/fs/init/fs.c
+++ b/fs/init/fs.c
@@ -612,10 +612,11 @@ static int __bch2_fs_read_write(struct bch_fs *c, bool early)
 
 	int ret = bch2_journal_reclaim_start(&c->journal) ?:
 		  bch2_btree_write_buffer_start(c) ?:
-		  bch2_copygc_start(c) ?:
-		  (!c->opts.read_only
-		   ? bch2_reconcile_start(c)
-		   : 0);
+		  bch2_copygc_start(c);
+	if (!ret && c->opts.background_target)
+		ret = bch2_set_fs_needs_reconcile(c);
+	if (!ret && !c->opts.read_only)
+		ret = bch2_reconcile_start(c);
 	if (ret) {
 		bch2_fs_read_only(c);
 		return ret;

--- a/fs/opts.h
+++ b/fs/opts.h
@@ -358,7 +358,7 @@ enum fsck_err_opts {
 	x(move_ios_in_flight,		u32,				\
 	  OPT_FS|OPT_MOUNT|OPT_RUNTIME|OPT_NODOC,			\
 	  OPT_UINT(1, 1024),						\
-	  BCH2_NO_SB_OPT,		64,				\
+	  BCH2_NO_SB_OPT,		1024,				\
 	  NULL,		"Maximum number of IOs to keep in flight by the move path")\
 	x(fsck,				u8,				\
 	  OPT_FS|OPT_MOUNT,						\

--- a/src/commands/set_option.rs
+++ b/src/commands/set_option.rs
@@ -13,32 +13,57 @@ fn opt_flags() -> u32 {
     c::opt_flags::OPT_FS as u32 | c::opt_flags::OPT_DEVICE as u32
 }
 
+fn schedule_reconcile_after_offline_io_opt_change(fs: &bcachefs_kernel::fs::Fs) -> Result<()> {
+    unsafe {
+        let _sb_lock = fs.sb_lock();
+
+        let ext_u64s =
+            (std::mem::size_of::<c::bch_sb_field_ext>() / std::mem::size_of::<u64>()) as u32;
+        let ext: &mut c::bch_sb_field_ext =
+            bcachefs_kernel::sb::io::sb_field_get_minsize(&mut (*fs.raw).disk_sb, ext_u64s)
+                .ok_or_else(|| anyhow::anyhow!("Error getting sb_field_ext"))?;
+
+        let pass = 1u64 << c::bch_recovery_pass::BCH_RECOVERY_PASS_set_fs_needs_reconcile as u64;
+        ext.recovery_passes_required[0] |= c::bch2_recovery_passes_to_stable(pass).to_le();
+        fs.write_super();
+    }
+
+    Ok(())
+}
+
 fn set_option_cmd() -> Command {
     Command::new("set-fs-option")
         .about("Set a filesystem option")
-        .long_about("\
+        .long_about(
+            "\
 Set a filesystem or device option on a running filesystem. Changes \
 are persisted to the superblock. Use -d to target a specific device \
 for device-scoped options. See <<sec:options>> for the full list of \
-available options.")
+available options.",
+        )
         .args(bch_option_args(opt_flags(), false))
-        .arg(Arg::new("dev-idx")
-            .short('d')
-            .long("dev-idx")
-            .action(ArgAction::Append)
-            .value_parser(clap::value_parser!(u32))
-            .help("Device index for device-specific options"))
-        .arg(Arg::new("devices")
-            .required(true)
-            .action(ArgAction::Append)
-            .help("Device path(s)"))
+        .arg(
+            Arg::new("dev-idx")
+                .short('d')
+                .long("dev-idx")
+                .action(ArgAction::Append)
+                .value_parser(clap::value_parser!(u32))
+                .help("Device index for device-specific options"),
+        )
+        .arg(
+            Arg::new("devices")
+                .required(true)
+                .action(ArgAction::Append)
+                .help("Device path(s)"),
+        )
 }
 
 fn cmd_set_option(argv: Vec<String>) -> Result<()> {
     let matches = set_option_cmd().get_matches_from(argv);
 
     let devices: Vec<&String> = matches.get_many::<String>("devices").unwrap().collect();
-    let dev_idxs: Vec<u32> = matches.get_many::<u32>("dev-idx")
+    let dev_idxs: Vec<u32> = matches
+        .get_many::<u32>("dev-idx")
         .map(|v| v.copied().collect())
         .unwrap_or_default();
 
@@ -126,7 +151,13 @@ fn set_option_offline(
         let c_value = CString::new(value.as_str())?;
         let mut val: u64 = 0;
         let ret = unsafe {
-            c::bch2_opt_parse(fs.raw, opt, c_value.as_ptr(), &mut val, std::ptr::null_mut())
+            c::bch2_opt_parse(
+                fs.raw,
+                opt,
+                c_value.as_ptr(),
+                &mut val,
+                std::ptr::null_mut(),
+            )
         };
         if ret < 0 {
             eprintln!("Error parsing {name}={value}");
@@ -135,22 +166,34 @@ fn set_option_offline(
 
         if flags & c::opt_flags::OPT_FS as u32 != 0 {
             let ret = unsafe {
-                c::bch2_opt_hook_pre_set(fs.raw, std::ptr::null_mut(), 0, opt_id, val, true, std::ptr::null_mut())
+                c::bch2_opt_hook_pre_set(
+                    fs.raw,
+                    std::ptr::null_mut(),
+                    0,
+                    opt_id,
+                    val,
+                    true,
+                    std::ptr::null_mut(),
+                )
             };
             if ret < 0 {
                 eprintln!("Error setting {name}: {ret}");
                 continue;
             }
-            unsafe { c::bch2_opt_set_sb(fs.raw, std::ptr::null_mut(), opt, val); }
+            let _changed = unsafe { c::bch2_opt_set_sb(fs.raw, std::ptr::null_mut(), opt, val) };
+            if unsafe { c::bch2_opt_is_inode_opt(opt_id) } {
+                schedule_reconcile_after_offline_io_opt_change(&fs)?;
+            }
         }
 
         if flags & c::opt_flags::OPT_DEVICE as u32 != 0 {
             let indices: Vec<u32> = if !dev_idxs.is_empty() {
                 dev_idxs.to_vec()
             } else {
-                devices.iter().filter_map(|dev| {
-                    name_to_dev_idx(fs.raw, dev).map(|i| i as u32)
-                }).collect()
+                devices
+                    .iter()
+                    .filter_map(|dev| name_to_dev_idx(fs.raw, dev).map(|i| i as u32))
+                    .collect()
             };
 
             for idx in indices {
@@ -167,7 +210,9 @@ fn set_option_offline(
                     eprintln!("Error setting {name}: {ret}");
                     continue;
                 }
-                unsafe { c::bch2_opt_set_sb(fs.raw, ca, opt, val); }
+                unsafe {
+                    c::bch2_opt_set_sb(fs.raw, ca, opt, val);
+                }
             }
         }
     }
@@ -179,15 +224,16 @@ fn name_to_dev_idx(c: *mut c::bch_fs, name: &str) -> Option<usize> {
     let devs_len = unsafe { (*c).devs.len() };
     for i in 0..devs_len {
         let ca = unsafe { (*c).devs[i] };
-        if ca.is_null() { continue; }
+        if ca.is_null() {
+            continue;
+        }
         // bch_dev.name is a [c_char; 32] array, not a pointer
         let ca_name_bytes = unsafe { &(*ca).name };
         // Find the null terminator
         let len = ca_name_bytes.iter().position(|&b| b == 0).unwrap_or(32);
         // c_char is i8, but from_utf8 wants u8 - use from_raw_parts to reinterpret
-        let ca_name_bytes_u8 = unsafe {
-            std::slice::from_raw_parts(ca_name_bytes[..len].as_ptr() as *const u8, len)
-        };
+        let ca_name_bytes_u8 =
+            unsafe { std::slice::from_raw_parts(ca_name_bytes[..len].as_ptr() as *const u8, len) };
         let ca_name = std::str::from_utf8(ca_name_bytes_u8).ok()?;
         if ca_name == name {
             return Some(i);


### PR DESCRIPTION
## Summary

Raise the default `move_ios_in_flight` from 64 to 1024.

The move path already has a separate 64 MiB byte-depth limit. On fragmented data, the current 64-IO default can become the active throttle long before the byte budget is useful, leaving only a few MiB of writes in flight while evacuation/reconcile is waiting on slow destination write or journal-flush latency.

This keeps the existing runtime option and its existing maximum; it only changes the default so internal evacuation/reconcile can keep a useful pipeline without manual tuning.

## Live motivation

On a cold-storage evacuation workload using the preceding move allocation / journal-flush stack, `moving_ctxts` showed:

- `wait reason: write ios in flight`
- `writes: ios 86/64 sectors 10336/131072`

That is roughly 5 MiB in flight against the 64 MiB byte limit, because the moved extents are small. The same sample moved about 0.6G in 60 seconds, around 10 MB/s, while the destination disk showed long write/flush waits.

## Validation

- `git diff --check`
- `make -j$(nproc) build/fs/opts.o build/fs/data/move.o build/fs/data/reconcile/work.o`

Stacked after the move-allocation / evacuation-performance work in koverstreet/bcachefs-tools#686.
