### PR TITLE
data update: avoid SRCU-held bio/bvec allocations

### DIFF
--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -969,23 +969,23 @@ static int bch2_extent_drop_ptrs(struct btree_trans *trans,
 		bch2_trans_commit(trans, &res.r, NULL, BCH_TRANS_COMMIT_no_enospc);
 }
 
-static int bch2_data_update_bios_init(struct data_update *m, struct bch_fs *c,
-				      struct bch_inode_opts *io_opts,
-				      unsigned buf_bytes)
+static int __bch2_data_update_bios_init(struct data_update *m, struct bch_fs *c,
+					struct bch_inode_opts *io_opts,
+					unsigned buf_bytes, gfp_t gfp)
 {
 	/* be paranoid */
 	buf_bytes = round_up(buf_bytes, c->opts.block_size);
 
 	unsigned nr_vecs = DIV_ROUND_UP(buf_bytes, PAGE_SIZE);
 
-	m->bvecs = kmalloc_array(nr_vecs, sizeof*(m->bvecs), GFP_KERNEL);
+	m->bvecs = kmalloc_array(nr_vecs, sizeof*(m->bvecs), gfp);
 	if (!m->bvecs)
 		return -ENOMEM;
 
 	bio_init(&m->rbio.bio,		NULL, m->bvecs, nr_vecs, REQ_OP_READ);
 	bio_init(&m->op.wbio.bio,	NULL, m->bvecs, nr_vecs, 0);
 
-	if (bch2_bio_alloc_pages(&m->op.wbio.bio, c->opts.block_size, buf_bytes, GFP_KERNEL)) {
+	if (bch2_bio_alloc_pages(&m->op.wbio.bio, c->opts.block_size, buf_bytes, gfp)) {
 		kfree(m->bvecs);
 		m->bvecs = NULL;
 		return -ENOMEM;
@@ -997,6 +997,21 @@ static int bch2_data_update_bios_init(struct data_update *m, struct bch_fs *c,
 	m->rbio.bio.bi_iter.bi_sector	= bkey_start_offset(&m->k.k->k);
 	m->op.wbio.bio.bi_ioprio	= IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
 	return 0;
+}
+
+static int bch2_data_update_bios_init(struct btree_trans *trans,
+				      struct data_update *m, struct bch_fs *c,
+				      struct bch_inode_opts *io_opts,
+				      unsigned buf_bytes)
+{
+	int ret = __bch2_data_update_bios_init(m, c, io_opts, buf_bytes, GFP_NOWAIT);
+
+	if (ret == -ENOMEM) {
+		bch2_trans_unlock_long(trans);
+		ret = __bch2_data_update_bios_init(m, c, io_opts, buf_bytes, GFP_KERNEL);
+	}
+
+	return ret;
 }
 
 static unsigned durability_available_on_target(struct bch_fs *c,
@@ -1526,7 +1541,7 @@ int bch2_data_update_init(struct btree_trans *trans,
 
 	bch2_trans_unlock(trans);
 
-	ret = bch2_data_update_bios_init(m, c, io_opts, buf_bytes);
+	ret = bch2_data_update_bios_init(trans, m, c, io_opts, buf_bytes);
 	if (ret)
 		goto out_nocow_unlock;
 

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -980,23 +980,23 @@ static int bch2_extent_drop_ptrs(struct btree_trans *trans,
 		bch2_trans_commit(trans, &res.r, NULL, BCH_TRANS_COMMIT_no_enospc);
 }
 
-static int bch2_data_update_bios_init(struct data_update *m, struct bch_fs *c,
-				      struct bch_inode_opts *io_opts,
-				      unsigned buf_bytes)
+static int __bch2_data_update_bios_init(struct data_update *m, struct bch_fs *c,
+					struct bch_inode_opts *io_opts,
+					unsigned buf_bytes, gfp_t gfp)
 {
 	/* be paranoid */
 	buf_bytes = round_up(buf_bytes, c->opts.block_size);
 
 	unsigned nr_vecs = DIV_ROUND_UP(buf_bytes, PAGE_SIZE);
 
-	m->bvecs = kmalloc_array(nr_vecs, sizeof*(m->bvecs), GFP_KERNEL);
+	m->bvecs = kmalloc_array(nr_vecs, sizeof*(m->bvecs), gfp);
 	if (!m->bvecs)
 		return -ENOMEM;
 
 	bio_init(&m->rbio.bio,		NULL, m->bvecs, nr_vecs, REQ_OP_READ);
 	bio_init(&m->op.wbio.bio,	NULL, m->bvecs, nr_vecs, 0);
 
-	if (bch2_bio_alloc_pages(&m->op.wbio.bio, c->opts.block_size, buf_bytes, GFP_KERNEL)) {
+	if (bch2_bio_alloc_pages(&m->op.wbio.bio, c->opts.block_size, buf_bytes, gfp)) {
 		kfree(m->bvecs);
 		m->bvecs = NULL;
 		return -ENOMEM;
@@ -1008,6 +1008,21 @@ static int bch2_data_update_bios_init(struct data_update *m, struct bch_fs *c,
 	m->rbio.bio.bi_iter.bi_sector	= bkey_start_offset(&m->k.k->k);
 	m->op.wbio.bio.bi_ioprio	= IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0);
 	return 0;
+}
+
+static int bch2_data_update_bios_init(struct btree_trans *trans,
+				      struct data_update *m, struct bch_fs *c,
+				      struct bch_inode_opts *io_opts,
+				      unsigned buf_bytes)
+{
+	int ret = __bch2_data_update_bios_init(m, c, io_opts, buf_bytes, GFP_NOWAIT);
+
+	if (ret == -ENOMEM) {
+		bch2_trans_unlock_long(trans);
+		ret = __bch2_data_update_bios_init(m, c, io_opts, buf_bytes, GFP_KERNEL);
+	}
+
+	return ret;
 }
 
 static unsigned durability_available_on_target(struct bch_fs *c,
@@ -1529,7 +1544,7 @@ int bch2_data_update_init(struct btree_trans *trans,
 
 	bch2_trans_unlock(trans);
 
-	ret = bch2_data_update_bios_init(m, c, io_opts, buf_bytes);
+	ret = bch2_data_update_bios_init(trans, m, c, io_opts, buf_bytes);
 	if (ret)
 		goto out_nocow_unlock;
 


### PR DESCRIPTION
bch2_data_update_bios_init() allocated data-update bvecs and bio pages with GFP_KERNEL while the transaction still held the btree trans SRCU read lock -- bch2_trans_unlock() drops node locks but not SRCU, so a long direct-reclaim stall in that allocation could stall SRCU grace periods for every other transaction on the filesystem. This matches the hang class reported in koverstreet/bcachefs#1069 and koverstreet/bcachefs#1165, where reconcile/copygc/writeback paths sat for minutes with SRCU-too-long warnings. The fix tries the allocation with GFP_NOWAIT first and only drops SRCU (via bch2_trans_unlock_long()) and retries with GFP_KERNEL on failure, so the common case keeps its SRCU lock and only the reclaim case pays for iterator revalidation; a tighter-scoped unlock is a reasonable follow-up but isn't done here, since the unconditional drop-and-retry is the smallest change that provably fixes the reported stall. Related: koverstreet/bcachefs-tools#659, koverstreet/bcachefs-tools#710. Validated by a clean rebuild against current master and a loop-file format/fsck smoke test; the actual NOWAIT-fails-then-retries path needs real allocation pressure on a live mounted filesystem and wasn't exercised here.
