### PR TITLE
docs: explain filesystem label updates

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -209,6 +209,11 @@ Don't encrypt master encryption key
 .It Fl L , Fl -fs_label Ns = Ns Ar label
 Create the filesystem with the specified
 .Ar label
+This is the filesystem label, distinct from per-device labels used for target
+selection. On a mounted filesystem it can be changed by tools that issue the
+standard Linux
+.Dv FS_IOC_SETFSLABEL
+ioctl.
 .It Fl U , Fl -uuid Ns = Ns Ar uuid
 Create the filesystem with the specified
 .Ar uuid

--- a/doc/bcachefs.5.rst.tmpl
+++ b/doc/bcachefs.5.rst.tmpl
@@ -38,6 +38,18 @@ OPTIONS
 -------
 OPTIONS_TABLE
 
+Filesystem label
+----------------
+
+The filesystem label is set at format time with ``--fs_label``/``-L``. It is
+separate from per-device labels used for target selection, such as
+``foreground_target=ssd`` or ``--label=ssd`` on an individual device.
+
+On a mounted filesystem, the filesystem label can be changed through the
+standard Linux ``FS_IOC_SETFSLABEL`` ioctl, and read through
+``FS_IOC_GETFSLABEL``. Tools that issue those ioctls operate on the filesystem
+label, not the per-device target labels.
+
 Device management
 -----------------
 Devices can be added, removed, and resized at will, at runtime. There is no


### PR DESCRIPTION
## Summary

Document the difference between:

- the filesystem label, set at format time with `--fs_label`/`-L`; and
- per-device labels used for target selection, such as `--label=ssd` and `foreground_target=ssd`.

The manual now also notes that a mounted filesystem label is handled through the standard Linux `FS_IOC_SETFSLABEL` / `FS_IOC_GETFSLABEL` ioctls. This addresses the confusion in koverstreet/bcachefs#933 without adding a new bcachefs-specific wrapper command for an existing standard ioctl.

## Testing

- `git diff --check`
- `python3 -m py_compile doc/macro2rst.py`
- `rst2man --halt=2 doc/bcachefs.5.rst.tmpl /tmp/bcachefs.5.fs-label-docs.man`

`mandoc -Tlint bcachefs.8` was not run because `mandoc` is not installed on this host.

## Related

- koverstreet/bcachefs#933
