### PR TITLE
doc: clarify version upgrade modes

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -356,6 +356,16 @@ Reconstruct alloc btree
 .It Fl -version_upgrade Ns = Ns ( Cm compatible | incompatible | none )
 Set superblock to latest version, allowing any new features
 to be used
+.Pp
+.Cm compatible
+is the default: compatible metadata upgrades may be applied automatically, and
+the filesystem may still downgrade those compatible version fields when mounted
+by an older kernel. Use
+.Cm incompatible
+only for an intentional one-way metadata upgrade that may prevent mounting with
+older kernels, and use
+.Cm none
+to avoid optional version upgrades.
 .It Fl -nocow
 Nocow mode: Writes will be done in place when possible.
 .sp


### PR DESCRIPTION
## Summary

- clarify the `version_upgrade` mount option modes in the manpage
- document that the default `compatible` mode may apply compatible metadata upgrades and still allow older kernels to downgrade compatible version fields
- call out `incompatible` as the intentional one-way upgrade mode and `none` as the way to avoid optional upgrades

## Context

This documents the compatibility model behind koverstreet/bcachefs#782. It does not change the kernel mount-time downgrade policy; it makes the existing manpage warning surface less cryptic for users who move between kernel versions.

## Testing

- `git diff --check`
- `groff -mandoc -Tascii bcachefs.8`
