### PR TITLE
subvolume: avoid blocking subvolume delete on held inodes

### DIFF
--- a/fs/debug/debug.c
+++ b/fs/debug/debug.c
@@ -837,9 +837,8 @@ static ssize_t bch2_fsck_damaged_paths_read(struct file *file, char __user *buf,
 	while (1) {
 		/*
 		 * copy_to_user() faults, and the fault path takes mmap_lock ->
-		 * snapshots.create_lock (page_mkwrite), while the buffered
-		 * write path takes create_lock -> btree. Holding btree locks
-		 * here closes that cycle.
+		 * snapshots.pagefault_lock -> btree (page_mkwrite dirtying).
+		 * Holding btree locks here closes that cycle.
 		 *
 		 * bch2_fsck_damaged_path_to_text() relocks via lockrestart_do().
 		 */

--- a/fs/snapshots/snapshot.c
+++ b/fs/snapshots/snapshot.c
@@ -282,6 +282,8 @@
 
 #include "snapshots/snapshot.h"
 
+#include "util/enumerated_ref.h"
+
 /*
  * Snapshot trees:
  *
@@ -1149,6 +1151,9 @@ int bch2_snapshots_read(struct bch_fs *c)
 
 void bch2_fs_snapshots_exit(struct bch_fs *c)
 {
+	if (cancel_delayed_work_sync(&c->snapshots.wait_for_pagecache_and_delete_work))
+		enumerated_ref_put(&c->writes, BCH_WRITE_REF_snapshot_delete_pagecache);
+
 	percpu_free_rwsem(&c->snapshots.create_lock);
 	kvfree(rcu_dereference_protected(c->snapshots.table, true));
 }
@@ -1275,4 +1280,3 @@ __cold void bch2_snapshot_id_list_to_text(struct printbuf *out, snapshot_id_list
 		prt_printf(out, "%u", *i);
 	}
 }
-

--- a/fs/snapshots/snapshot.c
+++ b/fs/snapshots/snapshot.c
@@ -1154,6 +1154,7 @@ void bch2_fs_snapshots_exit(struct bch_fs *c)
 	if (cancel_delayed_work_sync(&c->snapshots.wait_for_pagecache_and_delete_work))
 		enumerated_ref_put(&c->writes, BCH_WRITE_REF_snapshot_delete_pagecache);
 
+	percpu_free_rwsem(&c->snapshots.pagefault_lock);
 	percpu_free_rwsem(&c->snapshots.create_lock);
 	kvfree(rcu_dereference_protected(c->snapshots.table, true));
 }
@@ -1169,7 +1170,8 @@ void bch2_fs_snapshots_init_early(struct bch_fs *c)
 
 int bch2_fs_snapshots_init(struct bch_fs *c)
 {
-	return percpu_init_rwsem(&c->snapshots.create_lock);
+	return percpu_init_rwsem(&c->snapshots.create_lock) ?:
+	       percpu_init_rwsem(&c->snapshots.pagefault_lock);
 }
 
 /* to_text() methods: */

--- a/fs/snapshots/snapshot.c
+++ b/fs/snapshots/snapshot.c
@@ -282,6 +282,8 @@
 
 #include "snapshots/snapshot.h"
 
+#include "util/enumerated_ref.h"
+
 /*
  * Snapshot trees:
  *
@@ -1149,6 +1151,9 @@ int bch2_snapshots_read(struct bch_fs *c)
 
 void bch2_fs_snapshots_exit(struct bch_fs *c)
 {
+	if (cancel_delayed_work_sync(&c->snapshots.wait_for_pagecache_and_delete_work))
+		enumerated_ref_put(&c->writes, BCH_WRITE_REF_snapshot_delete_pagecache);
+
 	percpu_free_rwsem(&c->snapshots.create_lock);
 	kvfree(rcu_dereference_protected(c->snapshots.table, true));
 }
@@ -1276,4 +1281,3 @@ __cold void bch2_snapshot_id_list_to_text(struct printbuf *out, snapshot_id_list
 		prt_printf(out, "%u", *i);
 	}
 }
-

--- a/fs/snapshots/subvolume.c
+++ b/fs/snapshots/subvolume.c
@@ -804,12 +804,14 @@ static int bch2_subvolume_set_deleted(struct btree_trans *trans, u32 subvolid)
 
 static void bch2_subvolume_wait_for_pagecache_and_delete(struct work_struct *work)
 {
-	struct bch_fs *c = container_of(work, struct bch_fs,
+	struct bch_fs *c = container_of(to_delayed_work(work), struct bch_fs,
 				snapshots.wait_for_pagecache_and_delete_work);
 	int ret = 0;
+	bool requeue = false;
 
 	while (!ret) {
 		snapshot_id_list s;
+		snapshot_id_list busy = {};
 
 		scoped_guard(mutex, &c->snapshots.unlinked_lock) {
 			s = c->snapshots.unlinked;
@@ -819,19 +821,54 @@ static void bch2_subvolume_wait_for_pagecache_and_delete(struct work_struct *wor
 		if (!s.nr)
 			break;
 
-		bch2_evict_subvolume_inodes(c, &s);
+		ret = bch2_evict_subvolume_inodes(c, &s, &busy);
+		if (ret)
+			goto requeue_all;
 
 		CLASS(btree_trans, trans)(c);
 
-		darray_for_each(s, id) {
-			ret = bch2_subvolume_set_deleted(trans, *id);
-			bch_err_msg(c, ret, "deleting subvolume %u", *id);
-			if (ret)
-				break;
+		for (unsigned i = 0; i < s.nr; i++) {
+			u32 id = s.data[i];
+
+			if (snapshot_list_has_id(&busy, id)) {
+				requeue = true;
+				continue;
+			}
+
+			ret = bch2_subvolume_set_deleted(trans, id);
+			bch_err_msg(c, ret, "deleting subvolume %u", id);
+			if (ret) {
+				for (unsigned j = i; j < s.nr; j++)
+					snapshot_list_add_nodup(c, &busy, s.data[j]);
+				goto requeue_all;
+			}
 		}
 
+requeue_all:
+		if (busy.nr) {
+			scoped_guard(mutex, &c->snapshots.unlinked_lock) {
+				snapshot_id_list new = c->snapshots.unlinked;
+
+				c->snapshots.unlinked = busy;
+				darray_init(&busy);
+
+				darray_for_each(new, id)
+					if (!snapshot_list_has_id(&c->snapshots.unlinked, *id))
+						ret = ret ?: snapshot_list_add(c, &c->snapshots.unlinked, *id);
+				darray_exit(&new);
+			}
+			requeue = true;
+		}
+
+		darray_exit(&busy);
 		darray_exit(&s);
 	}
+
+	if (requeue &&
+	    queue_delayed_work(c->write_ref_wq,
+			       &c->snapshots.wait_for_pagecache_and_delete_work,
+			       HZ))
+		return;
 
 	enumerated_ref_put(&c->writes, BCH_WRITE_REF_snapshot_delete_pagecache);
 }
@@ -854,7 +891,7 @@ static int bch2_subvolume_wait_for_pagecache_and_delete_hook(struct btree_trans 
 	if (!enumerated_ref_tryget(&c->writes, BCH_WRITE_REF_snapshot_delete_pagecache))
 		return -EROFS;
 
-	if (!queue_work(c->write_ref_wq, &c->snapshots.wait_for_pagecache_and_delete_work))
+	if (!queue_delayed_work(c->write_ref_wq, &c->snapshots.wait_for_pagecache_and_delete_work, 0))
 		enumerated_ref_put(&c->writes, BCH_WRITE_REF_snapshot_delete_pagecache);
 	return 0;
 }
@@ -1007,7 +1044,6 @@ int bch2_fs_upgrade_for_subvolumes(struct bch_fs *c)
 
 void bch2_fs_subvolumes_init_early(struct bch_fs *c)
 {
-	INIT_WORK(&c->snapshots.wait_for_pagecache_and_delete_work,
-		  bch2_subvolume_wait_for_pagecache_and_delete);
+	INIT_DELAYED_WORK(&c->snapshots.wait_for_pagecache_and_delete_work,
+			  bch2_subvolume_wait_for_pagecache_and_delete);
 }
-

--- a/fs/snapshots/subvolume.c
+++ b/fs/snapshots/subvolume.c
@@ -804,12 +804,14 @@ static int bch2_subvolume_set_deleted(struct btree_trans *trans, u32 subvolid)
 
 static void bch2_subvolume_wait_for_pagecache_and_delete(struct work_struct *work)
 {
-	struct bch_fs *c = container_of(work, struct bch_fs,
+	struct bch_fs *c = container_of(to_delayed_work(work), struct bch_fs,
 				snapshots.wait_for_pagecache_and_delete_work);
 	int ret = 0;
+	bool requeue = false;
 
 	while (!ret) {
 		snapshot_id_list s;
+		snapshot_id_list busy = {};
 
 		scoped_guard(mutex, &c->snapshots.unlinked_lock) {
 			s = c->snapshots.unlinked;
@@ -819,19 +821,62 @@ static void bch2_subvolume_wait_for_pagecache_and_delete(struct work_struct *wor
 		if (!s.nr)
 			break;
 
-		bch2_evict_subvolume_inodes(c, &s);
+		ret = bch2_evict_subvolume_inodes(c, &s, &busy);
+		if (ret)
+			goto requeue_all;
 
 		CLASS(btree_trans, trans)(c);
 
-		darray_for_each(s, id) {
-			ret = bch2_subvolume_set_deleted(trans, *id);
-			bch_err_msg(c, ret, "deleting subvolume %u", *id);
-			if (ret)
-				break;
+		for (unsigned i = 0; i < s.nr; i++) {
+			u32 id = s.data[i];
+
+			if (snapshot_list_has_id(&busy, id)) {
+				requeue = true;
+				continue;
+			}
+
+			ret = bch2_subvolume_set_deleted(trans, id);
+			bch_err_msg(c, ret, "deleting subvolume %u", id);
+			if (ret) {
+				for (unsigned j = i; j < s.nr; j++)
+					snapshot_list_add_nodup(c, &busy, s.data[j]);
+				goto requeue_all;
+			}
 		}
 
+requeue_all:
+		if (busy.nr) {
+			/*
+			 * busy holds this batch's still-held subvolume ids (evicted
+			 * from s above); c->snapshots.unlinked may have gained fresh
+			 * entries from concurrent unlinks while we ran unlocked. Make
+			 * busy the new unlinked list and fold those fresh entries in,
+			 * skipping any id busy already carries, so a subvolume that's
+			 * both still-busy and newly-unlinked isn't queued twice.
+			 */
+			scoped_guard(mutex, &c->snapshots.unlinked_lock) {
+				snapshot_id_list new = c->snapshots.unlinked;
+
+				c->snapshots.unlinked = busy;
+				darray_init(&busy);
+
+				darray_for_each(new, id)
+					if (!snapshot_list_has_id(&c->snapshots.unlinked, *id))
+						ret = ret ?: snapshot_list_add(c, &c->snapshots.unlinked, *id);
+				darray_exit(&new);
+			}
+			requeue = true;
+		}
+
+		darray_exit(&busy);
 		darray_exit(&s);
 	}
+
+	if (requeue &&
+	    queue_delayed_work(c->write_ref_wq,
+			       &c->snapshots.wait_for_pagecache_and_delete_work,
+			       HZ))
+		return;
 
 	enumerated_ref_put(&c->writes, BCH_WRITE_REF_snapshot_delete_pagecache);
 }
@@ -854,7 +899,7 @@ static int bch2_subvolume_wait_for_pagecache_and_delete_hook(struct btree_trans 
 	if (!enumerated_ref_tryget(&c->writes, BCH_WRITE_REF_snapshot_delete_pagecache))
 		return -EROFS;
 
-	if (!queue_work(c->write_ref_wq, &c->snapshots.wait_for_pagecache_and_delete_work))
+	if (!queue_delayed_work(c->write_ref_wq, &c->snapshots.wait_for_pagecache_and_delete_work, 0))
 		enumerated_ref_put(&c->writes, BCH_WRITE_REF_snapshot_delete_pagecache);
 	return 0;
 }
@@ -1007,7 +1052,6 @@ int bch2_fs_upgrade_for_subvolumes(struct bch_fs *c)
 
 void bch2_fs_subvolumes_init_early(struct bch_fs *c)
 {
-	INIT_WORK(&c->snapshots.wait_for_pagecache_and_delete_work,
-		  bch2_subvolume_wait_for_pagecache_and_delete);
+	INIT_DELAYED_WORK(&c->snapshots.wait_for_pagecache_and_delete_work,
+			  bch2_subvolume_wait_for_pagecache_and_delete);
 }
-

--- a/fs/snapshots/types.h
+++ b/fs/snapshots/types.h
@@ -95,7 +95,7 @@ struct bch_fs_snapshots {
 	bool					need_table_rebuild;
 	struct percpu_rw_semaphore		create_lock;
 	struct snapshot_delete			delete;
-	struct work_struct			wait_for_pagecache_and_delete_work;
+	struct delayed_work			wait_for_pagecache_and_delete_work;
 	snapshot_id_list			unlinked;
 	struct mutex				unlinked_lock;
 };

--- a/fs/snapshots/types.h
+++ b/fs/snapshots/types.h
@@ -82,11 +82,24 @@ struct snapshot_delete {
  * page not yet) such that the snapshot captures an inconsistent state — the
  * shape that bit MySQL/InnoDB.
  *
- * Page-cache dirtying paths (buffered write_iter and mmap mkdirty) take this
- * lock as readers; snapshot creation takes it as a writer. O_DIRECT doesn't
- * need it — direct writes commit as atomic btree transactions, no page cache
- * staleness window. Buffered writeback is fine too — each writeback insert
- * is atomic w.r.t. the snapshot transaction.
+ * Page-cache dirtying paths take these locks as readers; snapshot creation
+ * takes them as writers. O_DIRECT doesn't need them — direct writes commit as
+ * atomic btree transactions, no page cache staleness window. Buffered
+ * writeback is fine too — each writeback insert is atomic w.r.t. the
+ * snapshot transaction.
+ *
+ * There are two locks because the two dirtying paths sit on opposite sides
+ * of mmap_lock, mirroring the sb_writers freeze levels (SB_FREEZE_WRITE vs
+ * SB_FREEZE_PAGEFAULT):
+ *
+ *   write_iter:   create_lock -> mmap_lock (faulting in user pages)
+ *   page_mkwrite: mmap_lock (held by caller) -> pagefault_lock
+ *
+ * One lock can't sit both above and below mmap_lock — that's an ABBA
+ * inversion. Snapshot creation write-locks create_lock first (draining
+ * syscall-level dirtiers, whose user-page faults may still take
+ * pagefault_lock as readers), then pagefault_lock (draining mmap dirtiers).
+ * Lock order: create_lock -> mmap_lock -> pagefault_lock.
  */
 struct bch_fs_snapshots {
 	struct snapshot_table __rcu		*table;
@@ -94,6 +107,7 @@ struct bch_fs_snapshots {
 	/* a topology repair invalidated descendants' is_ancestor bitmaps: */
 	bool					need_table_rebuild;
 	struct percpu_rw_semaphore		create_lock;
+	struct percpu_rw_semaphore		pagefault_lock;
 	struct snapshot_delete			delete;
 	struct delayed_work			wait_for_pagecache_and_delete_work;
 	snapshot_id_list			unlinked;

--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -2347,25 +2347,23 @@ static void bch2_evict_inode(struct inode *vinode)
 	inode->ei_inodes_idx = 0;
 }
 
-void bch2_evict_subvolume_inodes(struct bch_fs *c, snapshot_id_list *s)
+int bch2_evict_subvolume_inodes(struct bch_fs *c,
+				snapshot_id_list *pending,
+				snapshot_id_list *busy)
 {
 	/*
-	 * Initially, we scan for inodes without I_DONTCACHE, then mark them to
-	 * be pruned with d_mark_dontcache().
-	 *
-	 * Once we've had a clean pass where we didn't find any inodes without
-	 * I_DONTCACHE, we wait for them to be freed.
-	 *
-	 * fast_list_iter tracks position by integer index, so we can drop rcu
-	 * around the dcache work (held safe by our igrab ref) and resume from
-	 * the same slot on the next iteration.
+	 * Mark matching inodes so VFS drops them when their external holders
+	 * release references, but do not wait here: subvolume deletion must not
+	 * park a worker in TASK_UNINTERRUPTIBLE behind loop/NFS/export holders.
 	 */
+	int ret = 0;
+
 	rcu_read_lock();
 	struct genradix_iter iter;
 	struct bch_inode_info *inode;
 
 	fast_list_for_each(&c->vfs.inodes, iter, inode) {
-		if (!snapshot_list_has_id(s, inode->ei_inum.subvol))
+		if (!snapshot_list_has_id(pending, inode->ei_inum.subvol))
 			continue;
 
 		if (!(inode_state_read_once(&inode->v) & I_DONTCACHE) &&
@@ -2378,30 +2376,14 @@ void bch2_evict_subvolume_inodes(struct bch_fs *c, snapshot_id_list *s)
 
 			rcu_read_lock();
 		}
+
+		ret = snapshot_list_add_nodup(c, busy, inode->ei_inum.subvol);
+		if (ret)
+			break;
 	}
-
-	bool found = false;
-	do {
-		found = false;
-
-		fast_list_for_each(&c->vfs.inodes, iter, inode) {
-			if (!snapshot_list_has_id(s, inode->ei_inum.subvol))
-				continue;
-
-			found = true;
-
-			struct wait_bit_queue_entry wqe;
-			struct wait_queue_head *wq_head = inode_bit_waitqueue(&wqe, &inode->v, __I_NEW);
-			prepare_to_wait_event(wq_head, &wqe.wq_entry,
-					      TASK_UNINTERRUPTIBLE);
-			rcu_read_unlock();
-
-			schedule();
-			finish_wait(wq_head, &wqe.wq_entry);
-			rcu_read_lock();
-		}
-	} while (found);
 	rcu_read_unlock();
+
+	return ret;
 }
 
 static int bch2_statfs(struct dentry *dentry, struct kstatfs *buf)

--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -2450,25 +2450,31 @@ static void bch2_evict_inode(struct inode *vinode)
 	inode->ei_inodes_idx = 0;
 }
 
-void bch2_evict_subvolume_inodes(struct bch_fs *c, snapshot_id_list *s)
+int bch2_evict_subvolume_inodes(struct bch_fs *c,
+				snapshot_id_list *pending,
+				snapshot_id_list *busy)
 {
 	/*
-	 * Initially, we scan for inodes without I_DONTCACHE, then mark them to
-	 * be pruned with d_mark_dontcache().
+	 * Mark matching inodes so VFS drops them when their external holders
+	 * release references, but do not wait here: subvolume deletion must not
+	 * park a worker in TASK_UNINTERRUPTIBLE behind loop/NFS/export holders.
 	 *
-	 * Once we've had a clean pass where we didn't find any inodes without
-	 * I_DONTCACHE, we wait for them to be freed.
-	 *
-	 * fast_list_iter tracks position by integer index, so we can drop rcu
-	 * around the dcache work (held safe by our igrab ref) and resume from
-	 * the same slot on the next iteration.
+	 * snapshot_list_add_nodup() only ever adds ids that are already present
+	 * in @pending, so @busy can never grow past @pending->nr entries -
+	 * reserve that much room up front so the loop below can't hit
+	 * __bch2_darray_resize_noprof()'s GFP_KERNEL allocation (which may
+	 * sleep) while rcu_read_lock() is held.
 	 */
+	int ret = darray_make_room(busy, pending->nr);
+	if (ret)
+		return ret;
+
 	rcu_read_lock();
 	struct genradix_iter iter;
 	struct bch_inode_info *inode;
 
 	fast_list_for_each(&c->vfs.inodes, iter, inode) {
-		if (!snapshot_list_has_id(s, inode_inum(inode).subvol))
+		if (!snapshot_list_has_id(pending, inode_inum(inode).subvol))
 			continue;
 
 		if (!(inode_state_read_once(&inode->v) & I_DONTCACHE) &&
@@ -2481,30 +2487,14 @@ void bch2_evict_subvolume_inodes(struct bch_fs *c, snapshot_id_list *s)
 
 			rcu_read_lock();
 		}
+
+		ret = snapshot_list_add_nodup(c, busy, inode_inum(inode).subvol);
+		if (ret)
+			break;
 	}
-
-	bool found = false;
-	do {
-		found = false;
-
-		fast_list_for_each(&c->vfs.inodes, iter, inode) {
-			if (!snapshot_list_has_id(s, inode_inum(inode).subvol))
-				continue;
-
-			found = true;
-
-			struct wait_bit_queue_entry wqe;
-			struct wait_queue_head *wq_head = inode_bit_waitqueue(&wqe, &inode->v, __I_NEW);
-			prepare_to_wait_event(wq_head, &wqe.wq_entry,
-					      TASK_UNINTERRUPTIBLE);
-			rcu_read_unlock();
-
-			schedule();
-			finish_wait(wq_head, &wqe.wq_entry);
-			rcu_read_lock();
-		}
-	} while (found);
 	rcu_read_unlock();
+
+	return ret;
 }
 
 static int bch2_statfs(struct dentry *dentry, struct kstatfs *buf)

--- a/fs/vfs/fs.h
+++ b/fs/vfs/fs.h
@@ -3,6 +3,7 @@
 #define _BCACHEFS_FS_H
 
 #include "fs/inode.h"
+#include "snapshots/types.h"
 #include "fs/str_hash.h"
 #include "fs/quota_types.h"
 
@@ -244,7 +245,7 @@ int bch2_setattr_nonsize(struct mnt_idmap *,
 			 struct iattr *);
 int __bch2_unlink(struct inode *, struct dentry *, bool);
 
-void bch2_evict_subvolume_inodes(struct bch_fs *, snapshot_id_list *);
+int bch2_evict_subvolume_inodes(struct bch_fs *, snapshot_id_list *, snapshot_id_list *);
 
 int bch2_fiemap(struct inode *, struct fiemap_extent_info *, u64, u64);
 
@@ -268,8 +269,12 @@ static inline void bch2_dirty_inode(struct bch_fs *c, struct bch_inode_info *ino
 
 static inline int bch2_inode_or_descendents_is_open(struct btree_trans *trans, struct bpos p) { return 0; }
 
-static inline void bch2_evict_subvolume_inodes(struct bch_fs *c,
-					       snapshot_id_list *s) {}
+static inline int bch2_evict_subvolume_inodes(struct bch_fs *c,
+					      snapshot_id_list *pending,
+					      snapshot_id_list *busy)
+{
+	return 0;
+}
 
 static inline void bch2_fs_vfs_exit(struct bch_fs *c) {}
 static inline int bch2_fs_vfs_init(struct bch_fs *c) { return 0; }

--- a/fs/vfs/fs.h
+++ b/fs/vfs/fs.h
@@ -3,6 +3,7 @@
 #define _BCACHEFS_FS_H
 
 #include "fs/inode.h"
+#include "snapshots/types.h"
 #include "fs/str_hash.h"
 #include "fs/quota_types.h"
 
@@ -249,7 +250,7 @@ int bch2_setattr_nonsize(struct mnt_idmap *,
 			 struct iattr *);
 int __bch2_unlink(struct inode *, struct dentry *, bool);
 
-void bch2_evict_subvolume_inodes(struct bch_fs *, snapshot_id_list *);
+int bch2_evict_subvolume_inodes(struct bch_fs *, snapshot_id_list *, snapshot_id_list *);
 
 int bch2_fiemap(struct inode *, struct fiemap_extent_info *, u64, u64);
 
@@ -273,8 +274,12 @@ static inline void bch2_dirty_inode(struct bch_fs *c, struct bch_inode_info *ino
 
 static inline int bch2_inode_or_descendents_is_open(struct btree_trans *trans, struct bpos p) { return 0; }
 
-static inline void bch2_evict_subvolume_inodes(struct bch_fs *c,
-					       snapshot_id_list *s) {}
+static inline int bch2_evict_subvolume_inodes(struct bch_fs *c,
+					      snapshot_id_list *pending,
+					      snapshot_id_list *busy)
+{
+	return 0;
+}
 
 static inline void bch2_fs_vfs_exit(struct bch_fs *c) {}
 static inline int bch2_fs_vfs_init(struct bch_fs *c) { return 0; }

--- a/fs/vfs/ioctl.c
+++ b/fs/vfs/ioctl.c
@@ -399,14 +399,18 @@ static long __bch2_ioctl_subvolume_create(struct bch_fs *c, struct file *filp,
 		snapshot_src.subvol = inode_inum(to_bch_ei(dir)).subvol;
 
 	/*
-	 * Atomicity: take create_lock as a writer to block new page-cache
-	 * dirtiers (write_iter, page_mkwrite), then flush existing dirty
-	 * pages. Writeback's folio_clear_dirty_for_io path WPs every PTE
-	 * pointing at a dirty folio (via folio_mkclean), so when sync
-	 * returns no writable PTE remains — any subsequent mmap store
-	 * traps to page_mkwrite, which then blocks on the writer.
+	 * Atomicity: write-lock create_lock to block new syscall-level
+	 * dirtiers (write_iter), then pagefault_lock to block mmap dirtiers
+	 * (page_mkwrite), then flush existing dirty pages. Two locks because
+	 * the two dirtier classes sit on opposite sides of mmap_lock — see
+	 * the comment above bch_fs_snapshots. Writeback's
+	 * folio_clear_dirty_for_io path WPs every PTE pointing at a dirty
+	 * folio (via folio_mkclean), so when sync returns no writable PTE
+	 * remains — any subsequent mmap store traps to page_mkwrite, which
+	 * then blocks on pagefault_lock.
 	 */
 	percpu_down_write(&c->snapshots.create_lock);
+	percpu_down_write(&c->snapshots.pagefault_lock);
 	if (arg.flags & BCH_SUBVOL_SNAPSHOT_CREATE) {
 		scoped_guard(rwsem_read, &c->vfs_sb->s_umount)
 			sync_inodes_sb(c->vfs_sb);
@@ -414,6 +418,7 @@ static long __bch2_ioctl_subvolume_create(struct bch_fs *c, struct file *filp,
 	inode = __bch2_create(file_mnt_idmap(filp), to_bch_ei(dir),
 			      dst_dentry, arg.mode|S_IFDIR,
 			      0, snapshot_src, create_flags);
+	percpu_up_write(&c->snapshots.pagefault_lock);
 	percpu_up_write(&c->snapshots.create_lock);
 	error = PTR_ERR_OR_ZERO(inode);
 	if (error)

--- a/fs/vfs/pagecache.c
+++ b/fs/vfs/pagecache.c
@@ -733,7 +733,7 @@ vm_fault_t bch2_page_mkwrite(struct vm_fault *vmf)
 
 	bch2_folio_reservation_init(c, inode, &res);
 
-	percpu_down_read(&c->snapshots.create_lock);
+	percpu_down_read(&c->snapshots.pagefault_lock);
 	sb_start_pagefault(inode->v.i_sb);
 	file_update_time(file);
 
@@ -775,7 +775,7 @@ vm_fault_t bch2_page_mkwrite(struct vm_fault *vmf)
 	ret = VM_FAULT_LOCKED;
 out:
 	sb_end_pagefault(inode->v.i_sb);
-	percpu_up_read(&c->snapshots.create_lock);
+	percpu_up_read(&c->snapshots.pagefault_lock);
 
 	return ret;
 }


### PR DESCRIPTION
`umount` of a subvolume with inodes still held (a loop device backing file inside it, in the report) made subvolume deletion block forever waiting for pagecache eviction that could not proceed. This drops the blocking wait: eviction now collects candidate inodes and lets the holders drain, so subvolume delete no longer hangs behind a held inode. While testing, the eviction path itself turned out to sleep (`kvmalloc` `GFP_KERNEL`) inside `rcu_read_lock()`; the first commit restructures that scan so allocation happens outside the RCU section.

The second commit fixes a related deadlock in the same snapshot lifecycle: `snapshots.create_lock` was asked to live at two ranks against `mmap_lock` — `bch2_write_iter()` takes it and then faults in user pages, while `bch2_page_mkwrite()` takes it under `mmap_lock`. With a pending `percpu_down_write()` from snapshot creation the ABBA closes into a real deadlock. Pagefault paths get their own `pagefault_lock` so the ranks no longer cross.

Tested in a VM on this exact two-commit branch: koverstreet/ktest#77's subvol_delete_loop_holder passes in 5s with no sleeping-in-atomic or RCU splats in dmesg. Fixes koverstreet/bcachefs#1091.
