### PR TITLE
bcachefs: reserve LZ4HC output slop

### DIFF
--- a/fs/data/compress.c
+++ b/fs/data/compress.c
@@ -401,6 +401,12 @@ static int attempt_compress(struct bch_fs *c,
 			    void *src, size_t src_len,
 			    union bch_compression_opt compression)
 {
+	/*
+	 * LZ4HC uses LZ4_wildCopy(), which may overwrite up to 7 bytes past
+	 * its requested copy end. Keep that inside our bounce buffer even when
+	 * the compressed output ends exactly at the supplied limit.
+	 */
+	const size_t lz4hc_output_slop = 7;
 	enum bch_compression_type compression_type =
 		__bch2_compression_opt_to_type[compression.type];
 
@@ -420,9 +426,12 @@ static int attempt_compress(struct bch_fs *c,
 
 			return ret;
 		} else {
+			if (dst_len <= lz4hc_output_slop)
+				return -1;
+
 			int ret = LZ4_compress_HC(
 					src,		dst,
-					src_len,	dst_len,
+					src_len,	dst_len - lz4hc_output_slop,
 					compression.level,
 					workspace);
 


### PR DESCRIPTION
## Summary

- reserve 7 bytes of output slop before calling `LZ4_compress_HC()`
- keep LZ4HC wild-copy overrun inside the bcachefs compression bounce buffer when compressed output lands at the supplied limit
- let the existing compression retry path reduce the input size if the smaller HC output limit no longer fits

## Testing

- `git diff --check`
- `make generate_version && BINDGEN=/home/kom/.cargo/bin/bindgen LIBCLANG_PATH=/usr/lib/llvm-18/lib CARGO_BUILD_JOBS=4 make -j4`
- staged module build without unload/install side effects:
  `make -C /lib/modules/$(uname -r)/build M=/home/kom/tmp/bcachefs-module-lz4hc-output-margin modules -j4`
- GitHub Actions: Nix Flake actions run 28426617300, 17/17 jobs passed on head `714eff8ff23cc43ae15335d320375c66334b2c6e`

Fixes: koverstreet/bcachefs#658
