### PR TITLE
set_uuid: add offline filesystem UUID setter

### DIFF
--- a/doc/bcachefs.5.rst.tmpl
+++ b/doc/bcachefs.5.rst.tmpl
@@ -34,6 +34,20 @@ command (which internally mostly works via the extended attribute interface, but
 the set-file-option command takes care to propagate options to children
 correctly).
 
+Filesystem UUIDs
+----------------
+Bcachefs superblocks have both an internal UUID and a user-visible filesystem
+UUID. The user-visible UUID is reported by blkid and is used for ``UUID=``
+mounts; it can be selected at format time with ``bcachefs format --uuid`` and
+changed later, while the filesystem is unmounted, with:
+
+.. code-block:: bash
+
+  bcachefs set-fs-uuid <new-uuid> <device>
+
+For multi-device filesystems, all member devices must be present so every
+member superblock can be updated together. The internal UUID is not changed.
+
 OPTIONS
 -------
 OPTIONS_TABLE

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -95,6 +95,7 @@ pub mod reconcile;
 pub mod recover_super;
 pub mod recovery_pass;
 pub mod scrub;
+pub mod set_uuid;
 pub mod set_option;
 pub mod strip_alloc;
 pub mod subvolume;
@@ -202,7 +203,7 @@ static VERSION_CMD: CmdDef = {
 pub const COMMAND_GROUPS: &[GroupDef] = &[
     GroupDef { heading: "Superblock commands", commands: &[
         &format::CMD, &super_cmd::CMD, &recover_super::CMD,
-        &set_option::CMD, &counters::CMD, &strip_alloc::CMD,
+        &set_option::CMD, &set_uuid::CMD, &counters::CMD, &strip_alloc::CMD,
     ]},
     GroupDef { heading: "Images",                   commands: &[&image::CMD] },
     GroupDef { heading: "Mount",                    commands: &[&mount::CMD, &fusemount::CMD, &wait_devices::CMD] },

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -114,6 +114,7 @@ pub mod reconcile;
 pub mod recover_super;
 pub mod recovery_pass;
 pub mod scrub;
+pub mod set_uuid;
 pub mod set_option;
 pub mod strip_alloc;
 pub mod subvolume;
@@ -234,7 +235,7 @@ static VERSION_CMD: CmdDef = {
 pub const COMMAND_GROUPS: &[GroupDef] = &[
     GroupDef { heading: "Superblock commands", commands: &[
         &format::CMD, &super_cmd::CMD, &recover_super::CMD,
-        &set_option::CMD, &counters::CMD, &strip_alloc::CMD,
+        &set_option::CMD, &set_uuid::CMD, &counters::CMD, &strip_alloc::CMD,
     ]},
     GroupDef { heading: "Images",                   commands: &[&image::CMD] },
     GroupDef { heading: "Mount",                    commands: &[

--- a/src/commands/set_uuid.rs
+++ b/src/commands/set_uuid.rs
@@ -1,0 +1,80 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use bch_bindgen::fs::FsExt;
+use bcachefs_kernel::{c, opt_set};
+use bcachefs_kernel::fs::Fs;
+use clap::Parser;
+use uuid::Uuid;
+
+use crate::wrappers::sysfs;
+
+#[derive(Parser, Debug)]
+#[command(about = "Set the user-visible filesystem UUID on an unmounted filesystem")]
+pub struct Cli {
+    /// New user-visible filesystem UUID, as reported by blkid and UUID= mounts
+    uuid: Uuid,
+
+    /// Any member device path, or an explicit colon-separated member list
+    device: String,
+}
+
+fn cmd_set_fs_uuid(cli: Cli) -> Result<()> {
+    if cli.uuid == Uuid::nil() {
+        bail!("refusing to set nil filesystem UUID");
+    }
+
+    let scan_opts = c::bch_opts::default();
+    let mut sbs = crate::device_scan::scan_sbs(&cli.device, &scan_opts)
+        .context("scanning filesystem devices")?;
+
+    if sbs.is_empty() && !cli.device.contains(':') && !cli.device.contains('=') {
+        if let Ok(sb) = crate::device_scan::read_super_silent(Path::new(&cli.device), scan_opts) {
+            sbs.push((PathBuf::from(&cli.device), sb));
+        }
+    }
+
+    if sbs.is_empty() {
+        bail!("no bcachefs superblocks found");
+    }
+
+    let old_uuid = sbs[0].1.sb().uuid();
+    let expected = sbs[0].1.sb().number_of_devices() as usize;
+    if sbs.iter().any(|(_, sb)| sb.sb().uuid() != old_uuid) {
+        bail!("not all supplied devices belong to the same filesystem");
+    }
+    if sbs.len() != expected {
+        bail!(
+            "refusing to change UUID with {}/{} member devices present; pass all members explicitly",
+            sbs.len(),
+            expected,
+        );
+    }
+    if old_uuid == cli.uuid {
+        bail!("filesystem already has UUID {}", cli.uuid);
+    }
+
+    let devs: Vec<PathBuf> = sbs.into_iter().map(|(p, _)| p).collect();
+    for dev in &devs {
+        if sysfs::dev_mounted(&dev.to_string_lossy()) {
+            bail!("{} is mounted; set-fs-uuid only operates offline", dev.display());
+        }
+    }
+
+    let mut fs_opts = c::bch_opts::default();
+    opt_set!(fs_opts, nostart, 1);
+
+    let fs = Fs::open(&devs, fs_opts).context("opening filesystem offline")?;
+
+    {
+        let _lock = fs.sb_lock();
+        let disk_sb = unsafe { fs.disk_sb_mut() };
+        disk_sb.sb_mut().user_uuid.b = *cli.uuid.as_bytes();
+        fs.write_super_ret().context("writing updated superblock")?;
+    }
+
+    println!("Changed filesystem UUID from {} to {}", old_uuid, cli.uuid);
+    Ok(())
+}
+
+pub const CMD: super::CmdDef = typed_cmd!("set-fs-uuid", "Set filesystem UUID", Cli, cmd_set_fs_uuid);

--- a/src/commands/set_uuid.rs
+++ b/src/commands/set_uuid.rs
@@ -1,0 +1,81 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use bch_bindgen::fs::FsExt;
+use bcachefs_kernel::{c, opt_set};
+use bcachefs_kernel::fs::Fs;
+use clap::Parser;
+use uuid::Uuid;
+
+use crate::wrappers::handle::BcachefsHandle;
+
+#[derive(Parser, Debug)]
+#[command(about = "Set the user-visible filesystem UUID on an unmounted filesystem")]
+pub struct Cli {
+    /// New user-visible filesystem UUID, as reported by blkid and UUID= mounts
+    uuid: Uuid,
+
+    /// Any member device path, or an explicit colon-separated member list
+    device: String,
+}
+
+fn cmd_set_fs_uuid(cli: Cli) -> Result<()> {
+    if cli.uuid == Uuid::nil() {
+        bail!("refusing to set nil filesystem UUID");
+    }
+
+    let scan_opts = c::bch_opts::default();
+    let mut sbs = crate::device_scan::scan_sbs(&cli.device, &scan_opts)
+        .context("scanning filesystem devices")?;
+
+    if sbs.is_empty() && !cli.device.contains(':') && !cli.device.contains('=') {
+        if let Ok(sb) = crate::device_scan::read_super_silent(Path::new(&cli.device), scan_opts) {
+            sbs.push((PathBuf::from(&cli.device), sb));
+        }
+    }
+
+    if sbs.is_empty() {
+        bail!("no bcachefs superblocks found");
+    }
+
+    let old_uuid = sbs[0].1.sb().uuid();
+    let expected = sbs[0].1.sb().number_of_devices() as usize;
+    if sbs.iter().any(|(_, sb)| sb.sb().uuid() != old_uuid) {
+        bail!("not all supplied devices belong to the same filesystem");
+    }
+    if sbs.len() != expected {
+        bail!(
+            "refusing to change UUID with {}/{} member devices present; pass all members explicitly",
+            sbs.len(),
+            expected,
+        );
+    }
+    if old_uuid == cli.uuid {
+        bail!("filesystem already has UUID {}", cli.uuid);
+    }
+
+    let devs: Vec<PathBuf> = sbs.into_iter().map(|(p, _)| p).collect();
+    if BcachefsHandle::open_if_mounted_any(&devs)
+        .context("checking whether filesystem is mounted")?
+        .is_some()
+    {
+        bail!("filesystem is mounted; set-fs-uuid only operates offline");
+    }
+
+    let mut fs_opts = c::bch_opts::default();
+    opt_set!(fs_opts, nostart, 1);
+
+    let fs = Fs::open(&devs, fs_opts).context("opening filesystem offline")?;
+
+    {
+        let _lock = fs.sb_lock();
+        let disk_sb = unsafe { fs.disk_sb_mut() };
+        disk_sb.sb_mut().user_uuid.b = *cli.uuid.as_bytes();
+        fs.write_super_ret().context("writing updated superblock")?;
+    }
+
+    println!("Changed filesystem UUID from {} to {}", old_uuid, cli.uuid);
+    Ok(())
+}
+
+pub const CMD: super::CmdDef = typed_cmd!("set-fs-uuid", "Set filesystem UUID", Cli, cmd_set_fs_uuid);


### PR DESCRIPTION
Add `bcachefs set-fs-uuid <new-uuid> <device>` to change the user-visible filesystem UUID (superblock user_uuid) after format time, without touching the internal UUID. Refuses the nil UUID, mounted devices, and partial member sets. Manual page documents the internal/external UUID distinction.

Fixes koverstreet/bcachefs#989.

Tested on disposable single- and two-device images: set-fs-uuid changes the external UUID reported by show-super while the internal UUID stays fixed; a partial member list is refused with a clear device count.

Re-verified on a fresh single-device loop image after rebase: `format --uuid=1111...` -> `show-super` (external `1111...`, internal `ebafeb8b-...`) -> `set-fs-uuid 2222...` -> `show-super` (external `2222...`, internal unchanged). Also fixes the `msrv` CI failure: the mounted-device check called a `sysfs::dev_mounted()` that never existed in this tree; it now reuses `BcachefsHandle::open_if_mounted_any()`, the same mount check `open_online_or_offline()` and `set-fs-option` already use.
