### PR TITLE
list: add replica-count extent filter

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -798,6 +798,8 @@ Btree depth to descend to. (
 Start position to list from
 .It Fl e Ar inode Ns Cm \&: Ns Ar offset
 End position
+.It Fl -replicas-min Ar number
+Only list extents with at least this many fully allocated replicas.
 .It Fl m , Fl -mode ( Cm keys | formats | nodes | nodes-ondisk )
 (default:
 .Cm keys)

--- a/bcachefs.8
+++ b/bcachefs.8
@@ -790,6 +790,8 @@ Btree depth to descend to. (
 Start position to list from
 .It Fl e Ar inode Ns Cm \&: Ns Ar offset
 End position
+.It Fl -replicas-min Ar number
+Only list extents with at least this many fully allocated replicas.
 .It Fl m , Fl -mode ( Cm keys | formats | nodes | nodes-ondisk )
 (default:
 .Cm keys)

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,7 +1,6 @@
 use std::ops::ControlFlow;
 
 use anyhow::{bail, Result};
-use bcachefs_kernel::{btree_id, c};
 use bcachefs_kernel::btree::bkey::BkeySC;
 use bcachefs_kernel::btree::iter::BtreeIter;
 use bcachefs_kernel::btree::iter::BtreeIterFlags;
@@ -9,6 +8,7 @@ use bcachefs_kernel::btree::iter::BtreeNodeIter;
 use bcachefs_kernel::btree::iter::BtreeTrans;
 use bcachefs_kernel::fs::Fs;
 use bcachefs_kernel::opt_set;
+use bcachefs_kernel::{btree_id, c};
 use bch_bindgen::c::bch_degraded_actions;
 use clap::Parser;
 use std::io::{stdout, IsTerminal};
@@ -27,13 +27,7 @@ fn list_keys(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
         flags |= BtreeIterFlags::ALL_SNAPSHOTS;
     }
 
-    let mut iter = BtreeIter::new_level(
-        &trans,
-        opt.btree,
-        opt.start,
-        opt.level,
-        flags,
-    );
+    let mut iter = BtreeIter::new_level(&trans, opt.btree, opt.start, opt.level, flags);
 
     iter.for_each(&trans, |k| {
         if k.k.p > opt.end {
@@ -42,6 +36,15 @@ fn list_keys(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
 
         if let Some(ty) = opt.bkey_type {
             if k.k.type_ != ty.0 as u8 {
+                return ControlFlow::Continue(());
+            }
+        }
+
+        if let Some(min_replicas) = opt.replicas_min {
+            let replicas = unsafe {
+                c::bch2_bkey_nr_ptrs_fully_allocated(fs.raw, c::bkey_s_c { k: k.k, v: k.v })
+            };
+            if replicas < min_replicas {
                 return ControlFlow::Continue(());
             }
         }
@@ -154,6 +157,15 @@ fn list_keys_online(handle: &BcachefsHandle, fs: &Fs, opt: &Cli) -> anyhow::Resu
             }
         }
 
+        if let Some(min_replicas) = opt.replicas_min {
+            let replicas = unsafe {
+                c::bch2_bkey_nr_ptrs_fully_allocated(fs.raw, c::bkey_s_c { k: k.k, v: k.v })
+            };
+            if replicas < min_replicas {
+                continue;
+            }
+        }
+
         println!("{}", k.to_text(fs));
     }
 
@@ -171,7 +183,7 @@ fn list_online(handle: &BcachefsHandle, fs: &Fs, opt: &Cli) -> anyhow::Result<()
     list_keys_online(handle, fs, opt)
 }
 
-#[derive(Clone, clap::ValueEnum, Debug)]
+#[derive(Clone, clap::ValueEnum, Debug, PartialEq, Eq)]
 enum Mode {
     Keys,
     Formats,
@@ -191,7 +203,9 @@ nodes-ondisk shows the raw on-disk representation.\n\n\
 Use -b to select a btree (default: extents), -s/-e for start/end \
 position, -l for btree depth, -k to filter by key type. With -c, \
 runs fsck before listing. Output is used for debugging filesystem \
-state, verifying btree contents, and inspecting on-disk layout.")]
+state, verifying btree contents, and inspecting on-disk layout.\n\n\
+Use --replicas-min with the extents btree to find file extents whose \
+stored data has at least the requested number of fully allocated replicas.")]
 pub struct Cli {
     #[arg(short, long, default_value = "keys")]
     mode: Mode,
@@ -216,6 +230,10 @@ pub struct Cli {
     #[arg(short, long, default_value = "SPOS_MAX")]
     end: c::bpos,
 
+    /// Only list extents with at least this many fully allocated replicas
+    #[arg(long, value_parser = clap::value_parser!(u32).range(1..))]
+    replicas_min: Option<u32>,
+
     /// Check (fsck) the filesystem first
     #[arg(short, long)]
     fsck: bool,
@@ -234,13 +252,29 @@ pub struct Cli {
 }
 
 fn cmd_list_inner(opt: &Cli) -> anyhow::Result<()> {
+    if opt.replicas_min.is_some() {
+        if opt.btree != btree_id::extents {
+            bail!("--replicas-min can only be used with the extents btree");
+        }
+        if opt.mode != Mode::Keys {
+            bail!("--replicas-min can only be used with --mode keys");
+        }
+        if opt.level != 0 {
+            bail!("--replicas-min can only be used at leaf level");
+        }
+    }
+
     let mut fs_opts = c::bch_opts::default();
 
     opt_set!(fs_opts, noexcl, 1);
     opt_set!(fs_opts, nochanges, 1);
     opt_set!(fs_opts, read_only, 1);
     opt_set!(fs_opts, norecovery, 1);
-    opt_set!(fs_opts, degraded, bch_degraded_actions::BCH_DEGRADED_very as u8);
+    opt_set!(
+        fs_opts,
+        degraded,
+        bch_degraded_actions::BCH_DEGRADED_very as u8
+    );
     opt_set!(
         fs_opts,
         errors,
@@ -248,11 +282,7 @@ fn cmd_list_inner(opt: &Cli) -> anyhow::Result<()> {
     );
 
     if opt.fsck {
-        opt_set!(
-            fs_opts,
-            fix_errors,
-            c::fsck_err_opts::FSCK_FIX_yes as u8
-        );
+        opt_set!(fs_opts, fix_errors, c::fsck_err_opts::FSCK_FIX_yes as u8);
         opt_set!(fs_opts, norecovery, 0);
     }
 
@@ -291,7 +321,6 @@ fn cmd_list_inner(opt: &Cli) -> anyhow::Result<()> {
 }
 
 fn list(opt: Cli) -> Result<()> {
-
     // TODO: centralize this on the top level CLI
     logging::setup(opt.verbose, opt.colorize);
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -7,6 +7,7 @@ use bcachefs_kernel::btree::iter::BtreeIter;
 use bcachefs_kernel::btree::iter::BtreeIterFlags;
 use bcachefs_kernel::btree::iter::BtreeNodeIter;
 use bcachefs_kernel::btree::iter::BtreeTrans;
+use bcachefs_kernel::data::extents::bkey_ptrs_sc;
 use bcachefs_kernel::fs::Fs;
 use bcachefs_kernel::opt_set;
 use bch_bindgen::c::bch_degraded_actions;
@@ -17,6 +18,12 @@ use crate::logging;
 use crate::device_scan::OpenedFs;
 use crate::wrappers::handle::BcachefsHandle;
 use crate::wrappers::online_iter::{OnlineBtreeIter, OnlineIterFlags};
+
+fn extent_replicas(fs: &Fs, k: BkeySC<'_>) -> u32 {
+    bkey_ptrs_sc(&k.v())
+        .filter(|ptr| ptr.dev() != c::BCH_SB_MEMBER_INVALID as u64 && fs.dev_exists(ptr.dev() as u32))
+        .count() as u32
+}
 
 fn list_keys(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
@@ -42,6 +49,13 @@ fn list_keys(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
 
         if let Some(ty) = opt.bkey_type {
             if k.k.type_ != ty.0 as u8 {
+                return ControlFlow::Continue(());
+            }
+        }
+
+        if let Some(min_replicas) = opt.replicas_min {
+            let replicas = extent_replicas(fs, k);
+            if replicas < min_replicas {
                 return ControlFlow::Continue(());
             }
         }
@@ -154,6 +168,13 @@ fn list_keys_online(handle: &BcachefsHandle, fs: &Fs, opt: &Cli) -> anyhow::Resu
             }
         }
 
+        if let Some(min_replicas) = opt.replicas_min {
+            let replicas = extent_replicas(fs, k);
+            if replicas < min_replicas {
+                continue;
+            }
+        }
+
         println!("{}", k.to_text(fs));
     }
 
@@ -171,7 +192,7 @@ fn list_online(handle: &BcachefsHandle, fs: &Fs, opt: &Cli) -> anyhow::Result<()
     list_keys_online(handle, fs, opt)
 }
 
-#[derive(Clone, clap::ValueEnum, Debug)]
+#[derive(Clone, clap::ValueEnum, Debug, PartialEq, Eq)]
 enum Mode {
     Keys,
     Formats,
@@ -191,7 +212,9 @@ nodes-ondisk shows the raw on-disk representation.\n\n\
 Use -b to select a btree (default: extents), -s/-e for start/end \
 position, -l for btree depth, -k to filter by key type. With -c, \
 runs fsck before listing. Output is used for debugging filesystem \
-state, verifying btree contents, and inspecting on-disk layout.")]
+state, verifying btree contents, and inspecting on-disk layout.\n\n\
+Use --replicas-min with the extents btree to find file extents whose \
+stored data has at least the requested number of fully allocated replicas.")]
 pub struct Cli {
     #[arg(short, long, default_value = "keys")]
     mode: Mode,
@@ -216,6 +239,10 @@ pub struct Cli {
     #[arg(short, long, default_value = "SPOS_MAX")]
     end: c::bpos,
 
+    /// Only list extents with at least this many fully allocated replicas
+    #[arg(long, value_parser = clap::value_parser!(u32).range(1..))]
+    replicas_min: Option<u32>,
+
     /// Check (fsck) the filesystem first
     #[arg(short, long)]
     fsck: bool,
@@ -234,6 +261,18 @@ pub struct Cli {
 }
 
 fn cmd_list_inner(opt: &Cli) -> anyhow::Result<()> {
+    if opt.replicas_min.is_some() {
+        if opt.btree != btree_id::extents {
+            bail!("--replicas-min can only be used with the extents btree");
+        }
+        if opt.mode != Mode::Keys {
+            bail!("--replicas-min can only be used with --mode keys");
+        }
+        if opt.level != 0 {
+            bail!("--replicas-min can only be used at leaf level");
+        }
+    }
+
     let mut fs_opts = c::bch_opts::default();
 
     opt_set!(fs_opts, noexcl, 1);

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -6,6 +6,7 @@ use bcachefs_kernel::btree::iter::BtreeIter;
 use bcachefs_kernel::btree::iter::BtreeIterFlags;
 use bcachefs_kernel::btree::iter::BtreeNodeIter;
 use bcachefs_kernel::btree::iter::BtreeTrans;
+use bcachefs_kernel::data::extents::bkey_ptrs_sc;
 use bcachefs_kernel::fs::Fs;
 use bcachefs_kernel::opt_set;
 use bcachefs_kernel::{btree_id, c};
@@ -17,6 +18,12 @@ use crate::logging;
 use crate::device_scan::OpenedFs;
 use crate::wrappers::handle::BcachefsHandle;
 use crate::wrappers::online_iter::{OnlineBtreeIter, OnlineIterFlags};
+
+fn extent_replicas(fs: &Fs, k: BkeySC<'_>) -> u32 {
+    bkey_ptrs_sc(&k.v())
+        .filter(|ptr| ptr.dev() != c::BCH_SB_MEMBER_INVALID as u64 && fs.dev_exists(ptr.dev() as u32))
+        .count() as u32
+}
 
 fn list_keys(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
@@ -41,9 +48,7 @@ fn list_keys(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
         }
 
         if let Some(min_replicas) = opt.replicas_min {
-            let replicas = unsafe {
-                c::bch2_bkey_nr_ptrs_fully_allocated(fs.raw, c::bkey_s_c { k: k.k, v: k.v })
-            };
+            let replicas = extent_replicas(fs, k);
             if replicas < min_replicas {
                 return ControlFlow::Continue(());
             }
@@ -158,9 +163,7 @@ fn list_keys_online(handle: &BcachefsHandle, fs: &Fs, opt: &Cli) -> anyhow::Resu
         }
 
         if let Some(min_replicas) = opt.replicas_min {
-            let replicas = unsafe {
-                c::bch2_bkey_nr_ptrs_fully_allocated(fs.raw, c::bkey_s_c { k: k.k, v: k.v })
-            };
+            let replicas = extent_replicas(fs, k);
             if replicas < min_replicas {
                 continue;
             }


### PR DESCRIPTION
Related to koverstreet/bcachefs-tools#507.

`bcachefs fs usage` can show a degraded ("2x") data bucket that persists after file options are cleared, with no direct way to find the extents behind the aggregate count: getfattr is empty by then, and `list --inode` only helps once the inode is already known.

Adds `list --replicas-min N`, restricted to `--mode keys --btree extents` at leaf level, to filter the normal key listing to extents with fewer than N live replica pointers.

Tested offline against a 2-device loop-file filesystem formatted with `--replicas=2`: after writing a file, `list --replicas-min 2` on both devices returns its extents (durability 2 each), `--replicas-min 3` returns none, and passing `--btree`/`--mode`/`--level` outside the supported combination is rejected with an error.
