### PR TITLE
reconcile: rechecksum extents without rewriting data

### DIFF
--- a/fs/data/checksum.h
+++ b/fs/data/checksum.h
@@ -191,6 +191,20 @@ static inline bool bch2_crc_cmp(struct bch_csum l, struct bch_csum r)
 	return ((l.lo ^ r.lo) | (l.hi ^ r.hi)) != 0;
 }
 
+/* returns true if not equal */
+static inline bool bch2_crc_unpacked_cmp(struct bch_extent_crc_unpacked l,
+					 struct bch_extent_crc_unpacked r)
+{
+	return (l.csum_type		!= r.csum_type ||
+		l.compression_type	!= r.compression_type ||
+		l.compressed_size	!= r.compressed_size ||
+		l.uncompressed_size	!= r.uncompressed_size ||
+		l.offset		!= r.offset ||
+		l.live_size		!= r.live_size ||
+		l.nonce			!= r.nonce ||
+		bch2_crc_cmp(l.csum, r.csum));
+}
+
 /* for skipping ahead and encrypting/decrypting at an offset: */
 static inline struct nonce nonce_add(struct nonce nonce, unsigned offset)
 {

--- a/fs/data/extents.c
+++ b/fs/data/extents.c
@@ -612,20 +612,6 @@ bool bch2_reservation_merge(struct bch_fs *c, struct bkey_s _l, struct bkey_s_c 
 
 /* Extent checksum entries: */
 
-/* returns true if not equal */
-static inline bool bch2_crc_unpacked_cmp(struct bch_extent_crc_unpacked l,
-					 struct bch_extent_crc_unpacked r)
-{
-	return (l.csum_type		!= r.csum_type ||
-		l.compression_type	!= r.compression_type ||
-		l.compressed_size	!= r.compressed_size ||
-		l.uncompressed_size	!= r.uncompressed_size ||
-		l.offset		!= r.offset ||
-		l.live_size		!= r.live_size ||
-		l.nonce			!= r.nonce ||
-		bch2_crc_cmp(l.csum, r.csum));
-}
-
 static union bch_extent_entry *bkey_crc_find(const struct bch_fs *c, struct bkey_i *k,
 					     struct bch_extent_crc_unpacked crc)
 {

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -417,6 +417,19 @@ static int extent_ec_pending(struct btree_trans *trans, struct bkey_ptrs_c ptrs)
 	return false;
 }
 
+static bool crc_unpacked_same_layout(struct bch_extent_crc_unpacked l,
+				     struct bch_extent_crc_unpacked r)
+{
+	return l.csum_type		== r.csum_type &&
+		l.compression_type	== r.compression_type &&
+		l.compressed_size	== r.compressed_size &&
+		l.uncompressed_size	== r.uncompressed_size &&
+		l.live_size		== r.live_size &&
+		l.offset		== r.offset &&
+		l.nonce			== r.nonce &&
+		!bch2_crc_cmp(l.csum, r.csum);
+}
+
 int bch2_extent_reconcile_pending_mod(struct btree_trans *, struct btree_iter *,
 				      unsigned, struct bkey_s_c, bool);
 
@@ -448,6 +461,8 @@ static int reconcile_set_data_opts(struct btree_trans *trans,
 
 	unsigned csum_type = bch2_data_checksum_type_rb(c, *r);
 	unsigned compression_type = bch2_compression_opt_to_type(r->background_compression);
+	bool rechecksum_only = k.k->type == KEY_TYPE_extent &&
+		r->need_rb == BIT(BCH_RECONCILE_data_checksum);
 
 	if (r->need_rb & BIT(BCH_RECONCILE_data_replicas)) {
 		struct bkey_durability durability;
@@ -600,10 +615,37 @@ skip_ec:
 
 	scoped_guard(rcu) {
 		unsigned ptr_bit = 1;
+		unsigned checksum_ptrs_kill = 0;
+		bool can_rechecksum = rechecksum_only;
+		bool have_rechecksum_crc = false;
+		struct bch_extent_crc_unpacked rechecksum_crc = {};
+
 		bkey_for_each_ptr_decode(k.k, ptrs, p, entry) {
+			if (can_rechecksum &&
+			    (p.ptr.cached ||
+			     p.has_ec ||
+			     !p.crc.csum_type ||
+			     p.crc.csum_type == csum_type ||
+			     crc_is_compressed(p.crc) ||
+			     p.crc.offset ||
+			     p.crc.live_size != p.crc.uncompressed_size ||
+			     p.crc.compressed_size != p.crc.uncompressed_size ||
+			     bch2_csum_type_is_encryption(p.crc.csum_type) !=
+			     bch2_csum_type_is_encryption(csum_type)))
+				can_rechecksum = false;
+
+			if (can_rechecksum) {
+				if (!have_rechecksum_crc) {
+					rechecksum_crc = p.crc;
+					have_rechecksum_crc = true;
+				} else if (!crc_unpacked_same_layout(p.crc, rechecksum_crc)) {
+					can_rechecksum = false;
+				}
+			}
+
 			if ((r->need_rb & BIT(BCH_RECONCILE_data_checksum)) &&
 			    p.crc.csum_type != csum_type)
-				data_opts->ptrs_kill |= ptr_bit;
+				checksum_ptrs_kill |= ptr_bit;
 
 			if ((r->need_rb & BIT(BCH_RECONCILE_background_compression)) &&
 			    p.crc.compression_type != compression_type)
@@ -616,11 +658,17 @@ skip_ec:
 
 			ptr_bit <<= 1;
 		}
+
+		if (can_rechecksum && have_rechecksum_crc)
+			data_opts->type = BCH_DATA_UPDATE_rechecksum;
+		else
+			data_opts->ptrs_kill |= checksum_ptrs_kill;
 	}
 
 	bool ret = (data_opts->ptrs_kill ||
 		    data_opts->ptrs_kill_ec ||
-		    data_opts->extra_replicas);
+		    data_opts->extra_replicas ||
+		    data_opts->type == BCH_DATA_UPDATE_rechecksum);
 	if (!ret) {
 		if (r->need_rb == BIT(BCH_RECONCILE_data_replicas)) {
 			/*

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -13,6 +13,7 @@
 #include "btree/update.h"
 #include "btree/write_buffer.h"
 
+#include "data/checksum.h"
 #include "data/compress.h"
 #include "data/copygc.h"
 #include "data/ec/create.h"
@@ -474,6 +475,8 @@ static int reconcile_set_data_opts(struct btree_trans *trans,
 
 	unsigned csum_type = bch2_data_checksum_type_rb(c, rb);
 	unsigned compression_type = bch2_compression_opt_to_type(rb.background_compression);
+	bool rechecksum_only = k.k->type == KEY_TYPE_extent &&
+		r->need_rb == BIT(BCH_RECONCILE_data_checksum);
 
 	if (r->need_rb & BIT(BCH_RECONCILE_data_replicas)) {
 		struct bkey_durability durability;
@@ -626,10 +629,37 @@ skip_ec:
 
 	scoped_guard(rcu) {
 		unsigned ptr_bit = 1;
+		unsigned checksum_ptrs_kill = 0;
+		bool can_rechecksum = rechecksum_only;
+		bool have_rechecksum_crc = false;
+		struct bch_extent_crc_unpacked rechecksum_crc = {};
+
 		bkey_for_each_ptr_decode(k.k, ptrs, p, entry) {
+			if (can_rechecksum &&
+			    (p.ptr.cached ||
+			     p.has_ec ||
+			     !p.crc.csum_type ||
+			     p.crc.csum_type == csum_type ||
+			     crc_is_compressed(p.crc) ||
+			     p.crc.offset ||
+			     p.crc.live_size != p.crc.uncompressed_size ||
+			     p.crc.compressed_size != p.crc.uncompressed_size ||
+			     bch2_csum_type_is_encryption(p.crc.csum_type) !=
+			     bch2_csum_type_is_encryption(csum_type)))
+				can_rechecksum = false;
+
+			if (can_rechecksum) {
+				if (!have_rechecksum_crc) {
+					rechecksum_crc = p.crc;
+					have_rechecksum_crc = true;
+				} else if (bch2_crc_unpacked_cmp(p.crc, rechecksum_crc)) {
+					can_rechecksum = false;
+				}
+			}
+
 			if ((r->need_rb & BIT(BCH_RECONCILE_data_checksum)) &&
 			    p.crc.csum_type != csum_type)
-				data_opts->ptrs_kill |= ptr_bit;
+				checksum_ptrs_kill |= ptr_bit;
 
 			if ((r->need_rb & BIT(BCH_RECONCILE_background_compression)) &&
 			    p.crc.compression_type != compression_type)
@@ -642,11 +672,17 @@ skip_ec:
 
 			ptr_bit <<= 1;
 		}
+
+		if (can_rechecksum && have_rechecksum_crc)
+			data_opts->type = BCH_DATA_UPDATE_rechecksum;
+		else
+			data_opts->ptrs_kill |= checksum_ptrs_kill;
 	}
 
 	bool ret = (data_opts->ptrs_kill ||
 		    data_opts->ptrs_kill_ec ||
-		    data_opts->extra_replicas);
+		    data_opts->extra_replicas ||
+		    data_opts->type == BCH_DATA_UPDATE_rechecksum);
 	if (!ret) {
 		if (r->need_rb == BIT(BCH_RECONCILE_data_replicas)) {
 			/*

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -9,6 +9,7 @@
 #include "btree/bkey_buf.h"
 #include "btree/update.h"
 
+#include "data/checksum.h"
 #include "data/compress.h"
 #include "data/copygc.h"
 #include "data/extents.h"
@@ -568,6 +569,93 @@ static int data_update_index_update_key_nowrite(struct btree_trans *trans,
 	return 0;
 }
 
+static bool data_update_crc_eq(struct bch_extent_crc_unpacked l,
+			       struct bch_extent_crc_unpacked r)
+{
+	return l.csum_type		== r.csum_type &&
+		l.compression_type	== r.compression_type &&
+		l.compressed_size	== r.compressed_size &&
+		l.uncompressed_size	== r.uncompressed_size &&
+		l.live_size		== r.live_size &&
+		l.offset		== r.offset &&
+		l.nonce			== r.nonce &&
+		!bch2_crc_cmp(l.csum, r.csum);
+}
+
+static int data_update_index_update_key_rechecksum(struct btree_trans *trans,
+						   struct data_update *u,
+						   struct btree_iter *iter,
+						   struct bkey_s_c k,
+						   struct bch_extent_crc_unpacked old_crc,
+						   struct bch_extent_crc_unpacked new_crc)
+{
+	struct bch_fs *c = trans->c;
+	struct bkey_s_c old = bkey_i_to_s_c(u->k.k);
+
+	if (k.k->type != KEY_TYPE_extent ||
+	    !bch2_extents_match(c, k, old))
+		return 0;
+
+	struct bkey_i_extent *new = bkey_extent_init(
+		errptr_try(bch2_trans_kmalloc(trans, BKEY_EXTENT_U64s_MAX * sizeof(u64))));
+
+	new->k = *k.k;
+	set_bkey_val_bytes(&new->k, sizeof(new->v));
+
+	struct bkey_ptrs_c ptrs = bch2_bkey_ptrs_c(k);
+	const union bch_extent_entry *entry;
+	struct extent_ptr_decoded p;
+
+	bkey_for_each_ptr_decode(k.k, ptrs, p, entry) {
+		if (p.has_ec ||
+		    crc_is_compressed(p.crc) ||
+		    !data_update_crc_eq(p.crc, old_crc))
+			return 0;
+
+		p.crc = new_crc;
+		bch2_extent_ptr_decoded_append(c, &new->k_i, &p);
+	}
+
+	u64 flags = bch2_bkey_extent_flags(k);
+	if (flags)
+		try(bch2_bkey_extent_flags_set(c, &new->k_i, flags));
+
+	struct bch_inode_opts opts;
+	try(bch2_bkey_get_io_opts(trans, NULL, k, &opts));
+	try(bch2_bkey_set_needs_reconcile(trans, NULL, &opts, bkey_i_to_s(&new->k_i),
+					  BKEY_EXTENT_U64s_MAX,
+					  SET_NEEDS_RECONCILE_foreground,
+					  u->op.opts.change_cookie));
+
+	return bch2_trans_update(trans, iter, &new->k_i,
+				 BTREE_UPDATE_internal_snapshot_node|
+				 BTREE_TRIGGER_set_needs_reconcile_done);
+}
+
+static int data_update_index_update_rechecksum(struct btree_trans *trans,
+					       struct data_update *u,
+					       struct bch_extent_crc_unpacked old_crc,
+					       struct bch_extent_crc_unpacked new_crc)
+{
+	struct bch_fs *c = trans->c;
+	struct bkey_s_c old = bkey_i_to_s_c(u->k.k);
+
+	CLASS(disk_reservation, res)(c);
+
+	return for_each_btree_key_commit(trans, iter, u->btree_id,
+			bkey_start_pos(old.k),
+			BTREE_ITER_slots|BTREE_ITER_intent,
+			k, &res.r, NULL,
+			BCH_TRANS_COMMIT_no_check_rw|
+			BCH_TRANS_COMMIT_no_enospc, ({
+		if (bkey_le(old.k->p, bkey_start_pos(k.k)))
+			break;
+
+		data_update_index_update_key_rechecksum(trans, u, &iter, k,
+							old_crc, new_crc);
+	}));
+}
+
 static int data_update_index_update_nowrite(struct btree_trans *trans,
 					    struct data_update *u)
 {
@@ -665,6 +753,20 @@ void bch2_data_update_read_done(struct data_update *u)
 
 	if (unlikely(rbio->ret)) {
 		u->op.error = rbio->ret;
+		u->op.end_io(&u->op);
+		return;
+	}
+
+	if (u->opts.type == BCH_DATA_UPDATE_rechecksum) {
+		struct bch_extent_crc_unpacked new_crc;
+		int ret = bch2_rechecksum_bio(c, &rbio->bio, rbio->version,
+				crc, NULL, &new_crc, 0, crc.live_size,
+				u->op.csum_type);
+		if (!ret) {
+			CLASS(btree_trans, trans)(c);
+			ret = data_update_index_update_rechecksum(trans, u, crc, new_crc);
+		}
+		u->op.error = ret;
 		u->op.end_io(&u->op);
 		return;
 	}
@@ -1420,7 +1522,8 @@ int bch2_data_update_init(struct btree_trans *trans,
 		ptr_bit <<= 1;
 	}
 
-	if (m->opts.type != BCH_DATA_UPDATE_scrub &&
+	if (m->opts.type != BCH_DATA_UPDATE_rechecksum &&
+	    m->opts.type != BCH_DATA_UPDATE_scrub &&
 	    m->opts.type != BCH_DATA_UPDATE_scrub_no_repair) {
 		/*
 		 * If current extent durability is less than io_opts.data_replicas,

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -9,6 +9,7 @@
 #include "btree/bkey_buf.h"
 #include "btree/update.h"
 
+#include "data/checksum.h"
 #include "data/compress.h"
 #include "data/copygc.h"
 #include "data/extents.h"
@@ -568,6 +569,80 @@ static int data_update_index_update_key_nowrite(struct btree_trans *trans,
 	return 0;
 }
 
+static int data_update_index_update_key_rechecksum(struct btree_trans *trans,
+					   struct data_update *u,
+					   struct btree_iter *iter,
+					   struct bkey_s_c k,
+					   struct bch_extent_crc_unpacked old_crc,
+					   struct bch_extent_crc_unpacked new_crc)
+{
+	struct bch_fs *c = trans->c;
+	struct bkey_s_c old = bkey_i_to_s_c(u->k.k);
+
+	if (k.k->type != KEY_TYPE_extent ||
+	    !bch2_extents_match(c, k, old))
+		return 0;
+
+	struct bkey_i_extent *new = bkey_extent_init(
+		errptr_try(bch2_trans_kmalloc(trans, BKEY_EXTENT_U64s_MAX * sizeof(u64))));
+
+	new->k = *k.k;
+	set_bkey_val_bytes(&new->k, sizeof(new->v));
+
+	struct bkey_ptrs_c ptrs = bch2_bkey_ptrs_c(k);
+	const union bch_extent_entry *entry;
+	struct extent_ptr_decoded p;
+
+	bkey_for_each_ptr_decode(k.k, ptrs, p, entry) {
+		if (p.has_ec ||
+		    crc_is_compressed(p.crc) ||
+		    bch2_crc_unpacked_cmp(p.crc, old_crc))
+			return 0;
+
+		p.crc = new_crc;
+		bch2_extent_ptr_decoded_append(c, &new->k_i, &p);
+	}
+
+	u64 flags = bch2_bkey_extent_flags(k);
+	if (flags)
+		try(bch2_bkey_extent_flags_set(c, &new->k_i, flags));
+
+	struct bch_inode_opts opts;
+	try(bch2_bkey_get_io_opts(trans, NULL, k, &opts));
+	try(bch2_bkey_set_needs_reconcile(trans, NULL, &opts, bkey_i_to_s(&new->k_i),
+					  BKEY_EXTENT_U64s_MAX,
+					  SET_NEEDS_RECONCILE_foreground,
+					  u->op.opts.change_cookie));
+
+	return bch2_trans_update(trans, iter, &new->k_i,
+				 BTREE_UPDATE_internal_snapshot_node|
+				 BTREE_TRIGGER_set_needs_reconcile_done);
+}
+
+static int data_update_index_update_rechecksum(struct btree_trans *trans,
+					       struct data_update *u,
+					       struct bch_extent_crc_unpacked old_crc,
+					       struct bch_extent_crc_unpacked new_crc)
+{
+	struct bch_fs *c = trans->c;
+	struct bkey_s_c old = bkey_i_to_s_c(u->k.k);
+
+	CLASS(disk_reservation, res)(c);
+
+	return for_each_btree_key_commit(trans, iter, u->btree_id,
+			bkey_start_pos(old.k),
+			BTREE_ITER_slots|BTREE_ITER_intent,
+			k, &res.r, NULL,
+			BCH_TRANS_COMMIT_no_check_rw|
+			BCH_TRANS_COMMIT_no_enospc, ({
+		if (bkey_le(old.k->p, bkey_start_pos(k.k)))
+			break;
+
+		data_update_index_update_key_rechecksum(trans, u, &iter, k,
+							old_crc, new_crc);
+	}));
+}
+
 static int data_update_index_update_nowrite(struct btree_trans *trans,
 					    struct data_update *u)
 {
@@ -665,6 +740,20 @@ void bch2_data_update_read_done(struct data_update *u)
 
 	if (unlikely(rbio->ret)) {
 		u->op.error = rbio->ret;
+		u->op.end_io(&u->op);
+		return;
+	}
+
+	if (u->opts.type == BCH_DATA_UPDATE_rechecksum) {
+		struct bch_extent_crc_unpacked new_crc;
+		int ret = bch2_rechecksum_bio(c, &rbio->bio, rbio->version,
+				crc, NULL, &new_crc, 0, crc.live_size,
+			u->op.csum_type);
+		if (!ret) {
+			CLASS(btree_trans, trans)(c);
+			ret = data_update_index_update_rechecksum(trans, u, crc, new_crc);
+		}
+		u->op.error = ret;
 		u->op.end_io(&u->op);
 		return;
 	}
@@ -1424,7 +1513,8 @@ int bch2_data_update_init(struct btree_trans *trans,
 		ptr_bit <<= 1;
 	}
 
-	if (m->opts.type != BCH_DATA_UPDATE_scrub &&
+	if (m->opts.type != BCH_DATA_UPDATE_rechecksum &&
+	    m->opts.type != BCH_DATA_UPDATE_scrub &&
 	    m->opts.type != BCH_DATA_UPDATE_scrub_no_repair) {
 		/*
 		 * If current extent durability is less than io_opts.data_replicas,

--- a/fs/data/update.h
+++ b/fs/data/update.h
@@ -14,6 +14,7 @@ struct moving_context;
 	x(other)		\
 	x(copygc)		\
 	x(reconcile)		\
+	x(rechecksum)		\
 	x(promote)		\
 	x(self_heal)		\
 	x(scrub)		\


### PR DESCRIPTION
Addresses koverstreet/bcachefs#1152.

Changing `data_checksum` can make reconcile rewrite a valid whole,
uncompressed extent solely to replace its checksum metadata. This reuses the
completed read to compute the new checksum and updates the extent key without
allocating or writing replacement data.

The no-write path is limited to uncached, non-EC, whole uncompressed extents
whose replicas share a full CRC layout. Cached, EC, compressed, partial,
encryption-boundary, mixed-layout, and mixed-checksum cases retain the
existing rewrite path.

Validation:

- `git diff --check`
- `make -j4 build/fs/data/reconcile/work.o build/fs/data/update.o build/fs/data/extents.o`
- Ktest eligible whole-extent no-write oracle, data remount check, and offline
  fsck
- Ktest compressed rewrite control, data remount check, and offline fsck

The no-write path is runtime-validated for a whole uncompressed extent. The
compressed fallback is runtime-validated. Partial, cached, EC, encryption, and
mixed-replica forms retain the existing path; the partial case still needs a
fixture that creates a clipped CRC domain.

