### PR TITLE
commands: add get-file-option

### DIFF
--- a/src/commands/attr.rs
+++ b/src/commands/attr.rs
@@ -84,6 +84,41 @@ fn do_setattr(path: &Path, opts: &[(String, String)], remove_all: bool) -> Resul
     Ok(())
 }
 
+fn read_bcachefs_attr(path: &Path, attr: &str) -> Result<Option<String>> {
+    let path_c = CString::new(path.as_os_str().as_bytes())
+        .with_context(|| format!("invalid path {}", path.display()))?;
+    let attr_c = CString::new(attr)
+        .with_context(|| format!("invalid attribute name {attr}"))?;
+
+    let len = unsafe {
+        libc::getxattr(path_c.as_ptr(), attr_c.as_ptr(), std::ptr::null_mut(), 0)
+    };
+
+    if len < 0 {
+        let err = std::io::Error::last_os_error();
+        return match err.raw_os_error() {
+            Some(libc::ENODATA) | Some(libc::ENOTSUP) | Some(libc::EINVAL) => Ok(None),
+            _ => Err(err).with_context(|| format!("reading {attr} from {}", path.display())),
+        };
+    }
+
+    let mut buf = vec![0_u8; len as usize];
+    let read = unsafe {
+        libc::getxattr(path_c.as_ptr(), attr_c.as_ptr(), buf.as_mut_ptr().cast(), buf.len())
+    };
+
+    if read < 0 {
+        let err = std::io::Error::last_os_error();
+        return match err.raw_os_error() {
+            Some(libc::ENODATA) | Some(libc::ENOTSUP) | Some(libc::EINVAL) => Ok(None),
+            _ => Err(err).with_context(|| format!("reading {attr} from {}", path.display())),
+        };
+    }
+
+    buf.truncate(read as usize);
+    Ok(Some(String::from_utf8_lossy(&buf).into_owned()))
+}
+
 pub(super) fn setattr_cmd() -> Command {
     Command::new("set-file-option")
         .about("Set attributes on files in a bcachefs filesystem")
@@ -118,6 +153,65 @@ fn cmd_setattr(argv: Vec<String>) -> Result<()> {
     for path in files {
         do_setattr(Path::new(path), &opts, remove_all)?;
     }
+    Ok(())
+}
+
+pub(super) fn getattr_cmd() -> Command {
+    Command::new("get-file-option")
+        .about("Show file-level options")
+        .long_about("\
+Shows per-file or per-directory IO path options stored in a bcachefs \
+filesystem. By default only explicitly set file options are printed. Use \
+--effective to show inherited/effective options, or --all to include unset \
+options.")
+        .arg(Arg::new("effective")
+            .long("effective")
+            .short('e')
+            .action(ArgAction::SetTrue)
+            .help("Show inherited/effective file options"))
+        .arg(Arg::new("all")
+            .long("all")
+            .short('a')
+            .action(ArgAction::SetTrue)
+            .help("Show unset options as '-'"))
+        .arg(Arg::new("files")
+            .action(ArgAction::Append)
+            .required(true))
+}
+
+fn cmd_getattr(argv: Vec<String>) -> Result<()> {
+    let matches = getattr_cmd().get_matches_from(argv);
+    let effective = matches.get_flag("effective");
+    let all = matches.get_flag("all");
+    let prefix = if effective { "bcachefs_effective" } else { "bcachefs" };
+    let files: Vec<&String> = matches.get_many("files").unwrap().collect();
+    let names = opts::bch_option_names(c::opt_flags::OPT_INODE as u32);
+    let multi_file = files.len() > 1;
+
+    for file in files {
+        let path = Path::new(file);
+        for name in &names {
+            let attr = format!("{prefix}.{name}");
+            match read_bcachefs_attr(path, &attr)? {
+                Some(value) => {
+                    if multi_file {
+                        println!("{file}\t{name}\t{value}");
+                    } else {
+                        println!("{name}\t{value}");
+                    }
+                }
+                None if all => {
+                    if multi_file {
+                        println!("{file}\t{name}\t-");
+                    } else {
+                        println!("{name}\t-");
+                    }
+                }
+                None => {}
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -191,4 +285,5 @@ fn cmd_reflink_option_propagate(argv: Vec<String>) -> Result<()> {
 }
 
 pub const CMD_SETATTR: super::CmdDef = raw_cmd!("set-file-option", "Set file-level options", cmd_setattr);
+pub const CMD_GETATTR: super::CmdDef = raw_cmd!("get-file-option", "Show file-level options", cmd_getattr);
 pub const CMD_REFLINK_PROPAGATE: super::CmdDef = raw_cmd!("reflink-option-propagate", "Propagate options to reflinked files", cmd_reflink_option_propagate);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -213,7 +213,7 @@ pub const COMMAND_GROUPS: &[GroupDef] = &[
     GroupDef { heading: "Filesystem data",          commands: &[&reconcile::CMD, &scrub::CMD] },
     GroupDef { heading: "Encryption",               commands: &[&key::CMD_UNLOCK, &key::CMD_SET_PASSPHRASE, &key::CMD_REMOVE_PASSPHRASE] },
     GroupDef { heading: "Migrate",                  commands: &[&migrate::CMD_MIGRATE, &migrate::CMD_MIGRATE_SUPERBLOCK] },
-    GroupDef { heading: "File options",             commands: &[&attr::CMD_SETATTR, &attr::CMD_REFLINK_PROPAGATE] },
+    GroupDef { heading: "File options",             commands: &[&attr::CMD_SETATTR, &attr::CMD_GETATTR, &attr::CMD_REFLINK_PROPAGATE] },
     GroupDef { heading: "Debug", commands: &[
         &dump::CMD_DUMP, &dump::CMD_UNDUMP, &list::CMD, &list_journal::CMD,
         &kill_btree_node::CMD, &data_read::CMD, &unpoison::CMD,


### PR DESCRIPTION
Summary:

- add `bcachefs get-file-option` alongside `set-file-option`
- read explicit per-file options from `bcachefs.<option>` xattrs
- support `--effective` for inherited/effective `bcachefs_effective.<option>` values
- support `--all` to show unset options as `-`

This addresses the `get-file-option` part of koverstreet/bcachefs#846. The rest of that issue tracks broader feature requests, so this PR intentionally does not close it.

Validation:

- `git diff --check`
- `BINDGEN=/home/kom/.cargo/bin/bindgen cargo check -q -p bcachefs-tools`
- `make libbcachefs.a`
- `BINDGEN=/home/kom/.cargo/bin/bindgen cargo build -q -p bcachefs-tools`
- `./target/debug/bcachefs get-file-option --help`
- `./target/debug/bcachefs --help | rg -n -C 2 'File options|get-file-option|set-file-option|reflink-option'`
- `./target/debug/bcachefs get-file-option Cargo.toml`
- `./target/debug/bcachefs get-file-option --all Cargo.toml`

Notes:

- The build still reports existing warnings in `src/commands/list_journal.rs`, `src/commands/scrub.rs`, `linux/blkdev.c`, and `linux/semaphore.c`.
