### PR TITLE
fsck: repair extent duplicates with existing reflink_v

### DIFF
--- a/fs/alloc/backpointers.c
+++ b/fs/alloc/backpointers.c
@@ -525,6 +525,52 @@ static int extents_to_reflink(struct btree_trans *trans,
 				 BTREE_UPDATE_internal_snapshot_node);
 }
 
+static int extent_to_existing_reflink(struct btree_trans *trans,
+				      enum btree_id extent_btree, unsigned extent_level,
+				      struct bkey_s_c extent,
+				      u64 extent_overlap_start, u64 extent_overlap_end,
+				      struct bkey_s_c reflink_v,
+				      u64 reflink_v_overlap_start)
+{
+	struct bch_fs *c = trans->c;
+	u64 overlap_size = extent_overlap_end - extent_overlap_start;
+
+	BUG_ON(extent.k->type != KEY_TYPE_extent);
+	BUG_ON(reflink_v.k->type != KEY_TYPE_reflink_v);
+	BUG_ON(!overlap_size);
+
+	u64 reflink_v_idx = bkey_start_offset(reflink_v.k) + reflink_v_overlap_start;
+	u64 reflink_v_end = reflink_v_idx + overlap_size;
+
+	if (extent_overlap_end > extent.k->size ||
+	    reflink_v_idx < bkey_start_offset(reflink_v.k) ||
+	    reflink_v_end > reflink_v.k->p.offset)
+		return bch_err_throw(trans->c, fsck_repair_unimplemented);
+
+	CLASS(btree_node_iter, iter)(trans, extent_btree, extent.k->p, 0,
+				     extent_level, BTREE_ITER_intent);
+	try(bch2_btree_iter_traverse(&iter));
+
+	u64 extent_overlap_logical_start = bkey_start_offset(extent.k) + extent_overlap_start;
+	u64 extent_overlap_logical_end = extent_overlap_logical_start + overlap_size;
+	struct bkey_i *k_mut = errptr_try(bch2_bkey_make_mut_noupdate(trans, extent));
+
+	bch2_cut_front(c, SPOS(extent.k->p.inode, extent_overlap_logical_start,
+			       extent.k->p.snapshot), k_mut);
+	bch2_cut_back(SPOS(extent.k->p.inode, extent_overlap_logical_end,
+			   extent.k->p.snapshot), k_mut);
+
+	k_mut->k.type = KEY_TYPE_reflink_p;
+	set_bkey_val_bytes(&k_mut->k, sizeof(struct bch_reflink_p));
+
+	struct bkey_i_reflink_p *rp = bkey_i_to_reflink_p(k_mut);
+	memset(&rp->v, 0, sizeof(rp->v));
+	SET_REFLINK_P_IDX(&rp->v, reflink_v_idx);
+
+	return bch2_trans_update(trans, &iter, &rp->k_i,
+				 BTREE_UPDATE_internal_snapshot_node);
+}
+
 static int check_bp_dup(struct btree_trans *trans,
 			struct extents_to_bp_state *s,
 			struct bkey_s_c extent,
@@ -633,6 +679,61 @@ static int check_bp_dup(struct btree_trans *trans,
 						       k1_overlap_start, k1_overlap_end,
 						       other_bp.v->btree_id, other_bp.v->level, other_extent,
 						       k2_overlap_start, k2_overlap_end));
+			return 0;
+		}
+
+		if ((extent.k->type == KEY_TYPE_extent &&
+		     other_extent.k->type == KEY_TYPE_reflink_v) ||
+		    (extent.k->type == KEY_TYPE_reflink_v &&
+		     other_extent.k->type == KEY_TYPE_extent)) {
+			struct bkey_s_c direct_extent =
+				extent.k->type == KEY_TYPE_extent ? extent : other_extent;
+			struct bkey_s_c reflink_v =
+				extent.k->type == KEY_TYPE_reflink_v ? extent : other_extent;
+			enum btree_id direct_btree =
+				extent.k->type == KEY_TYPE_extent ? bp->v.btree_id : other_bp.v->btree_id;
+			unsigned direct_level =
+				extent.k->type == KEY_TYPE_extent ? bp->v.level : other_bp.v->level;
+			const struct bkey *direct_bp_k =
+				extent.k->type == KEY_TYPE_extent ? &bp->k : other_bp.k;
+			const struct bch_backpointer *direct_bp =
+				extent.k->type == KEY_TYPE_extent ? &bp->v : other_bp.v;
+			const struct bkey *reflink_bp_k =
+				extent.k->type == KEY_TYPE_reflink_v ? &bp->k : other_bp.k;
+			const struct bch_backpointer *reflink_bp =
+				extent.k->type == KEY_TYPE_reflink_v ? &bp->v : other_bp.v;
+			u32 direct_bp_sub, reflink_bp_sub;
+
+			scoped_guard(rcu) {
+				struct bch_dev *ca = bch2_dev_rcu_noerror(c, bp->k.p.inode);
+				if (!ca)
+					return 0;
+				bp_pos_to_bucket_and_offset(ca, direct_bp_k->p,  &direct_bp_sub);
+				bp_pos_to_bucket_and_offset(ca, reflink_bp_k->p, &reflink_bp_sub);
+			}
+
+			u32 overlap_sub_start = max(direct_bp_sub, reflink_bp_sub);
+			u32 overlap_sub_end   = min(direct_bp_sub + direct_bp->bucket_len,
+						    reflink_bp_sub + reflink_bp->bucket_len);
+			if (overlap_sub_end <= overlap_sub_start)
+				return 0;
+
+			u32 direct_overlap_start = overlap_sub_start - direct_bp_sub;
+			u32 direct_overlap_end   = overlap_sub_end   - direct_bp_sub;
+			u32 reflink_overlap_start = overlap_sub_start - reflink_bp_sub;
+
+			CLASS(printbuf, buf)();
+			prt_printf(&buf, "duplicate extent and reflink_v pointing to overlapping space on dev %llu, converting direct extent overlap to reflink_p\n",
+				   bp->k.p.inode);
+			bch2_bkey_val_to_text(&buf, c, extent);
+			prt_newline(&buf);
+			bch2_bkey_val_to_text(&buf, c, other_extent);
+
+			if (ret_fsck_err(trans, dup_extents_to_reflink, "%s", buf.buf))
+				try(extent_to_existing_reflink(trans,
+						       direct_btree, direct_level, direct_extent,
+						       direct_overlap_start, direct_overlap_end,
+						       reflink_v, reflink_overlap_start));
 			return 0;
 		}
 

--- a/fs/alloc/backpointers.c
+++ b/fs/alloc/backpointers.c
@@ -525,11 +525,35 @@ static int extents_to_reflink(struct btree_trans *trans,
 				 BTREE_UPDATE_internal_snapshot_node);
 }
 
+static bool extent_bp_is_uncompressed(struct bch_fs *c, struct bkey_s_c k,
+				      struct bpos bp_pos)
+{
+	struct bkey_ptrs_c ptrs = bch2_bkey_ptrs_c(k);
+	const union bch_extent_entry *entry;
+	struct extent_ptr_decoded p;
+	bool found = false;
+
+	bkey_for_each_ptr_decode(k.k, ptrs, p, entry) {
+		if (!bpos_eq(bch2_extent_ptr_to_bp_pos(c, k, p), bp_pos))
+			continue;
+
+		if (crc_is_compressed(p.crc))
+			return false;
+		found = true;
+	}
+
+	return found;
+}
+
 static int extent_to_existing_reflink(struct btree_trans *trans,
 				      enum btree_id extent_btree, unsigned extent_level,
 				      struct bkey_s_c extent,
+				      struct bpos extent_bp_pos,
+				      u64 extent_disk_sectors,
 				      u64 extent_overlap_start, u64 extent_overlap_end,
 				      struct bkey_s_c reflink_v,
+				      struct bpos reflink_v_bp_pos,
+				      u64 reflink_v_disk_sectors,
 				      u64 reflink_v_overlap_start)
 {
 	struct bch_fs *c = trans->c;
@@ -539,11 +563,24 @@ static int extent_to_existing_reflink(struct btree_trans *trans,
 	BUG_ON(reflink_v.k->type != KEY_TYPE_reflink_v);
 	BUG_ON(!overlap_size);
 
-	u64 reflink_v_idx = bkey_start_offset(reflink_v.k) + reflink_v_overlap_start;
-	u64 reflink_v_end = reflink_v_idx + overlap_size;
+	/*
+	 * Backpointer offsets are physical sectors, while bkey offsets are
+	 * logical sectors.  They are interchangeable only for 1:1 mappings;
+	 * compressed extents need encoded-extent-aware overlap handling.
+	 */
+	if (!extent_bp_is_uncompressed(c, extent, extent_bp_pos) ||
+	    !extent_bp_is_uncompressed(c, reflink_v, reflink_v_bp_pos) ||
+	    extent_disk_sectors != extent.k->size ||
+	    reflink_v_disk_sectors != reflink_v.k->size)
+		return bch_err_throw(trans->c, fsck_repair_unimplemented);
+
+	u64 reflink_v_start = bkey_start_offset(reflink_v.k);
+	u64 reflink_v_idx;
+	u64 reflink_v_end;
 
 	if (extent_overlap_end > extent.k->size ||
-	    reflink_v_idx < bkey_start_offset(reflink_v.k) ||
+	    check_add_overflow(reflink_v_start, reflink_v_overlap_start, &reflink_v_idx) ||
+	    check_add_overflow(reflink_v_idx, overlap_size, &reflink_v_end) ||
 	    reflink_v_end > reflink_v.k->p.offset)
 		return bch_err_throw(trans->c, fsck_repair_unimplemented);
 
@@ -566,6 +603,8 @@ static int extent_to_existing_reflink(struct btree_trans *trans,
 	struct bkey_i_reflink_p *rp = bkey_i_to_reflink_p(k_mut);
 	memset(&rp->v, 0, sizeof(rp->v));
 	SET_REFLINK_P_IDX(&rp->v, reflink_v_idx);
+	rp->v.front_pad = cpu_to_le32(reflink_v_idx - reflink_v_start);
+	rp->v.back_pad = cpu_to_le32(reflink_v.k->p.offset - reflink_v_end);
 
 	return bch2_trans_update(trans, &iter, &rp->k_i,
 				 BTREE_UPDATE_internal_snapshot_node);
@@ -712,15 +751,15 @@ static int check_bp_dup(struct btree_trans *trans,
 				bp_pos_to_bucket_and_offset(ca, reflink_bp_k->p, &reflink_bp_sub);
 			}
 
-			u32 overlap_sub_start = max(direct_bp_sub, reflink_bp_sub);
-			u32 overlap_sub_end   = min(direct_bp_sub + direct_bp->bucket_len,
-						    reflink_bp_sub + reflink_bp->bucket_len);
+			u64 overlap_sub_start = max_t(u64, direct_bp_sub, reflink_bp_sub);
+			u64 overlap_sub_end   = min((u64) direct_bp_sub + direct_bp->bucket_len,
+						    (u64) reflink_bp_sub + reflink_bp->bucket_len);
 			if (overlap_sub_end <= overlap_sub_start)
 				return 0;
 
-			u32 direct_overlap_start = overlap_sub_start - direct_bp_sub;
-			u32 direct_overlap_end   = overlap_sub_end   - direct_bp_sub;
-			u32 reflink_overlap_start = overlap_sub_start - reflink_bp_sub;
+			u64 direct_overlap_start = overlap_sub_start - direct_bp_sub;
+			u64 direct_overlap_end   = overlap_sub_end   - direct_bp_sub;
+			u64 reflink_overlap_start = overlap_sub_start - reflink_bp_sub;
 
 			CLASS(printbuf, buf)();
 			prt_printf(&buf, "duplicate extent and reflink_v pointing to overlapping space on dev %llu, converting direct extent overlap to reflink_p\n",
@@ -732,8 +771,12 @@ static int check_bp_dup(struct btree_trans *trans,
 			if (ret_fsck_err(trans, dup_extents_to_reflink, "%s", buf.buf))
 				try(extent_to_existing_reflink(trans,
 						       direct_btree, direct_level, direct_extent,
+						       direct_bp_k->p,
+						       direct_bp->bucket_len,
 						       direct_overlap_start, direct_overlap_end,
-						       reflink_v, reflink_overlap_start));
+						       reflink_v, reflink_bp_k->p,
+						       reflink_bp->bucket_len,
+						       reflink_overlap_start));
 			return 0;
 		}
 

--- a/fs/alloc/backpointers.c
+++ b/fs/alloc/backpointers.c
@@ -526,6 +526,91 @@ static int extents_to_reflink(struct btree_trans *trans,
 				 BTREE_UPDATE_internal_snapshot_node);
 }
 
+static bool extent_bp_is_uncompressed(struct bch_fs *c, struct bkey_s_c k,
+				      struct bpos bp_pos)
+{
+	struct bkey_ptrs_c ptrs = bch2_bkey_ptrs_c(k);
+	const union bch_extent_entry *entry;
+	struct extent_ptr_decoded p;
+	bool found = false;
+
+	bkey_for_each_ptr_decode(k.k, ptrs, p, entry) {
+		if (!bpos_eq(bch2_extent_ptr_to_bp_pos(c, k, p), bp_pos))
+			continue;
+
+		if (crc_is_compressed(p.crc))
+			return false;
+		found = true;
+	}
+
+	return found;
+}
+
+static int extent_to_existing_reflink(struct btree_trans *trans,
+				      enum btree_id extent_btree, unsigned extent_level,
+				      struct bkey_s_c extent,
+				      struct bpos extent_bp_pos,
+				      u64 extent_disk_sectors,
+				      u64 extent_overlap_start, u64 extent_overlap_end,
+				      struct bkey_s_c reflink_v,
+				      struct bpos reflink_v_bp_pos,
+				      u64 reflink_v_disk_sectors,
+				      u64 reflink_v_overlap_start)
+{
+	struct bch_fs *c = trans->c;
+	u64 overlap_size = extent_overlap_end - extent_overlap_start;
+
+	BUG_ON(extent.k->type != KEY_TYPE_extent);
+	BUG_ON(reflink_v.k->type != KEY_TYPE_reflink_v);
+	BUG_ON(!overlap_size);
+
+	/*
+	 * Backpointer offsets are physical sectors, while bkey offsets are
+	 * logical sectors. They are interchangeable only for 1:1 mappings;
+	 * compressed extents need encoded-extent-aware overlap handling.
+	 */
+	if (!extent_bp_is_uncompressed(c, extent, extent_bp_pos) ||
+	    !extent_bp_is_uncompressed(c, reflink_v, reflink_v_bp_pos) ||
+	    extent_disk_sectors != extent.k->size ||
+	    reflink_v_disk_sectors != reflink_v.k->size)
+		return bch_err_throw(trans->c, fsck_repair_unimplemented);
+
+	u64 reflink_v_start = bkey_start_offset(reflink_v.k);
+	u64 reflink_v_idx;
+	u64 reflink_v_end;
+
+	if (extent_overlap_end > extent.k->size ||
+	    check_add_overflow(reflink_v_start, reflink_v_overlap_start, &reflink_v_idx) ||
+	    check_add_overflow(reflink_v_idx, overlap_size, &reflink_v_end) ||
+	    reflink_v_end > reflink_v.k->p.offset)
+		return bch_err_throw(trans->c, fsck_repair_unimplemented);
+
+	CLASS(btree_node_iter, iter)(trans, extent_btree, extent.k->p, 0,
+				     extent_level, BTREE_ITER_intent);
+	try(bch2_btree_iter_traverse(&iter));
+
+	u64 extent_overlap_logical_start = bkey_start_offset(extent.k) + extent_overlap_start;
+	u64 extent_overlap_logical_end = extent_overlap_logical_start + overlap_size;
+	struct bkey_i *k_mut = errptr_try(bch2_bkey_make_mut_noupdate(trans, extent));
+
+	bch2_cut_front(c, SPOS(extent.k->p.inode, extent_overlap_logical_start,
+			       extent.k->p.snapshot), k_mut);
+	bch2_cut_back(SPOS(extent.k->p.inode, extent_overlap_logical_end,
+			   extent.k->p.snapshot), k_mut);
+
+	k_mut->k.type = KEY_TYPE_reflink_p;
+	set_bkey_val_bytes(&k_mut->k, sizeof(struct bch_reflink_p));
+
+	struct bkey_i_reflink_p *rp = bkey_i_to_reflink_p(k_mut);
+	memset(&rp->v, 0, sizeof(rp->v));
+	SET_REFLINK_P_IDX(&rp->v, reflink_v_idx);
+	rp->v.front_pad = cpu_to_le32(reflink_v_idx - reflink_v_start);
+	rp->v.back_pad = cpu_to_le32(reflink_v.k->p.offset - reflink_v_end);
+
+	return bch2_trans_update(trans, &iter, &rp->k_i,
+				 BTREE_UPDATE_internal_snapshot_node);
+}
+
 static int check_bp_dup(struct btree_trans *trans,
 			struct extents_to_bp_state *s,
 			struct bkey_s_c extent,
@@ -645,6 +730,68 @@ static int check_bp_dup(struct btree_trans *trans,
 						       other_bp.v->btree_id, other_bp.v->level, other_extent,
 						       k2_overlap_start, k2_overlap_end));
 			}
+			return 0;
+		}
+
+		if ((extent.k->type == KEY_TYPE_extent &&
+		     other_extent.k->type == KEY_TYPE_reflink_v) ||
+		    (extent.k->type == KEY_TYPE_reflink_v &&
+		     other_extent.k->type == KEY_TYPE_extent)) {
+			struct bkey_s_c direct_extent =
+				extent.k->type == KEY_TYPE_extent ? extent : other_extent;
+			struct bkey_s_c reflink_v =
+				extent.k->type == KEY_TYPE_reflink_v ? extent : other_extent;
+			enum btree_id direct_btree =
+				extent.k->type == KEY_TYPE_extent ? bp->v.btree_id : other_bp.v->btree_id;
+			unsigned direct_level =
+				extent.k->type == KEY_TYPE_extent ? bp->v.level : other_bp.v->level;
+			const struct bkey *direct_bp_k =
+				extent.k->type == KEY_TYPE_extent ? &bp->k : other_bp.k;
+			const struct bch_backpointer *direct_bp =
+				extent.k->type == KEY_TYPE_extent ? &bp->v : other_bp.v;
+			const struct bkey *reflink_bp_k =
+				extent.k->type == KEY_TYPE_reflink_v ? &bp->k : other_bp.k;
+			const struct bch_backpointer *reflink_bp =
+				extent.k->type == KEY_TYPE_reflink_v ? &bp->v : other_bp.v;
+			u32 direct_bp_sub, reflink_bp_sub;
+
+			scoped_guard(rcu) {
+				struct bch_dev *ca = bch2_dev_rcu_noerror(c, bp->k.p.inode);
+				if (!ca)
+					return 0;
+				bp_pos_to_bucket_and_offset(ca, direct_bp_k->p,  &direct_bp_sub);
+				bp_pos_to_bucket_and_offset(ca, reflink_bp_k->p, &reflink_bp_sub);
+			}
+
+			u64 overlap_sub_start = max_t(u64, direct_bp_sub, reflink_bp_sub);
+			u64 overlap_sub_end   = min((u64) direct_bp_sub + direct_bp->bucket_len,
+						    (u64) reflink_bp_sub + reflink_bp->bucket_len);
+			if (overlap_sub_end <= overlap_sub_start)
+				return 0;
+
+			u64 direct_overlap_start = overlap_sub_start - direct_bp_sub;
+			u64 direct_overlap_end   = overlap_sub_end   - direct_bp_sub;
+			u64 reflink_overlap_start = overlap_sub_start - reflink_bp_sub;
+
+			CLASS(printbuf, buf)();
+			prt_printf(&buf, "duplicate extent and reflink_v pointing to overlapping space on dev %llu, converting direct extent overlap to reflink_p\n",
+				   bp->k.p.inode);
+			bch2_bkey_val_to_text(&buf, c, extent);
+			prt_newline(&buf);
+			bch2_bkey_val_to_text(&buf, c, other_extent);
+
+			if (ret_fsck_err(trans, dup_extents_to_reflink, "%s", buf.buf))
+				try(extent_to_existing_reflink(trans,
+						       direct_btree, direct_level,
+						       direct_extent,
+						       direct_bp_k->p,
+						       direct_bp->bucket_len,
+						       direct_overlap_start,
+						       direct_overlap_end,
+						       reflink_v,
+						       reflink_bp_k->p,
+						       reflink_bp->bucket_len,
+						       reflink_overlap_start));
 			return 0;
 		}
 


### PR DESCRIPTION
## Summary

Repair the duplicate-pointer fsck case where a direct extent and an existing `reflink_v` point at overlapping physical sectors.

The existing duplicate repair path can turn two direct extents into `reflink_p` keys sharing a newly-created `reflink_v`. The adjacent corruption case from koverstreet/bcachefs#1166 has one side already represented by the shared `reflink_v`, while the other side is still a direct extent, so fsck currently falls through to `fsck_repair_unimplemented`.

This updates the existing mixed-case repair to:

- detect `KEY_TYPE_extent` + `KEY_TYPE_reflink_v` duplicate backpointers;
- compute the overlapping physical bucket slice;
- refuse compressed or otherwise non-1:1 mappings where physical offsets cannot be used as logical cuts;
- cut only the direct extent overlap;
- replace that slice with a `reflink_p` pointing at the existing `reflink_v`;
- preserve the existing `reflink_v` live range with front/back padding;
- keep overflow or out-of-range overlap math on the existing unimplemented repair path.

The branch is now rebuilt as one clean commit on current `origin/master`; the PR range contains only `fs/alloc/backpointers.c`.

Fixes koverstreet/bcachefs#1166

## Testing

Rebased onto current `origin/master` and rebuilt clean:

- `BINDGEN=$HOME/.cargo/bin/bindgen make -j16 fs/alloc/backpointers.o`
- `BINDGEN=$HOME/.cargo/bin/bindgen make -j16 bcachefs`
- `git diff --check origin/master...HEAD`
- generated-tree/scope gate: `git diff --name-only origin/master...HEAD` is exactly `fs/alloc/backpointers.c` and contains no `build/`, `target/`, object, module, archive, or cache paths.

I tried to reproduce the koverstreet/bcachefs#1166 corruption offline before merging this and could not. The reporters' own analysis traces it to `device evacuate` interrupted mid-copy under a live kernel mount: one side stays the original direct extent, the other becomes the already-copied `reflink_v` for the same physical sectors, a state that path only reaches through that interruption. Loop-file `bcachefs format`/`fsck` has no way to fabricate that race.

I also checked whether this tree's kernel-module-free path (`bcachefs fusemount`) could at least get me a legitimate `reflink_v` to hand-corrupt: `cp --reflink=always` against a fuse-mounted image fails with "Operation not supported" (FICLONE isn't implemented in bcachefs-fuse), so even the baseline reflink_v state isn't buildable offline, let alone the duplicate-pointer state on top of it.

What I did verify offline, as a negative control: `bcachefs format` + `bcachefs fsck` on a fresh image exercises `check_extents_to_backpointers` (the pass this patch changes) cleanly; wrote 8MiB through `bcachefs fusemount`, unmounted, and `fsck` again was still clean — no false positive from the new duplicate-detection path against ordinary non-overlapping extents.

No ktest test added: I don't have a way to build the on-disk fixture this repair targets without a live kernel mount and the evacuate-interrupt race, and this session had neither.
