### PR TITLE
docs: explain retained disk group labels

### DIFF
--- a/doc/bcachefs.5.rst.tmpl
+++ b/doc/bcachefs.5.rst.tmpl
@@ -85,6 +85,11 @@ For example, given disks formatted with these labels:
 Configuration options such as foreground_target may then refer to controller1,
 or controller1.hdd, or controller1.hdd1 - or to /dev/sda directly.
 
+Label entries are also retained when they no longer have member devices, if
+filesystem or per-file options may still refer to them. Such entries can appear
+in the internal disk-groups listing with an empty device set after removing a
+device; this avoids turning existing target references into dangling names.
+
 Data placement, caching
 -----------------------
 

--- a/fs/alloc/background.c
+++ b/fs/alloc/background.c
@@ -422,6 +422,9 @@
  * \texttt{foreground\_target=/dev/sda1}). Internally, both device references
  * and label references resolve to entries in the disk groups superblock field,
  * which maps label strings to device sets.
+ * Disk group entries may be retained after the last device in a label is
+ * removed, because filesystem and per-file target options may still refer to
+ * the label; preserving the entry avoids creating dangling target references.
  *
  * Four target options control where data is placed:
  *


### PR DESCRIPTION
## Summary

Document that disk group label entries may remain after the last device using the label is removed, because filesystem or per-file target options may still refer to that label.

This matches the behavior discussed in koverstreet/bcachefs#773: an empty `devs` set in the internal disk-groups listing is not necessarily corruption; retaining the entry avoids creating dangling target references until unused-label cleanup can reason about option references.

## Testing

- `git diff --check`
- `python3 -m py_compile doc/macro2rst.py`

## Related

- koverstreet/bcachefs#773
