### PR TITLE
recovery: log journal replay progress

### DIFF
--- a/fs/init/recovery.c
+++ b/fs/init/recovery.c
@@ -370,6 +370,23 @@ static int journal_sort_seq_cmp(const void *_l, const void *_r)
 		: cmp_int(l->allocated, r->allocated);
 }
 
+static void journal_replay_progress(struct bch_fs *c, const char *phase,
+				    size_t done, size_t total,
+				    unsigned long *next_print)
+{
+	if (time_before(jiffies, *next_print))
+		return;
+
+	*next_print = jiffies + HZ * 10;
+
+	unsigned percent = total
+		? div64_u64((u64) done * 100, total)
+		: 0;
+
+	bch_info(c, "journal replay: %s %u%%, done %zu/%zu keys",
+		 phase, percent, done, total);
+}
+
 DEFINE_DARRAY_NAMED(darray_journal_keys, struct journal_key *)
 
 int bch2_journal_replay(struct bch_fs *c)
@@ -380,6 +397,9 @@ int bch2_journal_replay(struct bch_fs *c)
 	u64 start_seq	= c->journal_replay_seq_start;
 	u64 end_seq	= c->journal_replay_seq_start;
 	bool immediate_flush = false;
+	unsigned long next_progress = jiffies + HZ * 10;
+	size_t accounting_total = 0, accounting_done = 0;
+	size_t sorted_done = 0, remaining_done = 0;
 	int ret = 0;
 
 	BUG_ON(!atomic_read(&keys->ref));
@@ -390,6 +410,12 @@ int bch2_journal_replay(struct bch_fs *c)
 					 keys->nr, start_seq, end_seq));
 
 	CLASS(btree_trans, trans)(c);
+
+	darray_for_each(*keys, k) {
+		struct bkey_i *bk = journal_key_k(c, k);
+
+		accounting_total += bk->k.type == KEY_TYPE_accounting && !k->allocated;
+	}
 
 	/*
 	 * Replay accounting keys first: we can't allow the write buffer to
@@ -416,6 +442,10 @@ int bch2_journal_replay(struct bch_fs *c)
 			return ret;
 
 		k->overwritten = true;
+		accounting_done++;
+		journal_replay_progress(c, "accounting",
+					accounting_done, accounting_total,
+					&next_progress);
 	}
 
 	set_bit(BCH_FS_accounting_replay_done, &c->flags);
@@ -427,6 +457,10 @@ int bch2_journal_replay(struct bch_fs *c)
 	 */
 	darray_for_each(*keys, k) {
 		cond_resched();
+		sorted_done++;
+		journal_replay_progress(c, "sorted pass",
+					sorted_done, keys->nr,
+					&next_progress);
 
 		/*
 		 * k->allocated means the key wasn't read in from the journal,
@@ -470,6 +504,9 @@ int bch2_journal_replay(struct bch_fs *c)
 
 	darray_for_each(keys_sorted, kp) {
 		cond_resched();
+		journal_replay_progress(c, "journal-order pass",
+					remaining_done, keys_sorted.nr,
+					&next_progress);
 
 		struct journal_key *k = *kp;
 
@@ -494,6 +531,7 @@ int bch2_journal_replay(struct bch_fs *c)
 		}
 
 		BUG_ON(k->btree_id != BTREE_ID_accounting && !k->overwritten);
+		remaining_done++;
 	}
 
 	bch2_trans_unlock_long(trans);


### PR DESCRIPTION
## Summary

Journal replay already logs the start and finish of replay, including the total
number of keys, but long replays can sit there without any visible indication
that work is still advancing.

This adds periodic replay progress messages, rate-limited to every 10 seconds,
for the replay phases that can take time:

- accounting key replay
- the sorted replay pass
- the fallback journal-order replay pass

The messages report phase-local percent and `done/total` key counts so mount
logs can distinguish a slow replay from one that stopped making progress.

## Validation

- `git diff --check`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 build/fs/init/recovery.o`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`

Fixes koverstreet/bcachefs-tools#593.
