### PR TITLE
doc: clarify durable target capacity

### DIFF
--- a/doc/bcachefs.5.rst.tmpl
+++ b/doc/bcachefs.5.rst.tmpl
@@ -123,7 +123,9 @@ be used to pin a specific file or directory to a specific device or target:
   promote_target=
 
 Note that if the target specified is full, the write will spill over to the rest
-of the filesystem.
+of the filesystem. Replication and device durability requirements still limit
+usable space: a device or target may have free buckets that cannot satisfy a
+write if the filesystem cannot place enough durable copies elsewhere.
 
 Data protection
 ---------------


### PR DESCRIPTION
## Summary

Clarify the target-placement docs so the existing spillover note also says that replicas and device durability still bound usable space.

## Context

This is the documentation side of koverstreet/bcachefs#653: in asymmetric target setups, a device may still show free buckets even though a write cannot place enough durable copies to satisfy the filesystem's replication policy.

This does not claim to fix the kernel ENOSPC/hung-task behavior reported there; it just makes the configuration caveat visible in the user manual.

## Validation

- `git diff --check`
- `rst2html5 --strict doc/bcachefs.5.rst.tmpl /tmp/bcachefs-target-capacity.html`
