### PR TITLE
btree: make write buffer flush waits SRCU-aware

### DIFF
--- a/fs/btree/write_buffer.c
+++ b/fs/btree/write_buffer.c
@@ -1017,14 +1017,14 @@ static int btree_write_buffer_flush_seq(struct btree_trans *trans, u64 max_seq,
 	struct bch_fs *c = trans->c;
 	int ret = 0, fetch_from_journal_err;
 
-	bch2_trans_unlock_long(trans);
+	bch2_trans_unlock(trans);
 
 	do {
 		fetch_from_journal_err = fetch_wb_keys_from_journal(c, max_seq);
 
-		closure_wait_event(&c->btree.write_buffer_flush_wait,
-				   !any_wb_pin_le(c, max_seq, did_work, caller) ||
-				   (ret = bch2_journal_error(&c->journal)));
+		trans_wait_event(trans, &c->btree.write_buffer_flush_wait,
+				 !any_wb_pin_le(c, max_seq, did_work, caller) ||
+				 (ret = bch2_journal_error(&c->journal)));
 	} while (!ret && fetch_from_journal_err);
 
 	return ret;


### PR DESCRIPTION
## Summary

`btree_write_buffer_flush_seq()` currently drops the transaction SRCU read lock immediately with `bch2_trans_unlock_long()` before waiting for write-buffer pins to drain.

Switch that wait to the existing SRCU-aware `trans_wait_event()` pattern:

- use `bch2_trans_unlock()` for the fast path;
- wait on `write_buffer_flush_wait` through `trans_wait_event()`;
- let the helper escalate to dropping SRCU only if the wait blocks long enough.

This is a narrow companion to the broader SRCU/blocking-wait discussion in koverstreet/bcachefs#1069. It follows the maintainer-requested shape there without doing another blanket `unlock_long()` conversion.

## Validation

- `git diff --check`
- `make generate_version`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 fs/btree/write_buffer.o`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
