### PR TITLE
docs: document scrub affected file paths

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -516,6 +516,14 @@ Make snapshot read-only
 .El
 .Sh Commands for managing filesystem data
 .Bl -tag -width Ds
+.It Nm Ic scrub Oo Fl -metadata Oc Ar filesystem
+Verify checksums and correct errors, if possible.
+When scrub finds checksum errors, affected file paths are currently reported in
+the kernel log.
+.Bl -tag -width Ds
+.It Fl -metadata
+Check metadata only
+.El
 .It Nm Ic data Ic rereplicate Ar filesystem
 Walks existing data in a filesystem,
 writing additional copies of any degraded data.

--- a/src/commands/scrub.rs
+++ b/src/commands/scrub.rs
@@ -266,4 +266,9 @@ fn scrub(cli: Cli) -> Result<()> {
     Ok(())
 }
 
-pub const CMD: super::CmdDef = typed_cmd!("scrub", "Verify data checksums", Cli, scrub);
+pub const CMD: super::CmdDef = typed_cmd!(
+    "scrub",
+    "Verify data checksums; affected paths are logged to dmesg",
+    Cli,
+    scrub
+);


### PR DESCRIPTION
## Summary

- document `bcachefs scrub` in the manpage filesystem-data section
- note that affected file paths from scrub checksum errors are currently reported in the kernel log
- update the scrub command summary so `bcachefs --help` points users at the current affected-path surface

References koverstreet/bcachefs#762.

## Testing

- `git diff --check`
- `cargo check -p bcachefs-tools` *(fails in local build script before checking this change: `run bindgen: Os { code: 2, kind: NotFound, message: "No such file or directory" }`)*
- `rustfmt --check src/commands/scrub.rs` *(not applied because stable rustfmt wants to reformat pre-existing code throughout the file)*
- `mandoc -Tlint bcachefs.8` *(not run: `mandoc` is not installed in this environment)*
