### PR TITLE
doc: add superblock recovery notes

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -17,6 +17,15 @@ Development notes specific to bcachefs. These are intended to supplement
    CodingStyle
    SubmittingPatches
 
+Operations
+----------
+
+.. toctree::
+   :maxdepth: 1
+   :numbered:
+
+   recovery
+
 Filesystem implementation
 -------------------------
 

--- a/Documentation/recovery.rst
+++ b/Documentation/recovery.rst
@@ -1,0 +1,51 @@
+.. SPDX-License-Identifier: GPL-2.0
+
+Recovery notes
+==============
+
+Damaged superblocks
+-------------------
+
+If one member reports a default superblock checksum error after an unclean
+shutdown, stop and preserve evidence before attempting repair. Do not run
+multiple mounts or fsck processes against the same filesystem at the same time:
+superblock sequence numbers are used to detect concurrent modification, and a
+repair attempt can be aborted if another process writes a newer superblock.
+
+Useful first checks are:
+
+.. code-block:: bash
+
+  bcachefs show-super /dev/bcachefs-member
+  bcachefs show-super -l /dev/bcachefs-member
+
+Run those checks on every available member. If the primary superblock on one
+device is unreadable but another copy or member still validates and shows the
+same filesystem UUID and member list, ``bcachefs recover-super`` can rewrite the
+damaged member's superblock from a backup copy or from another member:
+
+.. code-block:: bash
+
+  bcachefs recover-super /dev/damaged-member
+  bcachefs recover-super --src_device /dev/good-member --dev_idx N /dev/damaged-member
+
+Use the second form when the damaged member's own backup copies are not usable.
+``N`` is the damaged member's device index from the filesystem member list. The
+command prints the superblock it found and asks for confirmation unless
+``--yes`` is supplied.
+
+After recovering a member superblock, run offline fsck before mounting
+read-write:
+
+.. code-block:: bash
+
+  bcachefs fsck /dev/member0:/dev/member1:...
+
+If the filesystem cannot start because a member is missing or unreadable, use
+the normal degraded recovery options only after verifying which member copies
+are present. Prefer a read-only/nochanges attempt while collecting evidence; use
+more aggressive degraded modes only when the missing-data risk is understood.
+
+Whenever possible, make block-device images or hardware snapshots first. A
+superblock repair changes on-disk metadata, and a failed recovery attempt is
+much easier to debug when the original bytes are still available.


### PR DESCRIPTION
## Summary

Add a short recovery note for damaged member superblocks:

- inspect every available member with `show-super`
- avoid concurrent mount/fsck attempts while recovering
- describe when `recover-super` can use backup copies or another member
- remind operators to run offline fsck before rw mount and preserve device images when possible

## Context

Related to koverstreet/bcachefs#978, where one member's default superblock had a checksum error after an unclean shutdown and a later recovery attempt saw a superblock sequence mismatch.

This is documentation only; it does not change recovery behavior.

## Validation

- `git diff --check`
- `rst2html5 --strict Documentation/recovery.rst /tmp/bcachefs-recovery.html`
