### PR TITLE
unlock: file passphrase retry behavior is superseded

### DIFF
--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -73,7 +73,11 @@ fn cmd_unlock(cli: UnlockCli) -> Result<()> {
 
     match KeyHandle::new(&sb, &passphrase, cli.keyring) {
         Ok(_) => return Ok(()),
-        Err(e) if e.to_string().contains("incorrect passphrase") => {}
+        Err(e) if e.to_string().contains("incorrect passphrase") => {
+            if cli.file.is_some() {
+                return Err(e);
+            }
+        }
         Err(e) => return Err(e),
     }
 


### PR DESCRIPTION
## Status

This PR should not be reviewed as a code change in its current branch form.

The behavior this PR was trying to fix is already present on current `master` via `669ada14e` (`key: share the systemd-ask-password keyname with cryptsetup`). Current `cmd_unlock()` now handles file passphrases as:

- `Passphrase::read_from_file(file)?`
- `.check(&sb)`
- `ok_or_else(|| anyhow!("incorrect passphrase"))?`

and only uses the interactive/systemd prompt path when no `--file` was provided.

That means `bcachefs unlock -f <bad-file> <device>` returns `incorrect passphrase` from the file path instead of falling through to the prompted retry loop. The original stale branch is left draft because it conflicts with the refactored key code and should not be merged.

## Original intent

- make `bcachefs unlock -f <file>` fail immediately when the file passphrase is incorrect;
- keep interactive retries for the normal prompted unlock path;
- avoid hanging scripts/boot flows after a bad or empty passphrase file.

## Validation / evidence

- `git log -S'Passphrase::read_from_file' -- src/commands/key.rs` points to `669ada14e`.
- `origin/master:src/commands/key.rs` shows the file-passphrase path checks the passphrase and returns `anyhow!("incorrect passphrase")` before `KeyHandle::new()`.
- Related to koverstreet/bcachefs-tools#314 and koverstreet/ktest#61.

No fresh code is proposed here unless a maintainer wants this turned into a separate ktest/regression-only follow-up.
