### PR TITLE
debug: include coordinates in sector underflow logs

### DIFF
--- a/fs/data/write.c
+++ b/fs/data/write.c
@@ -908,8 +908,9 @@ static void bi_sectors_underflow(struct btree_trans *trans,
 	s64 bi_sectors = le64_to_cpu(inode->v.bi_sectors);
 
 	CLASS(bch_log_msg, msg)(trans->c);
-	prt_printf(&msg.m, "inode %llu i_sectors underflow: %lli + %lli < 0",
-		   inode->k.p.offset, bi_sectors, *i_sectors_delta);
+	prt_printf(&msg.m, "inode %llu snapshot %u i_sectors underflow: %lli + %lli < 0",
+		   inode->k.p.offset, inode->k.p.snapshot,
+		   bi_sectors, *i_sectors_delta);
 
 	msg.m.suppress = !bch2_count_fsck_err(trans->c, inode_i_sectors_underflow, &msg.m);
 

--- a/fs/vfs/io.c
+++ b/fs/vfs/io.c
@@ -144,8 +144,9 @@ void __bch2_i_sectors_acct(struct bch_fs *c, struct bch_inode_info *inode,
 {
 	if (unlikely((s64) inode->v.i_blocks + sectors < 0)) {
 		CLASS(bch_log_msg, msg)(c);
-		prt_printf(&msg.m, "inode %llu i_blocks underflow: %llu + %lli < 0 (ondisk %lli)",
-			   (u64) inode->v.i_ino, (u64) inode->v.i_blocks, sectors,
+		prt_printf(&msg.m, "subvol %llu inode %llu i_blocks underflow: %llu + %lli < 0 (ondisk %lli)",
+			   (u64) inode->ei_inum.subvol, (u64) inode->v.i_ino,
+			   (u64) inode->v.i_blocks, sectors,
 			   inode->ei_inode.bi_sectors);
 
 		msg.m.suppress = !bch2_count_fsck_err(c, vfs_inode_i_blocks_underflow, &msg.m);


### PR DESCRIPTION
## Summary

When inode sector accounting underflows, include the snapshot id in the
`i_sectors` warning and the subvolume id in the VFS `i_blocks` warning.

This is intended to make reports like koverstreet/bcachefs#984 easier to
triage: the visible symptom can repeat for the same inode number, and the
missing snapshot/subvolume coordinate makes it harder to tell whether the
same logical file/inode state is being updated or whether different snapshot
views are involved.

## Testing

- `git diff --check`
- `make -j32 fs/data/write.o fs/vfs/io.o`
