### PR TITLE
crypto: fix big-endian superblock encryption

### DIFF
--- a/fs/sb/io.rs
+++ b/fs/sb/io.rs
@@ -37,8 +37,9 @@ impl bch_sb {
     /// Get the nonce used to encrypt the superblock
     pub fn nonce(&self) -> nonce {
         let [a, b, c, d, e, f, g, h, _rest @ ..] = self.uuid.b;
-        let dword1 = u32::from_le_bytes([a, b, c, d]);
-        let dword2 = u32::from_le_bytes([e, f, g, h]);
+        // nonce.d is __le32, so keep the raw bytes.
+        let dword1 = u32::from_ne_bytes([a, b, c, d]);
+        let dword2 = u32::from_ne_bytes([e, f, g, h]);
         nonce {
             d: [0, 0, dword1, dword2],
         }

--- a/include/crypto/chacha.h
+++ b/include/crypto/chacha.h
@@ -61,10 +61,21 @@ static inline void chacha20_crypt(struct chacha_state *state, u8 *dst, const u8 
 {
 	u32 *key = state->x + 4;
 	u32 *iv  = state->x + 12;
+
+	/* libsodium reads key/nonce via LOAD32_LE, so re-serialize the
+	 * native-order words LE. */
+	u8 k[CHACHA_KEY_SIZE];
+	u8 n[8];
+	int i;
+	for (i = 0; i < CHACHA_KEY_WORDS; i++)
+		put_unaligned_le32(key[i], k + i * 4);
+	put_unaligned_le32(iv[2], n + 0);
+	put_unaligned_le32(iv[3], n + 4);
+
 	int ret = crypto_stream_chacha20_xor_ic(dst, src, bytes,
-						(void *) &iv[2],
+						n,
 						iv[0] | ((u64) iv[1] << 32),
-						(void *) key);
+						k);
 	BUG_ON(ret);
 }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -30,14 +30,14 @@ pub fn sb_is_encrypted(sb: &bch_sb_handle) -> bool {
     let bch_key_magic = u64::from_le_bytes(*BCH_KEY_MAGIC);
     sb.sb()
         .crypt()
-        .map(|c| c.key().magic != bch_key_magic)
+        .map(|c| u64::from_le(c.key().magic) != bch_key_magic)
         .unwrap_or(false)
 }
 
 /// Create an unencrypted (plaintext) key for the crypt field (remove-passphrase).
 pub fn unencrypted_key(key: &bch_key) -> bch_encrypted_key {
     bch_encrypted_key {
-        magic: u64::from_le_bytes(*BCH_KEY_MAGIC),
+        magic: u64::from_le_bytes(*BCH_KEY_MAGIC).to_le(),
         key: *key,
     }
 }
@@ -275,7 +275,7 @@ impl Passphrase {
     ) -> bch_encrypted_key {
         let crypt = sb.sb().crypt().expect("called on encrypted fs");
         let mut new_key = bch_encrypted_key {
-            magic: u64::from_le_bytes(*BCH_KEY_MAGIC),
+            magic: u64::from_le_bytes(*BCH_KEY_MAGIC).to_le(),
             key: *key,
         };
 
@@ -303,7 +303,7 @@ impl Passphrase {
         let mut sb_key = *crypt.key();
 
         ensure!(
-            sb_key.magic != bch_key_magic,
+            u64::from_le(sb_key.magic) != bch_key_magic,
             "filesystem encryption key is not passphrase-protected"
         );
 
@@ -317,7 +317,7 @@ impl Passphrase {
                 mem::size_of_val(&sb_key),
             )
         };
-        ensure!(sb_key.magic == bch_key_magic, "incorrect passphrase");
+        ensure!(u64::from_le(sb_key.magic) == bch_key_magic, "incorrect passphrase");
 
         Ok((passphrase_key, sb_key))
     }


### PR DESCRIPTION
`chacha20_crypt()`, `nonce()`, and the key-magic check read
native-order words where libsodium and the on-disk format
expect little-endian, so unlocking an encrypted fs on a
big-endian host always failed.

This commit serializes to LE to match.

Signed-off-by: Amaan Qureshi <git@amaanq.com>