### PR TITLE
move: limit rotational move concurrency

### DIFF
--- a/fs/data/copygc.c
+++ b/fs/data/copygc.c
@@ -506,6 +506,13 @@ static int bch2_copygc(struct moving_context *ctxt,
 		*i = NULL;
 
 		move_bucket_in_flight_add(buckets_in_flight, b);
+		bch2_moving_ctxt_reset_limits(ctxt);
+		/* Copygc walks physical source buckets, unlike target-directed reconcile. */
+		if (bch2_dev_rotational(c, b->k.bucket.inode))
+			bch2_moving_ctxt_set_rotational_limits(ctxt,
+					MOVE_ROTATIONAL_LIMIT_background,
+					MOVE_LIMITS_COPYGC_BUCKET,
+					b->k.bucket.inode);
 
 		ret = bch2_evacuate_bucket(ctxt, b, b->k.bucket, b->k.generation, data_opts);
 		if (ret)

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -73,6 +73,7 @@ static void move_write_done(struct bch_write_op *op)
 
 	atomic_sub(u->k.k->k.size, &ctxt->write_sectors);
 	atomic_dec(&ctxt->write_ios);
+	wake_up(&ctxt->wait);
 
 	/*
 	 * EC allocation failed — the write never happened but the extent
@@ -103,10 +104,6 @@ static void move_write(struct data_update *u)
 				     &ctxt->stats->sectors_error_corrected);
 	}
 
-	closure_get(&ctxt->cl);
-	atomic_add(u->k.k->k.size, &ctxt->write_sectors);
-	atomic_inc(&ctxt->write_ios);
-
 	bch2_data_update_read_done(u);
 }
 
@@ -116,6 +113,53 @@ struct data_update *bch2_moving_ctxt_next_pending_write(struct moving_context *c
 		list_first_entry_or_null(&ctxt->reads, struct data_update, read_list);
 
 	return u && u->read_done ? u : NULL;
+}
+
+static bool bch2_moving_ctxt_can_submit_write(struct moving_context *ctxt,
+					      struct data_update *u)
+{
+	u32 sectors = u ? u->k.k->k.size : 0;
+	u32 write_sectors = atomic_read(&ctxt->write_sectors);
+
+	return atomic_read(&ctxt->write_ios) < ctxt->max_ios_in_flight &&
+		(!write_sectors ||
+		 (write_sectors < ctxt->max_sectors_in_flight &&
+		  sectors <= ctxt->max_sectors_in_flight - write_sectors));
+}
+
+static bool bch2_moving_ctxt_reserve_write(struct moving_context *ctxt,
+					   struct data_update *u)
+{
+	u32 sectors = u->k.k->k.size;
+	u32 old, new;
+
+	/* Reserve the write window before submitting; check-then-add can overshoot. */
+	do {
+		old = atomic_read(&ctxt->write_sectors);
+		if (old && (old >= ctxt->max_sectors_in_flight ||
+			    sectors > ctxt->max_sectors_in_flight - old))
+			return false;
+		new = old + sectors;
+	} while (atomic_cmpxchg(&ctxt->write_sectors, old, new) != old);
+
+	do {
+		old = atomic_read(&ctxt->write_ios);
+		if (old >= ctxt->max_ios_in_flight) {
+			atomic_sub(sectors, &ctxt->write_sectors);
+			return false;
+		}
+		new = old + 1;
+	} while (atomic_cmpxchg(&ctxt->write_ios, old, new) != old);
+
+	closure_get(&ctxt->cl);
+	return true;
+}
+
+bool bch2_moving_ctxt_pending_write_ready(struct moving_context *ctxt)
+{
+	struct data_update *u = bch2_moving_ctxt_next_pending_write(ctxt);
+
+	return u && bch2_moving_ctxt_can_submit_write(ctxt, u);
 }
 
 static void move_read_endio(struct bio *bio)
@@ -135,7 +179,8 @@ void bch2_moving_ctxt_do_pending_writes(struct moving_context *ctxt)
 {
 	struct data_update *u;
 
-	while ((u = bch2_moving_ctxt_next_pending_write(ctxt))) {
+	while ((u = bch2_moving_ctxt_next_pending_write(ctxt)) &&
+	       bch2_moving_ctxt_reserve_write(ctxt, u)) {
 		bch2_trans_unlock_long(ctxt->trans);
 		list_del(&u->read_list);
 		move_write(u);
@@ -198,6 +243,7 @@ void bch2_moving_ctxt_init(struct moving_context *ctxt,
 	ctxt->stats	= stats;
 	ctxt->wp	= wp;
 	ctxt->wait_on_copygc = wait_on_copygc;
+	bch2_moving_ctxt_reset_limits(ctxt);
 
 	closure_init_stack(&ctxt->cl);
 
@@ -208,6 +254,41 @@ void bch2_moving_ctxt_init(struct moving_context *ctxt,
 
 	scoped_guard(mutex, &c->moving_context_lock)
 		list_add(&ctxt->list, &c->moving_context_list);
+}
+
+#define MOVE_ROTATIONAL_BG_IOS_IN_FLIGHT	8U
+#define MOVE_ROTATIONAL_BG_BYTES_IN_FLIGHT	(1U << 20)
+
+#define MOVE_ROTATIONAL_HIPRI_IOS_IN_FLIGHT	128U
+#define MOVE_ROTATIONAL_HIPRI_BYTES_IN_FLIGHT	(16U << 20)
+
+void bch2_moving_ctxt_reset_limits(struct moving_context *ctxt)
+{
+	struct bch_fs *c = ctxt->trans->c;
+
+	ctxt->max_sectors_in_flight = c->opts.move_bytes_in_flight >> 9;
+	ctxt->max_ios_in_flight = c->opts.move_ios_in_flight;
+	ctxt->limit_source = MOVE_LIMITS_DEFAULT;
+	ctxt->limit_source_id = 0;
+}
+
+void bch2_moving_ctxt_set_rotational_limits(struct moving_context *ctxt,
+					    enum move_rotational_limit limit,
+					    enum move_limit_source source,
+					    unsigned source_id)
+{
+	u32 max_ios = limit == MOVE_ROTATIONAL_LIMIT_hipri
+		? MOVE_ROTATIONAL_HIPRI_IOS_IN_FLIGHT
+		: MOVE_ROTATIONAL_BG_IOS_IN_FLIGHT;
+	u32 max_bytes = limit == MOVE_ROTATIONAL_LIMIT_hipri
+		? MOVE_ROTATIONAL_HIPRI_BYTES_IN_FLIGHT
+		: MOVE_ROTATIONAL_BG_BYTES_IN_FLIGHT;
+
+	ctxt->max_ios_in_flight = min(ctxt->max_ios_in_flight, max_ios);
+	ctxt->max_sectors_in_flight = min(ctxt->max_sectors_in_flight,
+					  max_bytes >> 9);
+	ctxt->limit_source = source;
+	ctxt->limit_source_id = source_id;
 }
 
 void bch2_move_stats_exit(struct bch_move_stats *stats, struct bch_fs *c)
@@ -489,15 +570,11 @@ int bch2_move_ratelimit(struct moving_context *ctxt)
 		}
 	} while (delay);
 
-	/*
-	 * XXX: these limits really ought to be per device, SSDs and hard drives
-	 * will want different limits
-	 */
 	move_ctxt_wait_event(ctxt,
-		atomic_read(&ctxt->write_sectors) < c->opts.move_bytes_in_flight >> 9 &&
-		atomic_read(&ctxt->read_sectors) < c->opts.move_bytes_in_flight >> 9 &&
-		atomic_read(&ctxt->write_ios) < c->opts.move_ios_in_flight &&
-		atomic_read(&ctxt->read_ios) < c->opts.move_ios_in_flight);
+		atomic_read(&ctxt->write_sectors) < ctxt->max_sectors_in_flight &&
+		atomic_read(&ctxt->read_sectors) < ctxt->max_sectors_in_flight &&
+		atomic_read(&ctxt->write_ios) < ctxt->max_ios_in_flight &&
+		atomic_read(&ctxt->read_ios) < ctxt->max_ios_in_flight);
 
 	return 0;
 }
@@ -767,6 +844,11 @@ int bch2_move_data_phys(struct bch_fs *c,
 {
 	struct moving_context ctxt __cleanup(bch2_moving_ctxt_exit);
 	bch2_moving_ctxt_init(&ctxt, c, rate, stats, wp, wait_on_copygc);
+
+	if (bch2_dev_rotational(c, dev))
+		bch2_moving_ctxt_set_rotational_limits(&ctxt,
+				MOVE_ROTATIONAL_LIMIT_background,
+				MOVE_LIMITS_PHYS_DEV, dev);
 
 	if (ctxt.stats) {
 		ctxt.stats->phys = true;
@@ -1254,15 +1336,33 @@ static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs 
 
 	prt_printf(out, "reads: ios %u/%u sectors %u/%u\n",
 		   atomic_read(&ctxt->read_ios),
-		   c->opts.move_ios_in_flight,
+		   ctxt->max_ios_in_flight,
 		   atomic_read(&ctxt->read_sectors),
-		   c->opts.move_bytes_in_flight >> 9);
+		   ctxt->max_sectors_in_flight);
 
 	prt_printf(out, "writes: ios %u/%u sectors %u/%u\n",
 		   atomic_read(&ctxt->write_ios),
-		   c->opts.move_ios_in_flight,
+		   ctxt->max_ios_in_flight,
 		   atomic_read(&ctxt->write_sectors),
-		   c->opts.move_bytes_in_flight >> 9);
+		   ctxt->max_sectors_in_flight);
+
+	prt_str(out, "limit source:\t");
+	switch (ctxt->limit_source) {
+	case MOVE_LIMITS_DEFAULT:
+		prt_str(out, "global\n");
+		break;
+	case MOVE_LIMITS_COPYGC_BUCKET:
+		prt_printf(out, "copygc bucket dev %u\n", ctxt->limit_source_id);
+		break;
+	case MOVE_LIMITS_RECONCILE_TARGET:
+		prt_str(out, "reconcile target ");
+		bch2_target_to_text(out, c, ctxt->limit_source_id);
+		prt_newline(out);
+		break;
+	case MOVE_LIMITS_PHYS_DEV:
+		prt_printf(out, "physical dev %u\n", ctxt->limit_source_id);
+		break;
+	}
 
 	guard(printbuf_indent)(out);
 

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -127,29 +127,41 @@ static bool bch2_moving_ctxt_can_submit_write(struct moving_context *ctxt,
 		  sectors <= ctxt->max_sectors_in_flight - write_sectors));
 }
 
-static bool bch2_moving_ctxt_reserve_write(struct moving_context *ctxt,
-					   struct data_update *u)
+static bool bch2_moving_ctxt_reserve_io(struct moving_context *ctxt,
+					atomic_t *sectors_in_flight,
+					atomic_t *ios_in_flight,
+					u32 sectors)
 {
-	u32 sectors = u->k.k->k.size;
 	u32 old, new;
 
-	/* Reserve the write window before submitting; check-then-add can overshoot. */
+	/* Reserve before submitting; check-then-add can overshoot under completion. */
 	do {
-		old = atomic_read(&ctxt->write_sectors);
+		old = atomic_read(sectors_in_flight);
 		if (old && (old >= ctxt->max_sectors_in_flight ||
 			    sectors > ctxt->max_sectors_in_flight - old))
 			return false;
 		new = old + sectors;
-	} while (atomic_cmpxchg(&ctxt->write_sectors, old, new) != old);
+	} while (atomic_cmpxchg(sectors_in_flight, old, new) != old);
 
 	do {
-		old = atomic_read(&ctxt->write_ios);
+		old = atomic_read(ios_in_flight);
 		if (old >= ctxt->max_ios_in_flight) {
-			atomic_sub(sectors, &ctxt->write_sectors);
+			atomic_sub(sectors, sectors_in_flight);
 			return false;
 		}
 		new = old + 1;
-	} while (atomic_cmpxchg(&ctxt->write_ios, old, new) != old);
+	} while (atomic_cmpxchg(ios_in_flight, old, new) != old);
+
+	return true;
+}
+
+static bool bch2_moving_ctxt_reserve_write(struct moving_context *ctxt,
+					   struct data_update *u)
+{
+	if (!bch2_moving_ctxt_reserve_io(ctxt,
+			&ctxt->write_sectors, &ctxt->write_ios,
+			u->k.k->k.size))
+		return false;
 
 	closure_get(&ctxt->cl);
 	return true;
@@ -338,15 +350,16 @@ static int __bch2_move_extent(struct moving_context *ctxt,
 
 	u32 size = k.k->size;
 
+	move_ctxt_wait_event(ctxt,
+		bch2_moving_ctxt_reserve_io(ctxt,
+			&ctxt->read_sectors, &ctxt->read_ios, size));
+
 	if (bucket_in_flight) {
 		u->b = bucket_in_flight;
 		atomic_inc(&u->b->count);
 	}
 
 	scoped_guard(mutex, &ctxt->lock) {
-		atomic_add(u->k.k->k.size, &ctxt->read_sectors);
-		atomic_inc(&ctxt->read_ios);
-
 		list_add_tail(&u->read_list, &ctxt->reads);
 		list_add_tail(&u->io_list, &ctxt->ios);
 

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -73,6 +73,7 @@ static void move_write_done(struct bch_write_op *op)
 
 	atomic_sub(u->k.k->k.size, &ctxt->write_sectors);
 	atomic_dec(&ctxt->write_ios);
+	wake_up(&ctxt->wait);
 
 	/*
 	 * EC allocation failed — the write never happened but the extent
@@ -103,10 +104,6 @@ static void move_write(struct data_update *u)
 				     &ctxt->stats->sectors_error_corrected);
 	}
 
-	closure_get(&ctxt->cl);
-	atomic_add(u->k.k->k.size, &ctxt->write_sectors);
-	atomic_inc(&ctxt->write_ios);
-
 	bch2_data_update_read_done(u);
 }
 
@@ -116,6 +113,53 @@ struct data_update *bch2_moving_ctxt_next_pending_write(struct moving_context *c
 		list_first_entry_or_null(&ctxt->reads, struct data_update, read_list);
 
 	return u && u->read_done ? u : NULL;
+}
+
+static bool bch2_moving_ctxt_can_submit_write(struct moving_context *ctxt,
+					      struct data_update *u)
+{
+	u32 sectors = u ? u->k.k->k.size : 0;
+	u32 write_sectors = atomic_read(&ctxt->write_sectors);
+
+	return atomic_read(&ctxt->write_ios) < ctxt->max_ios_in_flight &&
+		(!write_sectors ||
+		 (write_sectors < ctxt->max_sectors_in_flight &&
+		  sectors <= ctxt->max_sectors_in_flight - write_sectors));
+}
+
+static bool bch2_moving_ctxt_reserve_write(struct moving_context *ctxt,
+					   struct data_update *u)
+{
+	u32 sectors = u->k.k->k.size;
+	u32 old, new;
+
+	/* Reserve the write window before submitting; check-then-add can overshoot. */
+	do {
+		old = atomic_read(&ctxt->write_sectors);
+		if (old && (old >= ctxt->max_sectors_in_flight ||
+			    sectors > ctxt->max_sectors_in_flight - old))
+			return false;
+		new = old + sectors;
+	} while (atomic_cmpxchg(&ctxt->write_sectors, old, new) != old);
+
+	do {
+		old = atomic_read(&ctxt->write_ios);
+		if (old >= ctxt->max_ios_in_flight) {
+			atomic_sub(sectors, &ctxt->write_sectors);
+			return false;
+		}
+		new = old + 1;
+	} while (atomic_cmpxchg(&ctxt->write_ios, old, new) != old);
+
+	closure_get(&ctxt->cl);
+	return true;
+}
+
+bool bch2_moving_ctxt_pending_write_ready(struct moving_context *ctxt)
+{
+	struct data_update *u = bch2_moving_ctxt_next_pending_write(ctxt);
+
+	return u && bch2_moving_ctxt_can_submit_write(ctxt, u);
 }
 
 static void move_read_endio(struct bio *bio)
@@ -135,7 +179,8 @@ void bch2_moving_ctxt_do_pending_writes(struct moving_context *ctxt)
 {
 	struct data_update *u;
 
-	while ((u = bch2_moving_ctxt_next_pending_write(ctxt))) {
+	while ((u = bch2_moving_ctxt_next_pending_write(ctxt)) &&
+	       bch2_moving_ctxt_reserve_write(ctxt, u)) {
 		bch2_trans_unlock_long(ctxt->trans);
 		list_del(&u->read_list);
 		move_write(u);
@@ -198,6 +243,7 @@ void bch2_moving_ctxt_init(struct moving_context *ctxt,
 	ctxt->stats	= stats;
 	ctxt->wp	= wp;
 	ctxt->wait_on_copygc = wait_on_copygc;
+	bch2_moving_ctxt_reset_limits(ctxt);
 
 	closure_init_stack(&ctxt->cl);
 
@@ -208,6 +254,41 @@ void bch2_moving_ctxt_init(struct moving_context *ctxt,
 
 	scoped_guard(mutex, &c->moving_context_lock)
 		list_add(&ctxt->list, &c->moving_context_list);
+}
+
+#define MOVE_ROTATIONAL_BG_IOS_IN_FLIGHT	8U
+#define MOVE_ROTATIONAL_BG_BYTES_IN_FLIGHT	(1U << 20)
+
+#define MOVE_ROTATIONAL_HIPRI_IOS_IN_FLIGHT	128U
+#define MOVE_ROTATIONAL_HIPRI_BYTES_IN_FLIGHT	(16U << 20)
+
+void bch2_moving_ctxt_reset_limits(struct moving_context *ctxt)
+{
+	struct bch_fs *c = ctxt->trans->c;
+
+	ctxt->max_sectors_in_flight = c->opts.move_bytes_in_flight >> 9;
+	ctxt->max_ios_in_flight = c->opts.move_ios_in_flight;
+	ctxt->limit_source = MOVE_LIMITS_DEFAULT;
+	ctxt->limit_source_id = 0;
+}
+
+void bch2_moving_ctxt_set_rotational_limits(struct moving_context *ctxt,
+					    enum move_rotational_limit limit,
+					    enum move_limit_source source,
+					    unsigned source_id)
+{
+	u32 max_ios = limit == MOVE_ROTATIONAL_LIMIT_hipri
+		? MOVE_ROTATIONAL_HIPRI_IOS_IN_FLIGHT
+		: MOVE_ROTATIONAL_BG_IOS_IN_FLIGHT;
+	u32 max_bytes = limit == MOVE_ROTATIONAL_LIMIT_hipri
+		? MOVE_ROTATIONAL_HIPRI_BYTES_IN_FLIGHT
+		: MOVE_ROTATIONAL_BG_BYTES_IN_FLIGHT;
+
+	ctxt->max_ios_in_flight = min(ctxt->max_ios_in_flight, max_ios);
+	ctxt->max_sectors_in_flight = min(ctxt->max_sectors_in_flight,
+					  max_bytes >> 9);
+	ctxt->limit_source = source;
+	ctxt->limit_source_id = source_id;
 }
 
 void bch2_move_stats_exit(struct bch_move_stats *stats, struct bch_fs *c)
@@ -491,15 +572,11 @@ int bch2_move_ratelimit(struct moving_context *ctxt)
 		}
 	} while (delay);
 
-	/*
-	 * XXX: these limits really ought to be per device, SSDs and hard drives
-	 * will want different limits
-	 */
 	move_ctxt_wait_event(ctxt,
-		atomic_read(&ctxt->write_sectors) < c->opts.move_bytes_in_flight >> 9 &&
-		atomic_read(&ctxt->read_sectors) < c->opts.move_bytes_in_flight >> 9 &&
-		atomic_read(&ctxt->write_ios) < c->opts.move_ios_in_flight &&
-		atomic_read(&ctxt->read_ios) < c->opts.move_ios_in_flight);
+		atomic_read(&ctxt->write_sectors) < ctxt->max_sectors_in_flight &&
+		atomic_read(&ctxt->read_sectors) < ctxt->max_sectors_in_flight &&
+		atomic_read(&ctxt->write_ios) < ctxt->max_ios_in_flight &&
+		atomic_read(&ctxt->read_ios) < ctxt->max_ios_in_flight);
 
 	return 0;
 }
@@ -781,6 +858,11 @@ int bch2_move_data_phys(struct bch_fs *c,
 {
 	struct moving_context ctxt __cleanup(bch2_moving_ctxt_exit);
 	bch2_moving_ctxt_init(&ctxt, c, rate, stats, wp, wait_on_copygc);
+
+	if (bch2_dev_rotational(c, dev))
+		bch2_moving_ctxt_set_rotational_limits(&ctxt,
+				MOVE_ROTATIONAL_LIMIT_background,
+				MOVE_LIMITS_PHYS_DEV, dev);
 
 	if (ctxt.stats) {
 		ctxt.stats->phys = true;
@@ -1267,15 +1349,33 @@ static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs 
 
 	prt_printf(out, "reads: ios %u/%u sectors %u/%u\n",
 		   atomic_read(&ctxt->read_ios),
-		   c->opts.move_ios_in_flight,
+		   ctxt->max_ios_in_flight,
 		   atomic_read(&ctxt->read_sectors),
-		   c->opts.move_bytes_in_flight >> 9);
+		   ctxt->max_sectors_in_flight);
 
 	prt_printf(out, "writes: ios %u/%u sectors %u/%u\n",
 		   atomic_read(&ctxt->write_ios),
-		   c->opts.move_ios_in_flight,
+		   ctxt->max_ios_in_flight,
 		   atomic_read(&ctxt->write_sectors),
-		   c->opts.move_bytes_in_flight >> 9);
+		   ctxt->max_sectors_in_flight);
+
+	prt_str(out, "limit source:\t");
+	switch (ctxt->limit_source) {
+	case MOVE_LIMITS_DEFAULT:
+		prt_str(out, "global\n");
+		break;
+	case MOVE_LIMITS_COPYGC_BUCKET:
+		prt_printf(out, "copygc bucket dev %u\n", ctxt->limit_source_id);
+		break;
+	case MOVE_LIMITS_RECONCILE_TARGET:
+		prt_str(out, "reconcile target ");
+		bch2_target_to_text(out, c, ctxt->limit_source_id);
+		prt_newline(out);
+		break;
+	case MOVE_LIMITS_PHYS_DEV:
+		prt_printf(out, "physical dev %u\n", ctxt->limit_source_id);
+		break;
+	}
 
 	guard(printbuf_indent)(out);
 

--- a/fs/data/move.h
+++ b/fs/data/move.h
@@ -11,6 +11,13 @@
 
 struct bch_read_bio;
 
+enum move_limit_source {
+	MOVE_LIMITS_DEFAULT,
+	MOVE_LIMITS_COPYGC_BUCKET,
+	MOVE_LIMITS_RECONCILE_TARGET,
+	MOVE_LIMITS_PHYS_DEV,
+};
+
 /*
  * Tracks in-flight data movement IO for ratelimiting.
  *
@@ -19,7 +26,8 @@ struct bch_read_bio;
  *  - write_sectors/write_ios: read completion -> write completion
  *
  * bch2_move_ratelimit() blocks the caller until all counters are below
- * c->opts.move_bytes_in_flight / move_ios_in_flight.
+ * max_sectors_in_flight / max_ios_in_flight. These default to the global
+ * fs options, but callers may lower them for a slower device class.
  *
  * Extent moves (bch2_move_extent) and stripe repairs (bch2_stripe_repair)
  * both account through these counters.
@@ -37,6 +45,11 @@ struct moving_context {
 	struct bch_move_stats	*stats;
 	struct write_point_specifier wp;
 	bool			wait_on_copygc;
+
+	unsigned		max_sectors_in_flight;
+	unsigned		max_ios_in_flight;
+	enum move_limit_source	limit_source;
+	unsigned		limit_source_id;
 
 	/* For waiting on outstanding reads and writes: */
 	struct closure		cl;
@@ -66,7 +79,7 @@ struct moving_context {
 			break;							\
 		bch2_trans_unlock_long((_ctxt)->trans);				\
 		_ret = __wait_event_timeout((_ctxt)->wait,			\
-			     bch2_moving_ctxt_next_pending_write(_ctxt) ||	\
+			     bch2_moving_ctxt_pending_write_ready(_ctxt) ||	\
 			     (cond_finished = (_cond)), _timeout);		\
 		if (_ret || ( cond_finished))					\
 			break;							\
@@ -83,7 +96,7 @@ do {									\
 		break;							\
 	bch2_trans_unlock_long((_ctxt)->trans);				\
 	__wait_event((_ctxt)->wait,					\
-		     bch2_moving_ctxt_next_pending_write(_ctxt) ||	\
+		     bch2_moving_ctxt_pending_write_ready(_ctxt) ||	\
 		     (cond_finished = (_cond)));			\
 	if (cond_finished)						\
 		break;							\
@@ -98,7 +111,16 @@ void bch2_moving_ctxt_exit(struct moving_context *);
 void bch2_moving_ctxt_init(struct moving_context *, struct bch_fs *,
 			   struct bch_ratelimit *, struct bch_move_stats *,
 			   struct write_point_specifier, bool);
+void bch2_moving_ctxt_reset_limits(struct moving_context *);
+enum move_rotational_limit {
+	MOVE_ROTATIONAL_LIMIT_background,
+	MOVE_ROTATIONAL_LIMIT_hipri,
+};
+void bch2_moving_ctxt_set_rotational_limits(struct moving_context *,
+					    enum move_rotational_limit,
+					    enum move_limit_source, unsigned);
 struct data_update *bch2_moving_ctxt_next_pending_write(struct moving_context *);
+bool bch2_moving_ctxt_pending_write_ready(struct moving_context *);
 void bch2_moving_ctxt_do_pending_writes(struct moving_context *);
 void bch2_moving_ctxt_flush_all(struct moving_context *);
 void bch2_move_ctxt_wait_for_io(struct moving_context *);

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -789,6 +789,47 @@ static bool stripe_retry_must_wait(struct moving_context *ctxt,
 	return u && u->io_seq <= stripe_io_seq;
 }
 
+static bool reconcile_target_has_rotational(struct bch_fs *c,
+					    struct bch_inode_opts *opts,
+					    struct data_update_opts *data_opts,
+					    unsigned *target_ret)
+{
+	unsigned target = data_opts->target ?:
+		opts->background_target ?:
+		opts->foreground_target;
+	struct bch_devs_mask devs = target_rw_devs(c, BCH_DATA_user, target);
+	bool ret = false;
+
+	guard(rcu)();
+	for_each_member_device_rcu(c, ca, &devs)
+		if (bch2_dev_rotational(c, ca->dev_idx)) {
+			ret = true;
+			break;
+		}
+
+	*target_ret = target;
+	return ret;
+}
+
+static void reconcile_set_move_limits(struct moving_context *ctxt,
+				      struct bch_inode_opts *opts,
+				      struct data_update_opts *data_opts,
+				      struct bbpos work)
+{
+	struct bch_fs *c = ctxt->trans->c;
+	unsigned target;
+
+	if (!reconcile_target_has_rotational(c, opts, data_opts, &target))
+		return;
+
+	bch2_moving_ctxt_set_rotational_limits(ctxt,
+		work.btree == BTREE_ID_reconcile_hipri ||
+		work.btree == BTREE_ID_reconcile_hipri_phys
+		? MOVE_ROTATIONAL_LIMIT_hipri
+		: MOVE_ROTATIONAL_LIMIT_background,
+		MOVE_LIMITS_RECONCILE_TARGET, target);
+}
+
 static int do_retry_stripe(struct moving_context *ctxt, u64 idx)
 {
 	struct btree_trans *trans = ctxt->trans;
@@ -827,6 +868,8 @@ static int __do_reconcile_extent(struct moving_context *ctxt,
 				 struct bkey_s_c k,
 				 darray_stripe_retry *stripe_retry)
 {
+	bch2_moving_ctxt_reset_limits(ctxt);
+
 	if (k.k->type == KEY_TYPE_stripe)
 		return do_reconcile_stripe(ctxt, iter, k, stripe_retry);
 
@@ -849,6 +892,8 @@ static int __do_reconcile_extent(struct moving_context *ctxt,
 	int ret = reconcile_set_data_opts(trans, iter, level, k, opts, data_opts);
 	if (ret <= 0)
 		return ret;
+
+	reconcile_set_move_limits(ctxt, opts, data_opts, work);
 
 	if (work.btree == BTREE_ID_reconcile_pending) {
 		int ret = bch2_can_do_data_update(trans, opts, data_opts, k, NULL);

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -795,6 +795,47 @@ static bool stripe_retry_must_wait(struct moving_context *ctxt,
 	return u && u->io_seq <= stripe_io_seq;
 }
 
+static bool reconcile_target_has_rotational(struct bch_fs *c,
+					    struct bch_inode_opts *opts,
+					    struct data_update_opts *data_opts,
+					    unsigned *target_ret)
+{
+	unsigned target = data_opts->target ?:
+		opts->background_target ?:
+		opts->foreground_target;
+	struct bch_devs_mask devs = target_rw_devs(c, BCH_DATA_user, target);
+	bool ret = false;
+
+	guard(rcu)();
+	for_each_member_device_rcu(c, ca, &devs)
+		if (bch2_dev_rotational(c, ca->dev_idx)) {
+			ret = true;
+			break;
+		}
+
+	*target_ret = target;
+	return ret;
+}
+
+static void reconcile_set_move_limits(struct moving_context *ctxt,
+				      struct bch_inode_opts *opts,
+				      struct data_update_opts *data_opts,
+				      struct bbpos work)
+{
+	struct bch_fs *c = ctxt->trans->c;
+	unsigned target;
+
+	if (!reconcile_target_has_rotational(c, opts, data_opts, &target))
+		return;
+
+	bch2_moving_ctxt_set_rotational_limits(ctxt,
+		work.btree == BTREE_ID_reconcile_hipri ||
+		work.btree == BTREE_ID_reconcile_hipri_phys
+		? MOVE_ROTATIONAL_LIMIT_hipri
+		: MOVE_ROTATIONAL_LIMIT_background,
+		MOVE_LIMITS_RECONCILE_TARGET, target);
+}
+
 static int do_retry_stripe(struct moving_context *ctxt, u64 idx)
 {
 	struct btree_trans *trans = ctxt->trans;
@@ -833,6 +874,8 @@ static int __do_reconcile_extent(struct moving_context *ctxt,
 				 struct bkey_s_c k,
 				 darray_stripe_retry *stripe_retry)
 {
+	bch2_moving_ctxt_reset_limits(ctxt);
+
 	if (k.k->type == KEY_TYPE_stripe)
 		return do_reconcile_stripe(ctxt, iter, k, stripe_retry);
 
@@ -873,6 +916,8 @@ static int __do_reconcile_extent(struct moving_context *ctxt,
 	int ret = reconcile_set_data_opts(trans, iter, level, k, opts, data_opts);
 	if (ret <= 0)
 		return ret;
+
+	reconcile_set_move_limits(ctxt, opts, data_opts, work);
 
 	if (work.btree == BTREE_ID_reconcile_pending) {
 		int ret = bch2_can_do_data_update(trans, opts, data_opts, k, NULL);

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -795,26 +795,16 @@ static bool stripe_retry_must_wait(struct moving_context *ctxt,
 	return u && u->io_seq <= stripe_io_seq;
 }
 
-static bool reconcile_target_has_rotational(struct bch_fs *c,
-					    struct bch_inode_opts *opts,
-					    struct data_update_opts *data_opts,
-					    unsigned *target_ret)
+static bool reconcile_target_has_rotational(struct bch_fs *c, unsigned target)
 {
-	unsigned target = data_opts->target ?:
-		opts->background_target ?:
-		opts->foreground_target;
 	struct bch_devs_mask devs = target_rw_devs(c, BCH_DATA_user, target);
-	bool ret = false;
 
 	guard(rcu)();
 	for_each_member_device_rcu(c, ca, &devs)
-		if (bch2_dev_rotational(c, ca->dev_idx)) {
-			ret = true;
-			break;
-		}
+		if (bch2_dev_rotational(c, ca->dev_idx))
+			return true;
 
-	*target_ret = target;
-	return ret;
+	return false;
 }
 
 static void reconcile_set_move_limits(struct moving_context *ctxt,
@@ -823,9 +813,11 @@ static void reconcile_set_move_limits(struct moving_context *ctxt,
 				      struct bbpos work)
 {
 	struct bch_fs *c = ctxt->trans->c;
-	unsigned target;
+	unsigned target = data_opts->target ?:
+		opts->background_target ?:
+		opts->foreground_target;
 
-	if (!reconcile_target_has_rotational(c, opts, data_opts, &target))
+	if (!reconcile_target_has_rotational(c, target))
 		return;
 
 	bch2_moving_ctxt_set_rotational_limits(ctxt,
@@ -834,6 +826,22 @@ static void reconcile_set_move_limits(struct moving_context *ctxt,
 		? MOVE_ROTATIONAL_LIMIT_hipri
 		: MOVE_ROTATIONAL_LIMIT_background,
 		MOVE_LIMITS_RECONCILE_TARGET, target);
+}
+
+static void reconcile_scan_set_move_limits(struct moving_context *ctxt)
+{
+	struct bch_fs *c = ctxt->trans->c;
+	struct bch_inode_opts opts;
+
+	bch2_inode_opts_get(c, &opts, false);
+
+	unsigned target = opts.background_target ?: opts.foreground_target;
+
+	if (reconcile_target_has_rotational(c, target))
+		bch2_moving_ctxt_set_rotational_limits(ctxt,
+			MOVE_ROTATIONAL_LIMIT_background,
+			MOVE_LIMITS_RECONCILE_TARGET,
+			target);
 }
 
 static int do_retry_stripe(struct moving_context *ctxt, u64 idx)
@@ -1365,6 +1373,8 @@ static int do_reconcile_scan(struct moving_context *ctxt,
 
 	bch2_move_stats_init(&r->scan_stats, "reconcile_scan");
 	ctxt->stats = &r->scan_stats;
+	bch2_moving_ctxt_reset_limits(ctxt);
+	reconcile_scan_set_move_limits(ctxt);
 
 	struct reconcile_scan s = reconcile_scan_decode(c, cookie_pos.offset);
 	if (s.type == RECONCILE_SCAN_fs) {


### PR DESCRIPTION
## Summary

Background movement can submit enough concurrent IO to a rotational source or
target to make the rest of the filesystem look wedged behind journal and btree
flushes. Limit move read/write windows per moving context when the active
copygc bucket or reconcile target is rotational, while keeping the existing
global limits as the upper bound.

The series also reserves move windows before submit. That keeps the debugfs
`moving_ctxts` counters and the actual submitted IO from racing past the
reported maximum under concurrent completions.

## Validation

- `koverstreet/ktest#74` adds `rotational_target_move_window`.
- `rotational_target_move_window` passes in a local VM on the patched kernel:
  `PASSED rotational_target_move_window` and `TEST SUCCESS`.
- The passing `moving_ctxts` snapshots showed:
  - `reconcile_scan` limited to `8 ios / 2048 sectors`, source
    `reconcile target dst`
  - `reconcile_work` limited to `8 ios / 2048 sectors`, source
    `reconcile target dst`
- GitHub Actions for this PR are green:
  https://github.com/koverstreet/bcachefs-tools/actions/runs/31888510962

## Notes

This is intentionally scoped to move/reconcile/copygc IO window accounting.
It does not change allocator target selection policy.

