### PR TITLE
docs: explain data_allowed device option

### DIFF
--- a/doc/bcachefs.5.rst.tmpl
+++ b/doc/bcachefs.5.rst.tmpl
@@ -50,6 +50,18 @@ We generally avoid per-device options, preferring instead options that can be
 overridden on files or directories, but there are some:
 
  *durability*
+ *data_allowed*
+
+The ``data_allowed`` per-device option restricts which data types may be placed
+on a device. The accepted values are ``journal``, ``btree``, and ``user``; pass
+one or more of them as a comma-separated list. For example, a metadata device
+may use ``data_allowed=journal,btree``, while a bulk data device may use
+``data_allowed=user``.
+
+``show-super`` and usage reports may display additional data types under
+``Has data``, such as ``parity``. Those are internal allocation/accounting data
+types that describe what is currently present on the device. They are not extra
+values accepted by ``data_allowed``.
 
 Multipath devices
 -----------------


### PR DESCRIPTION
Document the `data_allowed` per-device option in the user manual template:

* accepted values are `journal`, `btree`, and `user`
* values are comma-separated when more than one is allowed
* `Has data` values such as `parity` are reporting/internal allocation state, not extra `data_allowed` inputs

Validation:
* `git diff --check`
* `rst2html5 --strict doc/bcachefs.5.rst.tmpl /tmp/bcachefs-data-allowed.html`

References koverstreet/bcachefs#632.
