### PR TITLE
show-super: add -s/--summary for a quick member inventory

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -44,6 +44,8 @@ Show runtime performance information
 .Bl -tag -width 22n -compact
 .It Ic device add
 Add a new device to an existing filesystem
+.It Ic device list
+List member devices and recorded device issues
 .It Ic device remove
 Remove a device from an existing filesystem
 .It Ic device online
@@ -460,6 +462,9 @@ Disk label
 .It Fl f , Fl -force
 Use device even if it appears to already be formatted
 .El
+.It Nm Ic device Ic list Ar device
+List filesystem member devices and recorded device issues, using only superblock
+metadata and device discovery.
 .It Nm Ic device Ic remove Oo Ar options Oc Ar device
 Remove a device from a filesystem
 .Bl -tag -width Ds

--- a/bcachefs.8
+++ b/bcachefs.8
@@ -257,6 +257,10 @@ Dump superblock information to stdout.
 List of sections to print
 .It Fl l , Fl -layout
 Print superblock layout
+.It Fl s , Fl -summary
+Print a concise one-line-per-member summary (path, state, error counts)
+instead of the full dump; works from a single surviving device's
+superblock even when the filesystem cannot be mounted
 .El
 .It Nm Ic set-fs-option Oo Ar options Oc Ar device
 .Bl -tag -width Ds

--- a/src/commands/device.rs
+++ b/src/commands/device.rs
@@ -215,6 +215,126 @@ fn open_dev_by_path_or_index(device: &str, fs_path: Option<&str>) -> Result<(Bca
     }
 }
 
+const BCH_SB_MEMBER_DELETED_UUID: [u8; 16] = [
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xd9, 0x6a, 0x60, 0xcf, 0x80, 0x3d, 0xf7, 0xef,
+];
+
+fn member_alive(m: &c::bch_member) -> bool {
+    let zero = [0u8; 16];
+    m.uuid.b != zero && m.uuid.b != BCH_SB_MEMBER_DELETED_UUID
+}
+
+fn find_scanned_path(
+    sbs: &[(PathBuf, c::bch_sb_handle)],
+    idx: u32,
+) -> Option<&Path> {
+    sbs.iter()
+        .find(|(_, sb)| sb.sb().dev_idx as u32 == idx)
+        .map(|(path, _)| path.as_path())
+}
+
+fn member_error_counts(m: &c::bch_member) -> [u64; 3] {
+    [
+        u64::from_le(m.errors[0]),
+        u64::from_le(m.errors[1]),
+        u64::from_le(m.errors[2]),
+    ]
+}
+
+fn issue_summary(m: &c::bch_member, found: bool) -> String {
+    let mut issues = Vec::new();
+    if !found {
+        issues.push("missing".to_string());
+    }
+
+    let state = m.member_state() as u8;
+    if state != BCH_MEMBER_STATE_rw as u8 {
+        issues.push(format!("state={}", bcachefs_kernel::sb::members::member_state_str(state)));
+    }
+
+    let [read, write, checksum] = member_error_counts(m);
+    if read != 0 {
+        issues.push(format!("read_errors={read}"));
+    }
+    if write != 0 {
+        issues.push(format!("write_errors={write}"));
+    }
+    if checksum != 0 {
+        issues.push(format!("checksum_errors={checksum}"));
+    }
+
+    if issues.is_empty() {
+        "ok".to_string()
+    } else {
+        issues.join(",")
+    }
+}
+
+#[derive(Parser, Debug)]
+#[command(about = "List filesystem member devices and recorded device issues")]
+pub struct ListCli {
+    /// Device path or UUID= filesystem selector
+    device: String,
+}
+
+fn cmd_device_list(cli: ListCli) -> Result<()> {
+    let opts = bcachefs_kernel::opts::parse_mount_opts(None, None, true).unwrap_or_default();
+    let sbs = crate::device_scan::scan_sbs(&cli.device, &opts)
+        .with_context(|| format!("scanning bcachefs devices for '{}'", cli.device))?;
+    let sbs = if sbs.is_empty() && !cli.device.contains(':') {
+        vec![(
+            PathBuf::from(&cli.device),
+            crate::device_scan::read_super_silent(&cli.device, opts)
+                .with_context(|| format!("reading bcachefs superblock from '{}'", cli.device))?,
+        )]
+    } else {
+        sbs
+    };
+    let sb = sbs.first()
+        .ok_or_else(|| anyhow!("no bcachefs devices found for '{}'", cli.device))?
+        .1
+        .sb();
+
+    println!("DEV\tPATH\tSTATE\tREAD_ERR\tWRITE_ERR\tCHECKSUM_ERR\tISSUES");
+
+    let print_member = |idx: u32, m: c::bch_member| {
+        if !member_alive(&m) {
+            return;
+        }
+
+        let path = find_scanned_path(&sbs, idx)
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "(not found)".to_string());
+        let state = m.member_state() as u8;
+        let [read, write, checksum] = member_error_counts(&m);
+        let issues = issue_summary(&m, path != "(not found)");
+
+        println!(
+            "{idx}\t{path}\t{}\t{read}\t{write}\t{checksum}\t{issues}",
+            bcachefs_kernel::sb::members::member_state_str(state),
+        );
+    };
+
+    if let Some(members) = bcachefs_kernel::sb::members::members_v2(sb) {
+        for idx in 0..members.nr_devices() {
+            if let Some(m) = members.get(idx) {
+                print_member(idx, m);
+            }
+        }
+    } else if let Some(members) = bcachefs_kernel::sb::members::members_v1(sb) {
+        for idx in 0..members.nr_devices() {
+            if let Some(m) = members.get(idx) {
+                print_member(idx, m);
+            }
+        }
+    } else {
+        bail!("superblock has no members field");
+    }
+
+    Ok(())
+}
+
 #[derive(Parser, Debug)]
 #[command(about = "Re-add a device to a running filesystem")]
 pub struct OnlineCli {
@@ -608,6 +728,7 @@ fn cmd_device_evacuate(cli: EvacuateCli) -> Result<()> {
 }
 
 pub const CMD_ADD: super::CmdDef = raw_cmd!("add", "Add a device to a filesystem", cmd_device_add);
+pub const CMD_LIST: super::CmdDef = typed_cmd!("list", "List member devices and recorded issues", ListCli, cmd_device_list);
 pub const CMD_ONLINE: super::CmdDef = typed_cmd!("online", "Bring a device online", OnlineCli, cmd_device_online);
 pub const CMD_OFFLINE: super::CmdDef = typed_cmd!("offline", "Take a device offline", OfflineCli, cmd_device_offline);
 pub const CMD_REMOVE: super::CmdDef = typed_cmd!("remove", "Remove a device", RemoveCli, cmd_device_remove);
@@ -618,7 +739,7 @@ pub const CMD_RESIZE_JOURNAL: super::CmdDef = typed_cmd!("resize-journal", "Resi
 pub const CMD: super::CmdDef = super::CmdDef {
     name: "device", about: "Manage devices within a filesystem", aliases: &[],
     kind: super::CmdKind::Group { children: &[
-        &CMD_ADD, &CMD_ONLINE, &CMD_OFFLINE, &CMD_REMOVE,
+        &CMD_ADD, &CMD_LIST, &CMD_ONLINE, &CMD_OFFLINE, &CMD_REMOVE,
         &CMD_EVACUATE, &CMD_SET_STATE, &CMD_RESIZE, &CMD_RESIZE_JOURNAL,
     ]},
 };

--- a/src/commands/super_cmd.rs
+++ b/src/commands/super_cmd.rs
@@ -40,11 +40,36 @@ pub struct ShowSuperCli {
     #[arg(short, long)]
     layout: bool,
 
+    /// Print a concise one-line-per-member summary (path, state, errors)
+    /// instead of the full superblock dump
+    #[arg(short = 's', long = "summary", conflicts_with_all = ["fields", "field_only", "layout"])]
+    summary: bool,
+
     /// Device path
     device: String,
 }
 
 fn cmd_show_super(cli: ShowSuperCli) -> Result<()> {
+
+    if cli.summary {
+        let mut fs_opts = c::bch_opts::default();
+        opt_set!(fs_opts, noexcl, 1);
+        opt_set!(fs_opts, nochanges, 1);
+        opt_set!(fs_opts, no_version_check, 1);
+        opt_set!(fs_opts, nostart, 1);
+
+        let fs = bcachefs_kernel::fs::Fs::open(&[std::path::PathBuf::from(&cli.device)], fs_opts)?;
+
+        let _ = fs.for_each_online_member(|ca| {
+            let sb = unsafe { &*ca.disk_sb.sb };
+            let mut buf = Printbuf::new();
+            unsafe { crate::wrappers::sb_display::sb_members_summary_to_text(&mut buf, sb) };
+            print!("{}", buf);
+            ControlFlow::Continue(())
+        });
+
+        return Ok(());
+    }
 
     let ext_bit = sb_field_type::ext.bit();
     let mut fields = ext_bit;

--- a/src/wrappers/sb_display.rs
+++ b/src/wrappers/sb_display.rs
@@ -145,3 +145,79 @@ pub unsafe fn sb_to_text_with_names(
     // sbs (Vec<(PathBuf, bch_sb_handle)>) is dropped here — freed by
     // Rust's allocator, not kvfree. This is the whole point.
 }
+
+/// Print a concise one-line-per-member summary: device index, path (or
+/// "(not found)" if no matching device was scanned), state, error
+/// counters, and a short issue tag ("ok" if none apply).
+///
+/// Reuses the same UUID-based device-path discovery as
+/// sb_to_text_with_names(), so it works purely from the superblock of a
+/// single surviving device — no online filesystem required.
+///
+/// # Safety
+/// `sb` must point to a valid `bch_sb`.
+pub unsafe fn sb_members_summary_to_text(out: &mut Printbuf, sb: &c::bch_sb) {
+    let uuid = uuid::Uuid::from_bytes(sb.user_uuid.b);
+    let device_str = format!("UUID={}", uuid);
+
+    let opts = bcachefs_kernel::opts::parse_mount_opts(None, None, true).unwrap_or_default();
+    let sbs = device_scan::scan_sbs(&device_str, &opts).unwrap_or_default();
+
+    out.aligned(|sub| {
+        write!(sub, "Device\tPath\tState\tRead err\tWrite err\tChecksum err\tIssues\r\n").unwrap();
+
+        let mut print_member = |idx: u32, m: c::bch_member| {
+            if !member_alive(&m) {
+                return;
+            }
+
+            let dev = find_dev(&sbs, idx);
+            let missing = dev.is_none();
+            let path = dev
+                .map(|(path, _)| path.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "(not found)".to_string());
+
+            let state = m.member_state() as u8;
+            let state_str = sb::members::member_state_str(state);
+            let err_read = u64::from_le(m.errors[0]);
+            let err_write = u64::from_le(m.errors[1]);
+            let err_checksum = u64::from_le(m.errors[2]);
+
+            let mut issues = Vec::new();
+            if missing {
+                issues.push("missing".to_string());
+            }
+            if state != c::bch_member_state::BCH_MEMBER_STATE_rw as u8 {
+                issues.push(format!("state={state_str}"));
+            }
+            if err_read != 0 {
+                issues.push(format!("read_errors={err_read}"));
+            }
+            if err_write != 0 {
+                issues.push(format!("write_errors={err_write}"));
+            }
+            if err_checksum != 0 {
+                issues.push(format!("checksum_errors={err_checksum}"));
+            }
+            let issues = if issues.is_empty() { "ok".to_string() } else { issues.join(",") };
+
+            write!(
+                sub, "{idx}\t{path}\t{state_str}\t{err_read}\t{err_write}\t{err_checksum}\t{issues}\r\n"
+            ).unwrap();
+        };
+
+        if let Some(members) = sb::members::members_v2(sb) {
+            for idx in 0..members.nr_devices() {
+                if let Some(m) = members.get(idx) {
+                    print_member(idx, m);
+                }
+            }
+        } else if let Some(members) = sb::members::members_v1(sb) {
+            for idx in 0..members.nr_devices() {
+                if let Some(m) = members.get(idx) {
+                    print_member(idx, m);
+                }
+            }
+        }
+    });
+}


### PR DESCRIPTION
koverstreet/bcachefs#851 asks for a way to list which member device has an issue (I/O errors, missing, degraded) without mounting the filesystem, since hunting through dozens of otherwise-healthy drives by hand to find the one bcachefs doesn't like is impractical.

`show-super` already has the building blocks for this: it discovers sibling member devices by UUID and prints full per-member detail (path, model, state, error counters) from a single surviving device's superblock, without needing the filesystem to be mountable. But that dump is around 25 lines per device, too slow to scan across many drives when all you want is "which members are missing or degraded."

This replaces the earlier version of this PR (a new `bcachefs device list` subcommand) with a much smaller change: a `-s`/`--summary` flag on the existing `show-super` command. It reuses the same UUID-based device scan and member-table readers `show-super` already has, and prints one line per member instead of the full dump: index, path (or `(not found)` for a missing device), state, error counters, and a short issue tag (`ok` when nothing is wrong). It's mutually exclusive with `-f`/`-F`/`-l` since it replaces the full dump rather than adding to it.

Related to koverstreet/bcachefs#851 — this addresses that issue's offline device issue listing ask; the issue's other asks (offline version upgrade, offline device add/remove, offline re-replication, userspace-only operation, mount-without-upgrade) are unaddressed by this PR.

## Testing

`BINDGEN=$HOME/.cargo/bin/bindgen make -j24 bcachefs`, then a disposable two-loop-device filesystem:

```
$ bcachefs show-super --summary /dev/loop28
Device  Path         State  Read err  Write err  Checksum err  Issues
0       /dev/loop28  rw     0         0          0             ok
1       /dev/loop29  rw     0         0          0             ok

# after detaching the second loop device (simulating a missing/dead member):
$ bcachefs show-super --summary /dev/loop28
Device  Path         State  Read err  Write err  Checksum err  Issues
0       /dev/loop28  rw     0         0          0             ok
1       (not found)  rw     0         0          0             missing
```

Only one device was ever passed on the command line in both runs — the second member's path is found (or reported missing) purely from superblock + UUID-based device discovery, same as plain `show-super` already does.
