### PR TITLE
key: align passphrase prompts with systemd cryptsetup

### DIFF
--- a/fs/sb/io.rs
+++ b/fs/sb/io.rs
@@ -30,6 +30,15 @@ impl bch_sb {
         uuid::Uuid::from_bytes(self.user_uuid.b)
     }
 
+    pub fn label(&self) -> &[u8] {
+        let len = self
+            .label
+            .iter()
+            .position(|b| *b == b'\0')
+            .unwrap_or(self.label.len());
+        &self.label[..len]
+    }
+
     pub fn number_of_devices(&self) -> u32 {
         unsafe { c::bch2_sb_nr_devices(self) }
     }

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -394,9 +394,9 @@ fn cmd_format(argv: Vec<String>) -> Result<()> {
     // Handle encryption
     let passphrase: Option<Passphrase> = if cfg.encrypted && !cfg.no_passphrase {
         let p = if let Some(ref path) = cfg.passphrase_file {
-            Passphrase::new_from_file(path)?
+            Passphrase::read_from_file(path)?
         } else {
-            Passphrase::new_from_prompt_twice()?
+            Passphrase::ask_for_new_passphrase()?
         };
         cfg.initialize = false;
         Some(p)

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -929,9 +929,9 @@ fn cmd_image_create(argv: Vec<String>) -> Result<()> {
 
     let passphrase: Option<Passphrase> = if encrypted && !no_passphrase {
         Some(if let Some(ref path) = passphrase_file {
-            Passphrase::new_from_file(path)?
+            Passphrase::read_from_file(path)?
         } else {
-            Passphrase::new_from_prompt_twice()?
+            Passphrase::ask_for_new_passphrase()?
         })
     } else {
         None

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -62,7 +62,7 @@ fn cmd_unlock(cli: UnlockCli) -> Result<()> {
     }
 
     let passphrase_correct = match cli.file {
-        Some(file) => Passphrase::new_from_file(file)?
+        Some(file) => Passphrase::read_from_file(file)?
             .check(&sb)
             .ok_or_else(|| anyhow!("incorrect passphrase"))?,
         None => Passphrase::ask_and_check(&sb)?,
@@ -138,7 +138,7 @@ pub struct SetPassphraseCli {
 fn cmd_set_passphrase(cli: SetPassphraseCli) -> Result<()> {
     let (fs, raw_key) = open_and_verify(&parse_device_list(&cli.devices))?;
 
-    let new_passphrase = Passphrase::new_from_prompt_twice()
+    let new_passphrase = Passphrase::ask_for_new_passphrase()
         .context("reading new passphrase")?;
 
     let encrypted_key = new_passphrase.encrypt_key(fs.sb_handle(), &raw_key);

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -62,33 +62,16 @@ fn cmd_unlock(cli: UnlockCli) -> Result<()> {
         bail!("{} is not encrypted", cli.device);
     }
 
-    let uuid = sb.sb().uuid();
-
-    // First attempt
     let passphrase = if let Some(ref file) = cli.file {
         Passphrase::new_from_file(file)?
     } else {
+        let uuid = sb.sb().uuid();
         Passphrase::new(&uuid)?
     };
 
-    match KeyHandle::new(&sb, &passphrase, cli.keyring) {
-        Ok(_) => return Ok(()),
-        Err(e) if e.to_string().contains("incorrect passphrase") => {}
-        Err(e) => return Err(e),
-    }
+    KeyHandle::new(&sb, &passphrase, cli.keyring)?;
 
-    // Retry up to 2 more times, always interactive
-    for _ in 0..2 {
-        eprintln!("incorrect passphrase");
-        let passphrase = Passphrase::new_from_prompt(&uuid)?;
-        match KeyHandle::new(&sb, &passphrase, cli.keyring) {
-            Ok(_) => return Ok(()),
-            Err(e) if e.to_string().contains("incorrect passphrase") => continue,
-            Err(e) => return Err(e),
-        }
-    }
-
-    bail!("incorrect passphrase limit reached");
+    Ok(())
 }
 
 // ---- shared helpers for set/remove-passphrase ----

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -104,14 +104,9 @@ fn open_and_verify(devs: &[PathBuf]) -> Result<(Fs, bch_key)> {
     }
 
     if sb_is_encrypted(sb_handle) {
-        let uuid = sb_handle.sb().uuid();
-        let old_passphrase =
-            Passphrase::new_from_prompt(&uuid).context("reading current passphrase")?;
         let PassphraseCorrect {
             cleartext_sb_key, ..
-        } = old_passphrase
-            .check(sb_handle)
-            .context("verifying current passphrase")?;
+        } = Passphrase::ask_and_check(&sb_handle)?;
         Ok((fs, cleartext_sb_key.key))
     } else {
         let raw_key = sb_handle.sb().crypt().unwrap().key().key;

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use bcachefs_kernel::c::bch_key;
 use bch_bindgen::c;
 use bcachefs_kernel::fs::Fs;
@@ -8,7 +8,7 @@ use bcachefs_kernel::opt_set;
 use bch_bindgen::sb::io as sb_io;
 use clap::Parser;
 
-use crate::key::{sb_is_encrypted, unencrypted_key, KeyHandle, Keyring, Passphrase};
+use crate::key::{sb_is_encrypted, unencrypted_key, KeyHandle, Keyring, Passphrase, PassphraseCorrect};
 
 // ---- unlock ----
 
@@ -32,7 +32,6 @@ pub struct UnlockCli {
 }
 
 fn cmd_unlock(cli: UnlockCli) -> Result<()> {
-
     let sb = sb_io::read_super(Path::new(&cli.device))
         .with_context(|| format!("Error opening {}", cli.device))?;
 
@@ -69,7 +68,10 @@ fn cmd_unlock(cli: UnlockCli) -> Result<()> {
         Passphrase::new(&uuid)?
     };
 
-    KeyHandle::new(&sb, &passphrase, cli.keyring)?;
+    let passphrase_correct = passphrase
+        .check(&sb)
+        .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+    KeyHandle::new(&passphrase_correct, cli.keyring)?;
 
     Ok(())
 }
@@ -107,11 +109,14 @@ fn open_and_verify(devs: &[PathBuf]) -> Result<(Fs, bch_key)> {
 
     if sb_is_encrypted(sb_handle) {
         let uuid = sb_handle.sb().uuid();
-        let old_passphrase = Passphrase::new_from_prompt(&uuid)
-            .context("reading current passphrase")?;
-        let (_, sb_key) = old_passphrase.check(sb_handle)
+        let old_passphrase =
+            Passphrase::new_from_prompt(&uuid).context("reading current passphrase")?;
+        let PassphraseCorrect {
+            cleartext_sb_key, ..
+        } = old_passphrase
+            .check(sb_handle)
             .context("verifying current passphrase")?;
-        Ok((fs, sb_key.key))
+        Ok((fs, cleartext_sb_key.key))
     } else {
         let raw_key = sb_handle.sb().crypt().unwrap().key().key;
         Ok((fs, raw_key))

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -61,16 +61,12 @@ fn cmd_unlock(cli: UnlockCli) -> Result<()> {
         bail!("{} is not encrypted", cli.device);
     }
 
-    let passphrase = if let Some(ref file) = cli.file {
-        Passphrase::new_from_file(file)?
-    } else {
-        let uuid = sb.sb().uuid();
-        Passphrase::new(&uuid)?
+    let passphrase_correct = match cli.file {
+        Some(file) => Passphrase::new_from_file(file)?
+            .check(&sb)
+            .ok_or_else(|| anyhow!("incorrect passphrase"))?,
+        None => Passphrase::ask_and_check(&sb)?,
     };
-
-    let passphrase_correct = passphrase
-        .check(&sb)
-        .ok_or_else(|| anyhow!("incorrect passphrase"))?;
     KeyHandle::new(&passphrase_correct, cli.keyring)?;
 
     Ok(())

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -677,7 +677,7 @@ fn cmd_migrate(argv: Vec<String>) -> Result<()> {
 
     // Handle encryption passphrase
     let passphrase: Option<Passphrase> = if encrypted && !no_passphrase {
-        Some(Passphrase::new_from_prompt_twice()?)
+        Some(Passphrase::ask_for_new_passphrase()?)
     } else {
         None
     };

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -6,7 +6,7 @@ use std::{
     ptr, str,
 };
 
-use anyhow::{ensure, Result};
+use anyhow::{anyhow, ensure, Result};
 use bcachefs_kernel::c::bch_sb_handle;
 use bcachefs_kernel::path_to_cstr;
 use clap::Parser;
@@ -133,12 +133,23 @@ fn handle_unlock(cli: &Cli, sb: &bch_sb_handle) -> Result<KeyHandle> {
     }
 
     if let Some(path) = cli.passphrase_file.as_deref() {
-        return Passphrase::new_from_file(path).and_then(|p| KeyHandle::new(sb, &p, Keyring::User));
+        let passphrase = Passphrase::new_from_file(path)?;
+        let passphrase_correct = passphrase
+            .check(sb)
+            .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+        return KeyHandle::new(&passphrase_correct, Keyring::User);
     }
 
     let uuid = sb.sb().uuid();
-    KeyHandle::new_from_search(&uuid)
-        .or_else(|_| Passphrase::new(&uuid).and_then(|p| KeyHandle::new(sb, &p, Keyring::User)))
+    if let Ok(handle) = KeyHandle::new_from_search(&uuid) {
+        return Ok(handle);
+    }
+
+    let passphrase = Passphrase::new(&uuid)?;
+    let passphrase_correct = passphrase
+        .check(sb)
+        .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+    KeyHandle::new(&passphrase_correct, Keyring::User)
 }
 
 fn cmd_mount_inner(cli: &Cli) -> Result<()> {

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -145,10 +145,7 @@ fn handle_unlock(cli: &Cli, sb: &bch_sb_handle) -> Result<KeyHandle> {
         return Ok(handle);
     }
 
-    let passphrase = Passphrase::new(&uuid)?;
-    let passphrase_correct = passphrase
-        .check(sb)
-        .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+    let passphrase_correct = Passphrase::ask_and_check(sb)?;
     KeyHandle::new(&passphrase_correct, Keyring::User)
 }
 

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -133,7 +133,7 @@ fn handle_unlock(cli: &Cli, sb: &bch_sb_handle) -> Result<KeyHandle> {
     }
 
     if let Some(path) = cli.passphrase_file.as_deref() {
-        let passphrase = Passphrase::new_from_file(path)?;
+        let passphrase = Passphrase::read_from_file(path)?;
         let passphrase_correct = passphrase
             .check(sb)
             .ok_or_else(|| anyhow!("incorrect passphrase"))?;

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     ffi::{CStr, CString},
     fs,
     io::{self, stdin, IsTerminal},
@@ -190,6 +191,10 @@ impl Passphrase {
 
     fn ask_from_systemd_and_check(sb: &bch_sb_handle) -> Result<PassphraseCorrect> {
         let uuid = sb.sb().uuid();
+        let mut label = String::from_utf8_lossy(sb.sb().label());
+        if label.is_empty() {
+            label = Cow::Owned(uuid.hyphenated().to_string());
+        }
         for i in 0..3 {
             let mut command = Command::new("systemd-ask-password");
             command
@@ -204,7 +209,7 @@ impl Passphrase {
                 command.arg("--accept-cached");
             }
             let output = command
-                .arg("Enter passphrase: ")
+                .arg(format!("Please enter passphrase for disk {label}:"))
                 .stdin(Stdio::inherit())
                 .stderr(Stdio::inherit())
                 .output()?;

--- a/src/key.rs
+++ b/src/key.rs
@@ -85,8 +85,20 @@ impl UnlockPolicy {
         match self {
             Self::Fail => KeyHandle::new_from_search(&uuid),
             Self::Wait => Ok(KeyHandle::wait_for_unlock(&uuid)?),
-            Self::Ask => Passphrase::new_from_prompt(&uuid).and_then(|p| KeyHandle::new(sb, &p, Keyring::User)),
-            Self::Stdin => Passphrase::new_from_stdin().and_then(|p| KeyHandle::new(sb, &p, Keyring::User)),
+            Self::Ask => {
+                let passphrase = Passphrase::new_from_prompt(&uuid)?;
+                let passphrase_correct = passphrase
+                    .check(sb)
+                    .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+                KeyHandle::new(&passphrase_correct, Keyring::User)
+            }
+            Self::Stdin => {
+                let passphrase = Passphrase::new_from_stdin()?;
+                let passphrase_correct = passphrase
+                    .check(sb)
+                    .ok_or_else(|| anyhow!("incorrect passphrase"))?;
+                KeyHandle::new(&passphrase_correct, Keyring::User)
+            }
         }
     }
 }
@@ -100,19 +112,17 @@ impl KeyHandle {
         CString::new(format!("bcachefs:{uuid}")).unwrap()
     }
 
-    pub fn new(sb: &bch_sb_handle, passphrase: &Passphrase, keyring: Keyring) -> Result<Self> {
-        let key_name = Self::format_key_name(&sb.sb().uuid());
+    pub fn new(passphrase_correct: &PassphraseCorrect, keyring: Keyring) -> Result<Self> {
+        let key_name = Self::format_key_name(&passphrase_correct.fs_uuid);
         let key_name = CStr::as_ptr(&key_name);
         let key_type = c"user";
-
-        let (passphrase_key, _sb_key) = passphrase.check(sb)?;
 
         let key_id = unsafe {
             keyutils::add_key(
                 key_type.as_ptr(),
                 key_name,
-                ptr::addr_of!(passphrase_key).cast(),
-                mem::size_of_val(&passphrase_key),
+                ptr::addr_of!(passphrase_correct.passphrase_key).cast(),
+                mem::size_of_val(&passphrase_correct.passphrase_key),
                 keyring.id(),
             )
         };
@@ -293,34 +303,46 @@ impl Passphrase {
         new_key
     }
 
-    pub fn check(&self, sb: &bch_sb_handle) -> Result<(bch_key, bch_encrypted_key)> {
+    pub fn check(&self, sb: &bch_sb_handle) -> Option<PassphraseCorrect> {
         let bch_key_magic = u64::from_le_bytes(*BCH_KEY_MAGIC);
 
         let crypt = sb
             .sb()
             .crypt()
-            .ok_or_else(|| anyhow!("filesystem is not encrypted"))?;
-        let mut sb_key = *crypt.key();
+            .expect("superblock should have crypt when calling Passphrase::check");
 
-        ensure!(
-            sb_key.magic != bch_key_magic,
-            "filesystem encryption key is not passphrase-protected"
+        assert!(
+            crypt.key().magic != bch_key_magic,
+            "sb_key should be encrypted when calling Passphrase::check",
         );
 
         let mut passphrase_key: bch_key = self.derive(crypt);
 
+        let mut cleartext_sb_key = *crypt.key();
         unsafe {
             bch2_chacha20(
                 ptr::addr_of_mut!(passphrase_key),
                 sb.sb().nonce(),
-                ptr::addr_of_mut!(sb_key).cast(),
-                mem::size_of_val(&sb_key),
+                ptr::addr_of_mut!(cleartext_sb_key).cast(),
+                mem::size_of_val(&cleartext_sb_key),
             )
         };
-        ensure!(sb_key.magic == bch_key_magic, "incorrect passphrase");
+        if cleartext_sb_key.magic != bch_key_magic {
+            return None;
+        }
 
-        Ok((passphrase_key, sb_key))
+        Some(PassphraseCorrect {
+            fs_uuid: sb.sb().uuid(),
+            passphrase_key,
+            cleartext_sb_key,
+        })
     }
+}
+
+pub struct PassphraseCorrect {
+    pub fs_uuid:          Uuid,
+    pub passphrase_key:   bch_key,
+    pub cleartext_sb_key: bch_encrypted_key,
 }
 
 fn is_dev_null(fd: BorrowedFd) -> io::Result<bool> {

--- a/src/key.rs
+++ b/src/key.rs
@@ -196,6 +196,7 @@ impl Passphrase {
                 .arg("--icon=drive-harddisk")
                 .arg(format!("--id=bcachefs:{}", uuid.as_hyphenated()))
                 .arg(format!("--keyname={}", uuid.as_hyphenated()))
+                .arg("--multiple")
                 .arg("-n");
             if i == 0 {
                 command.arg("--accept-cached");
@@ -208,9 +209,14 @@ impl Passphrase {
             if !output.status.success() {
                 bail!("systemd-ask-password returned an error");
             }
-            let passphrase = Self(CString::new(output.stdout)?);
-            if let Some(passphrase_correct) = passphrase.check(sb) {
-                return Ok(passphrase_correct);
+            for passphrase in output.stdout.split(|b| *b == b'\0') {
+                let p = Self(
+                    CString::new(passphrase)
+                        .expect("passphrase should not contain a NUL byte because the output was split on NUL bytes")
+                );
+                if let Some(passphrase_correct) = p.check(sb) {
+                    return Ok(passphrase_correct);
+                }
             }
         }
         bail!("incorrect passphrase limit reached");

--- a/src/key.rs
+++ b/src/key.rs
@@ -86,14 +86,14 @@ impl UnlockPolicy {
             Self::Fail => KeyHandle::new_from_search(&uuid),
             Self::Wait => Ok(KeyHandle::wait_for_unlock(&uuid)?),
             Self::Ask => {
-                let passphrase = Passphrase::new_from_prompt()?;
+                let passphrase = Passphrase::ask_in_terminal()?;
                 let passphrase_correct = passphrase
                     .check(sb)
                     .ok_or_else(|| anyhow!("incorrect passphrase"))?;
                 KeyHandle::new(&passphrase_correct, Keyring::User)
             }
             Self::Stdin => {
-                let passphrase = Passphrase::new_from_stdin()?;
+                let passphrase = Passphrase::read_from_stdin()?;
                 let passphrase_correct = passphrase
                     .check(sb)
                     .ok_or_else(|| anyhow!("incorrect passphrase"))?;
@@ -178,11 +178,11 @@ impl Passphrase {
 
     pub fn ask_and_check(sb: &bch_sb_handle) -> Result<PassphraseCorrect> {
         match StdinType::detect() {
-            StdinType::Terminal => Self::new_from_prompt()?
+            StdinType::Terminal => Self::ask_in_terminal()?
                 .check(sb)
                 .ok_or_else(|| anyhow!("incorrect passphrase")),
             StdinType::DevNull => Self::ask_from_systemd_and_check(sb),
-            StdinType::Other => Self::new_from_stdin()?
+            StdinType::Other => Self::read_from_stdin()?
                 .check(sb)
                 .ok_or_else(|| anyhow!("incorrect passphrase")),
         }
@@ -223,7 +223,7 @@ impl Passphrase {
     }
 
     /// Prompt for a passphrase with echo disabled.
-    fn prompt_hidden(prompt: &str) -> Result<Self> {
+    fn ask_in_terminal_with_prompt(prompt: &str) -> Result<Self> {
         let old = termios::tcgetattr(stdin())?;
         let mut new = old.clone();
         new.local_modes.remove(termios::LocalModes::ECHO);
@@ -241,23 +241,23 @@ impl Passphrase {
     }
 
     // blocks indefinitely if no input is available on stdin
-    pub fn new_from_prompt() -> Result<Self> {
-        Self::prompt_hidden("Enter passphrase: ")
+    pub fn ask_in_terminal() -> Result<Self> {
+        Self::ask_in_terminal_with_prompt("Enter passphrase: ")
     }
 
     /// Prompt for a new passphrase twice and verify they match.
-    pub fn new_from_prompt_twice() -> Result<Self> {
+    pub fn ask_for_new_passphrase() -> Result<Self> {
         if !stdin().is_terminal() {
-            return Self::new_from_stdin();
+            return Self::read_from_stdin();
         }
-        let pass1 = Self::prompt_hidden("Enter new passphrase: ")?;
-        let pass2 = Self::prompt_hidden("Enter same passphrase again: ")?;
+        let pass1 = Self::ask_in_terminal_with_prompt("Enter new passphrase: ")?;
+        let pass2 = Self::ask_in_terminal_with_prompt("Enter same passphrase again: ")?;
         ensure!(pass1.get().to_bytes() == pass2.get().to_bytes(), "Passphrases do not match");
         Ok(pass1)
     }
 
     // blocks indefinitely if no input is available on stdin
-    pub fn new_from_stdin() -> Result<Self> {
+    pub fn read_from_stdin() -> Result<Self> {
         info!("Trying to read passphrase from stdin...");
 
         let mut line = Zeroizing::new(String::new());
@@ -266,7 +266,7 @@ impl Passphrase {
         Ok(Self(CString::new(line.trim_end_matches('\n'))?))
     }
 
-    pub fn new_from_file(passphrase_file: impl AsRef<Path>) -> Result<Self> {
+    pub fn read_from_file(passphrase_file: impl AsRef<Path>) -> Result<Self> {
         let passphrase_file = passphrase_file.as_ref();
 
         info!(

--- a/src/key.rs
+++ b/src/key.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{anyhow, bail, ensure, Result};
 use bcachefs_kernel::c::{
     bch_key, bch_sb_handle,
     bch2_chacha20, bch_encrypted_key, bch_sb_field_crypt,
@@ -177,42 +177,43 @@ impl Passphrase {
     }
 
     pub fn ask_and_check(sb: &bch_sb_handle) -> Result<PassphraseCorrect> {
-        let passphrase = match StdinType::detect() {
-            StdinType::Terminal => Self::new_from_prompt()?,
-            StdinType::DevNull => {
-                let uuid = sb.sb().uuid();
-                Self::new_from_askpassword(&uuid)??
-            }
-            StdinType::Other => Self::new_from_stdin()?,
-        };
-        passphrase
-            .check(sb)
-            .ok_or_else(|| anyhow!("incorrect passphrase"))
+        match StdinType::detect() {
+            StdinType::Terminal => Self::new_from_prompt()?
+                .check(sb)
+                .ok_or_else(|| anyhow!("incorrect passphrase")),
+            StdinType::DevNull => Self::ask_from_systemd_and_check(sb),
+            StdinType::Other => Self::new_from_stdin()?
+                .check(sb)
+                .ok_or_else(|| anyhow!("incorrect passphrase")),
+        }
     }
 
-    // The outer result represents a failure when trying to run systemd-ask-password,
-    // it is non-critical and will cause the password to be asked internally.
-    // The inner result represent a successful request that returned an error
-    // this one results in an error.
-    fn new_from_askpassword(uuid: &Uuid) -> Result<Result<Self>> {
-        let output = Command::new("systemd-ask-password")
-            .arg("--icon=drive-harddisk")
-            .arg(format!("--id=bcachefs:{}", uuid.as_hyphenated()))
-            .arg(format!("--keyname={}", uuid.as_hyphenated()))
-            .arg("--accept-cached")
-            .arg("-n")
-            .arg("Enter passphrase: ")
-            .stdin(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .output()?;
-        Ok(if output.status.success() {
-            match CString::new(output.stdout) {
-                Ok(cstr) => Ok(Self(cstr)),
-                Err(e) => Err(e.into()),
+    fn ask_from_systemd_and_check(sb: &bch_sb_handle) -> Result<PassphraseCorrect> {
+        let uuid = sb.sb().uuid();
+        for i in 0..3 {
+            let mut command = Command::new("systemd-ask-password");
+            command
+                .arg("--icon=drive-harddisk")
+                .arg(format!("--id=bcachefs:{}", uuid.as_hyphenated()))
+                .arg(format!("--keyname={}", uuid.as_hyphenated()))
+                .arg("-n");
+            if i == 0 {
+                command.arg("--accept-cached");
             }
-        } else {
-            Err(anyhow!("systemd-ask-password returned an error"))
-        })
+            let output = command
+                .arg("Enter passphrase: ")
+                .stdin(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .output()?;
+            if !output.status.success() {
+                bail!("systemd-ask-password returned an error");
+            }
+            let passphrase = Self(CString::new(output.stdout)?);
+            if let Some(passphrase_correct) = passphrase.check(sb) {
+                return Ok(passphrase_correct);
+            }
+        }
+        bail!("incorrect passphrase limit reached");
     }
 
     /// Prompt for a passphrase with echo disabled.

--- a/src/key.rs
+++ b/src/key.rs
@@ -16,7 +16,7 @@ use bcachefs_kernel::c::{
     bch2_chacha20, bch_encrypted_key, bch_sb_field_crypt,
 };
 use bch_bindgen::keyutils::{self, keyctl_search};
-use log::{debug, info};
+use log::info;
 use rustix::termios;
 use uuid::Uuid;
 use zeroize::{ZeroizeOnDrop, Zeroizing};
@@ -177,16 +177,12 @@ impl Passphrase {
     }
 
     pub fn ask_and_check(sb: &bch_sb_handle) -> Result<PassphraseCorrect> {
-        let uuid = sb.sb().uuid();
         let passphrase = match StdinType::detect() {
-            StdinType::Terminal => match Self::new_from_askpassword(&uuid) {
-                Ok(phrase) => phrase?,
-                Err(_) => {
-                    debug!("Failed to start systemd-ask-password, doing the prompt ourselves");
-                    Self::new_from_prompt()?
-                }
-            },
-            StdinType::DevNull => Self::new_from_askpassword(&uuid)??,
+            StdinType::Terminal => Self::new_from_prompt()?,
+            StdinType::DevNull => {
+                let uuid = sb.sb().uuid();
+                Self::new_from_askpassword(&uuid)??
+            }
             StdinType::Other => Self::new_from_stdin()?,
         };
         passphrase

--- a/src/key.rs
+++ b/src/key.rs
@@ -194,8 +194,10 @@ impl Passphrase {
             let mut command = Command::new("systemd-ask-password");
             command
                 .arg("--icon=drive-harddisk")
-                .arg(format!("--id=bcachefs:{}", uuid.as_hyphenated()))
-                .arg(format!("--keyname={}", uuid.as_hyphenated()))
+                .arg(format!("--id=cryptsetup:UUID={}", uuid.as_hyphenated()))
+                .arg("--keyname=cryptsetup")
+                .arg("--credential=cryptsetup.passphrase")
+                .arg("--timeout=0")
                 .arg("--multiple")
                 .arg("-n");
             if i == 0 {

--- a/src/key.rs
+++ b/src/key.rs
@@ -86,7 +86,7 @@ impl UnlockPolicy {
             Self::Fail => KeyHandle::new_from_search(&uuid),
             Self::Wait => Ok(KeyHandle::wait_for_unlock(&uuid)?),
             Self::Ask => {
-                let passphrase = Passphrase::new_from_prompt(&uuid)?;
+                let passphrase = Passphrase::new_from_prompt()?;
                 let passphrase_correct = passphrase
                     .check(sb)
                     .ok_or_else(|| anyhow!("incorrect passphrase"))?;
@@ -179,7 +179,13 @@ impl Passphrase {
     pub fn ask_and_check(sb: &bch_sb_handle) -> Result<PassphraseCorrect> {
         let uuid = sb.sb().uuid();
         let passphrase = match StdinType::detect() {
-            StdinType::Terminal => Self::new_from_prompt(&uuid)?,
+            StdinType::Terminal => match Self::new_from_askpassword(&uuid) {
+                Ok(phrase) => phrase?,
+                Err(_) => {
+                    debug!("Failed to start systemd-ask-password, doing the prompt ourselves");
+                    Self::new_from_prompt()?
+                }
+            },
             StdinType::DevNull => Self::new_from_askpassword(&uuid)??,
             StdinType::Other => Self::new_from_stdin()?,
         };
@@ -232,11 +238,7 @@ impl Passphrase {
     }
 
     // blocks indefinitely if no input is available on stdin
-    pub fn new_from_prompt(uuid: &Uuid) -> Result<Self> {
-        match Self::new_from_askpassword(uuid) {
-            Ok(phrase) => return phrase,
-            Err(_) => debug!("Failed to start systemd-ask-password, doing the prompt ourselves"),
-        }
+    pub fn new_from_prompt() -> Result<Self> {
         Self::prompt_hidden("Enter passphrase: ")
     }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -167,7 +167,7 @@ impl Passphrase {
     }
 
     pub fn new(uuid: &Uuid) -> Result<Self> {
-        match get_stdin_type() {
+        match StdinType::detect() {
             StdinType::Terminal => Self::new_from_prompt(uuid),
             StdinType::DevNull => Self::new_from_askpassword(uuid)?,
             StdinType::Other => Self::new_from_stdin(),
@@ -340,13 +340,15 @@ enum StdinType {
     Other,
 }
 
-fn get_stdin_type() -> StdinType {
-    let stdin = stdin();
-    if stdin.is_terminal() {
-        StdinType::Terminal
-    } else if is_dev_null(stdin.as_fd()).unwrap_or(false) {
-        StdinType::DevNull
-    } else {
-        StdinType::Other
+impl StdinType {
+    fn detect() -> StdinType {
+        let stdin = stdin();
+        if stdin.is_terminal() {
+            StdinType::Terminal
+        } else if is_dev_null(stdin.as_fd()).unwrap_or(false) {
+            StdinType::DevNull
+        } else {
+            StdinType::Other
+        }
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -176,12 +176,16 @@ impl Passphrase {
         &self.0
     }
 
-    pub fn new(uuid: &Uuid) -> Result<Self> {
-        match StdinType::detect() {
-            StdinType::Terminal => Self::new_from_prompt(uuid),
-            StdinType::DevNull => Self::new_from_askpassword(uuid)?,
-            StdinType::Other => Self::new_from_stdin(),
-        }
+    pub fn ask_and_check(sb: &bch_sb_handle) -> Result<PassphraseCorrect> {
+        let uuid = sb.sb().uuid();
+        let passphrase = match StdinType::detect() {
+            StdinType::Terminal => Self::new_from_prompt(&uuid)?,
+            StdinType::DevNull => Self::new_from_askpassword(&uuid)??,
+            StdinType::Other => Self::new_from_stdin()?,
+        };
+        passphrase
+            .check(sb)
+            .ok_or_else(|| anyhow!("incorrect passphrase"))
     }
 
     // The outer result represents a failure when trying to run systemd-ask-password,


### PR DESCRIPTION
## Summary

This is a current-master carry of beviu's koverstreet/bcachefs-tools#551 stack.

It preserves the beviu-authored commits and keeps the reviewed behavior changes:

- align the systemd-ask-password key description, timeout, identifier, and credential name with systemd-cryptsetup;
- retry after wrong passphrases when the passphrase source can provide more than one candidate;
- avoid systemd-ask-password for explicit `-k ask`;
- only use systemd-ask-password when stdin is `/dev/null`;
- show the filesystem label or UUID in the passphrase prompt.

The original PR is currently conflicting against master. This branch is intended as a mergeable carry for maintainers if they prefer not to wait for the contributor branch to be rebased.

Related to koverstreet/bcachefs-tools#551.

## Notes

The old `bch_bindgen/src/bcachefs.rs` zeroize commit from the contributor branch is not carried here because that wrapper layer was removed upstream before this rebase. The cryptsetup/systemd-ask-password UX changes are carried forward.

## Testing

- `git diff --check origin/master..HEAD`
- `make generate_version`
- `BINDGEN=/home/kom/.cargo/bin/bindgen CARGO_TARGET_DIR=/home/kom/proj/bcachefs-tools-pr551-refresh/target-pr551-check cargo check -p bcachefs-tools`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
