### PR TITLE
docs: update Debian build dependencies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,7 +25,13 @@ the minimum supported Rust version (MSRV).
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
 ```
 
-Debian (Bullseye or later) and Ubuntu (20.04 or later): you can install these with
+Debian and Devuan releases older than Trixie do not provide a new enough
+toolchain and dependency stack for current bcachefs-tools master. In
+particular, Jessie, Bullseye, and Bookworm are no longer supported build
+environments for current master.
+
+Debian Trixie or later, or an Ubuntu release with comparable package versions:
+you can install the userspace build dependencies with
 
 ``` shell
 apt install -y pkg-config libaio-dev libblkid-dev libkeyutils-dev \
@@ -34,10 +40,16 @@ apt install -y pkg-config libaio-dev libblkid-dev libkeyutils-dev \
     python3 python3-docutils libclang-dev debhelper dh-python
 ```
 
-Starting from Debian Trixie and Ubuntu 23.10, you will additionally need:
+These releases also need systemd development headers:
 ```shell
 apt install -y systemd-dev
 ```
+
+Building the bundled kernel module or DKMS package additionally requires kernel
+headers, kernel Rust support, and userspace tools new enough for the vendored
+bcachefs kernel sources. If a distribution kernel is older than the bcachefs
+source snapshot in this repository, build against a newer kernel tree or use a
+packaged bcachefs-tools build for that distribution instead.
 
 Fedora: install build dependencies either with `dnf builddep bcachefs-tools` or with:
 ```shell

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,6 +10,7 @@ Build dependencies:
  * liblz4
  * libsodium
  * liburcu
+ * libunwind
  * libuuid
  * libzstd
  * pkg-config
@@ -35,19 +36,22 @@ cargo install bindgen-cli
 
 Set `$BINDGEN` if it lives somewhere `$PATH` will not find.
 
-Debian (Bullseye or later) and Ubuntu (20.04 or later): you can install these with
+Debian Trixie or later: install the userspace build dependencies with the
+following command. On Ubuntu and other Debian derivatives, use releases or
+backports with equivalent dependencies. Bookworm's stock liburcu 0.13.2 lacks
+the RCU polling API used by the bundled headers, so its packages alone are not
+sufficient to build current master.
 
 ``` shell
 apt install -y pkg-config libaio-dev libblkid-dev libkeyutils-dev \
-    liblz4-dev libsodium-dev liburcu-dev libzstd-dev \
+    liblz4-dev libsodium-dev libunwind-dev liburcu-dev libzstd-dev \
     uuid-dev zlib1g-dev valgrind libudev-dev udev git build-essential \
-    python3 python3-docutils libclang-dev debhelper dh-python
+    python3 python3-docutils libclang-dev debhelper dh-python systemd-dev
 ```
 
-Starting from Debian Trixie and Ubuntu 23.10, you will additionally need:
-```shell
-apt install -y systemd-dev
-```
+The kernel module and DKMS build also require headers and a Rust toolchain
+compatible with the bundled kernel sources. Installing the userspace dependencies
+does not by itself establish that the distribution kernel is supported.
 
 Fedora: install build dependencies either with `dnf builddep bcachefs-tools` or with:
 ```shell


### PR DESCRIPTION
The installation guide lists older distribution packages that cannot satisfy current master and omits libunwind, which the Makefile requires.

Document Trixie-era dependencies, allow equivalent packages/backports on other distributions, include libunwind-dev and systemd-dev in the apt command, and separate userspace prerequisites from kernel-module compatibility. Preserve the current Rust and bindgen installation guidance.

Checked the required polling API against the extracted Debian Bookworm liburcu-dev 0.13.2-1 headers: urcu_gp_poll_state and start_poll_synchronize_rcu are absent. Verified libunwind against Makefile's pkg-config list and ran git diff --check. This documentation-only change was not tested with a full distribution build.

References koverstreet/bcachefs-tools#371.
