### PR TITLE
docs: explain compressed random-read tuning

### DIFF
--- a/fs/data/compress.c
+++ b/fs/data/compress.c
@@ -12,8 +12,15 @@
  * The main tradeoff to be aware of: small random reads within a compressed
  * extent must read and decompress the entire extent (up to 128K) because the
  * checksum covers the whole extent. For workloads dominated by small random
- * reads (e.g. databases), compression may hurt read performance. Sequential
- * reads and large-block random reads are largely unaffected.
+ * reads (e.g. virtual machine images or databases), compression may hurt read
+ * performance. Sequential reads and large-block random reads are largely
+ * unaffected.
+ *
+ * The `encoded_extent_max` option bounds the amount of data that a small
+ * compressed read may have to pull in and decode. Lower values reduce random
+ * read amplification at the cost of compression ratio and metadata efficiency.
+ * Random-read-heavy workloads should prefer lz4 and/or a smaller
+ * `encoded_extent_max` over high-level zstd with large encoded extents.
  *
  * Data can be recompressed in the background with a different algorithm or
  * level via the `background_compression` option — for example, writing with


### PR DESCRIPTION
## Summary

- mention virtual machine images alongside databases as a random-read-heavy compressed workload
- document that `encoded_extent_max` bounds compressed read amplification
- suggest lz4 and/or smaller `encoded_extent_max` for random-read-heavy workloads instead of high-level zstd with large encoded extents

## Why

koverstreet/bcachefs#1150 has a useful synthetic reproduction showing the sharp performance cliff for small random reads into compressed extents, and the follow-up testing points at `encoded_extent_max` plus compression choice as the practical tuning surface.

The existing compression docs already mention the basic full-extent read/decode tradeoff; this adds the missing knob and workload guidance.

References koverstreet/bcachefs#1150.

## Verification

- `git diff --check origin/master...HEAD`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 build/fs/data/compress.o`
- Branch rebased on current `origin/master` and force-pushed from `b7f74600c6fdc560f1d992c588815295ee190713` to `c2d79a6f7dbe151fc3e857f032c8a3e38f4ecb0c`
- GitHub CI: 17/17 checks green for refreshed head `c2d79a6f7dbe151fc3e857f032c8a3e38f4ecb0c`
