### PR TITLE
docs: explain subvolume quota semantics

### DIFF
--- a/doc/bcachefs.5.rst.tmpl
+++ b/doc/bcachefs.5.rst.tmpl
@@ -128,4 +128,12 @@ of the filesystem.
 Data protection
 ---------------
 
-foo
+Bcachefs supports user, group, and project quotas via the ``usrquota``,
+``grpquota``, and ``prjquota`` options. Snapshot trees are charged through their
+master subvolume's inode ownership and project IDs; snapshot subvolumes do not
+have independent quota enforcement, and quota accounting for a snapshot tree is
+skipped if its master subvolume has been deleted.
+
+Subvolume and snapshot disk usage can be inspected with ``bcachefs subvolume
+list`` and ``bcachefs subvolume list-snapshots``. These commands report usage;
+they do not set btrfs-style qgroup/subvolume limits.


### PR DESCRIPTION
Clarify the current quota/subvolume behavior in the user manual:

- user/group/project quotas are the supported enforcement mechanism;
- snapshot trees are charged through the master subvolume's inode ownership and project IDs;
- snapshot subvolumes do not get independent quota enforcement;
- `subvolume list` / `list-snapshots` report usage, but do not set btrfs-style qgroup/subvolume limits.

This replaces the placeholder under `Data protection` and is related to koverstreet/bcachefs#754.

Validation:
- `git diff --check`
- `rst2man doc/bcachefs.5.rst.tmpl >/tmp/bcachefs-754-bcachefs5.5`
