### PR TITLE
doc: clarify subvolume move boundaries

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -499,6 +499,10 @@ Resize journal on a device
 Create a new subvolume
 .It Ic subvolume delete Oo Ar options Oc Ar path
 Delete an existing subvolume
+.Pp
+Subvolume roots may be renamed or moved as subvolume roots.
+Ordinary files and directories cannot be renamed across subvolume boundaries;
+copy or reflink data when reorganizing contents between subvolumes.
 .It Ic subvolume snapshot Oo Ar options Oc Ar source dest
 Create a snapshot of
 .Ar source

--- a/src/commands/subvolume.rs
+++ b/src/commands/subvolume.rs
@@ -34,7 +34,9 @@ enum Subcommands {
     #[command(visible_aliases = ["new"],
         long_about = "Creates a new subvolume at the given path. Subvolumes are \
 independently mountable filesystem trees, each with their own inode \
-number space.")]
+number space. Subvolume roots may be renamed or moved as subvolume \
+roots, but ordinary files and directories cannot be renamed across \
+subvolume boundaries.")]
     Create {
         /// Paths
         #[arg(required = true)]


### PR DESCRIPTION
Document the current subvolume move boundary in both the manpage and
`bcachefs subvolume create --help`.

Current kernel behavior allows renaming/moving subvolume roots as subvolume
roots, but ordinary files and directories still cannot be renamed across
subvolume boundaries. This makes the limitation visible near the subvolume
commands and points users toward copy/reflink based reorganization instead of
expecting a metadata rename.

References koverstreet/bcachefs#890.

Validation:
- `git diff --check`
- `groff -mandoc -Tascii bcachefs.8`
- `make generate_version && BINDGEN=/home/kom/.cargo/bin/bindgen cargo check -q -p bcachefs-tools`

Note: `rustfmt --check src/commands/subvolume.rs` currently wants to reformat
the existing file wholesale under stable rustfmt; I left that unrelated churn
out of this docs patch.
