### PR TITLE
opts: raise move IO window default

### DIFF
--- a/fs/opts.h
+++ b/fs/opts.h
@@ -366,7 +366,7 @@ enum fsck_err_opts {
 	x(move_ios_in_flight,		u32,				\
 	  OPT_FS|OPT_MOUNT|OPT_RUNTIME|OPT_NODOC,			\
 	  OPT_UINT(1, 1024),						\
-	  BCH2_NO_SB_OPT,		64,				\
+	  BCH2_NO_SB_OPT,		1024,				\
 	  NULL,		"Maximum number of IOs to keep in flight by the move path")\
 	x(fsck,				u8,				\
 	  OPT_FS|OPT_MOUNT,						\

--- a/fs/opts.h
+++ b/fs/opts.h
@@ -368,7 +368,7 @@ enum fsck_err_opts {
 	x(move_ios_in_flight,		u32,				\
 	  OPT_FS|OPT_MOUNT|OPT_RUNTIME|OPT_NODOC,			\
 	  OPT_UINT(1, 1024),						\
-	  BCH2_NO_SB_OPT,		64,				\
+	  BCH2_NO_SB_OPT,		1024,				\
 	  NULL,		"Maximum number of IOs to keep in flight by the move path")\
 	x(fsck,				u8,				\
 	  OPT_FS|OPT_MOUNT,						\


### PR DESCRIPTION
The move path defaults to a 64 MiB byte window, but only 64 IOs in flight. That leaves the byte window badly underfilled for small move writes.

On my live evacuation workload, `internal/moving_ctxts` showed reconcile stuck at the IO-count cap:

- `move_bytes_in_flight=64.0M`
- `move_ios_in_flight=64`
- `wait reason: write ios in flight`
- `writes: ios 64/64 sectors 7680/131072`

That is only about 3.75 MiB of the 64 MiB sector window occupied. The same profile showed move writes landing mostly as 64 KiB-class bios on the destination devices, so the 64 IO default can cap the move path well below the intended byte window.

Raise the default `move_ios_in_flight` to the existing maximum, 1024. This matches the current 64 MiB byte window for 64 KiB writes and keeps the driver autonomous instead of requiring users to manually retune the runtime option after mounting.

## Foreground IO impact (pending)

The numbers below only show the move/evacuate path getting fuller and faster with the new default. They do not measure the tradeoff this option exists to bound: foreground application IO latency/throughput while a move is running concurrently with `move_ios_in_flight=1024` versus the old default of 64. That concurrent-workload comparison (e.g. `fio`/`dd` against the live filesystem while a background evacuate runs) has not been run yet and is still pending.

## Validation

Local validation on head `588d268e195b`:

- `git diff --check`
- `BINDGEN=$HOME/.cargo/bin/bindgen make -j32 bcachefs`

Stack validation with this default plus the current evacuation-performance branches:

- `git diff --check`
- `bash -n tests/fs/bcachefs/evacuate_perf.ktest`
- `build-test-kernel run -i <gcc16-root-image> ... tests/fs/bcachefs/evacuate_perf.ktest evacuate_not_much_slower_than_source_read`

Observed ktest run:

- source direct read: 96.2 MiB/s
- device evacuate: 61.9 MiB/s
- default `move_ios_in_flight`: 1024
- default move write/read windows in `internal/moving_ctxts`: `ios 0/1024 sectors 0/131072`
- in-kernel offline fsck completed cleanly after the VM run
- VM output reached `TEST SUCCESS`; the local wrapper later needed a manual interrupt during QEMU/virtiofsd cleanup, after the test had already passed

Rebased onto current upstream master; `BINDGEN=$HOME/.cargo/bin/bindgen make -j16 bcachefs` builds clean at the new base. This is a single-constant default change (`fs/opts.h`, `OPT_UINT(1, 1024)` bound unchanged) with no other code touched; re-read through `bch2_opts_default`'s initializer in `fs/opts.c` confirms the new default flows through unchanged from the header, which this build exercises without needing a mounted filesystem.
