### PR TITLE
docs: list subvolume query commands in manpage

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -67,6 +67,10 @@ Create a new subvolume
 Delete an existing subvolume
 .It Ic subvolume snapshot
 Create a snapshot
+.It Ic subvolume list
+List subvolumes
+.It Ic subvolume list-snapshots
+List snapshots and their disk usage
 .El
 .Ss Commands for managing filesystem data
 .Bl -tag -width 18n -compact
@@ -512,6 +516,34 @@ if not specified the snapshot will be of the subvolume containing
 .Bl -tag -width Ds
 .It Fl r
 Make snapshot read-only
+.El
+.It Ic subvolume list Oo Ar options Oc Ar target
+List subvolumes in a mounted filesystem.
+.Bl -tag -width Ds
+.It Fl -json
+Output machine-readable JSON.
+.It Fl t , Fl -tree
+Show a hierarchical view.
+.It Fl R , Fl -recursive
+List subvolumes recursively.
+.It Fl s , Fl -snapshots
+Include snapshot subvolumes.
+.It Fl -readonly
+Only show read-only subvolumes.
+.It Fl -sort Ns = Ns ( Cm name | size | time )
+Sort output.
+.El
+.It Ic subvolume list-snapshots Oo Ar options Oc Ar target
+List snapshots and their disk usage in a mounted filesystem.
+.Bl -tag -width Ds
+.It Fl f , Fl -flat
+Show a flat list instead of the default tree.
+.It Fl -json
+Output machine-readable JSON, including snapshot IDs and parent relationships.
+.It Fl -readonly
+Only show read-only snapshots in flat view.
+.It Fl -sort Ns = Ns ( Cm name | size | time )
+Sort flat output.
 .El
 .El
 .Sh Commands for managing filesystem data


### PR DESCRIPTION
Related to koverstreet/bcachefs-tools#201.

This documents the existing subvolume query commands in the checked-in manpage:

- `bcachefs subvolume list`
- `bcachefs subvolume list-snapshots`
- their JSON/tree/flat/recursive/sort options

These are the existing filesystem-side primitives an external bootloader, boot menu generator, or initramfs integration would need for snapshot-aware boot selection.

This does not implement native bootloader support. Choosing which snapshot/root to boot remains bootloader and distro/initramfs policy.

Validation:
- `git diff --check`
- `groff -mandoc -Tascii bcachefs.8 >/tmp/bcachefs-201-manpage.txt` (only pre-existing empty-line warnings)
- compared the documented options with `bcachefs subvolume list --help` and `bcachefs subvolume list-snapshots --help`
