### PR TITLE
integration: cold-storage evacuation/write-pressure stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ endif
 BCACHEFS_DKMS_FORWARD := BCACHEFS_DEBUG \
                         BCACHEFS_TESTS \
                         BCACHEFS_INJECT_TRANSACTION_RESTARTS \
-                        BCACHEFS_RUST
+                        BCACHEFS_RUST \
+                        CC
 
 # Vars persisted into the *local* build.vars across invocations - a
 # superset of BCACHEFS_DKMS_FORWARD that also covers MAKE_DEBUG, the

--- a/dkms/Makefile
+++ b/dkms/Makefile
@@ -6,7 +6,7 @@ export BCACHEFS_DKMS=1
 # ifdefs in fs/Makefile. Empty / missing file is fine - unset names
 # export as no-ops.
 -include $(CURDIR)/build.vars
-export BCACHEFS_DEBUG BCACHEFS_TESTS BCACHEFS_INJECT_TRANSACTION_RESTARTS BCACHEFS_RUST
+export BCACHEFS_DEBUG BCACHEFS_TESTS BCACHEFS_INJECT_TRANSACTION_RESTARTS BCACHEFS_RUST CC
 
 ifneq (${KERNELRELEASE},)
 ccflags-y := -I$(src)/include

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -813,7 +813,7 @@ static u32 move_alloc_dev_congested(struct bch_dev *ca, u64 now)
 	u64 last = READ_ONCE(ca->congested_last);
 
 	if (time_after64(now, last))
-		congested -= (now - last) >> 12;
+		congested -= (now - last) >> 20;
 
 	return clamp(congested, 0LL, CONGESTED_MAX);
 }

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -645,7 +645,7 @@ again:
 		if (bch2_copygc_can_make_progress(ca)) {
 			copygc_can_make_progress = true;
 			req->copygc_can_make_progress = true;
-			bch2_copygc_wakeup(c);
+			bch2_copygc_wakeup_for_pressure(c);
 		}
 
 		track_event_change(&c->times[BCH_TIME_blocked_allocate], true);
@@ -1945,7 +1945,7 @@ static bool alloc_wait_advanced(struct bch_fs *c, struct alloc_request *req)
 			    !bch2_copygc_can_make_progress(ca))
 				return true;
 
-			bch2_copygc_wakeup(c);
+			bch2_copygc_wakeup_for_pressure(c);
 		}
 	}
 	BUG_ON(!found);

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -248,8 +248,7 @@ static void open_bucket_free_unused(struct bch_fs *c, struct open_bucket *ob)
 		bch2_alloc_wake_dev(bch2_dev_have_ref(c, ob->dev));
 }
 
-static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
-						enum bch_watermark watermark)
+void bch2_open_bucket_reclaim_unused_partials(struct bch_fs *c, unsigned min_free)
 {
 	struct bch_fs_allocator *a = &c->allocator;
 
@@ -258,8 +257,7 @@ static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
 		unsigned dev;
 
 		scoped_guard(spinlock, &a->freelist_lock) {
-			if (a->open_buckets_nr_free > bch2_open_buckets_reserved(watermark) ||
-			    !a->open_buckets_partial_nr)
+			if (a->open_buckets_nr_free > min_free || !a->open_buckets_partial_nr)
 				return;
 
 			ob = a->open_buckets +
@@ -326,7 +324,7 @@ static struct open_bucket *__try_alloc_bucket(struct bch_fs *c,
 		return NULL;
 	}
 
-	open_bucket_reclaim_unused_partials(c, req->watermark);
+	bch2_open_bucket_reclaim_unused_partials(c, bch2_open_buckets_reserved(req->watermark));
 
 	guard(spinlock)(&c->allocator.freelist_lock);
 

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -227,8 +227,11 @@ static inline bool is_superblock_bucket(struct bch_fs *c, struct bch_dev *ca, u6
 
 static void open_bucket_free_unused(struct bch_fs *c, struct open_bucket *ob)
 {
-	BUG_ON(c->allocator.open_buckets_partial_nr >=
-	       ARRAY_SIZE(c->allocator.open_buckets_partial));
+	if (unlikely(c->allocator.open_buckets_partial_nr >=
+		     ARRAY_SIZE(c->allocator.open_buckets_partial))) {
+		bch2_open_bucket_put(c, ob);
+		return;
+	}
 
 	scoped_guard(spinlock, &c->allocator.freelist_lock) {
 		guard(rcu)();
@@ -243,6 +246,31 @@ static void open_bucket_free_unused(struct bch_fs *c, struct open_bucket *ob)
 
 	scoped_guard(rcu)
 		bch2_alloc_wake_dev(bch2_dev_have_ref(c, ob->dev));
+}
+
+static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
+						enum bch_watermark watermark)
+{
+	struct bch_fs_allocator *a = &c->allocator;
+
+	while (1) {
+		struct open_bucket *ob;
+
+		scoped_guard(spinlock, &a->freelist_lock) {
+			if (a->open_buckets_nr_free > bch2_open_buckets_reserved(watermark) ||
+			    !a->open_buckets_partial_nr)
+				return;
+
+			ob = a->open_buckets +
+				a->open_buckets_partial[--a->open_buckets_partial_nr];
+			ob->on_partial_list = false;
+
+			scoped_guard(rcu)
+				bch2_dev_rcu(c, ob->dev)->nr_partial_buckets--;
+		}
+
+		bch2_open_bucket_put(c, ob);
+	}
 }
 
 static inline bool may_alloc_bucket(struct bch_fs *c,
@@ -288,6 +316,8 @@ static struct open_bucket *__try_alloc_bucket(struct bch_fs *c,
 		req->counters.skipped_nouse++;
 		return NULL;
 	}
+
+	open_bucket_reclaim_unused_partials(c, req->watermark);
 
 	guard(spinlock)(&c->allocator.freelist_lock);
 

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -51,6 +51,14 @@
 #include <linux/rcupdate.h>
 #include <linux/sched/signal.h>
 
+/*
+ * Move allocation uses congestion to steer background relocation away from
+ * devices that are already slow. Rotational devices can stay throughput-limited
+ * for seconds after a bad write/flush sample, so use a slower decay here than
+ * the read path's target-congestion check.
+ */
+#define MOVE_ALLOC_CONGESTION_DECAY_SHIFT	24
+
 static void bch2_trans_mutex_lock_norelock(struct btree_trans *trans,
 					   struct mutex *lock)
 {
@@ -813,12 +821,39 @@ static u32 move_alloc_dev_congested(struct bch_dev *ca, u64 now)
 	u64 last = READ_ONCE(ca->congested_last);
 
 	if (time_after64(now, last))
-		congested -= (now - last) >> 20;
+		congested -= (now - last) >> MOVE_ALLOC_CONGESTION_DECAY_SHIFT;
 
 	return clamp(congested, 0LL, CONGESTED_MAX);
 }
+
+static u32 move_alloc_dev_write_congested(struct bch_dev *ca)
+{
+	struct bch2_time_stats *stats = &ca->io_latency[WRITE].stats;
+	u64 latency = atomic64_read(&ca->cur_latency[WRITE]);
+	s64 typical = mean_and_variance_get_median(stats->duration_stats_weighted);
+	u64 threshold, over;
+	u32 max_pressure = max_t(u32, CONGESTED_MAX >> 3, 1);
+
+	if (stats->duration_stats.n < 32 || typical <= 0)
+		return 0;
+
+	threshold = (u64) typical << 3;
+	if (!threshold || latency <= threshold)
+		return 0;
+
+	over = latency - threshold;
+	if (over >= threshold)
+		return max_pressure;
+
+	return max_t(u32, div64_u64(over * max_pressure, threshold), 1);
+}
 #else
 static u32 move_alloc_dev_congested(struct bch_dev *ca, u64 now)
+{
+	return 0;
+}
+
+static u32 move_alloc_dev_write_congested(struct bch_dev *ca)
 {
 	return 0;
 }
@@ -834,7 +869,10 @@ static u32 move_alloc_dev_pressure(struct bch_fs *c,
 	if (!ca)
 		return U32_MAX;
 
-	return move_alloc_dev_congested(ca, now) +
+	return min_t(u32,
+		     move_alloc_dev_congested(ca, now) +
+		     move_alloc_dev_write_congested(ca),
+		     CONGESTED_MAX) +
 		move_alloc_dev_busy(c, req, dev);
 }
 
@@ -857,9 +895,13 @@ static void move_alloc_avoid_busy_devs(struct bch_fs *c,
 	/*
 	 * Background moves can otherwise pick the same emptiest device that
 	 * foreground writepoints or other movers are already filling, or a
-	 * device that is currently congested from unrelated IO. Keep the
-	 * free-space weighted allocator order primary; only let contention
-	 * break adjacent ties, so we do not defeat free-space balancing.
+	 * device that is currently congested from unrelated IO. Include a small
+	 * write-latency term here too: moving data should avoid a destination
+	 * whose write/flush path is already far slower than its recent norm.
+	 *
+	 * Keep the free-space weighted allocator order primary; only let
+	 * contention break adjacent ties, so we do not defeat free-space
+	 * balancing.
 	 */
 	for (unsigned j = 0; j + 1 < req->devs_sorted.nr; j++)
 		if (pressure[j] > pressure[j + 1]) {

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -58,7 +58,9 @@
  * the read path's target-congestion check.
  */
 #define MOVE_ALLOC_CONGESTION_DECAY_SHIFT	24
-#define MOVE_ALLOC_STALLED_THRESHOLD		(CONGESTED_MAX >> 3)
+#define MOVE_ALLOC_STALLED_THRESHOLD_SHIFT	3
+#define MOVE_ALLOC_STALLED_THRESHOLD		(CONGESTED_MAX >> MOVE_ALLOC_STALLED_THRESHOLD_SHIFT)
+#define MOVE_ALLOC_WRITE_LATENCY_SHIFT		3
 #define MOVE_ALLOC_BUSY_BUCKET_WEIGHT		(CONGESTED_MAX >> 1)
 
 static void bch2_trans_mutex_lock_norelock(struct btree_trans *trans,
@@ -876,7 +878,7 @@ static u32 move_alloc_dev_write_congested(struct bch_dev *ca)
 	if (stats->duration_stats.n < 32 || typical <= 0)
 		return 0;
 
-	threshold = (u64) typical << 3;
+	threshold = (u64) typical << MOVE_ALLOC_WRITE_LATENCY_SHIFT;
 	if (!threshold || latency <= threshold)
 		return 0;
 
@@ -952,7 +954,9 @@ static void move_alloc_avoid_busy_devs(struct bch_fs *c,
 	 * not congested. Once a device is visibly falling behind, sink it behind
 	 * less stalled choices; otherwise a much larger, mostly empty disk can keep
 	 * winning move allocations until it is saturated hard enough to leave move
-	 * writes stuck in the block layer.
+	 * writes stuck in the block layer. The threshold is intentionally lower
+	 * than the read path's target-congested cutoff: background moves should
+	 * step away before they can monopolize a slow write target.
 	 */
 	for (unsigned j = 1; j < req->devs_sorted.nr; j++)
 		for (unsigned i = j; i &&

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -255,6 +255,7 @@ static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
 
 	while (1) {
 		struct open_bucket *ob;
+		unsigned dev;
 
 		scoped_guard(spinlock, &a->freelist_lock) {
 			if (a->open_buckets_nr_free > bch2_open_buckets_reserved(watermark) ||
@@ -263,6 +264,7 @@ static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
 
 			ob = a->open_buckets +
 				a->open_buckets_partial[--a->open_buckets_partial_nr];
+			dev = ob->dev;
 			ob->on_partial_list = false;
 
 			scoped_guard(rcu)
@@ -270,6 +272,13 @@ static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
 		}
 
 		bch2_open_bucket_put(c, ob);
+
+		scoped_guard(rcu) {
+			struct bch_dev *ca = bch2_dev_rcu_noerror(c, dev);
+
+			if (ca)
+				bch2_alloc_wake_dev(ca);
+		}
 	}
 }
 

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -768,6 +768,69 @@ void bch2_dev_alloc_list(struct bch_fs *c,
 	bubble_sort(ret->data, ret->nr, dev_stripe_cmp);
 }
 
+static bool open_bucket_is_on_writepoint(struct bch_fs *c,
+					 struct write_point *wp,
+					 struct open_bucket *ob)
+{
+	struct open_bucket *wp_ob;
+	unsigned i;
+
+	open_bucket_for_each(c, &wp->ptrs, wp_ob, i)
+		if (wp_ob == ob)
+			return true;
+
+	return false;
+}
+
+static unsigned move_alloc_dev_busy(struct bch_fs *c,
+				    struct alloc_request *req,
+				    unsigned dev)
+{
+	struct bch_fs_allocator *a = &c->allocator;
+	unsigned busy = 0;
+
+	for (struct open_bucket *ob = a->open_buckets;
+	     ob < a->open_buckets + ARRAY_SIZE(a->open_buckets);
+	     ob++) {
+		guard(spinlock)(&ob->lock);
+
+		if (!ob->valid ||
+		    ob->dev != dev ||
+		    ob->data_type != BCH_DATA_user ||
+		    open_bucket_is_on_writepoint(c, req->wp, ob))
+			continue;
+
+		busy++;
+	}
+
+	return busy;
+}
+
+static void move_alloc_avoid_busy_devs(struct bch_fs *c,
+				       struct alloc_request *req)
+{
+	if (!(req->flags & BCH_WRITE_move) ||
+	    req->data_type != BCH_DATA_user ||
+	    req->devs_sorted.nr <= 1)
+		return;
+
+	unsigned busy[BCH_SB_MEMBERS_MAX];
+	for (unsigned i = 0; i < req->devs_sorted.nr; i++)
+		busy[i] = move_alloc_dev_busy(c, req, req->devs_sorted.data[i]);
+
+	/*
+	 * Background moves can otherwise pick the same emptiest device that
+	 * foreground writepoints or other movers are already filling. Keep all
+	 * candidates as fallbacks, but try quieter devices first.
+	 */
+	for (unsigned i = 0; i + 1 < req->devs_sorted.nr; i++)
+		for (unsigned j = 0; j + 1 < req->devs_sorted.nr - i; j++)
+			if (busy[j] > busy[j + 1]) {
+				swap(req->devs_sorted.data[j], req->devs_sorted.data[j + 1]);
+				swap(busy[j], busy[j + 1]);
+			}
+}
+
 static const u64 stripe_clock_hand_rescale	= 1ULL << 62; /* trigger rescale at */
 static const u64 stripe_clock_hand_max		= 1ULL << 56; /* max after rescale */
 static const u64 stripe_clock_hand_inv		= 1ULL << 52; /* max increment, if a device is empty */
@@ -866,6 +929,7 @@ int bch2_bucket_alloc_set_trans(struct btree_trans *trans,
 	BUG_ON(req->nr_effective >= req->nr_replicas);
 
 	bch2_dev_alloc_list(c, stripe, &req->devs_may_alloc, &req->devs_sorted);
+	move_alloc_avoid_busy_devs(c, req);
 
 	if (req->devs_sorted.nr <= 1)
 		req->will_retry_target_devices = false;

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -572,12 +572,13 @@ static bool req_dev_sizes_mismatched(struct bch_fs *c, struct alloc_request *req
 /*
  * Decide whether an alloc that came up empty-handed on the current candidate
  * device should bail (committing the request with whatever replicas it
- * already has) instead of waiting on freelist_wait. Bails iff the request
- * has at least one replica's worth to commit AND any of:
+ * already has) instead of waiting on freelist_wait. Bails iff any of:
  *
  *  - copygc_can_make_progress is false: the per-device check (set above by
  *    the caller from bch2_copygc_can_make_progress(ca)) says copygc can't
- *    free buckets here. No reason to wait — copygc isn't going to help.
+ *    free buckets here. No reason to wait — copygc isn't going to help. If the
+ *    caller still has target/all-device retries available, those retries run
+ *    before this check is reached.
  *
  *  - watermark == copygc and data_type != btree: the request itself is
  *    issued at copygc watermark, i.e. it IS the thing trying to free
@@ -596,11 +597,6 @@ static bool req_dev_sizes_mismatched(struct bch_fs *c, struct alloc_request *req
  */
 static bool req_alloc_should_bail(struct bch_fs *c, struct alloc_request *req)
 {
-	bool have_replicas = req->nr_effective ||
-		(req->devs_have && req->devs_have->nr);
-	if (!have_replicas)
-		return false;
-
 	return !req->copygc_can_make_progress ||
 	       (req->watermark == BCH_WATERMARK_copygc &&
 		req->data_type != BCH_DATA_btree) ||

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -58,6 +58,8 @@
  * the read path's target-congestion check.
  */
 #define MOVE_ALLOC_CONGESTION_DECAY_SHIFT	24
+#define MOVE_ALLOC_STALLED_THRESHOLD		(CONGESTED_MAX >> 1)
+#define MOVE_ALLOC_BUSY_BUCKET_WEIGHT		(CONGESTED_MAX >> 1)
 
 static void bch2_trans_mutex_lock_norelock(struct btree_trans *trans,
 					   struct mutex *lock)
@@ -790,9 +792,9 @@ static bool open_bucket_is_on_writepoint(struct bch_fs *c,
 	return false;
 }
 
-static unsigned move_alloc_dev_busy(struct bch_fs *c,
-				    struct alloc_request *req,
-				    unsigned dev)
+static u32 move_alloc_dev_busy(struct bch_fs *c,
+			       struct alloc_request *req,
+			       unsigned dev)
 {
 	struct bch_fs_allocator *a = &c->allocator;
 	unsigned busy = 0;
@@ -811,7 +813,7 @@ static unsigned move_alloc_dev_busy(struct bch_fs *c,
 		busy++;
 	}
 
-	return busy;
+	return min_t(u32, busy, 2) * MOVE_ALLOC_BUSY_BUCKET_WEIGHT;
 }
 
 #ifndef CONFIG_BCACHEFS_NO_LATENCY_ACCT
@@ -876,6 +878,16 @@ static u32 move_alloc_dev_pressure(struct bch_fs *c,
 		move_alloc_dev_busy(c, req, dev);
 }
 
+static bool move_alloc_dev_stalled(struct bch_fs *c,
+				   struct alloc_request *req,
+				   unsigned dev, u64 now)
+{
+	return (req->flags & BCH_WRITE_move) &&
+		req->data_type == BCH_DATA_user &&
+		move_alloc_dev_pressure(c, req, dev, now) >=
+		MOVE_ALLOC_STALLED_THRESHOLD;
+}
+
 static void move_alloc_avoid_busy_devs(struct bch_fs *c,
 				       struct alloc_request *req)
 {
@@ -899,14 +911,17 @@ static void move_alloc_avoid_busy_devs(struct bch_fs *c,
 	 * write-latency term here too: moving data should avoid a destination
 	 * whose write/flush path is already far slower than its recent norm.
 	 *
-	 * Keep the free-space weighted allocator order primary; only let
-	 * contention break adjacent ties, so we do not defeat free-space
-	 * balancing.
+	 * Keep the free-space weighted allocator order primary while devices are
+	 * only mildly busy. Once a device is clearly stalled, sink it behind less
+	 * stalled choices; otherwise a much larger, mostly empty disk can keep
+	 * winning move allocations while it is already saturated.
 	 */
-	for (unsigned j = 0; j + 1 < req->devs_sorted.nr; j++)
-		if (pressure[j] > pressure[j + 1]) {
-			swap(req->devs_sorted.data[j], req->devs_sorted.data[j + 1]);
-			swap(pressure[j], pressure[j + 1]);
+	for (unsigned j = 1; j < req->devs_sorted.nr; j++)
+		for (unsigned i = j; i &&
+		     pressure[i - 1] >= MOVE_ALLOC_STALLED_THRESHOLD &&
+		     pressure[i - 1] > pressure[i]; i--) {
+			swap(req->devs_sorted.data[i - 1], req->devs_sorted.data[i]);
+			swap(pressure[i - 1], pressure[i]);
 		}
 }
 
@@ -1112,6 +1127,9 @@ static bool want_bucket(struct bch_fs *c,
 		return false;
 
 	if (req->ec != (ob->ec != NULL))
+		return false;
+
+	if (move_alloc_dev_stalled(c, req, ob->dev, local_clock()))
 		return false;
 
 	return true;

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -58,7 +58,7 @@
  * the read path's target-congestion check.
  */
 #define MOVE_ALLOC_CONGESTION_DECAY_SHIFT	24
-#define MOVE_ALLOC_STALLED_THRESHOLD		(CONGESTED_MAX >> 1)
+#define MOVE_ALLOC_STALLED_THRESHOLD		(CONGESTED_MAX >> 3)
 #define MOVE_ALLOC_BUSY_BUCKET_WEIGHT		(CONGESTED_MAX >> 1)
 
 static void bch2_trans_mutex_lock_norelock(struct btree_trans *trans,
@@ -949,9 +949,10 @@ static void move_alloc_avoid_busy_devs(struct bch_fs *c,
 	 * whose write/flush path is already far slower than its recent norm.
 	 *
 	 * Keep the free-space weighted allocator order primary while devices are
-	 * only mildly busy. Once a device is clearly stalled, sink it behind less
-	 * stalled choices; otherwise a much larger, mostly empty disk can keep
-	 * winning move allocations while it is already saturated.
+	 * not congested. Once a device is visibly falling behind, sink it behind
+	 * less stalled choices; otherwise a much larger, mostly empty disk can keep
+	 * winning move allocations until it is saturated hard enough to leave move
+	 * writes stuck in the block layer.
 	 */
 	for (unsigned j = 1; j < req->devs_sorted.nr; j++)
 		for (unsigned i = j; i &&

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -806,6 +806,38 @@ static unsigned move_alloc_dev_busy(struct bch_fs *c,
 	return busy;
 }
 
+#ifndef CONFIG_BCACHEFS_NO_LATENCY_ACCT
+static u32 move_alloc_dev_congested(struct bch_dev *ca, u64 now)
+{
+	s64 congested = atomic_read(&ca->congested);
+	u64 last = READ_ONCE(ca->congested_last);
+
+	if (time_after64(now, last))
+		congested -= (now - last) >> 12;
+
+	return clamp(congested, 0LL, CONGESTED_MAX);
+}
+#else
+static u32 move_alloc_dev_congested(struct bch_dev *ca, u64 now)
+{
+	return 0;
+}
+#endif
+
+static u32 move_alloc_dev_pressure(struct bch_fs *c,
+				   struct alloc_request *req,
+				   unsigned dev, u64 now)
+{
+	guard(rcu)();
+	struct bch_dev *ca = bch2_dev_rcu_noerror(c, dev);
+
+	if (!ca)
+		return U32_MAX;
+
+	return move_alloc_dev_congested(ca, now) +
+		move_alloc_dev_busy(c, req, dev);
+}
+
 static void move_alloc_avoid_busy_devs(struct bch_fs *c,
 				       struct alloc_request *req)
 {
@@ -814,21 +846,26 @@ static void move_alloc_avoid_busy_devs(struct bch_fs *c,
 	    req->devs_sorted.nr <= 1)
 		return;
 
-	unsigned busy[BCH_SB_MEMBERS_MAX];
+	u32 pressure[BCH_SB_MEMBERS_MAX];
+	u64 now = local_clock();
+
 	for (unsigned i = 0; i < req->devs_sorted.nr; i++)
-		busy[i] = move_alloc_dev_busy(c, req, req->devs_sorted.data[i]);
+		pressure[i] = move_alloc_dev_pressure(c, req,
+						      req->devs_sorted.data[i],
+						      now);
 
 	/*
 	 * Background moves can otherwise pick the same emptiest device that
-	 * foreground writepoints or other movers are already filling. Keep all
-	 * candidates as fallbacks, but try quieter devices first.
+	 * foreground writepoints or other movers are already filling, or a
+	 * device that is currently congested from unrelated IO. Keep the
+	 * free-space weighted allocator order primary; only let contention
+	 * break adjacent ties, so we do not defeat free-space balancing.
 	 */
-	for (unsigned i = 0; i + 1 < req->devs_sorted.nr; i++)
-		for (unsigned j = 0; j + 1 < req->devs_sorted.nr - i; j++)
-			if (busy[j] > busy[j + 1]) {
-				swap(req->devs_sorted.data[j], req->devs_sorted.data[j + 1]);
-				swap(busy[j], busy[j + 1]);
-			}
+	for (unsigned j = 0; j + 1 < req->devs_sorted.nr; j++)
+		if (pressure[j] > pressure[j + 1]) {
+			swap(req->devs_sorted.data[j], req->devs_sorted.data[j + 1]);
+			swap(pressure[j], pressure[j + 1]);
+		}
 }
 
 static const u64 stripe_clock_hand_rescale	= 1ULL << 62; /* trigger rescale at */

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -1197,6 +1197,11 @@ static int bucket_alloc_set_partial(struct bch_fs *c,
 {
 	struct bch_fs_allocator *a = &c->allocator;
 
+	if ((req->flags & BCH_WRITE_move) &&
+	    req->data_type == BCH_DATA_user &&
+	    req->wp == &c->allocator.reconcile_write_point)
+		return 0;
+
 	if (!a->open_buckets_partial_nr)
 		return 0;
 

--- a/fs/alloc/foreground.h
+++ b/fs/alloc/foreground.h
@@ -157,6 +157,7 @@ static inline unsigned bch2_open_buckets_reserved(enum bch_watermark watermark)
 }
 
 struct open_bucket *bch2_bucket_alloc_trans(struct btree_trans *, struct alloc_request *);
+void bch2_open_bucket_reclaim_unused_partials(struct bch_fs *, unsigned);
 
 /*
  * freelist_wait wake helpers. Every wake_up site on

--- a/fs/bcachefs.h
+++ b/fs/bcachefs.h
@@ -430,6 +430,7 @@ struct io_count {
 	x(journal_read)					\
 	x(fs_journal_alloc)				\
 	x(fs_resize_on_mount)				\
+	x(evacuating_startup_scan)			\
 	x(fs_mi_field_upgrades)				\
 	x(sb_journal_sort)				\
 	x(btree_node_read)				\

--- a/fs/btree/read.c
+++ b/fs/btree/read.c
@@ -1080,7 +1080,7 @@ void bch2_btree_node_read(struct btree_trans *trans, struct btree *b,
 
 		if (sync) {
 			submit_bio_wait(bio);
-			bch2_latency_acct(ca, rb->start_time, READ);
+			bch2_latency_acct(ca, rb->start_time, READ, true);
 			btree_node_read_work(&rb->work);
 		} else {
 			submit_bio(bio);

--- a/fs/data/copygc.c
+++ b/fs/data/copygc.c
@@ -421,7 +421,8 @@ static int bch2_copygc(struct moving_context *ctxt,
 
 		move_bucket_in_flight_add(buckets_in_flight, b);
 		if (bch2_dev_rotational(c, b->k.bucket.inode))
-			bch2_moving_ctxt_set_rotational_limits(ctxt);
+			bch2_moving_ctxt_set_rotational_limits(ctxt,
+					MOVE_ROTATIONAL_LIMIT_background);
 
 		ret = bch2_evacuate_bucket(ctxt, b, b->k.bucket, b->k.generation, data_opts);
 		if (ret)

--- a/fs/data/copygc.c
+++ b/fs/data/copygc.c
@@ -422,7 +422,9 @@ static int bch2_copygc(struct moving_context *ctxt,
 		move_bucket_in_flight_add(buckets_in_flight, b);
 		if (bch2_dev_rotational(c, b->k.bucket.inode))
 			bch2_moving_ctxt_set_rotational_limits(ctxt,
-					MOVE_ROTATIONAL_LIMIT_background);
+					pressure
+					? MOVE_ROTATIONAL_LIMIT_hipri
+					: MOVE_ROTATIONAL_LIMIT_background);
 
 		ret = bch2_evacuate_bucket(ctxt, b, b->k.bucket, b->k.generation, data_opts);
 		if (ret)

--- a/fs/data/copygc.c
+++ b/fs/data/copygc.c
@@ -610,6 +610,7 @@ static int bch2_copygc_thread(void *arg)
 	}
 
 	move_buckets_wait(&ctxt, &buckets, true);
+	ret = ret ?: bch2_moving_ctxt_flush_all(&ctxt);
 	bch2_moving_ctxt_exit(&ctxt);
 	bch2_move_stats_exit(&move_stats, c);
 out:

--- a/fs/data/copygc.c
+++ b/fs/data/copygc.c
@@ -66,6 +66,12 @@ struct buckets_in_flight {
 	DARRAY(struct move_bucket *) to_evacuate;
 };
 
+struct copygc_lru_scan {
+	struct buckets_in_flight	*buckets_in_flight;
+	struct bpos		next_pos;
+	bool			saw_key;
+};
+
 static const struct rhashtable_params bch_move_bucket_params = {
 	.head_offset		= offsetof(struct move_bucket, hash),
 	.key_offset		= offsetof(struct move_bucket, k),
@@ -208,21 +214,69 @@ static int try_add_copygc_bucket(struct btree_trans *trans,
 	return buckets_in_flight->to_evacuate.nr >= nr_to_get;
 }
 
-static int bch2_copygc_get_buckets(struct moving_context *ctxt,
-			struct buckets_in_flight *buckets_in_flight)
+static int try_add_copygc_lru_bucket(struct btree_trans *trans,
+				     struct copygc_lru_scan *scan,
+				     struct bpos lru_pos)
+{
+	int ret = try_add_copygc_bucket(trans, scan->buckets_in_flight,
+					u64_to_bucket(lru_pos.offset),
+					lru_pos_time(lru_pos));
+
+	if (!bch2_err_matches(ret, BCH_ERR_transaction_restart)) {
+		scan->saw_key = true;
+		scan->next_pos = bpos_successor(lru_pos);
+	}
+
+	return ret;
+}
+
+static int __bch2_copygc_get_buckets(struct moving_context *ctxt,
+			struct copygc_lru_scan *scan,
+			struct bpos start,
+			struct bpos end)
 {
 	struct btree_trans *trans = ctxt->trans;
 
-	int ret = for_each_btree_key_max(trans, iter, BTREE_ID_lru,
-				  lru_start(BCH_LRU_BUCKET_FRAGMENTATION),
-				  lru_end(BCH_LRU_BUCKET_FRAGMENTATION),
-				  0, k,
-		try_add_copygc_bucket(trans, buckets_in_flight,
-				      u64_to_bucket(k.k->p.offset),
-				      lru_pos_time(k.k->p))
-	);
+	return for_each_btree_key_max(trans, iter, BTREE_ID_lru,
+				      start, end, 0, k,
+		try_add_copygc_lru_bucket(trans, scan, k.k->p));
+}
 
-	return ret < 0 ? ret : 0;
+static int bch2_copygc_get_buckets(struct moving_context *ctxt,
+			struct buckets_in_flight *buckets_in_flight)
+{
+	struct bch_fs *c = ctxt->trans->c;
+	struct bpos start = bpos_eq(c->copygc.bucket_fragmentation_cursor, POS_MIN)
+		? lru_start(BCH_LRU_BUCKET_FRAGMENTATION)
+		: c->copygc.bucket_fragmentation_cursor;
+	struct bpos end = lru_end(BCH_LRU_BUCKET_FRAGMENTATION);
+
+	if (bpos_lt(start, lru_start(BCH_LRU_BUCKET_FRAGMENTATION)) ||
+	    bpos_gt(start, end))
+		start = lru_start(BCH_LRU_BUCKET_FRAGMENTATION);
+
+	struct copygc_lru_scan scan = {
+		.buckets_in_flight	= buckets_in_flight,
+		.next_pos		= start,
+	};
+
+	int ret = __bch2_copygc_get_buckets(ctxt, &scan, start, end);
+	if (ret > 0)
+		ret = 0;
+	if (!ret && !scan.saw_key && !bpos_eq(start, lru_start(BCH_LRU_BUCKET_FRAGMENTATION))) {
+		scan.next_pos = lru_start(BCH_LRU_BUCKET_FRAGMENTATION);
+		ret = __bch2_copygc_get_buckets(ctxt, &scan, scan.next_pos, end);
+		if (ret > 0)
+			ret = 0;
+	}
+
+	if (!ret) {
+		if (!scan.saw_key || bpos_gt(scan.next_pos, end))
+			scan.next_pos = lru_start(BCH_LRU_BUCKET_FRAGMENTATION);
+		c->copygc.bucket_fragmentation_cursor = scan.next_pos;
+	}
+
+	return ret;
 }
 
 static int bch2_copygc_get_stripe_buckets(struct moving_context *ctxt,

--- a/fs/data/copygc.c
+++ b/fs/data/copygc.c
@@ -366,6 +366,8 @@ static int bch2_copygc(struct moving_context *ctxt,
 		*i = NULL;
 
 		move_bucket_in_flight_add(buckets_in_flight, b);
+		if (bch2_dev_rotational(c, b->k.bucket.inode))
+			bch2_moving_ctxt_set_rotational_limits(ctxt);
 
 		ret = bch2_evacuate_bucket(ctxt, b, b->k.bucket, b->k.generation, data_opts);
 		if (ret)

--- a/fs/data/copygc.c
+++ b/fs/data/copygc.c
@@ -470,6 +470,10 @@ __cold void bch2_copygc_wait_to_text(struct printbuf *out, struct bch_fs *c)
 	printbuf_tabstop_push(out, 32);
 	prt_printf(out, "running:\t%u\n",		c->copygc.running);
 	prt_printf(out, "pressure pending:\t%u\n",	READ_ONCE(c->copygc.pressure_pending));
+	prt_printf(out, "current run pressure:\t%u\n",	READ_ONCE(c->copygc.current_run_pressure));
+	prt_printf(out, "last run pressure:\t%u\n",	READ_ONCE(c->copygc.last_run_pressure));
+	prt_printf(out, "pressure run count:\t%u\n",	READ_ONCE(c->copygc.pressure_run_count));
+	prt_printf(out, "last pressure run:\t%u\n",	READ_ONCE(c->copygc.last_pressure_run));
 	prt_printf(out, "run count:\t%u\n",		c->copygc.run_count);
 	prt_printf(out, "copygc_wait:\t%llu\n",		c->copygc.wait);
 	prt_printf(out, "copygc_wait_at:\t%llu\n",	c->copygc.wait_at);
@@ -576,10 +580,19 @@ static int bch2_copygc_thread(void *arg)
 		kick = READ_ONCE(c->copygc.kick_count);
 		c->copygc.wait = 0;
 		bool pressure = xchg(&c->copygc.pressure_pending, false);
+		u32 run = READ_ONCE(c->copygc.run_count) + 1;
+		if (pressure) {
+			WRITE_ONCE(c->copygc.pressure_run_count,
+				   READ_ONCE(c->copygc.pressure_run_count) + 1);
+			WRITE_ONCE(c->copygc.last_pressure_run, run);
+		}
 
+		WRITE_ONCE(c->copygc.current_run_pressure, pressure);
 		c->copygc.running = true;
 		ret = bch2_copygc(&ctxt, &buckets, pressure, &did_work);
 		c->copygc.running = false;
+		WRITE_ONCE(c->copygc.last_run_pressure, pressure);
+		WRITE_ONCE(c->copygc.current_run_pressure, false);
 		c->copygc.run_count++;
 
 		wake_up(&c->copygc.running_wq);

--- a/fs/data/copygc.c
+++ b/fs/data/copygc.c
@@ -50,6 +50,7 @@
 #include "util/clock.h"
 
 #include <linux/freezer.h>
+#include <linux/ioprio.h>
 #include <linux/kthread.h>
 #include <linux/math64.h>
 #include <linux/sched/task.h>
@@ -326,6 +327,7 @@ err:
 noinline
 static int bch2_copygc(struct moving_context *ctxt,
 		       struct buckets_in_flight *buckets_in_flight,
+		       bool pressure,
 		       bool *did_work)
 {
 	struct btree_trans *trans = ctxt->trans;
@@ -333,6 +335,9 @@ static int bch2_copygc(struct moving_context *ctxt,
 	struct data_update_opts data_opts = {
 		.type		= BCH_DATA_UPDATE_copygc,
 		.commit_flags	= (unsigned) BCH_WATERMARK_copygc,
+		.ioprio		= pressure
+			? IOPRIO_PRIO_VALUE(IOPRIO_CLASS_BE, 7)
+			: 0,
 	};
 	u64 sectors_seen	= atomic64_read(&ctxt->stats->sectors_seen);
 	u64 sectors_moved	= atomic64_read(&ctxt->stats->sectors_moved);
@@ -464,6 +469,7 @@ __cold void bch2_copygc_wait_to_text(struct printbuf *out, struct bch_fs *c)
 {
 	printbuf_tabstop_push(out, 32);
 	prt_printf(out, "running:\t%u\n",		c->copygc.running);
+	prt_printf(out, "pressure pending:\t%u\n",	READ_ONCE(c->copygc.pressure_pending));
 	prt_printf(out, "run count:\t%u\n",		c->copygc.run_count);
 	prt_printf(out, "copygc_wait:\t%llu\n",		c->copygc.wait);
 	prt_printf(out, "copygc_wait_at:\t%llu\n",	c->copygc.wait_at);
@@ -569,9 +575,10 @@ static int bch2_copygc_thread(void *arg)
 
 		kick = READ_ONCE(c->copygc.kick_count);
 		c->copygc.wait = 0;
+		bool pressure = xchg(&c->copygc.pressure_pending, false);
 
 		c->copygc.running = true;
-		ret = bch2_copygc(&ctxt, &buckets, &did_work);
+		ret = bch2_copygc(&ctxt, &buckets, pressure, &did_work);
 		c->copygc.running = false;
 		c->copygc.run_count++;
 

--- a/fs/data/copygc.h
+++ b/fs/data/copygc.h
@@ -17,6 +17,12 @@ static inline void bch2_copygc_wakeup(struct bch_fs *c)
 		wake_up_process(p);
 }
 
+static inline void bch2_copygc_wakeup_for_pressure(struct bch_fs *c)
+{
+	WRITE_ONCE(c->copygc.pressure_pending, true);
+	bch2_copygc_wakeup(c);
+}
+
 void bch2_copygc_stop(struct bch_fs *);
 int bch2_copygc_start(struct bch_fs *);
 

--- a/fs/data/copygc_types.h
+++ b/fs/data/copygc_types.h
@@ -15,6 +15,7 @@ struct bch_fs_copygc {
 	u32			last_pressure_run;
 	u32			run_count;
 	u32			kick_count;
+	struct bpos		bucket_fragmentation_cursor;
 	wait_queue_head_t	running_wq;
 
 	/* Dedicated workqueue for btree updates: */

--- a/fs/data/copygc_types.h
+++ b/fs/data/copygc_types.h
@@ -8,6 +8,7 @@ struct bch_fs_copygc {
 	s64			wait_at;
 	s64			wait;
 	bool			running;
+	bool			pressure_pending;
 	u32			run_count;
 	u32			kick_count;
 	wait_queue_head_t	running_wq;
@@ -17,4 +18,3 @@ struct bch_fs_copygc {
 };
 
 #endif /* _BCACHEFS_COPYGC_TYPES_H */
-

--- a/fs/data/copygc_types.h
+++ b/fs/data/copygc_types.h
@@ -9,6 +9,10 @@ struct bch_fs_copygc {
 	s64			wait;
 	bool			running;
 	bool			pressure_pending;
+	bool			current_run_pressure;
+	bool			last_run_pressure;
+	u32			pressure_run_count;
+	u32			last_pressure_run;
 	u32			run_count;
 	u32			kick_count;
 	wait_queue_head_t	running_wq;

--- a/fs/data/migrate.c
+++ b/fs/data/migrate.c
@@ -7,6 +7,7 @@
 
 #include "alloc/backpointers.h"
 #include "alloc/buckets.h"
+#include "alloc/disk_groups.h"
 #include "alloc/replicas.h"
 
 #include "btree/bkey_buf.h"
@@ -27,6 +28,14 @@
 #include "sb/io.h"
 
 #include "init/progress.h"
+
+struct btree_ptr_location {
+	enum btree_id		btree;
+	unsigned int		rewrite_level;
+	struct bpos		pos;
+};
+
+DEFINE_DARRAY_NAMED(darray_btree_ptr_location, struct btree_ptr_location);
 
 static struct bkey_i *drop_dev_ptrs(struct btree_trans *trans, struct bkey_s_c k, unsigned dev_idx,
 				    unsigned flags, struct printbuf *err)
@@ -89,6 +98,102 @@ static int drop_btree_ptrs(struct btree_trans *trans, struct btree_iter *iter,
 	return bch2_btree_node_update_key(trans, iter, b, n, 0, false);
 }
 
+static unsigned int btree_ptr_rewrite_target(struct bch_fs *c)
+{
+	if (c->opts.metadata_target &&
+	    bch2_target_accepts_data(c, BCH_DATA_btree, c->opts.metadata_target))
+		return c->opts.metadata_target;
+
+	if (c->opts.foreground_target &&
+	    bch2_target_accepts_data(c, BCH_DATA_btree, c->opts.foreground_target))
+		return c->opts.foreground_target;
+
+	return 0;
+}
+
+static int drop_or_rewrite_btree_ptrs(struct btree_trans *trans,
+				      struct btree_iter *iter,
+				      struct btree *b, unsigned int dev_idx,
+				      unsigned int flags, struct printbuf *err)
+{
+	struct printbuf drop_err = PRINTBUF;
+	int ret = drop_btree_ptrs(trans, iter, b, dev_idx, flags, &drop_err);
+	bool drop_would_degrade = bch2_err_matches(ret, BCH_ERR_remove_would_lose_data);
+
+	if (drop_would_degrade)
+		ret = bch2_btree_node_rewrite_pos(trans, iter->btree_id,
+						  b->c.level + 1, b->key.k.p,
+						  btree_ptr_rewrite_target(trans->c),
+						  BCH_TRANS_COMMIT_no_enospc, 0);
+
+	if (bch2_err_matches(ret, BCH_ERR_transaction_restart))
+		goto out;
+
+	if (ret && drop_would_degrade) {
+		prt_printf(err,
+			   "cannot drop device metadata ptr without degrading metadata; "
+			   "btree node rewrite failed: %s\n  ",
+			   bch2_err_str(ret));
+		prt_str(err, bch2_printbuf_str(&drop_err));
+	} else if (ret) {
+		prt_str(err, bch2_printbuf_str(&drop_err));
+	}
+out:
+	printbuf_exit(&drop_err);
+	return ret;
+}
+
+static int btree_ptr_locations_collect(struct btree_trans *trans,
+				       struct progress_indicator *progress,
+				       unsigned int dev_idx,
+				       darray_btree_ptr_location *locations)
+{
+	struct bch_fs *c = trans->c;
+	size_t limit = (system_totalram_bytes() / 16) /
+		sizeof(struct btree_ptr_location);
+
+	for (unsigned btree = 0; btree < btree_id_nr_alive(c); btree++)
+		for (unsigned level = 0; level < BTREE_MAX_DEPTH; level++)
+			try(for_each_btree_node(trans, iter, btree, POS_MIN, level, 0, b, ({
+				int ret = bch2_progress_update_iter(trans, progress, &iter);
+				if (!ret &&
+				    bch2_bkey_has_device_c(c, bkey_i_to_s_c(&b->key), dev_idx)) {
+					struct btree_ptr_location loc = {
+						.btree		= btree,
+						.rewrite_level	= b->c.level + 1,
+						.pos		= b->key.k.p,
+					};
+
+					ret = locations->nr >= limit
+						? -ENOMEM
+						: darray_push_gfp(locations, loc, GFP_KERNEL|__GFP_NOWARN);
+				}
+				ret;
+			})));
+
+	return 0;
+}
+
+static int btree_ptr_location_drop_or_rewrite(struct btree_trans *trans,
+					      struct btree_ptr_location *loc,
+					      unsigned int dev_idx,
+					      unsigned int flags,
+					      struct printbuf *err)
+{
+	CLASS(btree_node_iter, iter)(trans, loc->btree, loc->pos, 0, loc->rewrite_level - 1, 0);
+	struct btree *b = bch2_btree_iter_peek_node(&iter);
+	int ret = PTR_ERR_OR_ZERO(b);
+
+	if (ret == -ENOENT)
+		return 0;
+	if (ret)
+		return ret;
+	if (!b)
+		return 0;
+
+	return drop_or_rewrite_btree_ptrs(trans, &iter, b, dev_idx, flags, err);
+}
+
 static int bch2_dev_usrdata_drop_key(struct btree_trans *trans,
 				     struct btree_iter *iter,
 				     struct bkey_s_c k,
@@ -122,7 +227,7 @@ static int bch2_dev_btree_drop_key(struct btree_trans *trans,
 	if (ret)
 		return ret == -BCH_ERR_backpointer_to_overwritten_btree_node ? 0 : ret;
 
-	return drop_btree_ptrs(trans, &iter, b, dev_idx, flags, err);
+	return drop_or_rewrite_btree_ptrs(trans, &iter, b, dev_idx, flags, err);
 }
 
 static int bch2_dev_usrdata_drop(struct bch_fs *c,
@@ -164,13 +269,13 @@ static int bch2_dev_metadata_drop(struct bch_fs *c,
 		return bch_err_throw(c, remove_with_metadata_missing_unimplemented);
 
 	CLASS(btree_trans, trans)(c);
+	CLASS(darray_btree_ptr_location, locations)();
 
-	for (unsigned btree = 0; btree < btree_id_nr_alive(c); btree++)
-		for (unsigned level = 0; level < BTREE_MAX_DEPTH; level++)
-			try(for_each_btree_node(trans, iter, btree, POS_MIN, level, 0, b, ({
-				bch2_progress_update_iter(trans, progress, &iter) ?:
-				drop_btree_ptrs(trans, &iter, b, dev_idx, flags, err);
-			})));
+	try(btree_ptr_locations_collect(trans, progress, dev_idx, &locations));
+
+	darray_for_each(locations, loc)
+		try(lockrestart_do(trans,
+			btree_ptr_location_drop_or_rewrite(trans, loc, dev_idx, flags, err)));
 
 	bch2_trans_unlock(trans);
 	bch2_btree_interior_updates_flush(c);
@@ -207,15 +312,31 @@ static int data_drop_bp(struct btree_trans *trans, unsigned dev_idx,
 		return bch2_dev_usrdata_drop_key(trans, &iter, k, dev_idx, flags, err);
 }
 
-static u64 dev_data_buckets(struct bch_dev *ca)
+static u64 dev_data_buckets_from_usage(struct bch_dev_usage usage)
 {
-	struct bch_dev_usage usage = bch2_dev_usage_read(ca);
 	u64 nr = 0;
 	for (unsigned i = 0; i < BCH_DATA_NR; i++)
 		if (!data_type_is_empty(i) && !data_type_is_hidden(i))
 			nr += usage.buckets[i];
 
 	return nr;
+}
+
+static u64 dev_data_buckets(struct bch_dev *ca)
+{
+	return dev_data_buckets_from_usage(bch2_dev_usage_read(ca));
+}
+
+static bool dev_only_has_btree_buckets(struct bch_dev_usage usage)
+{
+	for (unsigned i = 0; i < BCH_DATA_NR; i++)
+		if (!data_type_is_empty(i) &&
+		    !data_type_is_hidden(i) &&
+		    i != BCH_DATA_btree &&
+		    usage.buckets[i])
+			return false;
+
+	return usage.buckets[BCH_DATA_btree] != 0;
 }
 
 int bch2_dev_data_drop_by_backpointers(struct bch_fs *c, struct bch_dev *ca,
@@ -272,9 +393,30 @@ int bch2_dev_data_drop_by_backpointers(struct bch_fs *c, struct bch_dev *ca,
 			bch2_trans_commit(trans, &res.r, NULL, BCH_TRANS_COMMIT_no_enospc);
 		})));
 
-		u64 data_buckets = dev_data_buckets(ca);
+		bch2_trans_unlock_long(trans);
+		bch2_btree_interior_updates_flush(c);
+
+		struct bch_dev_usage usage = bch2_dev_usage_read(ca);
+		u64 data_buckets = dev_data_buckets_from_usage(usage);
 		if (!data_buckets)
 			return 0;
+
+		if (dev_only_has_btree_buckets(usage)) {
+			u64 old_data_buckets = data_buckets;
+
+			bch2_progress_init(&progress, "dropping metadata", c, ~0ULL, ~0ULL);
+			try(bch2_dev_metadata_drop(c, &progress, dev_idx, flags, err));
+
+			data_buckets = dev_data_buckets(ca);
+			if (!data_buckets)
+				return 0;
+
+			if (data_buckets >= old_data_buckets) {
+				prt_printf(err, "%s(): no progress dropping btree metadata, %llu data buckets remain\n",
+					   __func__, data_buckets);
+				return bch_err_throw(c, remove_by_backpointer_did_not_terminate);
+			}
+		}
 
 		if (data_buckets < min_data_buckets) {
 			min_data_buckets = data_buckets;

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -210,10 +210,8 @@ void bch2_moving_ctxt_account_noflush_commit(struct moving_context *ctxt, u32 se
 
 static bool bch2_moving_ctxt_needs_flush(struct moving_context *ctxt)
 {
-	struct bch_fs *c = ctxt->trans->c;
-
 	guard(mutex)(&ctxt->lock);
-	return ctxt->noflush_sectors >= c->opts.move_bytes_in_flight >> 9;
+	return ctxt->noflush_sectors >= ctxt->noflush_sectors_limit;
 }
 
 void bch2_moving_ctxt_exit(struct moving_context *ctxt)
@@ -260,6 +258,7 @@ void bch2_moving_ctxt_init(struct moving_context *ctxt,
 	ctxt->wait_on_copygc = wait_on_copygc;
 	ctxt->max_sectors_in_flight = c->opts.move_bytes_in_flight >> 9;
 	ctxt->max_ios_in_flight = c->opts.move_ios_in_flight;
+	ctxt->noflush_sectors_limit = c->opts.move_bytes_in_flight >> 9;
 
 	closure_init_stack(&ctxt->cl);
 
@@ -1326,7 +1325,7 @@ static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs 
 		   ctxt->max_sectors_in_flight);
 	prt_printf(out, "noflush sectors:\t%llu/%llu seq %llu\n",
 		   noflush_sectors,
-		   (u64) ctxt->max_sectors_in_flight,
+		   (u64) ctxt->noflush_sectors_limit,
 		   noflush_seq);
 
 	guard(printbuf_indent)(out);

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -41,7 +41,7 @@
 
 static inline u16 bch2_move_ioprio(struct data_update_opts *opts)
 {
-	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_BE, 7);
 }
 
 const char * const bch2_data_ops_strs[] = {

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -291,10 +291,7 @@ void bch2_moving_ctxt_init(struct moving_context *ctxt,
 	ctxt->stats	= stats;
 	ctxt->wp	= wp;
 	ctxt->wait_on_copygc = wait_on_copygc;
-	ctxt->max_sectors_in_flight = c->opts.move_bytes_in_flight >> 9;
-	ctxt->max_ios_in_flight = c->opts.move_ios_in_flight;
-	ctxt->noflush_sectors_limit =
-		max_t(u32, c->opts.move_bytes_in_flight, MOVE_NOFLUSH_MIN_BYTES) >> 9;
+	bch2_moving_ctxt_reset_limits(ctxt);
 
 	closure_init_stack(&ctxt->cl);
 
@@ -312,6 +309,16 @@ void bch2_moving_ctxt_init(struct moving_context *ctxt,
 
 #define MOVE_ROTATIONAL_HIPRI_IOS_IN_FLIGHT	128U
 #define MOVE_ROTATIONAL_HIPRI_BYTES_IN_FLIGHT	(16U << 20)
+
+void bch2_moving_ctxt_reset_limits(struct moving_context *ctxt)
+{
+	struct bch_fs *c = ctxt->trans->c;
+
+	ctxt->max_sectors_in_flight = c->opts.move_bytes_in_flight >> 9;
+	ctxt->max_ios_in_flight = c->opts.move_ios_in_flight;
+	ctxt->noflush_sectors_limit =
+		max_t(u32, c->opts.move_bytes_in_flight, MOVE_NOFLUSH_MIN_BYTES) >> 9;
+}
 
 void bch2_moving_ctxt_set_rotational_limits(struct moving_context *ctxt,
 					    enum move_rotational_limit limit)

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -124,6 +124,18 @@ struct data_update *bch2_moving_ctxt_next_pending_write(struct moving_context *c
 	return u && u->read_done ? u : NULL;
 }
 
+static bool bch2_moving_ctxt_can_submit_write(struct moving_context *ctxt)
+{
+	return atomic_read(&ctxt->write_sectors) < ctxt->max_sectors_in_flight &&
+		atomic_read(&ctxt->write_ios) < ctxt->max_ios_in_flight;
+}
+
+bool bch2_moving_ctxt_pending_write_ready(struct moving_context *ctxt)
+{
+	return bch2_moving_ctxt_next_pending_write(ctxt) &&
+		bch2_moving_ctxt_can_submit_write(ctxt);
+}
+
 static void move_read_endio(struct bio *bio)
 {
 	struct data_update *u = container_of(bio, struct data_update, rbio.bio);
@@ -141,7 +153,8 @@ void bch2_moving_ctxt_do_pending_writes(struct moving_context *ctxt)
 {
 	struct data_update *u;
 
-	while ((u = bch2_moving_ctxt_next_pending_write(ctxt))) {
+	while (bch2_moving_ctxt_can_submit_write(ctxt) &&
+	       (u = bch2_moving_ctxt_next_pending_write(ctxt))) {
 		bch2_trans_unlock_long(ctxt->trans);
 		list_del(&u->read_list);
 		move_write(u);

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -272,15 +272,26 @@ void bch2_moving_ctxt_init(struct moving_context *ctxt,
 		list_add(&ctxt->list, &c->moving_context_list);
 }
 
-#define MOVE_ROTATIONAL_IOS_IN_FLIGHT		8U
-#define MOVE_ROTATIONAL_BYTES_IN_FLIGHT		(1U << 20)
+#define MOVE_ROTATIONAL_BG_IOS_IN_FLIGHT	8U
+#define MOVE_ROTATIONAL_BG_BYTES_IN_FLIGHT	(1U << 20)
 
-void bch2_moving_ctxt_set_rotational_limits(struct moving_context *ctxt)
+#define MOVE_ROTATIONAL_HIPRI_IOS_IN_FLIGHT	128U
+#define MOVE_ROTATIONAL_HIPRI_BYTES_IN_FLIGHT	(16U << 20)
+
+void bch2_moving_ctxt_set_rotational_limits(struct moving_context *ctxt,
+					    enum move_rotational_limit limit)
 {
+	u32 max_ios = limit == MOVE_ROTATIONAL_LIMIT_hipri
+		? MOVE_ROTATIONAL_HIPRI_IOS_IN_FLIGHT
+		: MOVE_ROTATIONAL_BG_IOS_IN_FLIGHT;
+	u32 max_bytes = limit == MOVE_ROTATIONAL_LIMIT_hipri
+		? MOVE_ROTATIONAL_HIPRI_BYTES_IN_FLIGHT
+		: MOVE_ROTATIONAL_BG_BYTES_IN_FLIGHT;
+
 	ctxt->max_ios_in_flight = min(ctxt->max_ios_in_flight,
-				      MOVE_ROTATIONAL_IOS_IN_FLIGHT);
+				      max_ios);
 	ctxt->max_sectors_in_flight = min(ctxt->max_sectors_in_flight,
-					  MOVE_ROTATIONAL_BYTES_IN_FLIGHT >> 9);
+					  max_bytes >> 9);
 }
 
 void bch2_move_stats_exit(struct bch_move_stats *stats, struct bch_fs *c)
@@ -787,7 +798,8 @@ int bch2_move_data_phys(struct bch_fs *c,
 	bch2_moving_ctxt_init(&ctxt, c, rate, stats, wp, wait_on_copygc);
 
 	if (bch2_dev_rotational(c, dev))
-		bch2_moving_ctxt_set_rotational_limits(&ctxt);
+		bch2_moving_ctxt_set_rotational_limits(&ctxt,
+				MOVE_ROTATIONAL_LIMIT_background);
 
 	if (ctxt.stats) {
 		ctxt.stats->phys = true;

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -1201,6 +1201,25 @@ __cold void bch2_move_stats_to_text(struct printbuf *out, struct bch_move_stats 
 	prt_newline(out);
 }
 
+static const char *bch2_moving_ctxt_wait_reason(struct bch_fs *c,
+						struct moving_context *ctxt)
+{
+	u32 sectors_limit = c->opts.move_bytes_in_flight >> 9;
+
+	if (ctxt->wait_on_copygc && READ_ONCE(c->copygc.running))
+		return "copygc running";
+	if (atomic_read(&ctxt->write_ios) >= c->opts.move_ios_in_flight)
+		return "write ios in flight";
+	if (atomic_read(&ctxt->read_ios) >= c->opts.move_ios_in_flight)
+		return "read ios in flight";
+	if (atomic_read(&ctxt->write_sectors) >= sectors_limit)
+		return "write bytes in flight";
+	if (atomic_read(&ctxt->read_sectors) >= sectors_limit)
+		return "read bytes in flight";
+
+	return "none";
+}
+
 static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs *c, struct moving_context *ctxt)
 {
 	if (!out->nr_tabstops)
@@ -1208,6 +1227,9 @@ static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs 
 
 	bch2_move_stats_to_text(out, ctxt->stats);
 	guard(printbuf_indent)(out);
+
+	prt_printf(out, "wait reason:\t%s\n", bch2_moving_ctxt_wait_reason(c, ctxt));
+	prt_printf(out, "wait on copygc:\t%u\n", ctxt->wait_on_copygc);
 
 	prt_printf(out, "reads: ios %u/%u sectors %u/%u\n",
 		   atomic_read(&ctxt->read_ios),

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -212,7 +212,11 @@ int bch2_moving_ctxt_flush_all(struct moving_context *ctxt)
 		seq = ctxt->noflush_seq;
 
 	if (seq) {
-		int ret = bch2_journal_flush_seq(&c->journal, seq, TASK_UNINTERRUPTIBLE);
+		int ret = bch2_btree_write_buffer_flush_sync(ctxt->trans);
+		if (ret)
+			return ret;
+
+		ret = bch2_journal_flush_seq(&c->journal, seq, TASK_UNINTERRUPTIBLE);
 		if (ret)
 			return ret;
 

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -247,6 +247,8 @@ static bool bch2_moving_ctxt_needs_flush(struct moving_context *ctxt)
 	return ctxt->noflush_sectors >= ctxt->noflush_sectors_limit;
 }
 
+#define MOVE_NOFLUSH_MIN_BYTES			(16U << 20)
+
 void bch2_moving_ctxt_exit(struct moving_context *ctxt)
 {
 	struct bch_fs *c = ctxt->trans->c;
@@ -291,7 +293,8 @@ void bch2_moving_ctxt_init(struct moving_context *ctxt,
 	ctxt->wait_on_copygc = wait_on_copygc;
 	ctxt->max_sectors_in_flight = c->opts.move_bytes_in_flight >> 9;
 	ctxt->max_ios_in_flight = c->opts.move_ios_in_flight;
-	ctxt->noflush_sectors_limit = c->opts.move_bytes_in_flight >> 9;
+	ctxt->noflush_sectors_limit =
+		max_t(u32, c->opts.move_bytes_in_flight, MOVE_NOFLUSH_MIN_BYTES) >> 9;
 
 	closure_init_stack(&ctxt->cl);
 

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -109,10 +109,6 @@ static void move_write(struct data_update *u)
 				     &ctxt->stats->sectors_error_corrected);
 	}
 
-	closure_get(&ctxt->cl);
-	atomic_add(u->k.k->k.size, &ctxt->write_sectors);
-	atomic_inc(&ctxt->write_ios);
-
 	bch2_data_update_read_done(u);
 }
 
@@ -124,16 +120,49 @@ struct data_update *bch2_moving_ctxt_next_pending_write(struct moving_context *c
 	return u && u->read_done ? u : NULL;
 }
 
-static bool bch2_moving_ctxt_can_submit_write(struct moving_context *ctxt)
+static bool bch2_moving_ctxt_can_submit_write(struct moving_context *ctxt,
+					      struct data_update *u)
 {
-	return atomic_read(&ctxt->write_sectors) < ctxt->max_sectors_in_flight &&
-		atomic_read(&ctxt->write_ios) < ctxt->max_ios_in_flight;
+	u32 sectors = u ? u->k.k->k.size : 0;
+	u32 write_sectors = atomic_read(&ctxt->write_sectors);
+
+	return atomic_read(&ctxt->write_ios) < ctxt->max_ios_in_flight &&
+		(write_sectors + sectors <= ctxt->max_sectors_in_flight ||
+		 !write_sectors);
+}
+
+static bool bch2_moving_ctxt_reserve_write(struct moving_context *ctxt,
+					   struct data_update *u)
+{
+	u32 sectors = u->k.k->k.size;
+	int old, new;
+
+	/* Reserve the write window before submitting; check-then-add can overshoot. */
+	do {
+		old = atomic_read(&ctxt->write_sectors);
+		if (old && old + sectors > ctxt->max_sectors_in_flight)
+			return false;
+		new = old + sectors;
+	} while (atomic_cmpxchg(&ctxt->write_sectors, old, new) != old);
+
+	do {
+		old = atomic_read(&ctxt->write_ios);
+		if (old >= ctxt->max_ios_in_flight) {
+			atomic_sub(sectors, &ctxt->write_sectors);
+			return false;
+		}
+		new = old + 1;
+	} while (atomic_cmpxchg(&ctxt->write_ios, old, new) != old);
+
+	closure_get(&ctxt->cl);
+	return true;
 }
 
 bool bch2_moving_ctxt_pending_write_ready(struct moving_context *ctxt)
 {
-	return bch2_moving_ctxt_next_pending_write(ctxt) &&
-		bch2_moving_ctxt_can_submit_write(ctxt);
+	struct data_update *u = bch2_moving_ctxt_next_pending_write(ctxt);
+
+	return u && bch2_moving_ctxt_can_submit_write(ctxt, u);
 }
 
 static void move_read_endio(struct bio *bio)
@@ -153,8 +182,8 @@ void bch2_moving_ctxt_do_pending_writes(struct moving_context *ctxt)
 {
 	struct data_update *u;
 
-	while (bch2_moving_ctxt_can_submit_write(ctxt) &&
-	       (u = bch2_moving_ctxt_next_pending_write(ctxt))) {
+	while ((u = bch2_moving_ctxt_next_pending_write(ctxt)) &&
+	       bch2_moving_ctxt_reserve_write(ctxt, u)) {
 		bch2_trans_unlock_long(ctxt->trans);
 		list_del(&u->read_list);
 		move_write(u);

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -39,6 +39,11 @@
 #include <linux/ioprio.h>
 #include <linux/kthread.h>
 
+static inline u16 bch2_move_ioprio(struct data_update_opts *opts)
+{
+	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+}
+
 const char * const bch2_data_ops_strs[] = {
 #define x(t, n, ...) [n] = #t,
 	BCH_DATA_OPS()
@@ -253,7 +258,7 @@ static int __bch2_move_extent(struct moving_context *ctxt,
 
 	u->op.end_io		= move_write_done;
 	u->rbio.bio.bi_end_io	= move_read_endio;
-	u->rbio.bio.bi_ioprio	= IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+	u->rbio.bio.bi_ioprio	= bch2_move_ioprio(data_opts);
 
 	u32 size = k.k->size;
 

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -29,6 +29,7 @@
 
 #include "init/error.h"
 
+#include "journal/journal.h"
 #include "journal/reclaim.h"
 
 #include "sb/counters.h"
@@ -156,18 +157,59 @@ void bch2_move_ctxt_wait_for_io(struct moving_context *ctxt)
 		atomic_read(&ctxt->write_sectors) != sectors_pending);
 }
 
-void bch2_moving_ctxt_flush_all(struct moving_context *ctxt)
+int bch2_moving_ctxt_flush_all(struct moving_context *ctxt)
 {
+	struct bch_fs *c = ctxt->trans->c;
+	u64 seq;
+
 	move_ctxt_wait_event(ctxt, list_empty(&ctxt->reads));
 	bch2_trans_unlock_long(ctxt->trans);
 	closure_sync(&ctxt->cl);
+
+	scoped_guard(mutex, &ctxt->lock)
+		seq = ctxt->noflush_seq;
+
+	if (seq) {
+		int ret = bch2_journal_flush_seq(&c->journal, seq, TASK_UNINTERRUPTIBLE);
+		if (ret)
+			return ret;
+
+		scoped_guard(mutex, &ctxt->lock) {
+			if (ctxt->noflush_seq <= seq) {
+				ctxt->noflush_sectors = 0;
+				ctxt->noflush_seq = 0;
+			}
+		}
+	}
+
+	return 0;
+}
+
+void bch2_moving_ctxt_account_noflush_commit(struct moving_context *ctxt, u32 sectors, u64 seq)
+{
+	if (!seq)
+		return;
+
+	guard(mutex)(&ctxt->lock);
+	ctxt->noflush_sectors += sectors;
+	ctxt->noflush_seq = max(ctxt->noflush_seq, seq);
+}
+
+static bool bch2_moving_ctxt_needs_flush(struct moving_context *ctxt)
+{
+	struct bch_fs *c = ctxt->trans->c;
+
+	guard(mutex)(&ctxt->lock);
+	return ctxt->noflush_sectors >= c->opts.move_bytes_in_flight >> 9;
 }
 
 void bch2_moving_ctxt_exit(struct moving_context *ctxt)
 {
 	struct bch_fs *c = ctxt->trans->c;
 
-	bch2_moving_ctxt_flush_all(ctxt);
+	int ret = bch2_moving_ctxt_flush_all(ctxt);
+	if (ret)
+		bch_err_fn(c, ret);
 
 	EBUG_ON(atomic_read(&ctxt->write_sectors));
 	EBUG_ON(atomic_read(&ctxt->write_ios));
@@ -421,13 +463,6 @@ int bch2_move_ratelimit(struct moving_context *ctxt)
 	bool is_kthread = current->flags & PF_KTHREAD;
 	u64 delay;
 
-	if (ctxt->wait_on_copygc && c->copygc.running) {
-		bch2_moving_ctxt_flush_all(ctxt);
-		wait_event_freezable(c->copygc.running_wq,
-				    !c->copygc.running ||
-				    (is_kthread && kthread_should_stop()));
-	}
-
 	do {
 		delay = ctxt->rate ? bch2_ratelimit_delay(ctxt->rate) : 0;
 
@@ -441,10 +476,15 @@ int bch2_move_ratelimit(struct moving_context *ctxt)
 					delay);
 
 		if (unlikely(freezing(current))) {
-			bch2_moving_ctxt_flush_all(ctxt);
+			int ret = bch2_moving_ctxt_flush_all(ctxt);
+			if (ret)
+				return ret;
 			try_to_freeze();
 		}
 	} while (delay);
+
+	if (bch2_moving_ctxt_needs_flush(ctxt))
+		try(bch2_moving_ctxt_flush_all(ctxt));
 
 	/*
 	 * XXX: these limits really ought to be per device, SSDs and hard drives
@@ -739,7 +779,9 @@ int bch2_move_data_phys(struct bch_fs *c,
 		.sector_end	= end,
 	};
 
-	return __bch2_move_data_phys(&ctxt, NULL, &w, data_types, false, pred, arg);
+	int ret = __bch2_move_data_phys(&ctxt, NULL, &w, data_types, false, pred, arg);
+
+	return ret ?: bch2_moving_ctxt_flush_all(&ctxt);
 }
 
 struct evacuate_arg {
@@ -1028,7 +1070,9 @@ int bch2_scrub_journal(struct bch_fs *c, u64 *rewind_seq)
 			}
 		}
 
-		bch2_moving_ctxt_flush_all(&ctxt);
+		ret = bch2_moving_ctxt_flush_all(&ctxt);
+		if (ret)
+			move_ret = ret;
 
 		if (move_ret)
 			bch_err(c, "journal scrub: move error %s in flush range seq %llu-%llu",
@@ -1206,8 +1250,6 @@ static const char *bch2_moving_ctxt_wait_reason(struct bch_fs *c,
 {
 	u32 sectors_limit = c->opts.move_bytes_in_flight >> 9;
 
-	if (ctxt->wait_on_copygc && READ_ONCE(c->copygc.running))
-		return "copygc running";
 	if (atomic_read(&ctxt->write_ios) >= c->opts.move_ios_in_flight)
 		return "write ios in flight";
 	if (atomic_read(&ctxt->read_ios) >= c->opts.move_ios_in_flight)
@@ -1222,8 +1264,15 @@ static const char *bch2_moving_ctxt_wait_reason(struct bch_fs *c,
 
 static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs *c, struct moving_context *ctxt)
 {
+	u64 noflush_sectors, noflush_seq;
+
 	if (!out->nr_tabstops)
 		printbuf_tabstop_push(out, 32);
+
+	scoped_guard(mutex, &ctxt->lock) {
+		noflush_sectors = ctxt->noflush_sectors;
+		noflush_seq = ctxt->noflush_seq;
+	}
 
 	bch2_move_stats_to_text(out, ctxt->stats);
 	guard(printbuf_indent)(out);
@@ -1242,6 +1291,10 @@ static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs 
 		   c->opts.move_ios_in_flight,
 		   atomic_read(&ctxt->write_sectors),
 		   c->opts.move_bytes_in_flight >> 9);
+	prt_printf(out, "noflush sectors:\t%llu/%llu seq %llu\n",
+		   noflush_sectors,
+		   (u64) c->opts.move_bytes_in_flight >> 9,
+		   noflush_seq);
 
 	guard(printbuf_indent)(out);
 

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -245,6 +245,8 @@ void bch2_moving_ctxt_init(struct moving_context *ctxt,
 	ctxt->stats	= stats;
 	ctxt->wp	= wp;
 	ctxt->wait_on_copygc = wait_on_copygc;
+	ctxt->max_sectors_in_flight = c->opts.move_bytes_in_flight >> 9;
+	ctxt->max_ios_in_flight = c->opts.move_ios_in_flight;
 
 	closure_init_stack(&ctxt->cl);
 
@@ -255,6 +257,17 @@ void bch2_moving_ctxt_init(struct moving_context *ctxt,
 
 	scoped_guard(mutex, &c->moving_context_lock)
 		list_add(&ctxt->list, &c->moving_context_list);
+}
+
+#define MOVE_ROTATIONAL_IOS_IN_FLIGHT		8U
+#define MOVE_ROTATIONAL_BYTES_IN_FLIGHT		(1U << 20)
+
+void bch2_moving_ctxt_set_rotational_limits(struct moving_context *ctxt)
+{
+	ctxt->max_ios_in_flight = min(ctxt->max_ios_in_flight,
+				      MOVE_ROTATIONAL_IOS_IN_FLIGHT);
+	ctxt->max_sectors_in_flight = min(ctxt->max_sectors_in_flight,
+					  MOVE_ROTATIONAL_BYTES_IN_FLIGHT >> 9);
 }
 
 void bch2_move_stats_exit(struct bch_move_stats *stats, struct bch_fs *c)
@@ -459,7 +472,6 @@ static int bch2_move_extent_pred(struct moving_context *ctxt,
 
 int bch2_move_ratelimit(struct moving_context *ctxt)
 {
-	struct bch_fs *c = ctxt->trans->c;
 	bool is_kthread = current->flags & PF_KTHREAD;
 	u64 delay;
 
@@ -486,15 +498,11 @@ int bch2_move_ratelimit(struct moving_context *ctxt)
 	if (bch2_moving_ctxt_needs_flush(ctxt))
 		try(bch2_moving_ctxt_flush_all(ctxt));
 
-	/*
-	 * XXX: these limits really ought to be per device, SSDs and hard drives
-	 * will want different limits
-	 */
 	move_ctxt_wait_event(ctxt,
-		atomic_read(&ctxt->write_sectors) < c->opts.move_bytes_in_flight >> 9 &&
-		atomic_read(&ctxt->read_sectors) < c->opts.move_bytes_in_flight >> 9 &&
-		atomic_read(&ctxt->write_ios) < c->opts.move_ios_in_flight &&
-		atomic_read(&ctxt->read_ios) < c->opts.move_ios_in_flight);
+		atomic_read(&ctxt->write_sectors) < ctxt->max_sectors_in_flight &&
+		atomic_read(&ctxt->read_sectors) < ctxt->max_sectors_in_flight &&
+		atomic_read(&ctxt->write_ios) < ctxt->max_ios_in_flight &&
+		atomic_read(&ctxt->read_ios) < ctxt->max_ios_in_flight);
 
 	return 0;
 }
@@ -764,6 +772,9 @@ int bch2_move_data_phys(struct bch_fs *c,
 {
 	struct moving_context ctxt __cleanup(bch2_moving_ctxt_exit);
 	bch2_moving_ctxt_init(&ctxt, c, rate, stats, wp, wait_on_copygc);
+
+	if (bch2_dev_rotational(c, dev))
+		bch2_moving_ctxt_set_rotational_limits(&ctxt);
 
 	if (ctxt.stats) {
 		ctxt.stats->phys = true;
@@ -1245,18 +1256,15 @@ __cold void bch2_move_stats_to_text(struct printbuf *out, struct bch_move_stats 
 	prt_newline(out);
 }
 
-static const char *bch2_moving_ctxt_wait_reason(struct bch_fs *c,
-						struct moving_context *ctxt)
+static const char *bch2_moving_ctxt_wait_reason(struct moving_context *ctxt)
 {
-	u32 sectors_limit = c->opts.move_bytes_in_flight >> 9;
-
-	if (atomic_read(&ctxt->write_ios) >= c->opts.move_ios_in_flight)
+	if (atomic_read(&ctxt->write_ios) >= ctxt->max_ios_in_flight)
 		return "write ios in flight";
-	if (atomic_read(&ctxt->read_ios) >= c->opts.move_ios_in_flight)
+	if (atomic_read(&ctxt->read_ios) >= ctxt->max_ios_in_flight)
 		return "read ios in flight";
-	if (atomic_read(&ctxt->write_sectors) >= sectors_limit)
+	if (atomic_read(&ctxt->write_sectors) >= ctxt->max_sectors_in_flight)
 		return "write bytes in flight";
-	if (atomic_read(&ctxt->read_sectors) >= sectors_limit)
+	if (atomic_read(&ctxt->read_sectors) >= ctxt->max_sectors_in_flight)
 		return "read bytes in flight";
 
 	return "none";
@@ -1277,23 +1285,23 @@ static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs 
 	bch2_move_stats_to_text(out, ctxt->stats);
 	guard(printbuf_indent)(out);
 
-	prt_printf(out, "wait reason:\t%s\n", bch2_moving_ctxt_wait_reason(c, ctxt));
+	prt_printf(out, "wait reason:\t%s\n", bch2_moving_ctxt_wait_reason(ctxt));
 	prt_printf(out, "wait on copygc:\t%u\n", ctxt->wait_on_copygc);
 
 	prt_printf(out, "reads: ios %u/%u sectors %u/%u\n",
 		   atomic_read(&ctxt->read_ios),
-		   c->opts.move_ios_in_flight,
+		   ctxt->max_ios_in_flight,
 		   atomic_read(&ctxt->read_sectors),
-		   c->opts.move_bytes_in_flight >> 9);
+		   ctxt->max_sectors_in_flight);
 
 	prt_printf(out, "writes: ios %u/%u sectors %u/%u\n",
 		   atomic_read(&ctxt->write_ios),
-		   c->opts.move_ios_in_flight,
+		   ctxt->max_ios_in_flight,
 		   atomic_read(&ctxt->write_sectors),
-		   c->opts.move_bytes_in_flight >> 9);
+		   ctxt->max_sectors_in_flight);
 	prt_printf(out, "noflush sectors:\t%llu/%llu seq %llu\n",
 		   noflush_sectors,
-		   (u64) c->opts.move_bytes_in_flight >> 9,
+		   (u64) ctxt->max_sectors_in_flight,
 		   noflush_seq);
 
 	guard(printbuf_indent)(out);

--- a/fs/data/move.h
+++ b/fs/data/move.h
@@ -42,6 +42,7 @@ struct moving_context {
 
 	unsigned		max_sectors_in_flight;
 	unsigned		max_ios_in_flight;
+	unsigned		noflush_sectors_limit;
 
 	/* For waiting on outstanding reads and writes: */
 	struct closure		cl;

--- a/fs/data/move.h
+++ b/fs/data/move.h
@@ -108,6 +108,7 @@ void bch2_moving_ctxt_exit(struct moving_context *);
 void bch2_moving_ctxt_init(struct moving_context *, struct bch_fs *,
 			   struct bch_ratelimit *, struct bch_move_stats *,
 			   struct write_point_specifier, bool);
+void bch2_moving_ctxt_reset_limits(struct moving_context *);
 enum move_rotational_limit {
 	MOVE_ROTATIONAL_LIMIT_background,
 	MOVE_ROTATIONAL_LIMIT_hipri,

--- a/fs/data/move.h
+++ b/fs/data/move.h
@@ -19,7 +19,9 @@ struct bch_read_bio;
  *  - write_sectors/write_ios: read completion -> write completion
  *
  * bch2_move_ratelimit() blocks the caller until all counters are below
- * c->opts.move_bytes_in_flight / move_ios_in_flight.
+ * max_sectors_in_flight / max_ios_in_flight. These default to the global
+ * fs options, but callers may lower them when a move context is tied to
+ * a slower device class.
  *
  * Extent moves (bch2_move_extent) and stripe repairs (bch2_stripe_repair)
  * both account through these counters.
@@ -37,6 +39,9 @@ struct moving_context {
 	struct bch_move_stats	*stats;
 	struct write_point_specifier wp;
 	bool			wait_on_copygc;
+
+	unsigned		max_sectors_in_flight;
+	unsigned		max_ios_in_flight;
 
 	/* For waiting on outstanding reads and writes: */
 	struct closure		cl;
@@ -102,6 +107,7 @@ void bch2_moving_ctxt_exit(struct moving_context *);
 void bch2_moving_ctxt_init(struct moving_context *, struct bch_fs *,
 			   struct bch_ratelimit *, struct bch_move_stats *,
 			   struct write_point_specifier, bool);
+void bch2_moving_ctxt_set_rotational_limits(struct moving_context *);
 struct data_update *bch2_moving_ctxt_next_pending_write(struct moving_context *);
 void bch2_moving_ctxt_do_pending_writes(struct moving_context *);
 int bch2_moving_ctxt_flush_all(struct moving_context *);

--- a/fs/data/move.h
+++ b/fs/data/move.h
@@ -107,7 +107,13 @@ void bch2_moving_ctxt_exit(struct moving_context *);
 void bch2_moving_ctxt_init(struct moving_context *, struct bch_fs *,
 			   struct bch_ratelimit *, struct bch_move_stats *,
 			   struct write_point_specifier, bool);
-void bch2_moving_ctxt_set_rotational_limits(struct moving_context *);
+enum move_rotational_limit {
+	MOVE_ROTATIONAL_LIMIT_background,
+	MOVE_ROTATIONAL_LIMIT_hipri,
+};
+
+void bch2_moving_ctxt_set_rotational_limits(struct moving_context *,
+					    enum move_rotational_limit);
 struct data_update *bch2_moving_ctxt_next_pending_write(struct moving_context *);
 bool bch2_moving_ctxt_pending_write_ready(struct moving_context *);
 void bch2_moving_ctxt_do_pending_writes(struct moving_context *);

--- a/fs/data/move.h
+++ b/fs/data/move.h
@@ -75,7 +75,7 @@ struct moving_context {
 			break;							\
 		bch2_trans_unlock_long((_ctxt)->trans);				\
 		_ret = __wait_event_timeout((_ctxt)->wait,			\
-			     bch2_moving_ctxt_next_pending_write(_ctxt) ||	\
+			     bch2_moving_ctxt_pending_write_ready(_ctxt) ||	\
 			     (cond_finished = (_cond)), _timeout);		\
 		if (_ret || ( cond_finished))					\
 			break;							\
@@ -92,7 +92,7 @@ do {									\
 		break;							\
 	bch2_trans_unlock_long((_ctxt)->trans);				\
 	__wait_event((_ctxt)->wait,					\
-		     bch2_moving_ctxt_next_pending_write(_ctxt) ||	\
+		     bch2_moving_ctxt_pending_write_ready(_ctxt) ||	\
 		     (cond_finished = (_cond)));			\
 	if (cond_finished)						\
 		break;							\
@@ -109,6 +109,7 @@ void bch2_moving_ctxt_init(struct moving_context *, struct bch_fs *,
 			   struct write_point_specifier, bool);
 void bch2_moving_ctxt_set_rotational_limits(struct moving_context *);
 struct data_update *bch2_moving_ctxt_next_pending_write(struct moving_context *);
+bool bch2_moving_ctxt_pending_write_ready(struct moving_context *);
 void bch2_moving_ctxt_do_pending_writes(struct moving_context *);
 int bch2_moving_ctxt_flush_all(struct moving_context *);
 void bch2_moving_ctxt_account_noflush_commit(struct moving_context *, u32, u64);

--- a/fs/data/move.h
+++ b/fs/data/move.h
@@ -52,6 +52,10 @@ struct moving_context {
 	atomic_t		read_ios;
 	atomic_t		write_ios;
 
+	/* Moved data indexed without FUA; must be ordered by a journal flush. */
+	u64			noflush_sectors;
+	u64			noflush_seq;
+
 	wait_queue_head_t	wait;
 };
 
@@ -100,7 +104,8 @@ void bch2_moving_ctxt_init(struct moving_context *, struct bch_fs *,
 			   struct write_point_specifier, bool);
 struct data_update *bch2_moving_ctxt_next_pending_write(struct moving_context *);
 void bch2_moving_ctxt_do_pending_writes(struct moving_context *);
-void bch2_moving_ctxt_flush_all(struct moving_context *);
+int bch2_moving_ctxt_flush_all(struct moving_context *);
+void bch2_moving_ctxt_account_noflush_commit(struct moving_context *, u32, u64);
 void bch2_move_ctxt_wait_for_io(struct moving_context *);
 int bch2_move_ratelimit(struct moving_context *);
 

--- a/fs/data/read.c
+++ b/fs/data/read.c
@@ -81,7 +81,7 @@ static inline u32 bch2_dev_congested_read(struct bch_dev *ca, u64 now)
 	s64 congested = atomic_read(&ca->congested);
 	u64 last = READ_ONCE(ca->congested_last);
 	if (time_after64(now, last))
-		congested -= (now - last) >> 12;
+		congested -= (now - last) >> 20;
 
 	return clamp(congested, 0LL, CONGESTED_MAX);
 }

--- a/fs/data/reconcile/trigger.c
+++ b/fs/data/reconcile/trigger.c
@@ -934,8 +934,24 @@ int bch2_update_reconcile_opts(struct btree_trans *trans,
 	struct bch_extent_reconcile new;
 
 	int ret = bch2_bkey_needs_reconcile(trans, k, opts, &need_update_invalid_devs, &new);
-	if (ret <= 0)
+	if (ret < 0)
 		return ret;
+	if (!ret) {
+		/*
+		 * A scan may be replaying after the reconcile work indexes were
+		 * lost or never created. If the extent's reconcile opts already
+		 * match, the trigger path won't fire; make the work bit match the
+		 * extent metadata here.
+		 */
+		if (!level) {
+			enum reconcile_work_id w = bch2_bkey_reconcile_work_id(c, k);
+
+			if (w)
+				return bch2_btree_bit_mod_buffered(trans, reconcile_work_btree[w],
+						data_to_rb_work_pos(iter->btree_id, k.k->p), true);
+		}
+		return 0;
+	}
 
 	if (!level) {
 		unsigned buf_u64s = k.k->u64s + 1 + BCH_REPLICAS_MAX;

--- a/fs/data/reconcile/types.h
+++ b/fs/data/reconcile/types.h
@@ -22,6 +22,9 @@ struct bch_fs_reconcile {
 	struct bbpos			work_pos;
 	struct bch_move_stats		work_stats;
 	struct progress_indicator	progress;
+	u64				phys_workers_considered;
+	u64				phys_workers_started;
+	u64				phys_workers_skipped_empty;
 
 	struct bbpos			scan_start;
 	struct bbpos			scan_end;

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1696,7 +1696,7 @@ static int do_reconcile_phase_iter(struct reconcile_pass *p, u32 kick,
 
 		if (bch2_err_matches(ret, BCH_ERR_data_update_fail_need_copygc)) {
 			bch2_trans_unlock_long(trans);
-			bch2_copygc_wakeup(c);
+			bch2_copygc_wakeup_for_pressure(c);
 			wait_event(c->copygc.running_wq,
 				   c->copygc.run_count != *p->copygc_run_count ||
 				   kthread_should_stop());

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -33,6 +33,7 @@
 #include "util/clock.h"
 
 #include <linux/freezer.h>
+#include <linux/ioprio.h>
 #include <linux/kthread.h>
 #include <linux/sched/cputime.h>
 
@@ -434,6 +435,8 @@ static int reconcile_set_data_opts(struct btree_trans *trans,
 
 	data_opts->type			= BCH_DATA_UPDATE_reconcile;
 	data_opts->target		= r->background_target;
+	if (r->hipri)
+		data_opts->ioprio	= IOPRIO_PRIO_VALUE(IOPRIO_CLASS_BE, 7);
 
 	/*
 	 * we can't add/drop replicas from btree nodes incrementally, we always

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1460,7 +1460,9 @@ static CLOSURE_CALLBACK(do_reconcile_phys_thread)
 	struct bbpos work_pos = BBPOS(reconcile_phases[thr->reconcile_phase].btree,
 				      POS(thr->dev, 0));
 
-	while (!bch2_move_ratelimit(&ctxt)) {
+	int ret = 0;
+
+	while (!(ret = bch2_move_ratelimit(&ctxt))) {
 		if (!bch2_reconcile_enabled(c) ||
 		    test_bit(BCH_FS_going_ro, &c->flags))
 			break;
@@ -1473,7 +1475,7 @@ static CLOSURE_CALLBACK(do_reconcile_phys_thread)
 		    k.k->p.inode != thr->dev)
 			break;
 
-		int ret = lockrestart_do(trans,
+		ret = lockrestart_do(trans,
 			do_reconcile_extent_phys(&ctxt, &snapshot_io_opts,
 						 BBPOS(work_pos.btree, k.k->p),
 						 &last_flushed,
@@ -1481,6 +1483,12 @@ static CLOSURE_CALLBACK(do_reconcile_phys_thread)
 		if (ret)
 			break;
 	}
+
+	if (ret > 0)
+		ret = 0;
+	ret = ret ?: bch2_moving_ctxt_flush_all(&ctxt);
+	if (ret)
+		bch_err_fn(c, ret);
 
 	bch2_moving_ctxt_exit(&ctxt);
 	closure_return(cl);
@@ -1781,7 +1789,7 @@ static int do_reconcile(struct moving_context *ctxt)
 	struct bkey_i_cookie pending_cookie;
 	bkey_init(&pending_cookie.k);
 
-	bch2_moving_ctxt_flush_all(ctxt);
+	try(bch2_moving_ctxt_flush_all(ctxt));
 
 	struct wb_maybe_flush last_flushed __cleanup(wb_maybe_flush_exit);
 	wb_maybe_flush_init(&last_flushed);
@@ -1801,10 +1809,12 @@ static int do_reconcile(struct moving_context *ctxt)
 
 	r->running = true;
 
-	while (!bch2_move_ratelimit(ctxt) &&
+	while (!(ret = bch2_move_ratelimit(ctxt)) &&
 	       !test_bit(BCH_FS_going_ro, &c->flags)) {
 		if (!bch2_reconcile_enabled(c)) {
-			bch2_moving_ctxt_flush_all(ctxt);
+			ret = bch2_moving_ctxt_flush_all(ctxt);
+			if (ret)
+				goto out;
 			kthread_wait_freezable(bch2_reconcile_enabled(c) ||
 					       kthread_should_stop());
 			if (kthread_should_stop())
@@ -1841,12 +1851,17 @@ static int do_reconcile(struct moving_context *ctxt)
 			work.nr = 0;
 
 			if (kick != r->kick ||
-			    test_bit(BCH_FS_going_ro, &c->flags) ||
-			    bch2_move_ratelimit(ctxt))
+			    test_bit(BCH_FS_going_ro, &c->flags))
+				break;
+
+			ret = bch2_move_ratelimit(ctxt);
+			if (ret)
 				break;
 
 			/* Drain pending moves before the next phase. */
-			bch2_moving_ctxt_flush_all(ctxt);
+			ret = bch2_moving_ctxt_flush_all(ctxt);
+			if (ret)
+				goto out;
 		}
 
 		/* Completed a clean pass through all phases — we're done. */
@@ -1860,14 +1875,19 @@ out:
 
 	bch2_move_stats_exit(&r->work_stats, c);
 
+	if (ret > 0)
+		ret = 0;
+
 	if (!ret &&
 	    !kthread_should_stop() &&
 	    !atomic64_read(&r->work_stats.sectors_seen) &&
 	    !sectors_scanned &&
 	    kick == r->kick) {
-		bch2_moving_ctxt_flush_all(ctxt);
-		bch2_trans_unlock_long(trans);
-		reconcile_wait(c);
+		ret = bch2_moving_ctxt_flush_all(ctxt);
+		if (!ret) {
+			bch2_trans_unlock_long(trans);
+			reconcile_wait(c);
+		}
 	}
 
 	if (!bch2_err_matches(ret, EROFS))

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1483,19 +1483,78 @@ static CLOSURE_CALLBACK(do_reconcile_phys_thread)
 	closure_return(cl);
 }
 
+static int reconcile_phys_dev_has_work(struct bch_fs *c, unsigned reconcile_phase,
+				       unsigned dev, bool *has_work)
+{
+	enum btree_id btree = reconcile_phases[reconcile_phase].btree;
+	bool found = false;
+
+	*has_work = false;
+
+	int ret = bch2_trans_do(c, ({
+		found = false;
+
+		CLASS(btree_iter, iter)(trans, btree, POS(dev, 0), BTREE_ITER_prefetch);
+		int ret = 0;
+
+		while (true) {
+			struct bkey_s_c k = bch2_btree_iter_peek(&iter);
+
+			ret = bkey_err(k);
+			if (ret)
+				break;
+
+			if (!k.k || k.k->p.inode != dev)
+				break;
+
+			if (k.k->type == KEY_TYPE_set) {
+				found = true;
+				break;
+			}
+
+			bch2_btree_iter_advance(&iter);
+		}
+
+		ret;
+	}));
+
+	if (!ret)
+		*has_work = found;
+
+	return ret;
+}
+
 static int do_reconcile_phys(struct bch_fs *c, unsigned reconcile_phase)
 {
+	struct bch_fs_reconcile *r = &c->reconcile;
 	CLASS(darray_reconcile_phys_thr, thrs)();
 	CLASS(closure_stack, cl)();
+	u64 considered = 0, started = 0, skipped_empty = 0;
 
-	for_each_member_device(c, ca)
+	for_each_member_device(c, ca) {
+		bool has_work;
+
 		if (ca->mi.rotational &&
-		    bch2_dev_is_online(ca))
+		    bch2_dev_is_online(ca)) {
+			considered++;
+			try(reconcile_phys_dev_has_work(c, reconcile_phase, ca->dev_idx, &has_work));
+			if (!has_work) {
+				skipped_empty++;
+				continue;
+			}
+
 			try(darray_push(&thrs, ((reconcile_phys_thr) {
 						.c			= c,
 						.dev			= ca->dev_idx,
 						.reconcile_phase	= reconcile_phase,
 						})));
+			started++;
+		}
+	}
+
+	WRITE_ONCE(r->phys_workers_considered, considered);
+	WRITE_ONCE(r->phys_workers_started, started);
+	WRITE_ONCE(r->phys_workers_skipped_empty, skipped_empty);
 
 	darray_for_each(thrs, i)
 		closure_call(&i->cl, do_reconcile_phys_thread, system_unbound_wq, &cl);
@@ -1905,6 +1964,11 @@ __cold void bch2_reconcile_status_to_text(struct printbuf *out, struct bch_fs *c
 			}
 		}
 	}
+
+	prt_printf(out, "phys workers last phase: considered %llu started %llu skipped empty %llu\n",
+		   READ_ONCE(r->phys_workers_considered),
+		   READ_ONCE(r->phys_workers_started),
+		   READ_ONCE(r->phys_workers_skipped_empty));
 
 	struct task_struct *t;
 	scoped_guard(rcu) {

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1331,6 +1331,8 @@ static void reconcile_wait(struct bch_fs *c)
 	struct io_clock *clock = &c->io_clock[WRITE];
 	u64 now = atomic64_read(&clock->now);
 	u64 min_member_capacity = bch2_min_rw_member_capacity(c);
+	/* WRITE io_clock may not advance while the fs is idle. */
+	unsigned long wallclock_timeout = 5 * HZ;
 
 	if (reconcile_hipri_work_pending(c)) {
 		cond_resched();
@@ -1348,7 +1350,7 @@ static void reconcile_wait(struct bch_fs *c)
 		r->running		= false;
 	}
 
-	bch2_kthread_io_clock_wait_once(clock, r->wait_iotime_end, MAX_SCHEDULE_TIMEOUT);
+	bch2_kthread_io_clock_wait_once(clock, r->wait_iotime_end, wallclock_timeout);
 }
 
 struct reconcile_phase {

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -783,6 +783,42 @@ static bool stripe_retry_must_wait(struct moving_context *ctxt,
 	return u && u->io_seq <= stripe_io_seq;
 }
 
+static bool reconcile_target_has_rotational(struct bch_fs *c,
+					    struct bch_inode_opts *opts,
+					    struct data_update_opts *data_opts)
+{
+	unsigned target = data_opts->target ?:
+		opts->background_target ?:
+		opts->foreground_target;
+	struct bch_devs_mask devs = target_rw_devs(c, BCH_DATA_user, target);
+
+	guard(rcu)();
+	for_each_member_device_rcu(c, ca, &devs)
+		if (bch2_dev_rotational(c, ca->dev_idx))
+			return true;
+
+	return false;
+}
+
+static void reconcile_set_move_limits(struct moving_context *ctxt,
+				      struct bch_inode_opts *opts,
+				      struct data_update_opts *data_opts,
+				      struct bbpos work)
+{
+	struct bch_fs *c = ctxt->trans->c;
+
+	bch2_moving_ctxt_reset_limits(ctxt);
+
+	if (!reconcile_target_has_rotational(c, opts, data_opts))
+		return;
+
+	bch2_moving_ctxt_set_rotational_limits(ctxt,
+			work.btree == BTREE_ID_reconcile_hipri ||
+			work.btree == BTREE_ID_reconcile_hipri_phys
+			? MOVE_ROTATIONAL_LIMIT_hipri
+			: MOVE_ROTATIONAL_LIMIT_background);
+}
+
 static int do_retry_stripe(struct moving_context *ctxt, u64 idx)
 {
 	struct btree_trans *trans = ctxt->trans;
@@ -865,6 +901,7 @@ static int __do_reconcile_extent(struct moving_context *ctxt,
 		}
 	}
 
+	reconcile_set_move_limits(ctxt, opts, data_opts, work);
 	ret = bch2_move_extent(ctxt, NULL, opts, data_opts, iter, level, k);
 	BUG_ON(ret > 0);
 	ret = check_reconcile_pending_err(trans, opts, data_opts, k, ret);

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1439,6 +1439,9 @@ static CLOSURE_CALLBACK(do_reconcile_phys_thread)
 			      writepoint_ptr(&c->allocator.reconcile_write_point),
 			      true);
 
+	if (bch2_dev_rotational(c, thr->dev))
+		bch2_moving_ctxt_set_rotational_limits(&ctxt);
+
 	struct btree_trans *trans = ctxt.trans;
 
 	CLASS(darray_reconcile_work, work)();

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1440,7 +1440,10 @@ static CLOSURE_CALLBACK(do_reconcile_phys_thread)
 			      true);
 
 	if (bch2_dev_rotational(c, thr->dev))
-		bch2_moving_ctxt_set_rotational_limits(&ctxt);
+		bch2_moving_ctxt_set_rotational_limits(&ctxt,
+				reconcile_phases[thr->reconcile_phase].priority == RECONCILE_WORK_hipri
+				? MOVE_ROTATIONAL_LIMIT_hipri
+				: MOVE_ROTATIONAL_LIMIT_background);
 
 	struct btree_trans *trans = ctxt.trans;
 

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -491,12 +491,18 @@ static int data_update_index_update_key(struct btree_trans *trans,
 			      BTREE_TRIGGER_set_needs_reconcile_done));
 	bool flush = (u->op.flags & BCH_WRITE_flush) &&
 		bkey_next(insert) == u->op.insert_keys.top;
+	bool noflush = u->op.flags & BCH_WRITE_move_noflush;
+	u64 journal_seq = 0;
 
-	try(bch2_trans_commit_flush(trans, &u->op.res, NULL,
+	try(bch2_trans_commit_flush(trans, &u->op.res,
+				    noflush ? &journal_seq : NULL,
 				    flush ? &u->op.cl : NULL,
 				    BCH_TRANS_COMMIT_no_check_rw|
 				    BCH_TRANS_COMMIT_no_enospc|
 				    u->opts.commit_flags));
+
+	if (noflush)
+		bch2_moving_ctxt_account_noflush_commit(u->ctxt, new->k.size, journal_seq);
 
 	bch2_btree_iter_set_pos(iter, next_pos);
 
@@ -1380,8 +1386,13 @@ int bch2_data_update_init(struct btree_trans *trans,
 		BCH_WRITE_pages_owned|
 		BCH_WRITE_data_encoded|
 		BCH_WRITE_move|
-		BCH_WRITE_flush|
 		m->opts.write_flags;
+	if (ctxt) {
+		m->op.flags &= ~BCH_WRITE_flush;
+		m->op.flags |= BCH_WRITE_move_noflush;
+	} else {
+		m->op.flags |= BCH_WRITE_flush;
+	}
 	m->op.compression_opt	= io_opts->background_compression;
 	m->op.watermark		= max(m->opts.commit_flags & BCH_WATERMARK_MASK,
 				      BCH_WATERMARK_normal);

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -50,7 +50,7 @@ static const struct rhashtable_params bch_update_params = {
 
 static inline u16 bch2_move_ioprio(struct data_update_opts *opts)
 {
-	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_BE, 7);
 }
 
 static const char *bch2_ioprio_class_str(u16 ioprio)

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -48,6 +48,27 @@ static const struct rhashtable_params bch_update_params = {
 	.automatic_shrinking	= true,
 };
 
+static inline u16 bch2_move_ioprio(struct data_update_opts *opts)
+{
+	return opts->ioprio ?: IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+}
+
+static const char *bch2_ioprio_class_str(u16 ioprio)
+{
+	switch (IOPRIO_PRIO_CLASS(ioprio)) {
+	case IOPRIO_CLASS_NONE:
+		return "none";
+	case IOPRIO_CLASS_RT:
+		return "realtime";
+	case IOPRIO_CLASS_BE:
+		return "best-effort";
+	case IOPRIO_CLASS_IDLE:
+		return "idle";
+	default:
+		return "unknown";
+	}
+}
+
 bool bch2_data_update_in_flight(struct bch_fs *c, struct bbpos *pos,
 				enum bch_data_update_types type)
 {
@@ -894,6 +915,10 @@ __cold void bch2_data_update_opts_to_text(struct printbuf *out, struct bch_fs *c
 
 	prt_printf(out, "read_dev:\t%i\n", data_opts->read_dev);
 	prt_printf(out, "checksum_paranoia:\t%i\n", data_opts->checksum_paranoia);
+	u16 ioprio = bch2_move_ioprio(data_opts);
+	prt_printf(out, "ioprio:\t%s:%u\n",
+		   bch2_ioprio_class_str(ioprio),
+		   (unsigned) IOPRIO_PRIO_DATA(ioprio));
 
 	prt_str(out, "io path options:\t");
 	bch2_inode_opts_to_text(out, c, *io_opts);
@@ -995,7 +1020,7 @@ static int bch2_data_update_bios_init(struct data_update *m, struct bch_fs *c,
 	m->rbio.data_update		= true;
 	m->rbio.bio.bi_iter.bi_size	= buf_bytes;
 	m->rbio.bio.bi_iter.bi_sector	= bkey_start_offset(&m->k.k->k);
-	m->op.wbio.bio.bi_ioprio	= IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
+	m->op.wbio.bio.bi_ioprio	= bch2_move_ioprio(&m->opts);
 	return 0;
 }
 

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -489,10 +489,14 @@ static int data_update_index_update_key(struct btree_trans *trans,
 	try(bch2_trans_update(trans, iter, insert,
 			      BTREE_UPDATE_internal_snapshot_node|
 			      BTREE_TRIGGER_set_needs_reconcile_done));
-	try(bch2_trans_commit(trans, &u->op.res, NULL,
-			      BCH_TRANS_COMMIT_no_check_rw|
-			      BCH_TRANS_COMMIT_no_enospc|
-			      u->opts.commit_flags));
+	bool flush = (u->op.flags & BCH_WRITE_flush) &&
+		bkey_next(insert) == u->op.insert_keys.top;
+
+	try(bch2_trans_commit_flush(trans, &u->op.res, NULL,
+				    flush ? &u->op.cl : NULL,
+				    BCH_TRANS_COMMIT_no_check_rw|
+				    BCH_TRANS_COMMIT_no_enospc|
+				    u->opts.commit_flags));
 
 	bch2_btree_iter_set_pos(iter, next_pos);
 
@@ -1376,6 +1380,7 @@ int bch2_data_update_init(struct btree_trans *trans,
 		BCH_WRITE_pages_owned|
 		BCH_WRITE_data_encoded|
 		BCH_WRITE_move|
+		BCH_WRITE_flush|
 		m->opts.write_flags;
 	m->op.compression_opt	= io_opts->background_compression;
 	m->op.watermark		= max(m->opts.commit_flags & BCH_WATERMARK_MASK,

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -1059,7 +1059,7 @@ static unsigned durability_available_on_target(struct bch_fs *c,
 			durability += (write_flags & BCH_WRITE_cached) ? 1 : ca->mi.durability;
 		else if (bch2_copygc_can_make_progress(ca)) {
 			*need_copygc = true;
-			bch2_copygc_wakeup(c);
+			bch2_copygc_wakeup_for_pressure(c);
 		}
 
 		if (trace)

--- a/fs/data/update.h
+++ b/fs/data/update.h
@@ -39,6 +39,7 @@ struct data_update_opts {
 	enum bch_read_flags		read_flags;
 	enum bch_write_flags		write_flags;
 	enum bch_trans_commit_flags	commit_flags;
+	u16				ioprio;
 };
 
 struct data_update {

--- a/fs/data/write.c
+++ b/fs/data/write.c
@@ -774,7 +774,8 @@ static inline void bch2_congested_acct(struct bch_dev *ca, u64 io_latency,
 	}
 }
 
-void bch2_latency_acct(struct bch_dev *ca, u64 submit_time, int rw)
+void bch2_latency_acct(struct bch_dev *ca, u64 submit_time, int rw,
+		       bool account_congestion)
 {
 	atomic64_t *latency = &ca->cur_latency[rw];
 	u64 now = local_clock();
@@ -799,9 +800,10 @@ void bch2_latency_acct(struct bch_dev *ca, u64 submit_time, int rw)
 
 	/*
 	 * Only track read latency for congestion accounting: writes are subject
-	 * to heavy queuing delays from page cache writeback:
+	 * to heavy queuing delays from page cache writeback. Internal move
+	 * writes opt in because their latency is used to steer more move IO.
 	 */
-	if (rw == READ)
+	if (rw == READ || account_congestion)
 		bch2_congested_acct(ca, io_latency, now, rw);
 
 	__bch2_time_stats_update(&ca->io_latency[rw].stats, submit_time, now);
@@ -1476,8 +1478,15 @@ static void bch2_write_endio(struct bio *bio)
 	struct bch_fs *c		= wbio->c;
 	struct bch_dev *ca		= wbio->ca;
 
-	bch2_account_io_completion(ca, BCH_MEMBER_ERROR_write,
-				   wbio->submit_time, !bio->bi_status);
+	if (op->flags & BCH_WRITE_move) {
+		if (ca)
+			bch2_latency_acct(ca, wbio->submit_time, WRITE, true);
+		bch2_account_io_success_fail(ca, BCH_MEMBER_ERROR_write,
+					     !bio->bi_status);
+	} else {
+		bch2_account_io_completion(ca, BCH_MEMBER_ERROR_write,
+					   wbio->submit_time, !bio->bi_status);
+	}
 
 	if (unlikely(bio->bi_status)) {
 		guard(spinlock_irqsave)(&c->write_error_lock);

--- a/fs/data/write.c
+++ b/fs/data/write.c
@@ -2413,9 +2413,8 @@ err:
 
 		/*
 		 * Internal moves can be issued FUA, making the journal's cache
-		 * flush a no-op for them. Off by default: the per-write FUA
-		 * regresses background-move throughput, and the journal flushes
-		 * every device on commit regardless, so durability is unchanged.
+		 * flush a no-op for them. Otherwise, the data update path
+		 * flushes the journal commit that indexes the moved data.
 		 */
 		if ((op->flags & BCH_WRITE_move) && c->opts.move_writes_fua)
 			bio->bi_opf |= REQ_FUA;

--- a/fs/data/write_types.h
+++ b/fs/data/write_types.h
@@ -26,6 +26,7 @@
 	x(sync)				\
 	x(flush)			\
 	x(move)				\
+	x(move_noflush)			\
 	x(in_worker)			\
 	x(submitted)			\
 	x(convert_unwritten)

--- a/fs/debug/sysfs.c
+++ b/fs/debug/sysfs.c
@@ -831,10 +831,20 @@ static ssize_t sysfs_opt_store(struct bch_fs *c,
 			BUG();
 		}
 
-		if (changed) {
+		/*
+		 * Re-writing a filesystem-wide inode/IO option is an explicit
+		 * request to make existing data converge to that policy.  This
+		 * matters when the superblock already has e.g. background_target
+		 * set, but older extents were never scanned under that policy.
+		 */
+		bool reconcile = !ca && (opt->flags & OPT_FS) && bch2_opt_is_inode_opt(id);
+
+		if (changed || reconcile) {
 			if (!ca) {
-				bch2_opt_set_by_id(&c->opts, id, v);
-				clear_bit(id, c->mount_opts.d);
+				if (changed) {
+					bch2_opt_set_by_id(&c->opts, id, v);
+					clear_bit(id, c->mount_opts.d);
+				}
 			}
 
 			bch2_opt_hook_post_set(c, ca, 0, id, v);

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -932,6 +932,26 @@ int bch2_dev_set_state(struct bch_fs *c, struct bch_dev *ca,
 	return __bch2_dev_set_state(c, ca, new_state, flags, err);
 }
 
+int bch2_dev_evacuating_startup_scan(struct bch_fs *c)
+{
+	int ret = 0;
+
+	for_each_online_member(c, ca, BCH_DEV_READ_REF_evacuating_startup_scan) {
+		if (ca->mi.state != BCH_MEMBER_STATE_evacuating)
+			continue;
+
+		ret = bch2_set_reconcile_needs_scan(c,
+			(struct reconcile_scan) {
+				.type	= RECONCILE_SCAN_device,
+				.dev	= ca->dev_idx,
+			}, true);
+		if (ret)
+			break;
+	}
+
+	return ret;
+}
+
 /* Device add/removal: */
 
 static int __bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca,

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -939,7 +939,8 @@ static int __bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca,
 			     struct printbuf *err)
 {
 	unsigned data;
-	int ret;
+	bool was_rw = ca->mi.state == BCH_MEMBER_STATE_rw;
+	int ret, ret2;
 
 	lockdep_assert_held(&c->state_lock);
 
@@ -1073,6 +1074,16 @@ static int __bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca,
 err:
 	/* The device is staying; allow new references to it again: */
 	WRITE_ONCE(ca->removing, false);
+
+	if (test_bit(BCH_FS_rw, &c->flags) &&
+	    was_rw &&
+	    ca->mi.state == BCH_MEMBER_STATE_evacuating &&
+	    !enumerated_ref_is_zero(&ca->io_ref[READ])) {
+		prt_str(err, "Remove failed, restoring device state to rw\n");
+		ret2 = __bch2_dev_set_state(c, ca, BCH_MEMBER_STATE_rw, flags, err);
+		if (ret2)
+			prt_printf(err, "Error restoring device state: %s\n", bch2_err_str(ret2));
+	}
 
 	if (test_bit(BCH_FS_rw, &c->flags) &&
 	    ca->mi.state == BCH_MEMBER_STATE_rw &&

--- a/fs/init/dev.h
+++ b/fs/init/dev.h
@@ -30,6 +30,7 @@ int __bch2_dev_set_state(struct bch_fs *, struct bch_dev *,
 int bch2_dev_set_state(struct bch_fs *, struct bch_dev *,
 		       enum bch_member_state, int,
 		       struct printbuf *);
+int bch2_dev_evacuating_startup_scan(struct bch_fs *);
 
 int bch2_dev_add_initialize(struct bch_fs *, struct bch_dev *);
 

--- a/fs/init/error.h
+++ b/fs/init/error.h
@@ -248,9 +248,10 @@ void bch2_io_error_work(struct work_struct *);
 void bch2_io_error(struct bch_dev *, enum bch_member_error_type);
 
 #ifndef CONFIG_BCACHEFS_NO_LATENCY_ACCT
-void bch2_latency_acct(struct bch_dev *, u64, int);
+void bch2_latency_acct(struct bch_dev *, u64, int, bool);
 #else
-static inline void bch2_latency_acct(struct bch_dev *ca, u64 submit_time, int rw) {}
+static inline void bch2_latency_acct(struct bch_dev *ca, u64 submit_time, int rw,
+				     bool account_congestion) {}
 #endif
 
 static inline void bch2_account_io_success_fail(struct bch_dev *ca,
@@ -274,7 +275,7 @@ static inline void bch2_account_io_completion(struct bch_dev *ca,
 		return;
 
 	if (type != BCH_MEMBER_ERROR_checksum)
-		bch2_latency_acct(ca, submit_time, type);
+		bch2_latency_acct(ca, submit_time, type, type == BCH_MEMBER_ERROR_read);
 
 	bch2_account_io_success_fail(ca, type, success);
 }

--- a/fs/init/fs.c
+++ b/fs/init/fs.c
@@ -618,6 +618,8 @@ static int __bch2_fs_read_write(struct bch_fs *c, bool early)
 		ret = bch2_set_fs_needs_reconcile(c);
 	if (!ret && !c->opts.read_only)
 		ret = bch2_reconcile_start(c);
+	if (!ret && !c->opts.read_only)
+		ret = bch2_dev_evacuating_startup_scan(c);
 	if (ret) {
 		bch2_fs_read_only(c);
 		return ret;

--- a/fs/init/fs.c
+++ b/fs/init/fs.c
@@ -613,7 +613,8 @@ static int __bch2_fs_read_write(struct bch_fs *c, bool early)
 	int ret = bch2_journal_reclaim_start(&c->journal) ?:
 		  bch2_btree_write_buffer_start(c) ?:
 		  bch2_copygc_start(c);
-	if (!ret && c->opts.background_target)
+	if (!ret && c->opts.background_target &&
+	    c->opts.background_target != c->opts.foreground_target)
 		ret = bch2_set_fs_needs_reconcile(c);
 	if (!ret && !c->opts.read_only)
 		ret = bch2_reconcile_start(c);

--- a/fs/init/fs.c
+++ b/fs/init/fs.c
@@ -612,10 +612,11 @@ static int __bch2_fs_read_write(struct bch_fs *c, bool early)
 
 	int ret = bch2_journal_reclaim_start(&c->journal) ?:
 		  bch2_btree_write_buffer_start(c) ?:
-		  bch2_copygc_start(c) ?:
-		  (!c->opts.read_only
-		   ? bch2_reconcile_start(c)
-		   : 0);
+		  bch2_copygc_start(c);
+	if (!ret && c->opts.background_target)
+		ret = bch2_set_fs_needs_reconcile(c);
+	if (!ret && !c->opts.read_only)
+		ret = bch2_reconcile_start(c);
 	if (ret) {
 		bch2_fs_read_only(c);
 		return ret;

--- a/fs/opts.h
+++ b/fs/opts.h
@@ -366,7 +366,7 @@ enum fsck_err_opts {
 	x(move_ios_in_flight,		u32,				\
 	  OPT_FS|OPT_MOUNT|OPT_RUNTIME|OPT_NODOC,			\
 	  OPT_UINT(1, 1024),						\
-	  BCH2_NO_SB_OPT,		64,				\
+	  BCH2_NO_SB_OPT,		1024,				\
 	  NULL,		"Maximum number of IOs to keep in flight by the move path")\
 	x(fsck,				u8,				\
 	  OPT_FS|OPT_MOUNT,						\

--- a/fs/vfs/buffered.c
+++ b/fs/vfs/buffered.c
@@ -542,6 +542,8 @@ static bool can_write_now(struct bch_fs *c, unsigned replicas_want, struct closu
 	unsigned reserved = OPEN_BUCKETS_COUNT -
 		(OPEN_BUCKETS_COUNT - bch2_open_buckets_reserved(BCH_WATERMARK_normal)) / 2;
 
+	bch2_open_bucket_reclaim_unused_partials(c, reserved);
+
 	if (unlikely(c->allocator.open_buckets_nr_free <= reserved)) {
 		closure_wait(&c->allocator.open_buckets_wait, cl);
 		return false;

--- a/src/commands/set_option.rs
+++ b/src/commands/set_option.rs
@@ -13,32 +13,57 @@ fn opt_flags() -> u32 {
     c::opt_flags::OPT_FS as u32 | c::opt_flags::OPT_DEVICE as u32
 }
 
+fn schedule_reconcile_after_offline_io_opt_change(fs: &bcachefs_kernel::fs::Fs) -> Result<()> {
+    unsafe {
+        let _sb_lock = fs.sb_lock();
+
+        let ext_u64s =
+            (std::mem::size_of::<c::bch_sb_field_ext>() / std::mem::size_of::<u64>()) as u32;
+        let ext: &mut c::bch_sb_field_ext =
+            bcachefs_kernel::sb::io::sb_field_get_minsize(&mut (*fs.raw).disk_sb, ext_u64s)
+                .ok_or_else(|| anyhow::anyhow!("Error getting sb_field_ext"))?;
+
+        let pass = 1u64 << c::bch_recovery_pass::BCH_RECOVERY_PASS_set_fs_needs_reconcile as u64;
+        ext.recovery_passes_required[0] |= c::bch2_recovery_passes_to_stable(pass).to_le();
+        fs.write_super();
+    }
+
+    Ok(())
+}
+
 fn set_option_cmd() -> Command {
     Command::new("set-fs-option")
         .about("Set a filesystem option")
-        .long_about("\
+        .long_about(
+            "\
 Set a filesystem or device option on a running filesystem. Changes \
 are persisted to the superblock. Use -d to target a specific device \
 for device-scoped options. See <<sec:options>> for the full list of \
-available options.")
+available options.",
+        )
         .args(bch_option_args(opt_flags(), false))
-        .arg(Arg::new("dev-idx")
-            .short('d')
-            .long("dev-idx")
-            .action(ArgAction::Append)
-            .value_parser(clap::value_parser!(u32))
-            .help("Device index for device-specific options"))
-        .arg(Arg::new("devices")
-            .required(true)
-            .action(ArgAction::Append)
-            .help("Device path(s)"))
+        .arg(
+            Arg::new("dev-idx")
+                .short('d')
+                .long("dev-idx")
+                .action(ArgAction::Append)
+                .value_parser(clap::value_parser!(u32))
+                .help("Device index for device-specific options"),
+        )
+        .arg(
+            Arg::new("devices")
+                .required(true)
+                .action(ArgAction::Append)
+                .help("Device path(s)"),
+        )
 }
 
 fn cmd_set_option(argv: Vec<String>) -> Result<()> {
     let matches = set_option_cmd().get_matches_from(argv);
 
     let devices: Vec<&String> = matches.get_many::<String>("devices").unwrap().collect();
-    let dev_idxs: Vec<u32> = matches.get_many::<u32>("dev-idx")
+    let dev_idxs: Vec<u32> = matches
+        .get_many::<u32>("dev-idx")
         .map(|v| v.copied().collect())
         .unwrap_or_default();
 
@@ -140,7 +165,13 @@ fn set_option_offline(
         let c_value = CString::new(value.as_str())?;
         let mut val: u64 = 0;
         let ret = unsafe {
-            c::bch2_opt_parse(fs.raw, opt, c_value.as_ptr(), &mut val, std::ptr::null_mut())
+            c::bch2_opt_parse(
+                fs.raw,
+                opt,
+                c_value.as_ptr(),
+                &mut val,
+                std::ptr::null_mut(),
+            )
         };
         if ret < 0 {
             eprintln!("Error parsing {name}={value}");
@@ -149,22 +180,34 @@ fn set_option_offline(
 
         if flags & c::opt_flags::OPT_FS as u32 != 0 {
             let ret = unsafe {
-                c::bch2_opt_hook_pre_set(fs.raw, std::ptr::null_mut(), 0, opt_id, val, true, std::ptr::null_mut())
+                c::bch2_opt_hook_pre_set(
+                    fs.raw,
+                    std::ptr::null_mut(),
+                    0,
+                    opt_id,
+                    val,
+                    true,
+                    std::ptr::null_mut(),
+                )
             };
             if ret < 0 {
                 eprintln!("Error setting {name}: {ret}");
                 continue;
             }
-            unsafe { c::bch2_opt_set_sb(fs.raw, std::ptr::null_mut(), opt, val); }
+            let _changed = unsafe { c::bch2_opt_set_sb(fs.raw, std::ptr::null_mut(), opt, val) };
+            if unsafe { c::bch2_opt_is_inode_opt(opt_id) } {
+                schedule_reconcile_after_offline_io_opt_change(&fs)?;
+            }
         }
 
         if flags & c::opt_flags::OPT_DEVICE as u32 != 0 {
             let indices: Vec<u32> = if !dev_idxs.is_empty() {
                 dev_idxs.to_vec()
             } else {
-                devices.iter().filter_map(|dev| {
-                    name_to_dev_idx(fs.raw, dev).map(|i| i as u32)
-                }).collect()
+                devices
+                    .iter()
+                    .filter_map(|dev| name_to_dev_idx(fs.raw, dev).map(|i| i as u32))
+                    .collect()
             };
 
             for idx in indices {
@@ -181,7 +224,9 @@ fn set_option_offline(
                     eprintln!("Error setting {name}: {ret}");
                     continue;
                 }
-                unsafe { c::bch2_opt_set_sb(fs.raw, ca, opt, val); }
+                unsafe {
+                    c::bch2_opt_set_sb(fs.raw, ca, opt, val);
+                }
             }
         }
     }
@@ -193,15 +238,16 @@ fn name_to_dev_idx(c: *mut c::bch_fs, name: &str) -> Option<usize> {
     let devs_len = unsafe { (*c).devs.len() };
     for i in 0..devs_len {
         let ca = unsafe { (*c).devs[i] };
-        if ca.is_null() { continue; }
+        if ca.is_null() {
+            continue;
+        }
         // bch_dev.name is a [c_char; 32] array, not a pointer
         let ca_name_bytes = unsafe { &(*ca).name };
         // Find the null terminator
         let len = ca_name_bytes.iter().position(|&b| b == 0).unwrap_or(32);
         // c_char is i8, but from_utf8 wants u8 - use from_raw_parts to reinterpret
-        let ca_name_bytes_u8 = unsafe {
-            std::slice::from_raw_parts(ca_name_bytes[..len].as_ptr() as *const u8, len)
-        };
+        let ca_name_bytes_u8 =
+            unsafe { std::slice::from_raw_parts(ca_name_bytes[..len].as_ptr() as *const u8, len) };
         let ca_name = std::str::from_utf8(ca_name_bytes_u8).ok()?;
         if ca_name == name {
             return Some(i);


### PR DESCRIPTION
## Status

This PR is an integration/proof branch, not a review-ready unit.

Please do not review or merge it as one large patch stack. I am keeping it open
and draft as a current aggregate for the cold-storage evacuation/write-pressure
work while I continue splitting the useful pieces into smaller PRs.

Why: the previous shape mixed multiple independent fixes, live follow-ups, and
later pressure/journal/window experiments into one branch. That made it hard to
see which invariant each patch owned, and it risked hiding contradictions such
as move-window throughput vs foreground IO, congestion avoidance vs progress
when only slow targets remain, and journal/flush behavior that needs a clearer
model before it is reviewable.

## Current Review Units

The intended smaller review units are:

- #629: allocator/writeback target progress; avoid allocator waits with no
  progress and keep writeback reconcile moving.
- #601: metadata-drain behavior during device remove, to be reconciled with the
  newer direction that rw devices should not be removed directly.
- #631: skip empty reconcile phys workers.
- #632: evacuating/rw-startup scan intent.
- #641: best-effort IO for hipri reconcile moves.
- #645: copygc/move pressure ioprio and pressure wait visibility.
- #686: avoid busy/congested move allocation targets.
- #694: rotational move concurrency and move write-window pressure.
- #765: partial-bucket reclaim, if the forward-progress/stuck-state proof holds
  up.
- #766: journal wait batching for moved data writes; draft/design split that
  needs a flush/commit model check before review.

## Needs Rework Before Review

These pieces from the aggregate are not ready as-is:

- The default move IO window raise needs rework. It needs foreground IO impact
  data, not just evacuation throughput.
- The journal/flush batching direction is now split to #766, but still needs the
  flushing/commit model clarified first. I should not present it as a durability
  invariant until that is correct.
- The forward-progress framing needs exact stuck-state evidence. Some of this
  may be better described as thrash avoidance or scheduling/pressure policy.
- Partial-bucket reclaim needs to prove that it fixes a real stuck/progress
  case rather than masking throttling.

## Evidence So Far

The local evidence that led to this branch was live observation on my
`/srv/cold-storage` filesystem plus smaller tests, not a polished perf
methodology:

- `bcachefs fs usage`;
- sysfs `internal/moving_ctxts`, `reconcile_status`, and time stats;
- kernel logs;
- `iostat`/`vmstat`;
- DKMS reload A/B samples;
- semantic ktest/trace checks for move write flush/FUA behavior.

That evidence is useful for finding where progress stopped or changed, but it is
not enough for scheduler/window tradeoff claims. The next step is per-patch
proof, including foreground workload impact and current-master `REQ_FUA`
behavior.

## Integration Branch

- PR branch: `komzpa/move-write-congestion-clean`
- mirror/scratch branch: `komzpa/cold-storage-integration-20260702`
- base: `testing`
- current head: `c425995c5`

Until the split is done, this PR is only the integration comparison point for
the live cold-storage stack.
