### PR TITLE
reconcile: fan out phys write points

### DIFF
--- a/fs/data/reconcile/types.h
+++ b/fs/data/reconcile/types.h
@@ -22,6 +22,9 @@ struct bch_fs_reconcile {
 	struct bbpos			work_pos;
 	struct bch_move_stats		work_stats;
 	struct progress_indicator	progress;
+	u64				phys_workers_considered;
+	u64				phys_workers_started;
+	u64				phys_worker_writepoints_distinct;
 
 	struct bbpos			scan_start;
 	struct bbpos			scan_end;

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1412,6 +1412,12 @@ typedef struct {
 
 DEFINE_DARRAY(reconcile_phys_thr);
 
+static struct write_point_specifier reconcile_phys_writepoint(reconcile_phys_thr *thr)
+{
+	return writepoint_hashed(((unsigned long) thr->reconcile_phase << 32) |
+				 ((unsigned long) thr->dev << 1));
+}
+
 /*
  * Destructor ordering: closure_return() must be the last thing before the
  * function returns, but __cleanup destructors run after closure_return()
@@ -1431,7 +1437,7 @@ static CLOSURE_CALLBACK(do_reconcile_phys_thread)
 
 	struct moving_context ctxt;
 	bch2_moving_ctxt_init(&ctxt, c, NULL, &thr->stats,
-			      writepoint_ptr(&c->allocator.reconcile_write_point),
+			      reconcile_phys_writepoint(thr),
 			      true);
 
 	struct btree_trans *trans = ctxt.trans;
@@ -1483,17 +1489,41 @@ static CLOSURE_CALLBACK(do_reconcile_phys_thread)
 
 static int do_reconcile_phys(struct bch_fs *c, unsigned reconcile_phase)
 {
+	struct bch_fs_reconcile *r = &c->reconcile;
 	CLASS(darray_reconcile_phys_thr, thrs)();
 	CLASS(closure_stack, cl)();
+	u64 considered = 0, started = 0, writepoints_distinct = 0;
 
-	for_each_member_device(c, ca)
+	for_each_member_device(c, ca) {
 		if (ca->mi.rotational &&
-		    bch2_dev_is_online(ca))
+		    bch2_dev_is_online(ca)) {
+			considered++;
 			try(darray_push(&thrs, ((reconcile_phys_thr) {
 						.c			= c,
 						.dev			= ca->dev_idx,
 						.reconcile_phase	= reconcile_phase,
 						})));
+			started++;
+		}
+	}
+
+	darray_for_each(thrs, i) {
+		struct write_point_specifier wp = reconcile_phys_writepoint(i);
+		bool seen = false;
+
+		for (reconcile_phys_thr *j = thrs.data; j < i; j++)
+			if (reconcile_phys_writepoint(j).v == wp.v) {
+				seen = true;
+				break;
+			}
+
+		if (!seen)
+			writepoints_distinct++;
+	}
+
+	WRITE_ONCE(r->phys_workers_considered, considered);
+	WRITE_ONCE(r->phys_workers_started, started);
+	WRITE_ONCE(r->phys_worker_writepoints_distinct, writepoints_distinct);
 
 	darray_for_each(thrs, i)
 		closure_call(&i->cl, do_reconcile_phys_thread, system_unbound_wq, &cl);
@@ -1903,6 +1933,11 @@ __cold void bch2_reconcile_status_to_text(struct printbuf *out, struct bch_fs *c
 			}
 		}
 	}
+
+	prt_printf(out, "phys workers last phase: considered %llu started %llu distinct writepoints %llu\n",
+		   READ_ONCE(r->phys_workers_considered),
+		   READ_ONCE(r->phys_workers_started),
+		   READ_ONCE(r->phys_worker_writepoints_distinct));
 
 	struct task_struct *t;
 	scoped_guard(rcu) {

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1456,6 +1456,12 @@ typedef struct {
 
 DEFINE_DARRAY(reconcile_phys_thr);
 
+static struct write_point_specifier reconcile_phys_writepoint(reconcile_phys_thr *thr)
+{
+	return writepoint_hashed(((unsigned long) thr->reconcile_phase << 32) |
+				 ((unsigned long) thr->dev << 1));
+}
+
 /*
  * Destructor ordering: closure_return() must be the last thing before the
  * function returns, but __cleanup destructors run after closure_return()
@@ -1475,7 +1481,7 @@ static CLOSURE_CALLBACK(do_reconcile_phys_thread)
 
 	struct moving_context ctxt;
 	bch2_moving_ctxt_init(&ctxt, c, NULL, &thr->stats,
-			      writepoint_ptr(&c->allocator.reconcile_write_point),
+			      reconcile_phys_writepoint(thr),
 			      true);
 
 	struct btree_trans *trans = ctxt.trans;
@@ -1527,17 +1533,41 @@ static CLOSURE_CALLBACK(do_reconcile_phys_thread)
 
 static int do_reconcile_phys(struct bch_fs *c, unsigned reconcile_phase)
 {
+	struct bch_fs_reconcile *r = &c->reconcile;
 	CLASS(darray_reconcile_phys_thr, thrs)();
 	CLASS(closure_stack, cl)();
+	u64 considered = 0, started = 0, writepoints_distinct = 0;
 
-	for_each_member_device(c, ca)
+	for_each_member_device(c, ca) {
 		if (ca->mi.rotational &&
-		    bch2_dev_is_online(ca))
+		    bch2_dev_is_online(ca)) {
+			considered++;
 			try(darray_push(&thrs, ((reconcile_phys_thr) {
 						.c			= c,
 						.dev			= ca->dev_idx,
 						.reconcile_phase	= reconcile_phase,
 						})));
+			started++;
+		}
+	}
+
+	darray_for_each(thrs, i) {
+		struct write_point_specifier wp = reconcile_phys_writepoint(i);
+		bool seen = false;
+
+		for (reconcile_phys_thr *j = thrs.data; j < i; j++)
+			if (reconcile_phys_writepoint(j).v == wp.v) {
+				seen = true;
+				break;
+			}
+
+		if (!seen)
+			writepoints_distinct++;
+	}
+
+	WRITE_ONCE(r->phys_workers_considered, considered);
+	WRITE_ONCE(r->phys_workers_started, started);
+	WRITE_ONCE(r->phys_worker_writepoints_distinct, writepoints_distinct);
 
 	darray_for_each(thrs, i)
 		closure_call(&i->cl, do_reconcile_phys_thread, system_unbound_wq, &cl);
@@ -1947,6 +1977,11 @@ __cold void bch2_reconcile_status_to_text(struct printbuf *out, struct bch_fs *c
 			}
 		}
 	}
+
+	prt_printf(out, "phys workers last phase: considered %llu started %llu distinct writepoints %llu\n",
+		   READ_ONCE(r->phys_workers_considered),
+		   READ_ONCE(r->phys_workers_started),
+		   READ_ONCE(r->phys_worker_writepoints_distinct));
 
 	struct task_struct *t;
 	scoped_guard(rcu) {


### PR DESCRIPTION
Reconcile phys work currently fans out per rotational device, but every worker
uses the same allocator reconcile write point. With background compression in
the mix, that can make workers serialize on the writepoint lock while the
reconcile thread waits for the batch to finish.

This gives each reconcile phys worker a stable hashed writepoint derived from
the reconcile phase and device id. It also reports the last phys-worker counts
and distinct writepoint count in `reconcile_status`, so the sysfs status makes
it visible that the phys phase is actually using more than one writepoint.

Related to koverstreet/bcachefs#1079. This addresses the shared-writepoint
contention side; it does not claim to redesign the progress pointer reporting
for all reconcile phases.

This is a writepoint-selection/allocator behavior change, not a pure text
change. It has not been raised on #bcachefs-dev IRC yet, and I have not
gathered before/after writepoint lock-wait numbers from a real mounted fs
under background compression to confirm the contention theory -- posting
this for design feedback first, not as a measured-and-proven fix.

Validation:
- `git diff --check origin/testing..HEAD`
- `BINDGEN=$(command -v bindgen) make -j32` (clean build)
- `strings bcachefs | grep 'phys workers last phase'` confirms the new
  `reconcile_status` counters format string builds into the binary
- No kernel-mount or lock-contention testing has been done
