### PR TITLE
bcachefs: cap estimated progress percentages

### DIFF
--- a/fs/init/progress.c
+++ b/fs/init/progress.c
@@ -101,6 +101,14 @@ __cold void bch2_progress_to_text(struct printbuf *out, struct progress_indicato
 	unsigned percent = s->nodes_total
 		? div64_u64(s->nodes_seen * 100, s->nodes_total)
 		: 0;
+
+	/*
+	 * nodes_total is an estimate from accounting, and scans may rescan or
+	 * rewrite nodes while running. Keep the raw counters visible, but don't
+	 * print impossible percentages.
+	 */
+	percent = min(percent, 100U);
+
 	prt_printf(out, "%d%%, done %llu/%llu nodes, at ",
 		   percent, s->nodes_seen, s->nodes_total);
 	bch2_bbpos_to_text(out, s->pos);


### PR DESCRIPTION
## Summary

Progress indicators derive `nodes_total` from btree accounting, so it is an estimate rather than a hard upper bound. Device-removal metadata scans can rescan or rewrite nodes while they run, and old field reports showed messages like `dropping metadata: 285%`.

Keep the raw `done current/estimated nodes` counters visible, but cap the displayed percentage at 100 so the log line does not show impossible progress.

Related: https://github.com/koverstreet/bcachefs/issues/953

## Validation

- `git diff --check`
- `make -j32 fs/init/progress.o`

I also tried to run `./scripts/checkpatch.pl --strict ...`, but this `bcachefs-tools` checkout does not contain `scripts/checkpatch.pl`.
