### PR TITLE
docs: warn FIEMAP locations are unstable

### DIFF
--- a/doc/bcachefs.5.rst.tmpl
+++ b/doc/bcachefs.5.rst.tmpl
@@ -125,6 +125,21 @@ be used to pin a specific file or directory to a specific device or target:
 Note that if the target specified is full, the write will spill over to the rest
 of the filesystem.
 
+FIEMAP and block-level writes
+-----------------------------
+
+Tools such as ``filefrag`` use the kernel FIEMAP interface to report the
+physical locations of a file's extents. On bcachefs, those locations are an
+observation, not a stable userspace write ABI: background data movement such as
+copygc, rebalance, evacuation, or normal filesystem updates may relocate extents,
+and userspace has no interface to lock those moves out.
+
+Writing directly to the block device locations reported by FIEMAP, for example
+through a manually constructed device-mapper table, is therefore unsafe while
+the filesystem is mounted. This remains true even for preallocated files and
+files using ``nocow``; any block-level write path must be coordinated by the
+filesystem itself.
+
 Data protection
 ---------------
 


### PR DESCRIPTION
## Summary

Document that FIEMAP/filefrag extent locations on bcachefs are observations, not a stable userspace write ABI.

This addresses the safety question from koverstreet/bcachefs#774: even with a preallocated file or `nocow`, userspace should not write directly to the reported block device offsets while the filesystem is mounted, because bcachefs may move extents in the background and userspace cannot lock those moves out.

The supported direction for swapfile-style block I/O is filesystem-coordinated handling, not a manually constructed device-mapper table. The active swapfile work is koverstreet/bcachefs-tools#646, related to koverstreet/bcachefs#368.

## Testing

- `git diff --check`
- `python3 -m py_compile doc/macro2rst.py`
- `rst2man --halt=2 doc/bcachefs.5.rst.tmpl /tmp/bcachefs.5.rst.tmpl.man`

## Related

- koverstreet/bcachefs#774
- koverstreet/bcachefs#368
- koverstreet/bcachefs-tools#646
