### PR TITLE
data: catch compressed update decompression errors

### DIFF
--- a/fs/data/read.c
+++ b/fs/data/read.c
@@ -70,7 +70,7 @@ static bool bch2_poison_extents_on_checksum_error = true;
 module_param_named(poison_extents_on_checksum_error,
 		   bch2_poison_extents_on_checksum_error, bool, 0644);
 MODULE_PARM_DESC(poison_extents_on_checksum_error,
-		 "Extents with checksum errors are marked as poisoned - unsafe without read fua support");
+		 "Extents with checksum or decompression errors are marked as poisoned - unsafe without read fua support");
 
 static void bch2_read_bio_to_text_atomic(struct printbuf *, struct bch_read_bio *);
 
@@ -1406,7 +1406,8 @@ static noinline int read_extent_pick_err(struct btree_trans *trans,
 {
 	struct bch_fs *c = trans->c;
 
-	if (ret == -BCH_ERR_data_read_csum_err) {
+	if (ret == -BCH_ERR_data_read_csum_err ||
+	    bch2_err_matches(ret, BCH_ERR_decompress)) {
 		/* We can only return errors directly in the retry path */
 		BUG_ON(!(flags & BCH_READ_in_retry));
 

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -1380,6 +1380,9 @@ int bch2_data_update_init(struct btree_trans *trans,
 	struct extent_ptr_decoded p;
 	unsigned buf_bytes = 0;
 	bool unwritten = false;
+	bool verify_decompress = false;
+	unsigned target_compression_type =
+		bch2_compression_opt_to_type(m->op.compression_opt);
 	unsigned durability_keeping = 0;
 
 	if (m->opts.ptrs_kill)
@@ -1414,6 +1417,12 @@ int bch2_data_update_init(struct btree_trans *trans,
 		if (p.crc.compression_type == BCH_COMPRESSION_TYPE_incompressible)
 			m->op.incompressible = true;
 
+		verify_decompress |= crc_is_compressed(p.crc) &&
+			(p.crc.live_size != p.crc.uncompressed_size ||
+			 p.crc.uncompressed_size > c->opts.encoded_extent_max >> 9 ||
+			 bch2_csum_type_is_encryption(p.crc.csum_type) !=
+			 bch2_csum_type_is_encryption(m->op.csum_type) ||
+			 p.crc.compression_type != target_compression_type);
 		buf_bytes = max_t(unsigned, buf_bytes, p.crc.uncompressed_size << 9);
 		unwritten |= p.ptr.unwritten;
 
@@ -1530,7 +1539,8 @@ int bch2_data_update_init(struct btree_trans *trans,
 	if (ret)
 		goto out_nocow_unlock;
 
-	m->rbio.data_update_verify_decompress = m->opts.type == BCH_DATA_UPDATE_scrub;
+	m->rbio.data_update_verify_decompress =
+		m->opts.type == BCH_DATA_UPDATE_scrub || verify_decompress;
 
 	return 0;
 out_nocow_unlock:


### PR DESCRIPTION
## Summary

Issue koverstreet/bcachefs#1121 reports offline fsck/copygc hitting `ZSTD_error_dstSize_tooSmall` and `ZSTD_error_corruption_detected` while writing moved data from compressed encrypted extents, even though scrub succeeds.

Data update reads normally keep encoded data encoded so copygc/rewrite can write it back out, and only scrub requested read-time decompression verification. If a later write cannot keep the whole encoded extent as-is, decompression then happens in the write path, after the read path's replica retry and poison handling has already been bypassed.

This patch makes compressed data updates ask the read path to verify decompression when the write path may need to decode the compressed extent: partial live extents, encoded extents above the current limit, encryption-mode changes, or background-compression mismatches. It also treats final decompression failures like checksum failures for extent poisoning, so repeated background rewrites stop targeting a known-bad compressed extent.

Fixes koverstreet/bcachefs#1121.

## Testing

- `git diff --check`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 fs/data/read.o fs/data/update.o`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
