### PR TITLE
bcachefs: mark internal move writes idle for WBT

### DIFF
--- a/fs/data/write.c
+++ b/fs/data/write.c
@@ -2407,6 +2407,9 @@ err:
 		bio->bi_private	= &op->cl;
 		bio->bi_opf |= REQ_OP_WRITE;
 
+		if (op->flags & BCH_WRITE_move)
+			bio->bi_opf |= REQ_SYNC|REQ_IDLE;
+
 		/*
 		 * Internal moves can be issued FUA, making the journal's cache
 		 * flush a no-op for them. Off by default: the per-write FUA


### PR DESCRIPTION
## Summary

- mark internal move write bios with `REQ_SYNC|REQ_IDLE`
- keep the existing FUA handling for move writes unchanged
- let copygc/reconcile/evacuation writes avoid blk-wbt throttling while foreground writes remain WBT-accounted

## Why

Background move writes already run at low IO priority (see koverstreet/bcachefs-tools#645), but blk-wbt does not look only at `bi_ioprio`. The WBT bypass path expects sync + idle write flags.

On a live pool doing foreground work plus evacuation/reconcile, a kprobe on `rq_qos_wait` showed `bch-reconcile` reaching:

```text
rq_qos_wait -> wbt_wait -> blk_mq_submit_bio -> bch2_submit_wbio_replicas -> __bch2_write -> bch2_moving_ctxt_do_pending_writes -> bch2_move_ratelimit -> do_reconcile_phase_iter -> bch2_reconcile_thread
```

After this change, the same `rq_qos_wait` stack sampling no longer showed direct `bch-reconcile` or `bch-copygc` hits; remaining WBT waits were from unrelated foreground filesystem writes.

## Testing

- `make -j32 build/fs/data/write.o`
- live DKMS/remount on `7.1-amd64` with active reconcile/copygc work
- before/after `rq_qos_wait` kprobe stack sampling
