### PR TITLE
bcachefs: use SRCU-aware waits after dropping locks

### DIFF
--- a/fs/btree/commit.c
+++ b/fs/btree/commit.c
@@ -1320,7 +1320,7 @@ static noinline int bch2_trans_commit_btree_write_ratelimit(struct btree_trans *
 	struct bch_fs_btree_cache *bc = &c->btree.cache;
 
 	return drop_locks_do(trans, ({
-		closure_wait_event(&bc->nr_in_flight_wait,
+		trans_wait_event(trans, &bc->nr_in_flight_wait,
 			atomic_long_read(&bc->nr_in_flight_inner) < BTREE_WRITE_IO_LIMIT(c) * 3 / 4 &&
 			!bch2_btree_cache_should_throttle(c));
 		0;

--- a/fs/btree/interior.c
+++ b/fs/btree/interior.c
@@ -1435,8 +1435,8 @@ bch2_btree_update_start(struct btree_trans *trans, struct btree_path *path,
 			return ERR_PTR(-BCH_ERR_journal_reclaim_would_deadlock);
 
 		ret = drop_locks_do(trans,
-			({ closure_wait_event(&c->journal.async_wait,
-					      !journal_low_on_space(&c->journal)); 0; }));
+			({ trans_wait_event(trans, &c->journal.async_wait,
+					    !journal_low_on_space(&c->journal)); 0; }));
 		if (ret)
 			return ERR_PTR(ret);
 	}


### PR DESCRIPTION
## Summary

- use `trans_wait_event()` for the btree write throttling wait after `drop_locks_do()`
- use `trans_wait_event()` for the journal-low-space wait before btree update reservation
- keep the normal `bch2_trans_unlock()` fast path from `drop_locks_do()`, while letting long waits drop SRCU through the existing transaction-aware wait helper

## Context

This is a narrow follow-up to koverstreet/bcachefs#1069 and koverstreet/bcachefs-tools#659.

The earlier PR koverstreet/bcachefs-tools#659 handled the nocow-lock wait path. This patch covers the remaining direct `closure_wait_event()` calls inside `drop_locks_do(trans, ...)` scopes. `drop_locks_do()` already drops btree locks with `bch2_trans_unlock()`, but it does not drop the transaction SRCU read lock before the wrapped wait. Reusing `trans_wait_event()` keeps short waits cheap and escalates only if the wait outlives the transaction short-wait budget.

## Validation

- `git diff --check`
- `make generate_version && BINDGEN=/home/kom/.cargo/bin/bindgen LIBCLANG_PATH=/usr/lib/llvm-18/lib CARGO_BUILD_JOBS=4 make -j4 bcachefs`
- safe staged kbuild module compile without unload/install side effects:
  `make -C /lib/modules/$(uname -r)/build M=/home/kom/tmp/bcachefs-module-srcu-aware-wait-next modules -j4`
- GitHub Actions: Nix Flake actions run 28428366238, 17/17 jobs passed on head `bd0506446be2b8186975c1edce51db30a20274cf`
