### PR TITLE
fs: add JSON output for usage

### DIFF
--- a/src/commands/fs_usage.rs
+++ b/src/commands/fs_usage.rs
@@ -3,16 +3,17 @@ use std::fmt::Write as FmtWrite;
 use anyhow::{anyhow, Result};
 use bch_bindgen::c;
 use clap::Parser;
+use serde::Serialize;
 
 use crate::commands::DeviceNameArgs;
 use crate::wrappers::accounting::{
-    AccountingEntry, DiskAccountingKind, data_type, data_type_is_empty, disk_accounting_type,
+    data_type, data_type_is_empty, disk_accounting_type, AccountingEntry, DiskAccountingKind,
 };
 use crate::wrappers::handle::{BcachefsHandle, DevUsage};
-use bcachefs_kernel::{btree, metadata_version};
-use bcachefs_kernel::opts::{prt_data_type, prt_compression_type, prt_reconcile_type};
-use bcachefs_kernel::util::printbuf::Printbuf;
 use crate::wrappers::sysfs::{self, DeviceNameMode, DevInfo, bcachefs_kernel_version};
+use bcachefs_kernel::opts::{prt_compression_type, prt_data_type, prt_reconcile_type};
+use bcachefs_kernel::util::printbuf::Printbuf;
+use bcachefs_kernel::{btree, metadata_version};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
 #[clap(rename_all = "snake_case")]
@@ -24,14 +25,29 @@ enum Field {
     Devices,
 }
 
+impl Field {
+    fn as_str(self) -> &'static str {
+        match self {
+            Field::Replicas => "replicas",
+            Field::Btree => "btree",
+            Field::Compression => "compression",
+            Field::RebalanceWork => "rebalance_work",
+            Field::Devices => "devices",
+        }
+    }
+}
+
 #[derive(Parser, Debug)]
-#[command(name = "usage", about = "Display detailed filesystem usage",
+#[command(
+    name = "usage",
+    about = "Display detailed filesystem usage",
     long_about = "Displays filesystem space usage broken down by category. \
 Output modes: replicas (data/metadata replication), btree (per-btree \
 space), compression (ratios and savings), rebalance_work (pending \
 reconcile work), devices (per-device breakdown). Use -f to select \
 specific fields, -a for all, -h for human-readable sizes.",
-    disable_help_flag = true)]
+    disable_help_flag = true
+)]
 pub struct Cli {
     /// Print help
     #[arg(long = "help", action = clap::ArgAction::Help)]
@@ -52,28 +68,49 @@ pub struct Cli {
     #[command(flatten)]
     device_names: DeviceNameArgs,
 
+    /// Print machine-readable JSON
+    #[arg(long = "json")]
+    json: bool,
+
     /// Filesystem mountpoints
     #[arg(default_value = ".")]
     mountpoints: Vec<String>,
 }
 
 fn fs_usage(cli: Cli) -> Result<()> {
-
     let fields: Vec<Field> = if cli.all {
-        vec![Field::Replicas, Field::Btree, Field::Compression,
-             Field::RebalanceWork, Field::Devices]
+        vec![
+            Field::Replicas,
+            Field::Btree,
+            Field::Compression,
+            Field::RebalanceWork,
+            Field::Devices,
+        ]
     } else if cli.fields.is_empty() {
         vec![Field::RebalanceWork]
     } else {
         cli.fields
     };
 
-    for path in &cli.mountpoints {
-        let mut out = Printbuf::new();
-        out.set_human_readable(cli.human_readable);
-        let name_mode = cli.device_names.name_mode();
-        fs_usage_to_text(&mut out, path, &fields, name_mode)?;
-        print!("{}", out);
+    if cli.json {
+        let filesystems: Result<Vec<_>> = cli
+            .mountpoints
+            .iter()
+            .map(|path| fs_usage_to_json(path, &fields, cli.device_names.name_mode()))
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&FsUsageJsonRoot {
+                filesystems: filesystems?,
+            })?
+        );
+    } else {
+        for path in &cli.mountpoints {
+            let mut out = Printbuf::new();
+            out.set_human_readable(cli.human_readable);
+            fs_usage_to_text(&mut out, path, &fields, cli.device_names.name_mode())?;
+            print!("{}", out);
+        }
     }
 
     Ok(())
@@ -85,37 +122,178 @@ struct DevContext {
     leaving: u64,
 }
 
-fn fs_usage_to_text(
-    out: &mut Printbuf,
-    path: &str,
-    fields: &[Field],
-    name_mode: DeviceNameMode,
-) -> Result<()> {
-    let handle = BcachefsHandle::open(path)
-        .map_err(|e| anyhow!("opening filesystem '{}': {}", path, e))?;
+const SECTOR_BYTES: u64 = 512;
 
-    let sysfs_path = sysfs::sysfs_path_from_fd(handle.sysfs_fd())?;
-    let devs = sysfs::fs_get_devices(&sysfs_path, name_mode)?;
-
-    fs_usage_v1_to_text(out, &handle, &devs, fields)
-        .map_err(|e| anyhow!("query_accounting ioctl failed (kernel too old?): {}", e))?;
-
-    devs_usage_to_text(out, &handle, &devs, fields)?;
-
-    Ok(())
+#[derive(Serialize)]
+struct FsUsageJsonRoot {
+    filesystems: Vec<FsUsageJson>,
 }
 
-fn fs_usage_v1_to_text(
-    out: &mut Printbuf,
-    handle: &BcachefsHandle,
-    devs: &[DevInfo],
-    fields: &[Field],
-) -> Result<(), errno::Errno> {
+#[derive(Serialize)]
+struct FsUsageJson {
+    mountpoint: String,
+    filesystem: String,
+    fields: Vec<&'static str>,
+    capacity_sectors: u64,
+    capacity_bytes: u64,
+    used_sectors: u64,
+    used_bytes: u64,
+    online_reserved_sectors: u64,
+    online_reserved_bytes: u64,
+    replicas_summary: ReplicasSummaryJson,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    replicas: Vec<ReplicaUsageJson>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    persistent_reserved: Vec<PersistentReservedJson>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    compression: Vec<CompressionUsageJson>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    btree: Vec<BtreeUsageJson>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    rebalance_work: Vec<SectorsJson>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    reconcile_work: Vec<ReconcileWorkJson>,
+    devices: Vec<DeviceUsageJson>,
+}
+
+#[derive(Serialize)]
+struct ReplicasSummaryJson {
+    replicated: Vec<DurabilityUsageJson>,
+    erasure_coded: Vec<EcUsageJson>,
+    cached_sectors: u64,
+    cached_bytes: u64,
+    reserved_sectors: u64,
+    reserved_bytes: u64,
+}
+
+#[derive(Serialize)]
+struct DurabilityUsageJson {
+    durability: u32,
+    degraded: u32,
+    sectors: u64,
+    bytes: u64,
+}
+
+#[derive(Serialize)]
+struct EcUsageJson {
+    data: u8,
+    parity: u8,
+    degraded: u32,
+    sectors: u64,
+    bytes: u64,
+}
+
+#[derive(Serialize)]
+struct ReplicaUsageJson {
+    data_type: String,
+    required: u8,
+    replicas: u8,
+    durability: u32,
+    degraded: u32,
+    devices: Vec<String>,
+    sectors: u64,
+    bytes: u64,
+}
+
+#[derive(Serialize)]
+struct PersistentReservedJson {
+    replicas: u8,
+    sectors: u64,
+    bytes: u64,
+}
+
+#[derive(Serialize)]
+struct CompressionUsageJson {
+    compression_type: String,
+    extents: u64,
+    compressed_sectors: u64,
+    compressed_bytes: u64,
+    uncompressed_sectors: u64,
+    uncompressed_bytes: u64,
+    average_extent_bytes: u64,
+}
+
+#[derive(Serialize)]
+struct BtreeUsageJson {
+    btree: String,
+    sectors: u64,
+    bytes: u64,
+}
+
+#[derive(Serialize)]
+struct ReconcileWorkJson {
+    work_type: String,
+    data_sectors: u64,
+    data_bytes: u64,
+    metadata_sectors: u64,
+    metadata_bytes: u64,
+}
+
+#[derive(Serialize)]
+struct SectorsJson {
+    sectors: u64,
+    bytes: u64,
+}
+
+#[derive(Serialize)]
+struct DeviceUsageJson {
+    label: Option<String>,
+    device_index: u32,
+    device: String,
+    state: String,
+    capacity_sectors: u64,
+    capacity_bytes: u64,
+    used_sectors: u64,
+    used_bytes: u64,
+    hidden_sectors: u64,
+    hidden_bytes: u64,
+    used_percent: u64,
+    leaving_sectors: u64,
+    leaving_bytes: u64,
+    bucket_size_sectors: u32,
+    bucket_size_bytes: u64,
+    buckets: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data_types: Option<Vec<DeviceDataTypeUsageJson>>,
+}
+
+#[derive(Serialize)]
+struct DeviceDataTypeUsageJson {
+    data_type: String,
+    sectors: u64,
+    bytes: u64,
+    buckets: u64,
+    fragmented_sectors: u64,
+    fragmented_bytes: u64,
+}
+
+fn sectors_to_bytes(sectors: u64) -> u64 {
+    sectors.saturating_mul(SECTOR_BYTES)
+}
+
+fn printbuf_to_string(f: impl FnOnce(&mut Printbuf)) -> String {
+    let mut out = Printbuf::new();
+    f(&mut out);
+    out.to_string()
+}
+
+fn data_type_name(t: data_type) -> String {
+    printbuf_to_string(|out| prt_data_type(out, t))
+}
+
+fn compression_type_name(t: bcachefs_kernel::c::bch_compression_type) -> String {
+    printbuf_to_string(|out| prt_compression_type(out, t))
+}
+
+fn reconcile_type_name(t: bcachefs_kernel::c::bch_reconcile_accounting_type) -> String {
+    printbuf_to_string(|out| prt_reconcile_type(out, t))
+}
+
+fn accounting_types_for_fields(fields: &[Field]) -> u32 {
     let has = |f: Field| -> bool { fields.contains(&f) };
 
     let mut accounting_types: u32 =
-        disk_accounting_type::replicas.bit() |
-        disk_accounting_type::persistent_reserved.bit();
+        disk_accounting_type::replicas.bit() | disk_accounting_type::persistent_reserved.bit();
 
     if has(Field::Compression) {
         accounting_types |= disk_accounting_type::compression.bit();
@@ -133,7 +311,84 @@ fn fs_usage_v1_to_text(
         }
     }
 
-    let result = handle.query_accounting(accounting_types)?;
+    accounting_types
+}
+
+fn fs_usage_to_text(
+    out: &mut Printbuf,
+    path: &str,
+    fields: &[Field],
+    name_mode: DeviceNameMode,
+) -> Result<()> {
+    let handle =
+        BcachefsHandle::open(path).map_err(|e| anyhow!("opening filesystem '{}': {}", path, e))?;
+
+    let sysfs_path = sysfs::sysfs_path_from_fd(handle.sysfs_fd())?;
+    let devs = sysfs::fs_get_devices(&sysfs_path, name_mode)?;
+
+    fs_usage_v1_to_text(out, &handle, &devs, fields)
+        .map_err(|e| anyhow!("query_accounting ioctl failed (kernel too old?): {}", e))?;
+
+    devs_usage_to_text(out, &handle, &devs, fields)?;
+
+    Ok(())
+}
+
+fn fs_usage_to_json(
+    path: &str,
+    fields: &[Field],
+    name_mode: DeviceNameMode,
+) -> Result<FsUsageJson> {
+    let handle =
+        BcachefsHandle::open(path).map_err(|e| anyhow!("opening filesystem '{}': {}", path, e))?;
+
+    let sysfs_path = sysfs::sysfs_path_from_fd(handle.sysfs_fd())?;
+    let devs = sysfs::fs_get_devices(&sysfs_path, name_mode)?;
+    let result = handle
+        .query_accounting(accounting_types_for_fields(fields))
+        .map_err(|e| anyhow!("query_accounting ioctl failed (kernel too old?): {}", e))?;
+
+    let mut sorted: Vec<&AccountingEntry> = result.entries.iter().collect();
+    sorted.sort_by_key(|a| a.pos);
+
+    let uuid = uuid::Uuid::from_bytes(handle.uuid());
+    let devices = collect_dev_contexts(&handle, &devs)?
+        .into_iter()
+        .map(|d| device_usage_to_json(d, fields.contains(&Field::Devices)))
+        .collect();
+
+    Ok(FsUsageJson {
+        mountpoint: path.to_string(),
+        filesystem: uuid.hyphenated().to_string(),
+        fields: fields.iter().map(|f| f.as_str()).collect(),
+        capacity_sectors: result.capacity,
+        capacity_bytes: sectors_to_bytes(result.capacity),
+        used_sectors: result.used,
+        used_bytes: sectors_to_bytes(result.used),
+        online_reserved_sectors: result.online_reserved,
+        online_reserved_bytes: sectors_to_bytes(result.online_reserved),
+        replicas_summary: replicas_summary_to_json(&sorted, &devs),
+        replicas: replicas_to_json(&sorted, &devs, fields.contains(&Field::Replicas)),
+        persistent_reserved: persistent_reserved_to_json(
+            &sorted,
+            fields.contains(&Field::Replicas),
+        ),
+        compression: compression_to_json(&sorted, fields.contains(&Field::Compression)),
+        btree: btree_to_json(&sorted, fields.contains(&Field::Btree)),
+        rebalance_work: rebalance_work_to_json(&sorted, fields.contains(&Field::RebalanceWork)),
+        reconcile_work: reconcile_work_to_json(&sorted, fields.contains(&Field::RebalanceWork)),
+        devices,
+    })
+}
+
+fn fs_usage_v1_to_text(
+    out: &mut Printbuf,
+    handle: &BcachefsHandle,
+    devs: &[DevInfo],
+    fields: &[Field],
+) -> Result<(), errno::Errno> {
+    let has = |f: Field| -> bool { fields.contains(&f) };
+    let result = handle.query_accounting(accounting_types_for_fields(fields))?;
 
     // Sort entries by bpos
     let mut sorted: Vec<&AccountingEntry> = result.entries.iter().collect();
@@ -163,26 +418,40 @@ fn fs_usage_v1_to_text(
     // Detailed replicas
     if has(Field::Replicas) {
         out.aligned(|sub| {
-            write!(sub, "\nData type\tRequired/total\tDurability\tDevices\tUsage\n").unwrap();
+            write!(
+                sub,
+                "\nData type\tRequired/total\tDurability\tDevices\tUsage\n"
+            )
+            .unwrap();
 
             for entry in &sorted {
                 match entry.pos.decode() {
                     DiskAccountingKind::PersistentReserved { nr_replicas } => {
                         let sectors = entry.counter(0);
-                        if sectors == 0 { continue; }
+                        if sectors == 0 {
+                            continue;
+                        }
                         write!(sub, "reserved:\t1/{}\t\t[]\t ", nr_replicas).unwrap();
                         sub.units_sectors(sectors);
                         write!(sub, "\r\n").unwrap();
                     }
-                    DiskAccountingKind::Replicas { data_type, nr_devs, nr_required, devs: dev_list } => {
+                    DiskAccountingKind::Replicas {
+                        data_type,
+                        nr_devs,
+                        nr_required,
+                        devs: dev_list,
+                    } => {
                         let sectors = entry.counter(0);
-                        if sectors == 0 { continue; }
+                        if sectors == 0 {
+                            continue;
+                        }
 
                         let dev_list = &dev_list[..nr_devs as usize];
                         let dur = replicas_durability(nr_devs, nr_required, dev_list, devs);
 
                         prt_data_type(sub, data_type);
-                        write!(sub, ":\t{}/{}\t{}\t[", nr_required, nr_devs, dur.durability).unwrap();
+                        write!(sub, ":\t{}/{}\t{}\t[", nr_required, nr_devs, dur.durability)
+                            .unwrap();
 
                         prt_dev_list(sub, dev_list, devs);
                         write!(sub, "]\t").unwrap();
@@ -198,16 +467,22 @@ fn fs_usage_v1_to_text(
 
     // Compression
     if has(Field::Compression) {
-        let compr: Vec<_> = sorted.iter()
+        let compr: Vec<_> = sorted
+            .iter()
             .filter(|e| e.pos.accounting_type() == Some(disk_accounting_type::compression))
             .collect();
         if !compr.is_empty() {
             out.aligned(|sub| {
                 write!(sub, "\nCompression:\n").unwrap();
-                write!(sub, "type\tcompressed\runcompressed\raverage extent size\r\n").unwrap();
+                write!(
+                    sub,
+                    "type\tcompressed\runcompressed\raverage extent size\r\n"
+                )
+                .unwrap();
 
                 for entry in &compr {
-                    if let DiskAccountingKind::Compression { compression_type } = entry.pos.decode() {
+                    if let DiskAccountingKind::Compression { compression_type } = entry.pos.decode()
+                    {
                         prt_compression_type(sub, compression_type);
                         write!(sub, "\t").unwrap();
 
@@ -222,7 +497,9 @@ fn fs_usage_v1_to_text(
 
                         let avg = if nr_extents > 0 {
                             (sectors_uncompressed << 9) / nr_extents
-                        } else { 0 };
+                        } else {
+                            0
+                        };
                         sub.units_u64(avg);
                         write!(sub, "\r\n").unwrap();
                     }
@@ -233,7 +510,8 @@ fn fs_usage_v1_to_text(
 
     // Btree usage
     if has(Field::Btree) {
-        let btrees: Vec<_> = sorted.iter()
+        let btrees: Vec<_> = sorted
+            .iter()
             .filter(|e| e.pos.accounting_type() == Some(disk_accounting_type::btree))
             .collect();
         if !btrees.is_empty() {
@@ -252,7 +530,8 @@ fn fs_usage_v1_to_text(
 
     // Rebalance / reconcile work
     if has(Field::RebalanceWork) {
-        let rebalance: Vec<_> = sorted.iter()
+        let rebalance: Vec<_> = sorted
+            .iter()
             .filter(|e| e.pos.accounting_type() == Some(disk_accounting_type::rebalance_work))
             .collect();
         if !rebalance.is_empty() {
@@ -263,7 +542,8 @@ fn fs_usage_v1_to_text(
             }
         }
 
-        let reconcile: Vec<_> = sorted.iter()
+        let reconcile: Vec<_> = sorted
+            .iter()
             .filter(|e| e.pos.accounting_type() == Some(disk_accounting_type::reconcile_work))
             .collect();
         if !reconcile.is_empty() {
@@ -284,6 +564,281 @@ fn fs_usage_v1_to_text(
     }
 
     Ok(())
+}
+
+fn dev_list_to_json(dev_list: &[u8], devs: &[DevInfo]) -> Vec<String> {
+    dev_list
+        .iter()
+        .map(|&dev_idx| {
+            if dev_idx == c::BCH_SB_MEMBER_INVALID as u8 {
+                "none".to_string()
+            } else if let Some(d) = devs.iter().find(|d| d.idx == dev_idx as u32) {
+                d.dev.clone()
+            } else {
+                dev_idx.to_string()
+            }
+        })
+        .collect()
+}
+
+fn replicas_summary_to_json(sorted: &[&AccountingEntry], devs: &[DevInfo]) -> ReplicasSummaryJson {
+    let mut replicated: DurabilityMatrix = Vec::new();
+    let mut ec_configs: Vec<EcConfig> = Vec::new();
+    let mut cached: u64 = 0;
+    let mut reserved: u64 = 0;
+
+    for entry in sorted {
+        match entry.pos.decode() {
+            DiskAccountingKind::PersistentReserved { .. } => {
+                reserved += entry.counter(0);
+            }
+            DiskAccountingKind::Replicas {
+                data_type,
+                nr_devs,
+                nr_required,
+                devs: dev_list,
+            } => {
+                if data_type == data_type::cached {
+                    cached += entry.counter(0);
+                    continue;
+                }
+
+                let dev_list = &dev_list[..nr_devs as usize];
+                let d = replicas_durability(nr_devs, nr_required, dev_list, devs);
+
+                if nr_required > 1 {
+                    ec_config_add(
+                        &mut ec_configs,
+                        nr_required,
+                        nr_devs,
+                        d.degraded,
+                        entry.counter(0),
+                    );
+                } else {
+                    durability_matrix_add(
+                        &mut replicated,
+                        d.durability,
+                        d.degraded,
+                        entry.counter(0),
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let replicated = replicated
+        .iter()
+        .enumerate()
+        .flat_map(|(durability, row)| {
+            row.iter()
+                .enumerate()
+                .filter_map(move |(degraded, &sectors)| {
+                    (sectors != 0).then(|| DurabilityUsageJson {
+                        durability: durability as u32,
+                        degraded: degraded as u32,
+                        sectors,
+                        bytes: sectors_to_bytes(sectors),
+                    })
+                })
+        })
+        .collect();
+
+    ec_configs.sort_by_key(|c| (c.nr_data, c.nr_parity));
+    let erasure_coded = ec_configs
+        .iter()
+        .flat_map(|cfg| {
+            cfg.degraded
+                .iter()
+                .enumerate()
+                .filter_map(move |(degraded, &sectors)| {
+                    (sectors != 0).then(|| EcUsageJson {
+                        data: cfg.nr_data,
+                        parity: cfg.nr_parity,
+                        degraded: degraded as u32,
+                        sectors,
+                        bytes: sectors_to_bytes(sectors),
+                    })
+                })
+        })
+        .collect();
+
+    ReplicasSummaryJson {
+        replicated,
+        erasure_coded,
+        cached_sectors: cached,
+        cached_bytes: sectors_to_bytes(cached),
+        reserved_sectors: reserved,
+        reserved_bytes: sectors_to_bytes(reserved),
+    }
+}
+
+fn replicas_to_json(
+    sorted: &[&AccountingEntry],
+    devs: &[DevInfo],
+    include: bool,
+) -> Vec<ReplicaUsageJson> {
+    if !include {
+        return Vec::new();
+    }
+
+    sorted
+        .iter()
+        .filter_map(|entry| {
+            if let DiskAccountingKind::Replicas {
+                data_type,
+                nr_devs,
+                nr_required,
+                devs: dev_list,
+            } = entry.pos.decode()
+            {
+                let sectors = entry.counter(0);
+                if sectors == 0 {
+                    return None;
+                }
+
+                let dev_list = &dev_list[..nr_devs as usize];
+                let dur = replicas_durability(nr_devs, nr_required, dev_list, devs);
+
+                Some(ReplicaUsageJson {
+                    data_type: data_type_name(data_type),
+                    required: nr_required,
+                    replicas: nr_devs,
+                    durability: dur.durability,
+                    degraded: dur.degraded,
+                    devices: dev_list_to_json(dev_list, devs),
+                    sectors,
+                    bytes: sectors_to_bytes(sectors),
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn persistent_reserved_to_json(
+    sorted: &[&AccountingEntry],
+    include: bool,
+) -> Vec<PersistentReservedJson> {
+    if !include {
+        return Vec::new();
+    }
+
+    sorted
+        .iter()
+        .filter_map(|entry| {
+            if let DiskAccountingKind::PersistentReserved { nr_replicas } = entry.pos.decode() {
+                let sectors = entry.counter(0);
+                (sectors != 0).then(|| PersistentReservedJson {
+                    replicas: nr_replicas,
+                    sectors,
+                    bytes: sectors_to_bytes(sectors),
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn compression_to_json(sorted: &[&AccountingEntry], include: bool) -> Vec<CompressionUsageJson> {
+    if !include {
+        return Vec::new();
+    }
+
+    sorted
+        .iter()
+        .filter_map(|entry| {
+            if let DiskAccountingKind::Compression { compression_type } = entry.pos.decode() {
+                let extents = entry.counter(0);
+                let uncompressed_sectors = entry.counter(1);
+                let compressed_sectors = entry.counter(2);
+                let average_extent_bytes = if extents > 0 {
+                    (uncompressed_sectors << 9) / extents
+                } else {
+                    0
+                };
+
+                Some(CompressionUsageJson {
+                    compression_type: compression_type_name(compression_type),
+                    extents,
+                    compressed_sectors,
+                    compressed_bytes: sectors_to_bytes(compressed_sectors),
+                    uncompressed_sectors,
+                    uncompressed_bytes: sectors_to_bytes(uncompressed_sectors),
+                    average_extent_bytes,
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn btree_to_json(sorted: &[&AccountingEntry], include: bool) -> Vec<BtreeUsageJson> {
+    if !include {
+        return Vec::new();
+    }
+
+    sorted
+        .iter()
+        .filter_map(|entry| {
+            if let DiskAccountingKind::Btree { id } = entry.pos.decode() {
+                let sectors = entry.counter(0);
+                Some(BtreeUsageJson {
+                    btree: btree::types::btree_id_str(id).to_string(),
+                    sectors,
+                    bytes: sectors_to_bytes(sectors),
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn rebalance_work_to_json(sorted: &[&AccountingEntry], include: bool) -> Vec<SectorsJson> {
+    if !include {
+        return Vec::new();
+    }
+
+    sorted
+        .iter()
+        .filter(|e| e.pos.accounting_type() == Some(disk_accounting_type::rebalance_work))
+        .map(|entry| {
+            let sectors = entry.counter(0);
+            SectorsJson {
+                sectors,
+                bytes: sectors_to_bytes(sectors),
+            }
+        })
+        .collect()
+}
+
+fn reconcile_work_to_json(sorted: &[&AccountingEntry], include: bool) -> Vec<ReconcileWorkJson> {
+    if !include {
+        return Vec::new();
+    }
+
+    sorted
+        .iter()
+        .filter_map(|entry| {
+            if let DiskAccountingKind::ReconcileWork { work_type } = entry.pos.decode() {
+                let data_sectors = entry.counter(0);
+                let metadata_sectors = entry.counter(1);
+                Some(ReconcileWorkJson {
+                    work_type: reconcile_type_name(work_type),
+                    data_sectors,
+                    data_bytes: sectors_to_bytes(data_sectors),
+                    metadata_sectors,
+                    metadata_bytes: sectors_to_bytes(metadata_sectors),
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 // ──────────────────────────── Replicas summary ──────────────────────────────
@@ -316,13 +871,21 @@ fn replicas_durability(
         durability = (nr_devs - nr_required + 1) as u32;
     }
 
-    Durability { durability, degraded }
+    Durability {
+        durability,
+        degraded,
+    }
 }
 
 /// Durability x degraded matrix: matrix[durability][degraded] = sectors
 type DurabilityMatrix = Vec<Vec<u64>>;
 
-fn durability_matrix_add(matrix: &mut DurabilityMatrix, durability: u32, degraded: u32, sectors: u64) {
+fn durability_matrix_add(
+    matrix: &mut DurabilityMatrix,
+    durability: u32,
+    degraded: u32,
+    sectors: u64,
+) {
     while matrix.len() <= durability as usize {
         matrix.push(Vec::new());
     }
@@ -359,13 +922,17 @@ fn prt_sector_row(out: &mut Printbuf, values: &[u64]) {
 
 fn durability_matrix_to_text(out: &mut Printbuf, matrix: &DurabilityMatrix) {
     let max_degraded = matrix.iter().map(|r| r.len()).max().unwrap_or(0);
-    if max_degraded == 0 { return; }
+    if max_degraded == 0 {
+        return;
+    }
 
     out.aligned(|sub| {
         prt_degraded_header(sub, max_degraded);
 
         for (dur, row) in matrix.iter().enumerate() {
-            if row.is_empty() { continue; }
+            if row.is_empty() {
+                continue;
+            }
             write!(sub, "{}x:\t", dur).unwrap();
             prt_sector_row(sub, row);
         }
@@ -374,17 +941,30 @@ fn durability_matrix_to_text(out: &mut Printbuf, matrix: &DurabilityMatrix) {
 
 /// EC entries grouped by stripe config: (nr_data, nr_parity) → [degraded] = sectors
 struct EcConfig {
-    nr_data:    u8,
-    nr_parity:  u8,
-    degraded:   Vec<u64>,
+    nr_data: u8,
+    nr_parity: u8,
+    degraded: Vec<u64>,
 }
 
-fn ec_config_add(configs: &mut Vec<EcConfig>, nr_required: u8, nr_devs: u8, degraded: u32, sectors: u64) {
+fn ec_config_add(
+    configs: &mut Vec<EcConfig>,
+    nr_required: u8,
+    nr_devs: u8,
+    degraded: u32,
+    sectors: u64,
+) {
     let nr_parity = nr_devs - nr_required;
-    let cfg = match configs.iter_mut().find(|c| c.nr_data == nr_required && c.nr_parity == nr_parity) {
+    let cfg = match configs
+        .iter_mut()
+        .find(|c| c.nr_data == nr_required && c.nr_parity == nr_parity)
+    {
         Some(c) => c,
         None => {
-            configs.push(EcConfig { nr_data: nr_required, nr_parity, degraded: Vec::new() });
+            configs.push(EcConfig {
+                nr_data: nr_required,
+                nr_parity,
+                degraded: Vec::new(),
+            });
             configs.last_mut().unwrap()
         }
     };
@@ -398,7 +978,9 @@ fn ec_configs_to_text(out: &mut Printbuf, configs: &mut [EcConfig]) {
     configs.sort_by_key(|c| (c.nr_data, c.nr_parity));
 
     let max_degraded = configs.iter().map(|c| c.degraded.len()).max().unwrap_or(0);
-    if max_degraded == 0 { return; }
+    if max_degraded == 0 {
+        return;
+    }
 
     out.aligned(|sub| {
         prt_degraded_header(sub, max_degraded);
@@ -410,11 +992,7 @@ fn ec_configs_to_text(out: &mut Printbuf, configs: &mut [EcConfig]) {
     });
 }
 
-fn replicas_summary_to_text(
-    out: &mut Printbuf,
-    sorted: &[&AccountingEntry],
-    devs: &[DevInfo],
-) {
+fn replicas_summary_to_text(out: &mut Printbuf, sorted: &[&AccountingEntry], devs: &[DevInfo]) {
     let mut replicated: DurabilityMatrix = Vec::new();
     let mut ec_configs: Vec<EcConfig> = Vec::new();
     let mut cached: u64 = 0;
@@ -425,7 +1003,12 @@ fn replicas_summary_to_text(
             DiskAccountingKind::PersistentReserved { .. } => {
                 reserved += entry.counter(0);
             }
-            DiskAccountingKind::Replicas { data_type, nr_devs, nr_required, devs: dev_list } => {
+            DiskAccountingKind::Replicas {
+                data_type,
+                nr_devs,
+                nr_required,
+                devs: dev_list,
+            } => {
                 if data_type == data_type::cached {
                     cached += entry.counter(0);
                     continue;
@@ -435,9 +1018,20 @@ fn replicas_summary_to_text(
                 let d = replicas_durability(nr_devs, nr_required, dev_list, devs);
 
                 if nr_required > 1 {
-                    ec_config_add(&mut ec_configs, nr_required, nr_devs, d.degraded, entry.counter(0));
+                    ec_config_add(
+                        &mut ec_configs,
+                        nr_required,
+                        nr_devs,
+                        d.degraded,
+                        entry.counter(0),
+                    );
                 } else {
-                    durability_matrix_add(&mut replicated, d.durability, d.degraded, entry.counter(0));
+                    durability_matrix_add(
+                        &mut replicated,
+                        d.durability,
+                        d.degraded,
+                        entry.counter(0),
+                    );
                 }
             }
             _ => {}
@@ -476,7 +1070,9 @@ fn replicas_summary_to_text(
 /// Print a device list like [sda sdb sdc].
 fn prt_dev_list(out: &mut Printbuf, dev_list: &[u8], devs: &[DevInfo]) {
     for (i, &dev_idx) in dev_list.iter().enumerate() {
-        if i > 0 { write!(out, " ").unwrap(); }
+        if i > 0 {
+            write!(out, " ").unwrap();
+        }
         if dev_idx == c::BCH_SB_MEMBER_INVALID as u8 {
             write!(out, "none").unwrap();
         } else if let Some(d) = devs.iter().find(|d| d.idx == dev_idx as u32) {
@@ -489,14 +1085,7 @@ fn prt_dev_list(out: &mut Printbuf, dev_list: &[u8], devs: &[DevInfo]) {
 
 // ──────────────────────────── Device usage ───────────────────────────────────
 
-fn devs_usage_to_text(
-    out: &mut Printbuf,
-    handle: &BcachefsHandle,
-    devs: &[DevInfo],
-    fields: &[Field],
-) -> Result<()> {
-    let has = |f: Field| -> bool { fields.contains(&f) };
-
+fn collect_dev_contexts(handle: &BcachefsHandle, devs: &[DevInfo]) -> Result<Vec<DevContext>> {
     // Query dev_leaving accounting if available
     let dev_leaving_map = match handle.query_accounting(disk_accounting_type::dev_leaving.bit()) {
         Ok(result) => result.entries,
@@ -512,15 +1101,99 @@ fn devs_usage_to_text(
             None
         };
         let leaving = dev_leaving_sectors(&dev_leaving_map, dev.idx);
-        dev_ctxs.push(DevContext { info: dev.clone(), usage, leaving });
+        dev_ctxs.push(DevContext {
+            info: dev.clone(),
+            usage,
+            leaving,
+        });
     }
 
     // Sort by label, then dev name, then idx
     dev_ctxs.sort_by(|a, b| {
-        a.info.label.cmp(&b.info.label)
+        a.info
+            .label
+            .cmp(&b.info.label)
             .then(a.info.dev.cmp(&b.info.dev))
             .then(a.info.idx.cmp(&b.info.idx))
     });
+
+    Ok(dev_ctxs)
+}
+
+fn device_usage_to_json(d: DevContext, include_data_types: bool) -> DeviceUsageJson {
+    let (state, hidden, capacity, used, pct, bucket_size_sectors, buckets, data_types) =
+        if let Some(usage) = &d.usage {
+            let hidden = usage.hidden_sectors();
+            let capacity = usage.capacity_sectors() - hidden;
+            let used = usage.used_sectors() - hidden;
+            let pct = if usage.nr_buckets > 0 {
+                usage.used_buckets() * 100 / usage.nr_buckets
+            } else {
+                0
+            };
+            let data_types = include_data_types.then(|| {
+                usage.iter_typed()
+                    .map(|(dt_type, dt)| {
+                        let sectors = if data_type_is_empty(dt_type) {
+                            dt.buckets * usage.bucket_size as u64
+                        } else {
+                            dt.sectors
+                        };
+                        DeviceDataTypeUsageJson {
+                            data_type: data_type_name(dt_type),
+                            sectors,
+                            bytes: sectors_to_bytes(sectors),
+                            buckets: dt.buckets,
+                            fragmented_sectors: dt.fragmented,
+                            fragmented_bytes: sectors_to_bytes(dt.fragmented),
+                        }
+                    })
+                    .collect()
+            });
+
+            (
+                bcachefs_kernel::sb::members::member_state_str(usage.state).to_string(),
+                hidden,
+                capacity,
+                used,
+                pct,
+                usage.bucket_size,
+                usage.nr_buckets,
+                data_types,
+            )
+        } else {
+            ("offline".to_string(), 0, 0, 0, 0, 0, 0, None)
+        };
+
+    DeviceUsageJson {
+        label: d.info.label,
+        device_index: d.info.idx,
+        device: d.info.dev,
+        state,
+        capacity_sectors: capacity,
+        capacity_bytes: sectors_to_bytes(capacity),
+        used_sectors: used,
+        used_bytes: sectors_to_bytes(used),
+        hidden_sectors: hidden,
+        hidden_bytes: sectors_to_bytes(hidden),
+        used_percent: pct,
+        leaving_sectors: d.leaving,
+        leaving_bytes: sectors_to_bytes(d.leaving),
+        bucket_size_sectors,
+        bucket_size_bytes: sectors_to_bytes(bucket_size_sectors as u64),
+        buckets,
+        data_types,
+    }
+}
+
+fn devs_usage_to_text(
+    out: &mut Printbuf,
+    handle: &BcachefsHandle,
+    devs: &[DevInfo],
+    fields: &[Field],
+) -> Result<()> {
+    let has = |f: Field| -> bool { fields.contains(&f) };
+    let dev_ctxs = collect_dev_contexts(handle, devs)?;
 
     let has_leaving = dev_ctxs.iter().any(|d| d.leaving != 0);
 
@@ -566,7 +1239,9 @@ fn devs_usage_to_text(
 
                 let pct = if usage.nr_buckets > 0 {
                     usage.used_buckets() * 100 / usage.nr_buckets
-                } else { 0 };
+                } else {
+                    0
+                };
                 write!(sub, "\r{:>2}%\r", pct).unwrap();
 
                 if d.leaving > 0 {
@@ -592,10 +1267,19 @@ fn dev_usage_full_to_text(out: &mut Printbuf, d: &DevContext) {
     };
 
     let state = bcachefs_kernel::sb::members::member_state_str(u.state);
-    let pct = if u.nr_buckets > 0 { u.used_buckets() * 100 / u.nr_buckets } else { 0 };
+    let pct = if u.nr_buckets > 0 {
+        u.used_buckets() * 100 / u.nr_buckets
+    } else {
+        0
+    };
 
     out.aligned(|sub| {
-        writeln!(sub, "{} (device {}):\t{}\t{}\t{:>2}%", label, d.info.idx, d.info.dev, state, pct).unwrap();
+        writeln!(
+            sub,
+            "{} (device {}):\t{}\t{}\t{:>2}%",
+            label, d.info.idx, d.info.dev, state, pct
+        )
+        .unwrap();
 
         {
             let sub = &mut *sub.indent(2);
@@ -633,7 +1317,8 @@ fn dev_usage_full_to_text(out: &mut Printbuf, d: &DevContext) {
 }
 
 fn dev_leaving_sectors(entries: &[AccountingEntry], dev_idx: u32) -> u64 {
-    entries.iter()
+    entries
+        .iter()
         .find_map(|e| match e.pos.decode() {
             DiskAccountingKind::DevLeaving { dev } if dev == dev_idx => Some(e.counter(0)),
             _ => None,

--- a/src/commands/fs_usage.rs
+++ b/src/commands/fs_usage.rs
@@ -3,16 +3,17 @@ use std::fmt::Write as FmtWrite;
 use anyhow::{anyhow, Result};
 use bch_bindgen::c;
 use clap::Parser;
+use serde::{Serialize, Serializer};
 
 use crate::commands::DeviceNameArgs;
 use crate::wrappers::accounting::{
-    AccountingEntry, DiskAccountingKind, data_type, data_type_is_empty, disk_accounting_type,
+    data_type, data_type_is_empty, disk_accounting_type, AccountingEntry, DiskAccountingKind,
 };
 use crate::wrappers::handle::{BcachefsHandle, DevUsage};
-use bcachefs_kernel::{btree, metadata_version};
-use bcachefs_kernel::opts::{prt_data_type, prt_compression_type, prt_reconcile_type};
+use crate::wrappers::sysfs::{self, bcachefs_kernel_version, DevInfo, DeviceNameMode};
+use bcachefs_kernel::opts::{prt_compression_type, prt_data_type, prt_reconcile_type};
 use bcachefs_kernel::util::printbuf::Printbuf;
-use crate::wrappers::sysfs::{self, DeviceNameMode, DevInfo, bcachefs_kernel_version};
+use bcachefs_kernel::{btree, metadata_version};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
 #[clap(rename_all = "snake_case")]
@@ -24,14 +25,29 @@ enum Field {
     Devices,
 }
 
+impl Field {
+    fn as_str(self) -> &'static str {
+        match self {
+            Field::Replicas => "replicas",
+            Field::Btree => "btree",
+            Field::Compression => "compression",
+            Field::RebalanceWork => "rebalance_work",
+            Field::Devices => "devices",
+        }
+    }
+}
+
 #[derive(Parser, Debug)]
-#[command(name = "usage", about = "Display detailed filesystem usage",
+#[command(
+    name = "usage",
+    about = "Display detailed filesystem usage",
     long_about = "Displays filesystem space usage broken down by category. \
 Output modes: replicas (data/metadata replication), btree (per-btree \
 space), compression (ratios and savings), rebalance_work (pending \
 reconcile work), devices (per-device breakdown). Use -f to select \
 specific fields, -a for all, -h for human-readable sizes.",
-    disable_help_flag = true)]
+    disable_help_flag = true
+)]
 pub struct Cli {
     /// Print help
     #[arg(long = "help", action = clap::ArgAction::Help)]
@@ -52,73 +68,252 @@ pub struct Cli {
     #[command(flatten)]
     device_names: DeviceNameArgs,
 
+    /// Print machine-readable JSON
+    #[arg(long = "json")]
+    json: bool,
+
     /// Filesystem mountpoints
     #[arg(default_value = ".")]
     mountpoints: Vec<String>,
 }
 
+/// Every field is decoded from the accounting ioctl exactly once, into an
+/// `FsUsage`. --json is `serde_json::to_string_pretty(&model)`; the
+/// human-readable path prints from the same model. There is exactly one
+/// place that walks accounting entries or per-device usage.
 fn fs_usage(cli: Cli) -> Result<()> {
-
     let fields: Vec<Field> = if cli.all {
-        vec![Field::Replicas, Field::Btree, Field::Compression,
-             Field::RebalanceWork, Field::Devices]
+        vec![
+            Field::Replicas,
+            Field::Btree,
+            Field::Compression,
+            Field::RebalanceWork,
+            Field::Devices,
+        ]
     } else if cli.fields.is_empty() {
         vec![Field::RebalanceWork]
     } else {
         cli.fields
     };
 
-    for path in &cli.mountpoints {
-        let mut out = Printbuf::new();
-        out.set_human_readable(cli.human_readable);
-        let name_mode = cli.device_names.name_mode();
-        fs_usage_to_text(&mut out, path, &fields, name_mode)?;
-        print!("{}", out);
+    let name_mode = cli.device_names.name_mode();
+    let filesystems: Result<Vec<FsUsage>> = cli
+        .mountpoints
+        .iter()
+        .map(|path| fs_usage_collect(path, &fields, name_mode))
+        .collect();
+    let filesystems = filesystems?;
+
+    if cli.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&FsUsageRoot { filesystems })?
+        );
+    } else {
+        for fs in &filesystems {
+            let mut out = Printbuf::new();
+            out.set_human_readable(cli.human_readable);
+            fs_usage_to_text(&mut out, fs);
+            print!("{}", out);
+        }
     }
 
     Ok(())
 }
 
-struct DevContext {
-    info: DevInfo,
-    usage: Option<DevUsage>,
+// ──────────────────────────── Data model ─────────────────────────────────────
+//
+// Sectors are the single unit tracked internally (the ioctl's native unit,
+// and what `Printbuf::units_sectors` already expects). JSON fields carry a
+// `_bytes` suffix and convert at serialize time via `ser_bytes`/`ser_bytes32`
+// so there is one source number per quantity, not a sectors/bytes pair.
+
+const SECTOR_BYTES: u64 = 512;
+
+fn sectors_to_bytes(sectors: u64) -> u64 {
+    sectors.saturating_mul(SECTOR_BYTES)
+}
+
+fn ser_bytes<S: Serializer>(sectors: &u64, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_u64(sectors_to_bytes(*sectors))
+}
+
+fn ser_bytes32<S: Serializer>(sectors: &u32, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_u64(sectors_to_bytes(*sectors as u64))
+}
+
+#[derive(Serialize)]
+struct FsUsageRoot {
+    filesystems: Vec<FsUsage>,
+}
+
+#[derive(Serialize)]
+struct FsUsage {
+    mountpoint: String,
+    uuid: String,
+    fields: Vec<&'static str>,
+    #[serde(rename = "capacity_bytes", serialize_with = "ser_bytes")]
+    capacity: u64,
+    #[serde(rename = "used_bytes", serialize_with = "ser_bytes")]
+    used: u64,
+    #[serde(rename = "online_reserved_bytes", serialize_with = "ser_bytes")]
+    online_reserved: u64,
+    replicas_summary: ReplicasSummary,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    replicas: Vec<ReplicaUsage>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    persistent_reserved: Vec<PersistentReserved>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    compression: Vec<CompressionUsage>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    btree: Vec<BtreeUsage>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    rebalance_work: Vec<RebalanceEntry>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    reconcile_work: Vec<ReconcileWork>,
+    devices: Vec<DeviceUsage>,
+}
+
+#[derive(Serialize)]
+struct ReplicasSummary {
+    replicated: Vec<DurabilityUsage>,
+    erasure_coded: Vec<EcUsage>,
+    #[serde(rename = "cached_bytes", serialize_with = "ser_bytes")]
+    cached: u64,
+    #[serde(rename = "reserved_bytes", serialize_with = "ser_bytes")]
+    reserved: u64,
+}
+
+#[derive(Serialize)]
+struct DurabilityUsage {
+    durability: u32,
+    degraded: u32,
+    #[serde(rename = "bytes", serialize_with = "ser_bytes")]
+    sectors: u64,
+}
+
+#[derive(Serialize)]
+struct EcUsage {
+    data: u8,
+    parity: u8,
+    degraded: u32,
+    #[serde(rename = "bytes", serialize_with = "ser_bytes")]
+    sectors: u64,
+}
+
+#[derive(Serialize)]
+struct ReplicaUsage {
+    data_type: String,
+    required: u8,
+    replicas: u8,
+    durability: u32,
+    degraded: u32,
+    devices: Vec<String>,
+    #[serde(rename = "bytes", serialize_with = "ser_bytes")]
+    sectors: u64,
+}
+
+#[derive(Serialize)]
+struct PersistentReserved {
+    replicas: u8,
+    #[serde(rename = "bytes", serialize_with = "ser_bytes")]
+    sectors: u64,
+}
+
+#[derive(Serialize)]
+struct CompressionUsage {
+    compression_type: String,
+    extents: u64,
+    #[serde(rename = "compressed_bytes", serialize_with = "ser_bytes")]
+    compressed_sectors: u64,
+    #[serde(rename = "uncompressed_bytes", serialize_with = "ser_bytes")]
+    uncompressed_sectors: u64,
+    average_extent_bytes: u64,
+}
+
+#[derive(Serialize)]
+struct BtreeUsage {
+    btree: String,
+    #[serde(rename = "bytes", serialize_with = "ser_bytes")]
+    sectors: u64,
+}
+
+#[derive(Serialize)]
+struct ReconcileWork {
+    work_type: String,
+    #[serde(rename = "data_bytes", serialize_with = "ser_bytes")]
+    data_sectors: u64,
+    #[serde(rename = "metadata_bytes", serialize_with = "ser_bytes")]
+    metadata_sectors: u64,
+}
+
+#[derive(Serialize)]
+struct RebalanceEntry {
+    #[serde(rename = "bytes", serialize_with = "ser_bytes")]
+    sectors: u64,
+}
+
+#[derive(Serialize)]
+struct DeviceUsage {
+    label: Option<String>,
+    device_index: u32,
+    device: String,
+    state: String,
+    #[serde(rename = "capacity_bytes", serialize_with = "ser_bytes")]
+    capacity: u64,
+    #[serde(rename = "used_bytes", serialize_with = "ser_bytes")]
+    used: u64,
+    #[serde(rename = "hidden_bytes", serialize_with = "ser_bytes")]
+    hidden: u64,
+    used_percent: u64,
+    #[serde(rename = "leaving_bytes", serialize_with = "ser_bytes")]
     leaving: u64,
     /// Sectors this device holds in stripe data blocks that are empty. Zero
     /// when the accounting hasn't been computed - see stripe_frag_accounting.
+    #[serde(rename = "stripe_empty_bytes", serialize_with = "ser_bytes")]
     stripe_empty: u64,
+    #[serde(rename = "bucket_size_bytes", serialize_with = "ser_bytes32")]
+    bucket_size: u32,
+    buckets: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data_types: Option<Vec<DeviceDataTypeUsage>>,
 }
 
-fn fs_usage_to_text(
-    out: &mut Printbuf,
-    path: &str,
-    fields: &[Field],
-    name_mode: DeviceNameMode,
-) -> Result<()> {
-    let handle = BcachefsHandle::open(path)
-        .map_err(|e| anyhow!("opening filesystem '{}': {}", path, e))?;
-
-    let sysfs_path = sysfs::sysfs_path_from_fd(handle.sysfs_fd())?;
-    let devs = sysfs::fs_get_devices(&sysfs_path, name_mode)?;
-
-    fs_usage_v1_to_text(out, &handle, &devs, fields)
-        .map_err(|e| anyhow!("query_accounting ioctl failed (kernel too old?): {}", e))?;
-
-    devs_usage_to_text(out, &handle, &devs, fields)?;
-
-    Ok(())
+#[derive(Serialize)]
+struct DeviceDataTypeUsage {
+    data_type: String,
+    #[serde(rename = "bytes", serialize_with = "ser_bytes")]
+    sectors: u64,
+    buckets: u64,
+    #[serde(rename = "fragmented_bytes", serialize_with = "ser_bytes")]
+    fragmented: u64,
 }
 
-fn fs_usage_v1_to_text(
-    out: &mut Printbuf,
-    handle: &BcachefsHandle,
-    devs: &[DevInfo],
-    fields: &[Field],
-) -> Result<(), errno::Errno> {
+// ──────────────────────────── Formatting helpers ─────────────────────────────
+
+fn printbuf_to_string(f: impl FnOnce(&mut Printbuf)) -> String {
+    let mut out = Printbuf::new();
+    f(&mut out);
+    out.to_string()
+}
+
+fn data_type_name(t: data_type) -> String {
+    printbuf_to_string(|out| prt_data_type(out, t))
+}
+
+fn compression_type_name(t: bcachefs_kernel::c::bch_compression_type) -> String {
+    printbuf_to_string(|out| prt_compression_type(out, t))
+}
+
+fn reconcile_type_name(t: bcachefs_kernel::c::bch_reconcile_accounting_type) -> String {
+    printbuf_to_string(|out| prt_reconcile_type(out, t))
+}
+
+fn accounting_types_for_fields(fields: &[Field]) -> u32 {
     let has = |f: Field| -> bool { fields.contains(&f) };
 
     let mut accounting_types: u32 =
-        disk_accounting_type::replicas.bit() |
-        disk_accounting_type::persistent_reserved.bit();
+        disk_accounting_type::replicas.bit() | disk_accounting_type::persistent_reserved.bit();
 
     if has(Field::Compression) {
         accounting_types |= disk_accounting_type::compression.bit();
@@ -136,160 +331,309 @@ fn fs_usage_v1_to_text(
         }
     }
 
-    let result = handle.query_accounting(accounting_types)?;
+    accounting_types
+}
 
-    // Sort entries by bpos
+// ──────────────────────────── Single decode pass ─────────────────────────────
+
+fn fs_usage_collect(path: &str, fields: &[Field], name_mode: DeviceNameMode) -> Result<FsUsage> {
+    let handle =
+        BcachefsHandle::open(path).map_err(|e| anyhow!("opening filesystem '{}': {}", path, e))?;
+
+    let sysfs_path = sysfs::sysfs_path_from_fd(handle.sysfs_fd())?;
+    let devs = sysfs::fs_get_devices(&sysfs_path, name_mode)?;
+
+    let result = handle
+        .query_accounting(accounting_types_for_fields(fields))
+        .map_err(|e| anyhow!("query_accounting ioctl failed (kernel too old?): {}", e))?;
+
     let mut sorted: Vec<&AccountingEntry> = result.entries.iter().collect();
     sorted.sort_by_key(|a| a.pos);
 
-    // Header
     let uuid = uuid::Uuid::from_bytes(handle.uuid());
-    writeln!(out, "Filesystem: {}", uuid.hyphenated()).unwrap();
+    let devices = collect_dev_contexts(&handle, &devs)?
+        .into_iter()
+        .map(|d| build_device_usage(d, fields.contains(&Field::Devices)))
+        .collect();
 
-    out.aligned(|sub| {
-        write!(sub, "Size:\t").unwrap();
-        sub.units_sectors(result.capacity);
-        write!(sub, "\r\n").unwrap();
-
-        write!(sub, "Used:\t").unwrap();
-        sub.units_sectors(result.used);
-        write!(sub, "\r\n").unwrap();
-
-        write!(sub, "Online reserved:\t").unwrap();
-        sub.units_sectors(result.online_reserved);
-        write!(sub, "\r\n").unwrap();
-    });
-
-    // Replicas summary
-    replicas_summary_to_text(out, &sorted, devs);
-
-    // Detailed replicas
-    if has(Field::Replicas) {
-        out.aligned(|sub| {
-            write!(sub, "\nData type\tRequired/total\tDurability\tDevices\tUsage\n").unwrap();
-
-            for entry in &sorted {
-                match entry.pos.decode() {
-                    DiskAccountingKind::PersistentReserved { nr_replicas } => {
-                        let sectors = entry.counter(0);
-                        if sectors == 0 { continue; }
-                        write!(sub, "reserved:\t1/{}\t\t[]\t ", nr_replicas).unwrap();
-                        sub.units_sectors(sectors);
-                        write!(sub, "\r\n").unwrap();
-                    }
-                    DiskAccountingKind::Replicas { data_type, nr_devs, nr_required, devs: dev_list } => {
-                        let sectors = entry.counter(0);
-                        if sectors == 0 { continue; }
-
-                        let dev_list = &dev_list[..nr_devs as usize];
-                        let dur = replicas_durability(nr_devs, nr_required, dev_list, devs);
-
-                        prt_data_type(sub, data_type);
-                        write!(sub, ":\t{}/{}\t{}\t[", nr_required, nr_devs, dur.durability).unwrap();
-
-                        prt_dev_list(sub, dev_list, devs);
-                        write!(sub, "]\t").unwrap();
-
-                        sub.units_sectors(sectors);
-                        write!(sub, "\r\n").unwrap();
-                    }
-                    _ => {}
-                }
-            }
-        });
-    }
-
-    // Compression
-    if has(Field::Compression) {
-        let compr: Vec<_> = sorted.iter()
-            .filter(|e| e.pos.accounting_type() == Some(disk_accounting_type::compression))
-            .collect();
-        if !compr.is_empty() {
-            out.aligned(|sub| {
-                write!(sub, "\nCompression:\n").unwrap();
-                write!(sub, "type\tcompressed\runcompressed\raverage extent size\r\n").unwrap();
-
-                for entry in &compr {
-                    if let DiskAccountingKind::Compression { compression_type } = entry.pos.decode() {
-                        prt_compression_type(sub, compression_type);
-                        write!(sub, "\t").unwrap();
-
-                        let nr_extents = entry.counter(0);
-                        let sectors_uncompressed = entry.counter(1);
-                        let sectors_compressed = entry.counter(2);
-
-                        sub.units_sectors(sectors_compressed);
-                        write!(sub, "\r").unwrap();
-                        sub.units_sectors(sectors_uncompressed);
-                        write!(sub, "\r").unwrap();
-
-                        let avg = if nr_extents > 0 {
-                            (sectors_uncompressed << 9) / nr_extents
-                        } else { 0 };
-                        sub.units_u64(avg);
-                        write!(sub, "\r\n").unwrap();
-                    }
-                }
-            });
-        }
-    }
-
-    // Btree usage
-    if has(Field::Btree) {
-        let btrees: Vec<_> = sorted.iter()
-            .filter(|e| e.pos.accounting_type() == Some(disk_accounting_type::btree))
-            .collect();
-        if !btrees.is_empty() {
-            out.aligned(|sub| {
-                write!(sub, "\nBtree usage:\n").unwrap();
-                for entry in &btrees {
-                    if let DiskAccountingKind::Btree { id } = entry.pos.decode() {
-                        write!(sub, "{}:\t", btree::types::btree_id_str(id)).unwrap();
-                        sub.units_sectors(entry.counter(0));
-                        write!(sub, "\r\n").unwrap();
-                    }
-                }
-            });
-        }
-    }
-
-    // Rebalance / reconcile work
-    if has(Field::RebalanceWork) {
-        let rebalance: Vec<_> = sorted.iter()
-            .filter(|e| e.pos.accounting_type() == Some(disk_accounting_type::rebalance_work))
-            .collect();
-        if !rebalance.is_empty() {
-            write!(out, "\nPending rebalance work:\n").unwrap();
-            for entry in &rebalance {
-                out.units_sectors(entry.counter(0));
-                out.newline();
-            }
-        }
-
-        let reconcile: Vec<_> = sorted.iter()
-            .filter(|e| e.pos.accounting_type() == Some(disk_accounting_type::reconcile_work))
-            .collect();
-        if !reconcile.is_empty() {
-            out.aligned(|sub| {
-                write!(sub, "\nPending reconcile:\tdata\rmetadata\r\n").unwrap();
-                for entry in &reconcile {
-                    if let DiskAccountingKind::ReconcileWork { work_type } = entry.pos.decode() {
-                        prt_reconcile_type(sub, work_type);
-                        write!(sub, ":\t").unwrap();
-                        sub.units_sectors(entry.counter(0));
-                        write!(sub, "\r").unwrap();
-                        sub.units_sectors(entry.counter(1));
-                        write!(sub, "\r\n").unwrap();
-                    }
-                }
-            });
-        }
-    }
-
-    Ok(())
+    Ok(FsUsage {
+        mountpoint: path.to_string(),
+        uuid: uuid.hyphenated().to_string(),
+        fields: fields.iter().map(|f| f.as_str()).collect(),
+        capacity: result.capacity,
+        used: result.used,
+        online_reserved: result.online_reserved,
+        replicas_summary: build_replicas_summary(&sorted, &devs),
+        replicas: build_replicas(&sorted, &devs, fields.contains(&Field::Replicas)),
+        persistent_reserved: build_persistent_reserved(&sorted, fields.contains(&Field::Replicas)),
+        compression: build_compression(&sorted, fields.contains(&Field::Compression)),
+        btree: build_btree(&sorted, fields.contains(&Field::Btree)),
+        rebalance_work: build_rebalance_work(&sorted, fields.contains(&Field::RebalanceWork)),
+        reconcile_work: build_reconcile_work(&sorted, fields.contains(&Field::RebalanceWork)),
+        devices,
+    })
 }
 
-// ──────────────────────────── Replicas summary ──────────────────────────────
+fn dev_list_names(dev_list: &[u8], devs: &[DevInfo]) -> Vec<String> {
+    dev_list
+        .iter()
+        .map(|&dev_idx| {
+            if dev_idx == c::BCH_SB_MEMBER_INVALID as u8 {
+                "none".to_string()
+            } else if let Some(d) = devs.iter().find(|d| d.idx == dev_idx as u32) {
+                d.dev.clone()
+            } else {
+                dev_idx.to_string()
+            }
+        })
+        .collect()
+}
+
+fn build_replicas_summary(sorted: &[&AccountingEntry], devs: &[DevInfo]) -> ReplicasSummary {
+    let mut replicated: DurabilityMatrix = Vec::new();
+    let mut ec_configs: Vec<EcConfig> = Vec::new();
+    let mut cached: u64 = 0;
+    let mut reserved: u64 = 0;
+
+    for entry in sorted {
+        match entry.pos.decode() {
+            DiskAccountingKind::PersistentReserved { .. } => {
+                reserved += entry.counter(0);
+            }
+            DiskAccountingKind::Replicas {
+                data_type,
+                nr_devs,
+                nr_required,
+                devs: dev_list,
+            } => {
+                if data_type == data_type::cached {
+                    cached += entry.counter(0);
+                    continue;
+                }
+
+                let dev_list = &dev_list[..nr_devs as usize];
+                let d = replicas_durability(nr_devs, nr_required, dev_list, devs);
+
+                if nr_required > 1 {
+                    ec_config_add(
+                        &mut ec_configs,
+                        nr_required,
+                        nr_devs,
+                        d.degraded,
+                        entry.counter(0),
+                    );
+                } else {
+                    durability_matrix_add(
+                        &mut replicated,
+                        d.durability,
+                        d.degraded,
+                        entry.counter(0),
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let replicated = replicated
+        .iter()
+        .enumerate()
+        .flat_map(|(durability, row)| {
+            row.iter()
+                .enumerate()
+                .filter_map(move |(degraded, &sectors)| {
+                    (sectors != 0).then(|| DurabilityUsage {
+                        durability: durability as u32,
+                        degraded: degraded as u32,
+                        sectors,
+                    })
+                })
+        })
+        .collect();
+
+    ec_configs.sort_by_key(|c| (c.nr_data, c.nr_parity));
+    let erasure_coded = ec_configs
+        .iter()
+        .flat_map(|cfg| {
+            cfg.degraded
+                .iter()
+                .enumerate()
+                .filter_map(move |(degraded, &sectors)| {
+                    (sectors != 0).then(|| EcUsage {
+                        data: cfg.nr_data,
+                        parity: cfg.nr_parity,
+                        degraded: degraded as u32,
+                        sectors,
+                    })
+                })
+        })
+        .collect();
+
+    ReplicasSummary {
+        replicated,
+        erasure_coded,
+        cached,
+        reserved,
+    }
+}
+
+fn build_replicas(
+    sorted: &[&AccountingEntry],
+    devs: &[DevInfo],
+    include: bool,
+) -> Vec<ReplicaUsage> {
+    if !include {
+        return Vec::new();
+    }
+
+    sorted
+        .iter()
+        .filter_map(|entry| {
+            let DiskAccountingKind::Replicas {
+                data_type,
+                nr_devs,
+                nr_required,
+                devs: dev_list,
+            } = entry.pos.decode()
+            else {
+                return None;
+            };
+
+            let sectors = entry.counter(0);
+            if sectors == 0 {
+                return None;
+            }
+
+            let dev_list = &dev_list[..nr_devs as usize];
+            let dur = replicas_durability(nr_devs, nr_required, dev_list, devs);
+
+            Some(ReplicaUsage {
+                data_type: data_type_name(data_type),
+                required: nr_required,
+                replicas: nr_devs,
+                durability: dur.durability,
+                degraded: dur.degraded,
+                devices: dev_list_names(dev_list, devs),
+                sectors,
+            })
+        })
+        .collect()
+}
+
+fn build_persistent_reserved(
+    sorted: &[&AccountingEntry],
+    include: bool,
+) -> Vec<PersistentReserved> {
+    if !include {
+        return Vec::new();
+    }
+
+    sorted
+        .iter()
+        .filter_map(|entry| {
+            let DiskAccountingKind::PersistentReserved { nr_replicas } = entry.pos.decode() else {
+                return None;
+            };
+            let sectors = entry.counter(0);
+            (sectors != 0).then(|| PersistentReserved {
+                replicas: nr_replicas,
+                sectors,
+            })
+        })
+        .collect()
+}
+
+fn build_compression(sorted: &[&AccountingEntry], include: bool) -> Vec<CompressionUsage> {
+    if !include {
+        return Vec::new();
+    }
+
+    sorted
+        .iter()
+        .filter_map(|entry| {
+            let DiskAccountingKind::Compression { compression_type } = entry.pos.decode() else {
+                return None;
+            };
+
+            let extents = entry.counter(0);
+            let uncompressed_sectors = entry.counter(1);
+            let compressed_sectors = entry.counter(2);
+            let average_extent_bytes = if extents > 0 {
+                (uncompressed_sectors << 9) / extents
+            } else {
+                0
+            };
+
+            Some(CompressionUsage {
+                compression_type: compression_type_name(compression_type),
+                extents,
+                compressed_sectors,
+                uncompressed_sectors,
+                average_extent_bytes,
+            })
+        })
+        .collect()
+}
+
+fn build_btree(sorted: &[&AccountingEntry], include: bool) -> Vec<BtreeUsage> {
+    if !include {
+        return Vec::new();
+    }
+
+    sorted
+        .iter()
+        .filter_map(|entry| {
+            let DiskAccountingKind::Btree { id } = entry.pos.decode() else {
+                return None;
+            };
+            Some(BtreeUsage {
+                btree: btree::types::btree_id_str(id).to_string(),
+                sectors: entry.counter(0),
+            })
+        })
+        .collect()
+}
+
+fn build_rebalance_work(sorted: &[&AccountingEntry], include: bool) -> Vec<RebalanceEntry> {
+    if !include {
+        return Vec::new();
+    }
+
+    sorted
+        .iter()
+        .filter(|e| e.pos.accounting_type() == Some(disk_accounting_type::rebalance_work))
+        .map(|entry| RebalanceEntry {
+            sectors: entry.counter(0),
+        })
+        .collect()
+}
+
+fn build_reconcile_work(sorted: &[&AccountingEntry], include: bool) -> Vec<ReconcileWork> {
+    if !include {
+        return Vec::new();
+    }
+
+    sorted
+        .iter()
+        .filter_map(|entry| {
+            let DiskAccountingKind::ReconcileWork { work_type } = entry.pos.decode() else {
+                return None;
+            };
+            Some(ReconcileWork {
+                work_type: reconcile_type_name(work_type),
+                data_sectors: entry.counter(0),
+                metadata_sectors: entry.counter(1),
+            })
+        })
+        .collect()
+}
+
+// ──────────────────────────── Replicas summary shaping ───────────────────────
+//
+// These matrices exist only to lay the text table out in columns; the model
+// above already carries the decoded (durability, degraded, sectors) tuples,
+// so text rendering pivots that flat list back into a grid instead of
+// touching accounting entries again.
 
 pub struct Durability {
     pub durability: u32,
@@ -326,7 +670,10 @@ pub fn replicas_durability(
         durability = (nr_devs - nr_required + 1) as u32;
     }
 
-    Durability { durability, degraded }
+    Durability {
+        durability,
+        degraded,
+    }
 }
 
 /// How many more devices this replicas entry can lose before its data becomes
@@ -354,7 +701,12 @@ pub fn replicas_spare_redundancy(
 /// Durability x degraded matrix: matrix[durability][degraded] = sectors
 type DurabilityMatrix = Vec<Vec<u64>>;
 
-fn durability_matrix_add(matrix: &mut DurabilityMatrix, durability: u32, degraded: u32, sectors: u64) {
+fn durability_matrix_add(
+    matrix: &mut DurabilityMatrix,
+    durability: u32,
+    degraded: u32,
+    sectors: u64,
+) {
     while matrix.len() <= durability as usize {
         matrix.push(Vec::new());
     }
@@ -363,6 +715,64 @@ fn durability_matrix_add(matrix: &mut DurabilityMatrix, durability: u32, degrade
         row.push(0);
     }
     row[degraded as usize] += sectors;
+}
+
+fn matrix_from_flat(items: &[DurabilityUsage]) -> DurabilityMatrix {
+    let mut matrix = DurabilityMatrix::new();
+    for it in items {
+        durability_matrix_add(&mut matrix, it.durability, it.degraded, it.sectors);
+    }
+    matrix
+}
+
+/// EC entries grouped by stripe config: (nr_data, nr_parity) → [degraded] = sectors
+struct EcConfig {
+    nr_data: u8,
+    nr_parity: u8,
+    degraded: Vec<u64>,
+}
+
+fn ec_config_add(
+    configs: &mut Vec<EcConfig>,
+    nr_required: u8,
+    nr_devs: u8,
+    degraded: u32,
+    sectors: u64,
+) {
+    let nr_parity = nr_devs - nr_required;
+    let cfg = match configs
+        .iter_mut()
+        .find(|c| c.nr_data == nr_required && c.nr_parity == nr_parity)
+    {
+        Some(c) => c,
+        None => {
+            configs.push(EcConfig {
+                nr_data: nr_required,
+                nr_parity,
+                degraded: Vec::new(),
+            });
+            configs.last_mut().unwrap()
+        }
+    };
+    while cfg.degraded.len() <= degraded as usize {
+        cfg.degraded.push(0);
+    }
+    cfg.degraded[degraded as usize] += sectors;
+}
+
+fn ec_configs_from_flat(items: &[EcUsage]) -> Vec<EcConfig> {
+    let mut configs = Vec::new();
+    for it in items {
+        ec_config_add(
+            &mut configs,
+            it.data,
+            it.data + it.parity,
+            it.degraded,
+            it.sectors,
+        );
+    }
+    configs.sort_by_key(|c| (c.nr_data, c.nr_parity));
+    configs
 }
 
 /// Print the degradation header row: "undegraded  -1x  -2x ..."
@@ -391,144 +801,61 @@ fn prt_sector_row(out: &mut Printbuf, values: &[u64]) {
 
 fn durability_matrix_to_text(out: &mut Printbuf, matrix: &DurabilityMatrix) {
     let max_degraded = matrix.iter().map(|r| r.len()).max().unwrap_or(0);
-    if max_degraded == 0 { return; }
+    if max_degraded == 0 {
+        return;
+    }
 
     out.aligned(|sub| {
         prt_degraded_header(sub, max_degraded);
 
         for (dur, row) in matrix.iter().enumerate() {
-            if row.is_empty() { continue; }
+            if row.is_empty() {
+                continue;
+            }
             write!(sub, "{}x:\t", dur).unwrap();
             prt_sector_row(sub, row);
         }
     });
 }
 
-/// EC entries grouped by stripe config: (nr_data, nr_parity) → [degraded] = sectors
-struct EcConfig {
-    nr_data:    u8,
-    nr_parity:  u8,
-    degraded:   Vec<u64>,
-}
-
-fn ec_config_add(configs: &mut Vec<EcConfig>, nr_required: u8, nr_devs: u8, degraded: u32, sectors: u64) {
-    let nr_parity = nr_devs - nr_required;
-    let cfg = match configs.iter_mut().find(|c| c.nr_data == nr_required && c.nr_parity == nr_parity) {
-        Some(c) => c,
-        None => {
-            configs.push(EcConfig { nr_data: nr_required, nr_parity, degraded: Vec::new() });
-            configs.last_mut().unwrap()
-        }
-    };
-    while cfg.degraded.len() <= degraded as usize {
-        cfg.degraded.push(0);
-    }
-    cfg.degraded[degraded as usize] += sectors;
-}
-
-fn ec_configs_to_text(out: &mut Printbuf, configs: &mut [EcConfig]) {
-    configs.sort_by_key(|c| (c.nr_data, c.nr_parity));
-
+fn ec_configs_to_text(out: &mut Printbuf, configs: &[EcConfig]) {
     let max_degraded = configs.iter().map(|c| c.degraded.len()).max().unwrap_or(0);
-    if max_degraded == 0 { return; }
+    if max_degraded == 0 {
+        return;
+    }
 
     out.aligned(|sub| {
         prt_degraded_header(sub, max_degraded);
 
-        for cfg in configs.iter() {
+        for cfg in configs {
             write!(sub, "{}+{}:\t", cfg.nr_data, cfg.nr_parity).unwrap();
             prt_sector_row(sub, &cfg.degraded);
         }
     });
 }
 
-fn replicas_summary_to_text(
-    out: &mut Printbuf,
-    sorted: &[&AccountingEntry],
-    devs: &[DevInfo],
-) {
-    let mut replicated: DurabilityMatrix = Vec::new();
-    let mut ec_configs: Vec<EcConfig> = Vec::new();
-    let mut cached: u64 = 0;
-    let mut reserved: u64 = 0;
-
-    for entry in sorted {
-        match entry.pos.decode() {
-            DiskAccountingKind::PersistentReserved { .. } => {
-                reserved += entry.counter(0);
-            }
-            DiskAccountingKind::Replicas { data_type, nr_devs, nr_required, devs: dev_list } => {
-                if data_type == data_type::cached {
-                    cached += entry.counter(0);
-                    continue;
-                }
-
-                let dev_list = &dev_list[..nr_devs as usize];
-                let d = replicas_durability(nr_devs, nr_required, dev_list, devs);
-
-                if nr_required > 1 {
-                    ec_config_add(&mut ec_configs, nr_required, nr_devs, d.degraded, entry.counter(0));
-                } else {
-                    durability_matrix_add(&mut replicated, d.durability, d.degraded, entry.counter(0));
-                }
-            }
-            _ => {}
-        }
-    }
-
-    let has_ec = !ec_configs.is_empty();
-
-    writeln!(out).unwrap();
-    if has_ec {
-        writeln!(out, "Replicated:").unwrap();
-    }
-    durability_matrix_to_text(out, &replicated);
-
-    if has_ec {
-        write!(out, "\nErasure coded (data+parity):\n").unwrap();
-        ec_configs_to_text(out, &mut ec_configs);
-    }
-
-    if cached > 0 || reserved > 0 {
-        out.aligned(|sub| {
-            if cached > 0 {
-                write!(sub, "cached:\t").unwrap();
-                sub.units_sectors(cached);
-                write!(sub, "\r\n").unwrap();
-            }
-            if reserved > 0 {
-                write!(sub, "reserved:\t").unwrap();
-                sub.units_sectors(reserved);
-                write!(sub, "\r\n").unwrap();
-            }
-        });
-    }
-}
-
-/// Print a device list like [sda sdb sdc].
-fn prt_dev_list(out: &mut Printbuf, dev_list: &[u8], devs: &[DevInfo]) {
-    for (i, &dev_idx) in dev_list.iter().enumerate() {
-        if i > 0 { write!(out, " ").unwrap(); }
-        if dev_idx == c::BCH_SB_MEMBER_INVALID as u8 {
-            write!(out, "none").unwrap();
-        } else if let Some(d) = devs.iter().find(|d| d.idx == dev_idx as u32) {
-            write!(out, "{}", d.dev).unwrap();
-        } else {
-            write!(out, "{}", dev_idx).unwrap();
-        }
-    }
-}
-
 // ──────────────────────────── Device usage ───────────────────────────────────
 
-fn devs_usage_to_text(
-    out: &mut Printbuf,
-    handle: &BcachefsHandle,
-    devs: &[DevInfo],
-    fields: &[Field],
-) -> Result<()> {
-    let has = |f: Field| -> bool { fields.contains(&f) };
+struct DevContext {
+    info: DevInfo,
+    usage: Option<DevUsage>,
+    leaving: u64,
+    /// Sectors this device holds in stripe data blocks that are empty. Zero
+    /// when the accounting hasn't been computed - see stripe_frag_accounting.
+    stripe_empty: u64,
+}
 
+fn dev_leaving_sectors(entries: &[AccountingEntry], dev_idx: u32) -> u64 {
+    entries
+        .iter()
+        .find_map(|e| match e.pos.decode() {
+            DiskAccountingKind::DevLeaving { dev } if dev == dev_idx => Some(e.counter(0)),
+            _ => None,
+        })
+        .unwrap_or(0)
+}
+
+fn collect_dev_contexts(handle: &BcachefsHandle, devs: &[DevInfo]) -> Result<Vec<DevContext>> {
     // Query dev_leaving accounting if available
     let dev_leaving_map = match handle.query_accounting(disk_accounting_type::dev_leaving.bit()) {
         Ok(result) => result.entries,
@@ -545,97 +872,341 @@ fn devs_usage_to_text(
     let mut dev_ctxs: Vec<DevContext> = Vec::new();
     for dev in devs {
         let usage = if dev.online {
-            Some(handle.dev_usage(dev.idx)
-                .map_err(|e| anyhow!("getting usage for device {}: {}", dev.idx, e))?)
+            Some(
+                handle
+                    .dev_usage(dev.idx)
+                    .map_err(|e| anyhow!("getting usage for device {}: {}", dev.idx, e))?,
+            )
         } else {
             None
         };
         let leaving = dev_leaving_sectors(&dev_leaving_map, dev.idx);
         let stripe_empty = dev_stripe_empty_sectors(&dev_stripe_frag_map, dev.idx);
-        dev_ctxs.push(DevContext { info: dev.clone(), usage, leaving, stripe_empty });
+        dev_ctxs.push(DevContext {
+            info: dev.clone(),
+            usage,
+            leaving,
+            stripe_empty,
+        });
     }
 
     // Sort by label, then dev name, then idx
     dev_ctxs.sort_by(|a, b| {
-        a.info.label.cmp(&b.info.label)
+        a.info
+            .label
+            .cmp(&b.info.label)
             .then(a.info.dev.cmp(&b.info.dev))
             .then(a.info.idx.cmp(&b.info.idx))
     });
 
-    let has_leaving = dev_ctxs.iter().any(|d| d.leaving != 0);
+    Ok(dev_ctxs)
+}
 
-    out.newline();
+fn build_device_usage(d: DevContext, include_data_types: bool) -> DeviceUsage {
+    let Some(usage) = &d.usage else {
+        return DeviceUsage {
+            label: d.info.label,
+            device_index: d.info.idx,
+            device: d.info.dev,
+            state: "offline".to_string(),
+            capacity: 0,
+            used: 0,
+            hidden: 0,
+            used_percent: 0,
+            leaving: d.leaving,
+            stripe_empty: d.stripe_empty,
+            bucket_size: 0,
+            buckets: 0,
+            data_types: None,
+        };
+    };
 
-    if has(Field::Devices) {
-        // Full per-device breakdown
-        for d in &dev_ctxs {
-            dev_usage_full_to_text(out, d);
-        }
+    let hidden = usage.hidden_sectors();
+    let capacity = usage.capacity_sectors() - hidden;
+    let used = usage.used_sectors() - hidden;
+    let used_percent = if usage.nr_buckets > 0 {
+        usage.used_buckets() * 100 / usage.nr_buckets
     } else {
-        // Summary table
-        out.aligned(|sub| {
-            write!(sub, "Device label\tDevice\tState\tSize\rUsed\rUse%\r").unwrap();
-            if has_leaving {
-                write!(sub, "Leaving\r").unwrap();
-            }
-            sub.newline();
-
-            for d in &dev_ctxs {
-                let label = d.info.label.as_deref().unwrap_or("(no label)");
-                write!(sub, "{} (device {}):\t{}\t", label, d.info.idx, d.info.dev).unwrap();
-
-                let Some(usage) = &d.usage else {
-                    write!(sub, "offline\t-\r-\r-\r").unwrap();
-                    if has_leaving {
-                        write!(sub, "\r").unwrap();
-                    }
-                    sub.newline();
-                    continue;
+        0
+    };
+    let data_types = include_data_types.then(|| {
+        usage
+            .iter_typed()
+            .map(|(dt_type, dt)| {
+                let sectors = if data_type_is_empty(dt_type) {
+                    dt.buckets * usage.bucket_size as u64
+                } else {
+                    dt.sectors
                 };
-
-                let hidden = usage.hidden_sectors();
-                let capacity = usage.capacity_sectors() - hidden;
-                let used = usage.used_sectors() - hidden;
-                let state = bcachefs_kernel::sb::members::member_state_str(usage.state);
-
-                write!(sub, "{}\t", state).unwrap();
-
-                sub.units_sectors(capacity);
-                write!(sub, "\r").unwrap();
-                sub.units_sectors(used);
-
-                let pct = if usage.nr_buckets > 0 {
-                    usage.used_buckets() * 100 / usage.nr_buckets
-                } else { 0 };
-                write!(sub, "\r{:>2}%\r", pct).unwrap();
-
-                if d.leaving > 0 {
-                    sub.units_sectors(d.leaving);
-                    write!(sub, "\r").unwrap();
+                DeviceDataTypeUsage {
+                    data_type: data_type_name(dt_type),
+                    sectors,
+                    buckets: dt.buckets,
+                    fragmented: dt.fragmented,
                 }
+            })
+            .collect()
+    });
 
-                sub.newline();
+    DeviceUsage {
+        label: d.info.label,
+        device_index: d.info.idx,
+        device: d.info.dev,
+        state: bcachefs_kernel::sb::members::member_state_str(usage.state).to_string(),
+        capacity,
+        used,
+        hidden,
+        used_percent,
+        leaving: d.leaving,
+        stripe_empty: d.stripe_empty,
+        bucket_size: usage.bucket_size,
+        buckets: usage.nr_buckets,
+        data_types,
+    }
+}
+
+// ──────────────────────────── Text rendering ──────────────────────────────────
+//
+// Everything below prints from the already-decoded `FsUsage` model — no
+// function here touches an `AccountingEntry` or `DevUsage` directly.
+
+fn fs_usage_to_text(out: &mut Printbuf, fs: &FsUsage) {
+    writeln!(out, "Filesystem: {}", fs.uuid).unwrap();
+
+    out.aligned(|sub| {
+        write!(sub, "Size:\t").unwrap();
+        sub.units_sectors(fs.capacity);
+        write!(sub, "\r\n").unwrap();
+
+        write!(sub, "Used:\t").unwrap();
+        sub.units_sectors(fs.used);
+        write!(sub, "\r\n").unwrap();
+
+        write!(sub, "Online reserved:\t").unwrap();
+        sub.units_sectors(fs.online_reserved);
+        write!(sub, "\r\n").unwrap();
+    });
+
+    replicas_summary_to_text(out, &fs.replicas_summary);
+
+    if fs.fields.contains(&"replicas") {
+        replicas_detail_to_text(out, &fs.persistent_reserved, &fs.replicas);
+    }
+
+    compression_to_text(out, &fs.compression);
+    btree_to_text(out, &fs.btree);
+    rebalance_work_to_text(out, &fs.rebalance_work);
+    reconcile_work_to_text(out, &fs.reconcile_work);
+
+    devices_to_text(out, &fs.devices, fs.fields.contains(&"devices"));
+}
+
+fn replicas_summary_to_text(out: &mut Printbuf, summary: &ReplicasSummary) {
+    let matrix = matrix_from_flat(&summary.replicated);
+    let ec_configs = ec_configs_from_flat(&summary.erasure_coded);
+    let has_ec = !ec_configs.is_empty();
+
+    writeln!(out).unwrap();
+    if has_ec {
+        writeln!(out, "Replicated:").unwrap();
+    }
+    durability_matrix_to_text(out, &matrix);
+
+    if has_ec {
+        write!(out, "\nErasure coded (data+parity):\n").unwrap();
+        ec_configs_to_text(out, &ec_configs);
+    }
+
+    if summary.cached > 0 || summary.reserved > 0 {
+        out.aligned(|sub| {
+            if summary.cached > 0 {
+                write!(sub, "cached:\t").unwrap();
+                sub.units_sectors(summary.cached);
+                write!(sub, "\r\n").unwrap();
+            }
+            if summary.reserved > 0 {
+                write!(sub, "reserved:\t").unwrap();
+                sub.units_sectors(summary.reserved);
+                write!(sub, "\r\n").unwrap();
             }
         });
     }
-
-    Ok(())
 }
 
-fn dev_usage_full_to_text(out: &mut Printbuf, d: &DevContext) {
-    let label = d.info.label.as_deref().unwrap_or("(no label)");
-    let Some(u) = &d.usage else {
+fn replicas_detail_to_text(
+    out: &mut Printbuf,
+    persistent_reserved: &[PersistentReserved],
+    replicas: &[ReplicaUsage],
+) {
+    out.aligned(|sub| {
+        write!(
+            sub,
+            "\nData type\tRequired/total\tDurability\tDevices\tUsage\n"
+        )
+        .unwrap();
+
+        for r in persistent_reserved {
+            write!(sub, "reserved:\t1/{}\t\t[]\t ", r.replicas).unwrap();
+            sub.units_sectors(r.sectors);
+            write!(sub, "\r\n").unwrap();
+        }
+
+        for r in replicas {
+            write!(
+                sub,
+                "{}:\t{}/{}\t{}\t[{}]\t",
+                r.data_type,
+                r.required,
+                r.replicas,
+                r.durability,
+                r.devices.join(" "),
+            )
+            .unwrap();
+            sub.units_sectors(r.sectors);
+            write!(sub, "\r\n").unwrap();
+        }
+    });
+}
+
+fn compression_to_text(out: &mut Printbuf, compr: &[CompressionUsage]) {
+    if compr.is_empty() {
+        return;
+    }
+    out.aligned(|sub| {
+        write!(sub, "\nCompression:\n").unwrap();
+        write!(
+            sub,
+            "type\tcompressed\runcompressed\raverage extent size\r\n"
+        )
+        .unwrap();
+
+        for c in compr {
+            write!(sub, "{}\t", c.compression_type).unwrap();
+            sub.units_sectors(c.compressed_sectors);
+            write!(sub, "\r").unwrap();
+            sub.units_sectors(c.uncompressed_sectors);
+            write!(sub, "\r").unwrap();
+            sub.units_u64(c.average_extent_bytes);
+            write!(sub, "\r\n").unwrap();
+        }
+    });
+}
+
+fn btree_to_text(out: &mut Printbuf, btrees: &[BtreeUsage]) {
+    if btrees.is_empty() {
+        return;
+    }
+    out.aligned(|sub| {
+        write!(sub, "\nBtree usage:\n").unwrap();
+        for b in btrees {
+            write!(sub, "{}:\t", b.btree).unwrap();
+            sub.units_sectors(b.sectors);
+            write!(sub, "\r\n").unwrap();
+        }
+    });
+}
+
+fn rebalance_work_to_text(out: &mut Printbuf, rebalance: &[RebalanceEntry]) {
+    if rebalance.is_empty() {
+        return;
+    }
+    write!(out, "\nPending rebalance work:\n").unwrap();
+    for r in rebalance {
+        out.units_sectors(r.sectors);
+        out.newline();
+    }
+}
+
+fn reconcile_work_to_text(out: &mut Printbuf, reconcile: &[ReconcileWork]) {
+    if reconcile.is_empty() {
+        return;
+    }
+    out.aligned(|sub| {
+        write!(sub, "\nPending reconcile:\tdata\rmetadata\r\n").unwrap();
+        for r in reconcile {
+            write!(sub, "{}:\t", r.work_type).unwrap();
+            sub.units_sectors(r.data_sectors);
+            write!(sub, "\r").unwrap();
+            sub.units_sectors(r.metadata_sectors);
+            write!(sub, "\r\n").unwrap();
+        }
+    });
+}
+
+fn devices_to_text(out: &mut Printbuf, devices: &[DeviceUsage], detailed: bool) {
+    out.newline();
+
+    if detailed {
+        for d in devices {
+            dev_usage_full_to_text(out, d);
+        }
+        return;
+    }
+
+    let has_leaving = devices.iter().any(|d| d.leaving != 0);
+
+    out.aligned(|sub| {
+        write!(sub, "Device label\tDevice\tState\tSize\rUsed\rUse%\r").unwrap();
+        if has_leaving {
+            write!(sub, "Leaving\r").unwrap();
+        }
+        sub.newline();
+
+        for d in devices {
+            let label = d.label.as_deref().unwrap_or("(no label)");
+            write!(
+                sub,
+                "{} (device {}):\t{}\t",
+                label, d.device_index, d.device
+            )
+            .unwrap();
+
+            if d.state == "offline" {
+                write!(sub, "offline\t-\r-\r-\r").unwrap();
+                if has_leaving {
+                    write!(sub, "\r").unwrap();
+                }
+                sub.newline();
+                continue;
+            }
+
+            write!(sub, "{}\t", d.state).unwrap();
+            sub.units_sectors(d.capacity);
+            write!(sub, "\r").unwrap();
+            sub.units_sectors(d.used);
+            write!(sub, "\r{:>2}%\r", d.used_percent).unwrap();
+
+            if d.leaving > 0 {
+                sub.units_sectors(d.leaving);
+                write!(sub, "\r").unwrap();
+            }
+
+            sub.newline();
+        }
+    });
+}
+
+fn dev_usage_full_to_text(out: &mut Printbuf, d: &DeviceUsage) {
+    let label = d.label.as_deref().unwrap_or("(no label)");
+    let Some(data_types) = &d.data_types else {
         out.aligned(|sub| {
-            writeln!(sub, "{} (device {}):\t{}\toffline\tusage unavailable", label, d.info.idx, d.info.dev).unwrap();
+            writeln!(
+                sub,
+                "{} (device {}):\t{}\toffline\tusage unavailable",
+                label, d.device_index, d.device
+            )
+            .unwrap();
         });
         return;
     };
 
-    let state = bcachefs_kernel::sb::members::member_state_str(u.state);
-    let pct = if u.nr_buckets > 0 { u.used_buckets() * 100 / u.nr_buckets } else { 0 };
-
     out.aligned(|sub| {
-        writeln!(sub, "{} (device {}):\t{}\t{}\t{:>2}%", label, d.info.idx, d.info.dev, state, pct).unwrap();
+        writeln!(
+            sub,
+            "{} (device {}):\t{}\t{}\t{:>2}%",
+            label, d.device_index, d.device, d.state, d.used_percent
+        )
+        .unwrap();
 
         {
             let sub = &mut *sub.indent(2);
@@ -649,17 +1220,9 @@ fn dev_usage_full_to_text(out: &mut Printbuf, d: &DevContext) {
             }
             write!(sub, "\r\n").unwrap();
 
-            for (dt_type, dt) in u.iter_typed() {
-                prt_data_type(sub, dt_type);
-                write!(sub, ":\t").unwrap();
-
-                let sectors = if data_type_is_empty(dt_type) {
-                    dt.buckets * u.bucket_size as u64
-                } else {
-                    dt.sectors
-                };
-                sub.units_sectors(sectors);
-
+            for dt in data_types {
+                write!(sub, "{}:\t", dt.data_type).unwrap();
+                sub.units_sectors(dt.sectors);
                 write!(sub, "\r{}\r", dt.buckets).unwrap();
 
                 if dt.fragmented > 0 {
@@ -676,11 +1239,11 @@ fn dev_usage_full_to_text(out: &mut Printbuf, d: &DevContext) {
             }
 
             write!(sub, "capacity:\t").unwrap();
-            sub.units_sectors(u.capacity_sectors());
-            write!(sub, "\r{}\r\n", u.nr_buckets).unwrap();
+            sub.units_sectors(d.capacity);
+            write!(sub, "\r{}\r\n", d.buckets).unwrap();
 
             write!(sub, "bucket size:\t").unwrap();
-            sub.units_sectors(u.bucket_size as u64);
+            sub.units_sectors(d.bucket_size as u64);
             write!(sub, "\r\n").unwrap();
         }
     });
@@ -707,5 +1270,4 @@ fn dev_leaving_sectors(entries: &[AccountingEntry], dev_idx: u32) -> u64 {
         })
         .unwrap_or(0)
 }
-
 pub const CMD: super::CmdDef = typed_cmd!("usage", "Show filesystem disk usage", Cli, fs_usage);

--- a/src/commands/fs_usage.rs
+++ b/src/commands/fs_usage.rs
@@ -914,7 +914,7 @@ fn build_device_usage(d: DevContext, include_data_types: bool) -> DeviceUsage {
     };
 
     let hidden = usage.hidden_sectors();
-    let capacity = usage.capacity_sectors() - hidden;
+    let capacity = usage.capacity_sectors();
     let used = usage.used_sectors() - hidden;
     let used_percent = if usage.nr_buckets > 0 {
         usage.used_buckets() * 100 / usage.nr_buckets
@@ -1164,7 +1164,7 @@ fn devices_to_text(out: &mut Printbuf, devices: &[DeviceUsage], detailed: bool) 
             }
 
             write!(sub, "{}\t", d.state).unwrap();
-            sub.units_sectors(d.capacity);
+            sub.units_sectors(d.capacity.saturating_sub(d.hidden));
             write!(sub, "\r").unwrap();
             sub.units_sectors(d.used);
             write!(sub, "\r{:>2}%\r", d.used_percent).unwrap();
@@ -1264,3 +1264,51 @@ fn dev_leaving_sectors(entries: &[AccountingEntry], dev_idx: u32) -> u64 {
         .unwrap_or(0)
 }
 pub const CMD: super::CmdDef = typed_cmd!("usage", "Show filesystem disk usage", Cli, fs_usage);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_device() -> DeviceUsage {
+        DeviceUsage {
+            label: Some("fixture".to_string()),
+            device_index: 1,
+            device: "sdx".to_string(),
+            state: "rw".to_string(),
+            capacity: 100,
+            used: 40,
+            hidden: 7,
+            used_percent: 40,
+            leaving: 0,
+            stripe_empty: 0,
+            bucket_size: 1,
+            buckets: 100,
+            data_types: Some(vec![DeviceDataTypeUsage {
+                data_type: "user".to_string(),
+                is_stripe: false,
+                sectors: 40,
+                buckets: 40,
+                fragmented: 0,
+            }]),
+        }
+    }
+
+    #[test]
+    fn device_capacity_preserves_total_and_summary_hides_reserved_space() {
+        let device = fixture_device();
+
+        let json = serde_json::to_value(&device).unwrap();
+        assert_eq!(json["capacity_bytes"], 100 * SECTOR_BYTES);
+        assert_eq!(json["hidden_bytes"], 7 * SECTOR_BYTES);
+
+        let mut summary = Printbuf::new();
+        devices_to_text(&mut summary, &[device], false);
+        assert!(summary.as_str().contains("47616"));
+        assert!(!summary.as_str().contains("51200"));
+
+        let mut detailed = Printbuf::new();
+        dev_usage_full_to_text(&mut detailed, &fixture_device());
+        assert!(detailed.as_str().contains("51200"));
+        assert!(!detailed.as_str().contains("47616"));
+    }
+}

--- a/src/commands/fs_usage.rs
+++ b/src/commands/fs_usage.rs
@@ -282,6 +282,8 @@ struct DeviceUsage {
 #[derive(Serialize)]
 struct DeviceDataTypeUsage {
     data_type: String,
+    #[serde(skip)]
+    is_stripe: bool,
     #[serde(rename = "bytes", serialize_with = "ser_bytes")]
     sectors: u64,
     buckets: u64,
@@ -845,16 +847,6 @@ struct DevContext {
     stripe_empty: u64,
 }
 
-fn dev_leaving_sectors(entries: &[AccountingEntry], dev_idx: u32) -> u64 {
-    entries
-        .iter()
-        .find_map(|e| match e.pos.decode() {
-            DiskAccountingKind::DevLeaving { dev } if dev == dev_idx => Some(e.counter(0)),
-            _ => None,
-        })
-        .unwrap_or(0)
-}
-
 fn collect_dev_contexts(handle: &BcachefsHandle, devs: &[DevInfo]) -> Result<Vec<DevContext>> {
     // Query dev_leaving accounting if available
     let dev_leaving_map = match handle.query_accounting(disk_accounting_type::dev_leaving.bit()) {
@@ -940,6 +932,7 @@ fn build_device_usage(d: DevContext, include_data_types: bool) -> DeviceUsage {
                 };
                 DeviceDataTypeUsage {
                     data_type: data_type_name(dt_type),
+                    is_stripe: dt_type == data_type::stripe,
                     sectors,
                     buckets: dt.buckets,
                     fragmented: dt.fragmented,
@@ -1231,7 +1224,7 @@ fn dev_usage_full_to_text(out: &mut Printbuf, d: &DeviceUsage) {
 
                 if show_empty {
                     write!(sub, "\r").unwrap();
-                    if dt_type == data_type::stripe {
+                    if dt.is_stripe {
                         sub.units_sectors(d.stripe_empty);
                     }
                 }


### PR DESCRIPTION
Filesystem usage currently offers only human-readable tables. Add --json by decoding accounting and device usage once into a shared FsUsage model, then rendering both text and JSON from that model. Quantities are stored internally in sectors and serialized as byte fields; the filesystem identifier is uuid.

The model preserves offline-device degradation, spare redundancy and stripe-fragment accounting. Detailed device capacity remains total capacity; the summary subtracts hidden sectors. A regression fixture covers this distinction across JSON and both text forms.

Validation: userspace build, cargo check --workspace, the focused fs_usage regression test, and git diff --check passed. A read-only comparison on a mounted filesystem produced valid JSON, matching text structure and identical capacity rows for all 11 listed devices; active counters varied between reads. A nonexistent mountpoint returned an error. Full workspace tests are blocked by a malformed cached paste-test-suite dependency.

Addresses koverstreet/bcachefs-tools#188.
