### PR TITLE
docs: clarify erasure coding replica limit

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -132,7 +132,10 @@ Btree node size, default 256k
 .It Fl -errors Ns = Ns ( Cm continue | ro | panic )
 Action to take on filesystem error
 .It Fl -data_replicas Ns = Ns Ar number
-Number of data replicas
+Number of data replicas.
+With erasure coding enabled, this is currently capped at
+.Ar 3
+.Pq RAID6 .
 .It Fl -metadata_replicas Ns = Ns Ar number
 Number of metadata replicas
 .It Fl -data_replicas_required Ns = Ns Ar number
@@ -163,7 +166,7 @@ Device or label to move data to in the background
 .It Fl -promote_target Ns = Ns Ar target
 Device or label to promote data to on read
 .It Fl -erasure_code
-Enable erasure coding (DO NOT USE YET)
+Enable erasure coding (RAID5/6; data replicas are capped at 3)
 .It Fl -inodes_32bit
 Constrain inode numbers to 32 bits
 .It Fl -shared_inode_numbers
@@ -257,7 +260,10 @@ Action to take on filesystem error
 .It Fl -metadata_replicas Ns = Ns Ar number
 Number of metadata replicas
 .It Fl -data_replicas Ns = Ns Ar number
-Number of data replicas
+Number of data replicas.
+With erasure coding enabled, this is currently capped at
+.Ar 3
+.Pq RAID6 .
 .It Fl -metadata_replicas_required Ns = Ns Ar number
 
 .It Fl -data_replicas_required Ns = Ns Ar number
@@ -284,7 +290,7 @@ Device or label to move data to in the background
 .It Fl -promote_target Ns = Ns Ar target
 Device or label to promote data to on read
 .It Fl -erasure_code
-Enable erasure coding (DO NOT USE YET)
+Enable erasure coding (RAID5/6; data replicas are capped at 3)
 .It Fl -inodes_32bit
 Constrain inode numbers to 32 bits
 .It Fl -shared_inode_numbers
@@ -582,7 +588,10 @@ When applied to directories, attributes are propagated recursively to all files
 and subdirectories within.
 .Bl -tag -width Ds
 .It Fl -data_replicas Ns = Ns Ar number
-Number of data replicas
+Number of data replicas.
+With erasure coding enabled, this is currently capped at
+.Ar 3
+.Pq RAID6 .
 .It Fl -data_checksum Ns = Ns ( Cm none | crc32c | crc64 | xxhash )
 Set data checksum type (default:
 .Cm crc32c ) .
@@ -600,7 +609,7 @@ Device or label to move data to in the background
 .It Fl -promote_target Ns = Ns Ar target
 Device or label to promote data to on read
 .It Fl -erasure_code
-Enable erasure coding (DO NOT USE YET)
+Enable erasure coding (RAID5/6; data replicas are capped at 3)
 .It Fl -project
 
 .It Fl -nocow

--- a/fs/opts.h
+++ b/fs/opts.h
@@ -164,7 +164,7 @@ enum fsck_err_opts {
 	  OPT_FS|OPT_INODE|OPT_FORMAT|OPT_MOUNT_OLD|OPT_RUNTIME,	\
 	  OPT_UINT(1, BCH_REPLICAS_MAX + 1),				\
 	  BCH_SB_DATA_REPLICAS_WANT,	1,				\
-	  "#",		"Number of data replicas")			\
+	  "#",		"Number of data replicas (erasure coding currently caps this at 3, RAID6)")\
 	x(encoded_extent_max,		u32,				\
 	  OPT_FS|OPT_FORMAT|						\
 	  OPT_HUMAN_READABLE|OPT_MUST_BE_POW_2|OPT_SB_FIELD_SECTORS|OPT_SB_FIELD_ILOG2,\
@@ -225,7 +225,7 @@ enum fsck_err_opts {
 	  OPT_FS|OPT_INODE|OPT_FORMAT|OPT_MOUNT_OLD|OPT_RUNTIME,	\
 	  OPT_BOOL(),							\
 	  BCH_SB_ERASURE_CODE,		false,				\
-	  NULL,		"Enable erasure coding (RAID5/6, but no write hole)")\
+	  NULL,		"Enable erasure coding (RAID5/6; data replicas are capped at 3)")\
 	x(ec_max_data_blocks,		u8,				\
 	  OPT_FS|OPT_FORMAT|OPT_MOUNT|OPT_RUNTIME,			\
 	  OPT_UINT(0, 15),						\

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -76,6 +76,7 @@ Usage: bcachefs format [OPTION]... <devices>
 Options:
 {fs_opts}\
       --replicas=#             Sets both data and metadata replicas
+                               With erasure coding, data replicas are capped at 3 (RAID6)
       --encrypted              Enable whole filesystem encryption (chacha20/poly1305)
       --passphrase_file=file   File containing passphrase used for encryption/decryption
       --no_passphrase          Don't encrypt master encryption key

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -723,6 +723,7 @@ Options:
                                6.16+ regenerates alloc info on first rw mount
 {fs_opts}\
       --replicas=#             Sets both data and metadata replicas
+                               With erasure coding, data replicas are capped at 3 (RAID6)
       --encrypted              Enable whole filesystem encryption (chacha20/poly1305)
       --passphrase_file=file   File containing passphrase used for encryption/decryption
       --no_passphrase          Don't encrypt master encryption key


### PR DESCRIPTION
Related to koverstreet/bcachefs#540 and koverstreet/bcachefs#1077.

This documents the current erasure-coding replica limit on the option/help surfaces users see when trying to configure EC:

- `data_replicas` help now says erasure coding currently caps the value at 3 / RAID6
- `erasure_code` help now says the current implementation is RAID5/6 and caps data replicas at 3
- `format --help` and `image create --help` note the same cap next to the `--replicas` shorthand
- the checked-in manpage repeats the limit for format, set-fs-option, and set-file-option

For koverstreet/bcachefs#540 specifically, the current mapping is: `data_replicas=2` gives one parity block, `data_replicas=3` gives two parity blocks, and the current RAID5/6 implementation caps EC at two parity blocks. The data-stripe width is chosen by the filesystem from available target devices, with `ec_max_data_blocks=N` available as a cap.

This does not implement arbitrary-parity erasure coding. The current kernel EC path is still wired to RAID5/6 helpers, so `data_replicas > 3` remains a larger EC backend/design feature.

Validation:
- `git diff --check`
- clean `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
- `./bcachefs format --help`
- `./bcachefs image create --help`
- `./bcachefs set-file-option --help`
- `groff -mandoc -Tascii bcachefs.8 >/tmp/bcachefs-1077-manpage.txt` (only pre-existing empty-line warnings)
