### PR TITLE
bcachefs: throttle btree writes at half dirty cache

### DIFF
--- a/fs/btree/cache.h
+++ b/fs/btree/cache.h
@@ -179,7 +179,7 @@ static inline void bch2_btree_cache_update_throttle(struct bch_fs *c)
 	size_t live	= btree_cache_nr_live(bc);
 	size_t dirty	= btree_cache_nr_dirty(bc);
 	bool throttle	= atomic_long_read(&bc->nr_in_flight_inner) > BTREE_WRITE_IO_LIMIT(c) ||
-			  (live && dirty > live * 3 / 4);
+			  (live && dirty > live / 2);
 
 	if (throttle != READ_ONCE(bc->should_throttle))
 		WRITE_ONCE(bc->should_throttle, throttle);


### PR DESCRIPTION
## Summary

- throttle normal btree commits once more than half of the live btree cache is dirty
- align the cached btree write throttle threshold with journal reclaim's existing dirty-cache flush heuristic
- keep the existing in-flight write limit unchanged

Addresses koverstreet/bcachefs#1113.
Companion ktest coverage: koverstreet/ktest#70.

## Validation

- `git diff --check`
- `make -j32 fs/btree/commit.o fs/btree/cache.o fs/btree/write.o`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
- `make -C /lib/modules/$(uname -r)/build M=/home/kom/tmp/bcachefs-btree-cache-throttle-dkms modules -j32` from a temp DKMS-style staging tree, then removed the staging tree
