### PR TITLE
docs: clarify encrypted master key storage

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -205,7 +205,7 @@ Sets both data and metadata replicas
 Enable whole filesystem encryption (chacha20/poly1305);
 passphrase will be prompted for.
 .It Fl -no_passphrase
-Don't encrypt master encryption key
+Store master encryption key unencrypted in superblock
 .It Fl L , Fl -fs_label Ns = Ns Ar label
 Create the filesystem with the specified
 .Ar label
@@ -561,7 +561,7 @@ Root of filesystem to migrate
 .It Fl -encrypted
 Enable whole filesystem encryption (chacha20/poly1305)
 .It Fl -no_passphrase
-Don't encrypt master encryption key
+Store master encryption key unencrypted in superblock
 .It Fl F
 Force, even if metadata file already exists
 .El

--- a/doc/bcachefs.5.rst.tmpl
+++ b/doc/bcachefs.5.rst.tmpl
@@ -38,6 +38,21 @@ OPTIONS
 -------
 OPTIONS_TABLE
 
+Encryption key storage
+----------------------
+
+When a filesystem is formatted with ``--encrypted``, bcachefs creates a random
+master key for encrypting filesystem data and metadata. By default that master
+key is stored in the superblock encrypted by a key derived from the passphrase;
+unlocking supplies the passphrase-derived key to the kernel keyring so the
+kernel can decrypt the stored master key.
+
+The ``--no_passphrase`` option does not create a detached or externally supplied
+master key. It stores the master key unencrypted in the superblock, which allows
+the filesystem to use encryption-format metadata without requiring an unlock
+secret. Detached raw master-key storage would require a different unlock and
+superblock contract.
+
 Device management
 -----------------
 Devices can be added, removed, and resized at will, at runtime. There is no

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -78,7 +78,7 @@ Options:
       --replicas=#             Sets both data and metadata replicas
       --encrypted              Enable whole filesystem encryption (chacha20/poly1305)
       --passphrase_file=file   File containing passphrase used for encryption/decryption
-      --no_passphrase          Don't encrypt master encryption key
+      --no_passphrase          Store master encryption key unencrypted in superblock
   -L, --fs_label=label
   -U, --uuid=uuid
       --superblock_size=size

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -725,7 +725,7 @@ Options:
       --replicas=#             Sets both data and metadata replicas
       --encrypted              Enable whole filesystem encryption (chacha20/poly1305)
       --passphrase_file=file   File containing passphrase used for encryption/decryption
-      --no_passphrase          Don't encrypt master encryption key
+      --no_passphrase          Store master encryption key unencrypted in superblock
   -L, --fs_label=label
   -U, --uuid=uuid
       --superblock_size=size

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -302,7 +302,7 @@ Usage: bcachefs migrate [OPTION]...
 Options:
   -f fs                        Root of filesystem to migrate(s)
       --encrypted              Enable whole filesystem encryption (chacha20/poly1305)
-      --no_passphrase          Don't encrypt master encryption key
+      --no_passphrase          Store master encryption key unencrypted in superblock
   -F                           Force, even if metadata file already exists
   -h, --help                   Display this help and exit
 


### PR DESCRIPTION
## Summary

Clarify current bcachefs encryption key storage behavior:

- `--encrypted` creates a random master key and stores it in the superblock encrypted by a passphrase-derived key.
- `--no_passphrase` does not mean detached or externally supplied master-key storage; it stores the master key unencrypted in the superblock.
- true detached raw master-key storage would need a different unlock/superblock contract.

This addresses the current-state question in koverstreet/bcachefs#808 without pretending the requested detached-key feature is implemented.

## Testing

- `git diff --check`
- `python3 -m py_compile doc/macro2rst.py`
- `rst2man --halt=2 doc/bcachefs.5.rst.tmpl /tmp/bcachefs.5.encryption-docs.man`

`rustfmt --check src/commands/format.rs src/commands/image.rs src/commands/migrate.rs` was also tried, but it wants existing whole-file style churn in these files. This patch only changes help strings in those Rust files, so I left the unrelated rustfmt churn out.

## Related

- koverstreet/bcachefs#808
