### PR TITLE
format: show negated device boolean options

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -220,6 +220,8 @@ Device specific options:
 .Bl -tag -width Ds
 .It Fl -discard
 Enable discard/TRIM support
+.It Fl -nodiscard
+Disable discard/TRIM support for subsequent devices
 .It Fl -fs_size Ns = Ns Ar size
 Create the filesystem using
 .Ar size
@@ -455,6 +457,8 @@ Size of filesystem on device
 Set bucket size
 .It Fl -discard
 Enable discards
+.It Fl -nodiscard
+Disable discards
 .It Fl l , Fl -label Ns = Ns Ar label
 Disk label
 .It Fl f , Fl -force

--- a/bcachefs.8
+++ b/bcachefs.8
@@ -228,6 +228,8 @@ Device specific options:
 .Bl -tag -width Ds
 .It Fl -discard
 Enable discard/TRIM support
+.It Fl -nodiscard
+Disable discard/TRIM support for subsequent devices
 .It Fl -fs_size Ns = Ns Ar size
 Create the filesystem using
 .Ar size
@@ -533,6 +535,8 @@ Size of filesystem on device
 Set bucket size
 .It Fl -discard
 Enable discards
+.It Fl -nodiscard
+Disable discards
 .It Fl l , Fl -label Ns = Ns Ar label
 Disk label
 .It Fl f , Fl -force

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -66,7 +66,7 @@ fn format_usage() {
     );
     let dev_opts = opts_usage_str(
         c::opt_flags::OPT_DEVICE as u32,
-        c::opt_flags::OPT_FS as u32,
+        0,
     );
 
     print!("\

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -73,7 +73,7 @@ fn format_usage() {
     );
     let dev_opts = opts_usage_str(
         c::opt_flags::OPT_DEVICE as u32,
-        c::opt_flags::OPT_FS as u32,
+        0,
     );
 
     print!("\

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -710,7 +710,7 @@ fn image_create_usage() {
     );
     let dev_opts = opts_usage_str(
         c::opt_flags::OPT_DEVICE as u32,
-        c::opt_flags::OPT_FS as u32,
+        0,
     );
 
     print!("\

--- a/src/commands/opts.rs
+++ b/src/commands/opts.rs
@@ -36,7 +36,11 @@ pub fn opts_usage_str(flags_all: u32, flags_none: u32) -> String {
         let Some(name) = opt.name() else { continue };
 
         let mut col = 0;
-        let s = format!("      --{name}");
+        let s = if opt.type_ == c::opt_type::BCH_OPT_BOOL {
+            format!("      --{name}, --no{name}")
+        } else {
+            format!("      --{name}")
+        };
         col += s.len();
         out.push_str(&s);
 


### PR DESCRIPTION
Expose the existing negated boolean device options in custom usage output.

The parser already accepts `--nodiscard` and `--no-discard` for `bcachefs format`, but the custom `format --help` output hid `discard` because it filtered out device options that also have filesystem scope. That left the `--discard` scope workaround from koverstreet/bcachefs-tools#33 hard to discover.

This changes the custom format/image usage paths to include all device-scoped options and prints boolean options as `--foo, --nofoo`, so `bcachefs format --help` now shows, in the device-specific options section:

```
      --discard, --nodiscard   Enable discard/TRIM support
```

It also documents `--nodiscard` in the manpage format/device-add sections.

Related: koverstreet/bcachefs-tools#33

Rebased onto current master and built clean. Compared `bcachefs format --help` and `bcachefs image create --help` against a master-only build: `--discard, --nodiscard` appears exactly once in each, in the device-specific options block, with no duplicate entries anywhere else in the output. Confirmed `--nodiscard`/`--no-discard` both still parse.
