### PR TITLE
sb: let btree bitmap gc shrink shift

### DIFF
--- a/fs/bcachefs.h
+++ b/fs/bcachefs.h
@@ -517,6 +517,7 @@ struct bch_dev {
 	 */
 	struct bch_member_cpu	mi;
 	u64			btree_allocated_bitmap_gc;
+	u8			btree_allocated_bitmap_gc_shift;
 	atomic64_t		errors[BCH_MEMBER_ERROR_NR];
 	unsigned long		write_errors_start;
 

--- a/fs/bcachefs.h
+++ b/fs/bcachefs.h
@@ -543,6 +543,7 @@ struct bch_dev {
 	 */
 	struct bch_member_cpu	mi;
 	u64			btree_allocated_bitmap_gc;
+	u8			btree_allocated_bitmap_gc_shift;
 	atomic64_t		errors[BCH_MEMBER_ERROR_NR];
 	unsigned long		write_errors_start;
 

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -583,6 +583,7 @@ static struct bch_dev *__bch2_dev_alloc(struct bch_fs *c,
 
 	ca->mi = bch2_mi_to_cpu(member);
 	ca->btree_allocated_bitmap_gc = le64_to_cpu(member->btree_allocated_bitmap);
+	ca->btree_allocated_bitmap_gc_shift = member->btree_bitmap_shift;
 
 	for (i = 0; i < ARRAY_SIZE(member->errors); i++)
 		atomic64_set(&ca->errors[i], le64_to_cpu(member->errors[i]));

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -589,6 +589,7 @@ static struct bch_dev *__bch2_dev_alloc(struct bch_fs *c,
 
 	ca->mi = bch2_mi_to_cpu(member);
 	ca->btree_allocated_bitmap_gc = le64_to_cpu(member->btree_allocated_bitmap);
+	ca->btree_allocated_bitmap_gc_shift = member->btree_bitmap_shift;
 
 	for (i = 0; i < ARRAY_SIZE(member->errors); i++)
 		atomic64_set(&ca->errors[i], le64_to_cpu(member->errors[i]));

--- a/fs/sb/members.c
+++ b/fs/sb/members.c
@@ -583,49 +583,53 @@ bool bch2_dev_btree_bitmap_marked_nogc(struct bch_fs *c, struct bkey_s_c k)
 	return __bch2_dev_btree_bitmap_marked(c, k, false);
 }
 
+static void bch2_btree_bitmap_mark_sectors(u64 *bitmap, u8 *shift,
+					   u64 start, unsigned sectors)
+{
+	u64 end = start + sectors;
+
+	int resize = ilog2(roundup_pow_of_two(end)) - (*shift + 6);
+	if (resize > 0) {
+		u64 old_bitmap = *bitmap;
+		u64 new_bitmap = 0;
+
+		for (unsigned i = 0; i < 64; i++)
+			if (old_bitmap & BIT_ULL(i))
+				new_bitmap |= BIT_ULL(i >> resize);
+
+		*bitmap = new_bitmap;
+		*shift += resize;
+	}
+
+	BUG_ON(*shift >= BCH_MI_BTREE_BITMAP_SHIFT_MAX);
+	BUG_ON(end > 64ULL << *shift);
+
+	for (unsigned bit = start >> *shift;
+	     (u64) bit << *shift < end;
+	     bit++)
+		*bitmap |= BIT_ULL(bit);
+}
+
 static void __bch2_dev_btree_bitmap_mark(struct bch_dev *ca,
 					 struct bch_sb_field_members_v2 *mi,
 					 u64 start, unsigned sectors, bool *write_sb)
 {
 	struct bch_member *m = __bch2_members_v2_get_mut(mi, ca->dev_idx);
+	u64 old_bitmap = le64_to_cpu(m->btree_allocated_bitmap);
+	u8 old_shift = m->btree_bitmap_shift;
+	u64 new_bitmap = old_bitmap;
+	u8 new_shift = old_shift;
 
-	u64 end = start + sectors;
-
-	int resize = ilog2(roundup_pow_of_two(end)) - (m->btree_bitmap_shift + 6);
-	if (resize > 0) {
-		u64 old_bitmap = le64_to_cpu(m->btree_allocated_bitmap);
-		u64 new_bitmap = 0;
-		u64 new_gc_bitmap = 0;
-
-		for (unsigned i = 0; i < 64; i++) {
-			if (old_bitmap & BIT_ULL(i))
-				new_bitmap |= BIT_ULL(i >> resize);
-			if (ca->btree_allocated_bitmap_gc & BIT_ULL(i))
-				new_gc_bitmap |= BIT_ULL(i >> resize);
-		}
-
+	bch2_btree_bitmap_mark_sectors(&new_bitmap, &new_shift, start, sectors);
+	if (new_bitmap != old_bitmap || new_shift != old_shift) {
 		m->btree_allocated_bitmap = cpu_to_le64(new_bitmap);
-		m->btree_bitmap_shift += resize;
+		m->btree_bitmap_shift = new_shift;
 		*write_sb = true;
-
-		ca->btree_allocated_bitmap_gc = new_gc_bitmap;
 	}
 
-	BUG_ON(m->btree_bitmap_shift >= BCH_MI_BTREE_BITMAP_SHIFT_MAX);
-	BUG_ON(end > 64ULL << m->btree_bitmap_shift);
-
-	for (unsigned bit = start >> m->btree_bitmap_shift;
-	     (u64) bit << m->btree_bitmap_shift < end;
-	     bit++) {
-		__le64 b = cpu_to_le64(BIT_ULL(bit));
-
-		if (!(m->btree_allocated_bitmap & b)) {
-			m->btree_allocated_bitmap |= b;
-			*write_sb = true;
-		}
-
-		ca->btree_allocated_bitmap_gc |= BIT_ULL(bit);
-	}
+	bch2_btree_bitmap_mark_sectors(&ca->btree_allocated_bitmap_gc,
+				       &ca->btree_allocated_bitmap_gc_shift,
+				       start, sectors);
 }
 
 void bch2_dev_btree_bitmap_mark_locked(struct bch_fs *c, struct bkey_s_c k, bool *write_sb)
@@ -654,6 +658,27 @@ void bch2_dev_btree_bitmap_mark(struct bch_fs *c, struct bkey_s_c k)
 		bch2_write_super(c);
 }
 
+static void __bch2_dev_btree_bitmap_gc_mark(struct bch_dev *ca, u64 start, unsigned sectors)
+{
+	bch2_btree_bitmap_mark_sectors(&ca->btree_allocated_bitmap_gc,
+				       &ca->btree_allocated_bitmap_gc_shift,
+				       start, sectors);
+}
+
+static void bch2_dev_btree_bitmap_gc_mark(struct bch_fs *c, struct bkey_s_c k)
+{
+	guard(memalloc_flags)(PF_MEMALLOC_NOFS);
+	guard(mutex)(&c->sb_lock);
+	guard(rcu)();
+	bkey_for_each_ptr(bch2_bkey_ptrs_c(k), ptr) {
+		struct bch_dev *ca = bch2_dev_rcu_noerror(c, ptr->dev);
+		if (!ca)
+			continue;
+
+		__bch2_dev_btree_bitmap_gc_mark(ca, ptr->offset, btree_sectors(c));
+	}
+}
+
 static int btree_bitmap_gc_btree_level(struct btree_trans *trans,
 				       struct progress_indicator *progress,
 				       enum btree_id btree, unsigned level)
@@ -662,8 +687,7 @@ static int btree_bitmap_gc_btree_level(struct btree_trans *trans,
 	CLASS(btree_node_iter, iter)(trans, btree, POS_MIN, 0, level, BTREE_ITER_prefetch);
 
 	try(for_each_btree_key_continue(trans, iter, 0, k, ({
-		if (!bch2_dev_btree_bitmap_marked(c, k))
-			bch2_dev_btree_bitmap_mark(c, k);
+		bch2_dev_btree_bitmap_gc_mark(c, k);
 
 		bch2_progress_update_iter(trans, progress, &iter);
 	})));
@@ -679,8 +703,10 @@ int bch2_btree_bitmap_gc(struct bch_fs *c)
 	scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
 		guard(mutex)(&c->sb_lock);
 		guard(rcu)();
-		for_each_member_device_rcu(c, ca, NULL)
+		for_each_member_device_rcu(c, ca, NULL) {
 			ca->btree_allocated_bitmap_gc = 0;
+			ca->btree_allocated_bitmap_gc_shift = 0;
+		}
 	}
 
 	{
@@ -695,8 +721,7 @@ int bch2_btree_bitmap_gc(struct bch_fs *c)
 			struct btree *b;
 			try(lockrestart_do(trans, PTR_ERR_OR_ZERO(b = bch2_btree_iter_peek_node(&iter))));
 
-			if (!bch2_dev_btree_bitmap_marked(c, bkey_i_to_s_c(&b->key)))
-				bch2_dev_btree_bitmap_mark(c, bkey_i_to_s_c(&b->key));
+			bch2_dev_btree_bitmap_gc_mark(c, bkey_i_to_s_c(&b->key));
 		}
 	}
 
@@ -709,10 +734,13 @@ int bch2_btree_bitmap_gc(struct bch_fs *c)
 		scoped_guard(rcu)
 			for_each_member_device_rcu(c, ca, NULL) {
 				sectors_marked_old += hweight64(ca->mi.btree_allocated_bitmap) << ca->mi.btree_bitmap_shift;
-				sectors_marked_new += hweight64(ca->btree_allocated_bitmap_gc) << ca->mi.btree_bitmap_shift;
+				sectors_marked_new += hweight64(ca->btree_allocated_bitmap_gc) << ca->btree_allocated_bitmap_gc_shift;
 
 				struct bch_member *m = __bch2_members_v2_get_mut(mi, ca->dev_idx);
 				m->btree_allocated_bitmap = cpu_to_le64(ca->btree_allocated_bitmap_gc);
+				m->btree_bitmap_shift = ca->btree_allocated_bitmap_gc_shift;
+				ca->mi.btree_allocated_bitmap = ca->btree_allocated_bitmap_gc;
+				ca->mi.btree_bitmap_shift = ca->btree_allocated_bitmap_gc_shift;
 			}
 		bch2_write_super(c);
 	}

--- a/fs/sb/members.c
+++ b/fs/sb/members.c
@@ -654,49 +654,53 @@ bool bch2_dev_btree_bitmap_marked_nogc(struct bch_fs *c, struct bkey_s_c k)
 	return __bch2_dev_btree_bitmap_marked(c, k, false);
 }
 
+static void bch2_btree_bitmap_mark_sectors(u64 *bitmap, u8 *shift,
+					   u64 start, unsigned sectors)
+{
+	u64 end = start + sectors;
+
+	int resize = ilog2(roundup_pow_of_two(end)) - (*shift + 6);
+	if (resize > 0) {
+		u64 old_bitmap = *bitmap;
+		u64 new_bitmap = 0;
+
+		for (unsigned i = 0; i < 64; i++)
+			if (old_bitmap & BIT_ULL(i))
+				new_bitmap |= BIT_ULL(i >> resize);
+
+		*bitmap = new_bitmap;
+		*shift += resize;
+	}
+
+	BUG_ON(*shift >= BCH_MI_BTREE_BITMAP_SHIFT_MAX);
+	BUG_ON(end > 64ULL << *shift);
+
+	for (unsigned bit = start >> *shift;
+	     (u64) bit << *shift < end;
+	     bit++)
+		*bitmap |= BIT_ULL(bit);
+}
+
 static void __bch2_dev_btree_bitmap_mark(struct bch_dev *ca,
 					 struct bch_sb_field_members_v2 *mi,
 					 u64 start, unsigned sectors, struct sb_write *w)
 {
 	struct bch_member *m = __bch2_members_v2_get_mut(mi, ca->dev_idx);
+	u64 old_bitmap = le64_to_cpu(m->btree_allocated_bitmap);
+	u8 old_shift = m->btree_bitmap_shift;
+	u64 new_bitmap = old_bitmap;
+	u8 new_shift = old_shift;
 
-	u64 end = start + sectors;
-
-	int resize = ilog2(roundup_pow_of_two(end)) - (m->btree_bitmap_shift + 6);
-	if (resize > 0) {
-		u64 old_bitmap = le64_to_cpu(m->btree_allocated_bitmap);
-		u64 new_bitmap = 0;
-		u64 new_gc_bitmap = 0;
-
-		for (unsigned i = 0; i < 64; i++) {
-			if (old_bitmap & BIT_ULL(i))
-				new_bitmap |= BIT_ULL(i >> resize);
-			if (ca->btree_allocated_bitmap_gc & BIT_ULL(i))
-				new_gc_bitmap |= BIT_ULL(i >> resize);
-		}
-
+	bch2_btree_bitmap_mark_sectors(&new_bitmap, &new_shift, start, sectors);
+	if (new_bitmap != old_bitmap || new_shift != old_shift) {
 		m->btree_allocated_bitmap = cpu_to_le64(new_bitmap);
-		m->btree_bitmap_shift += resize;
+		m->btree_bitmap_shift = new_shift;
 		sb_dirty(w);
-
-		ca->btree_allocated_bitmap_gc = new_gc_bitmap;
 	}
 
-	BUG_ON(m->btree_bitmap_shift >= BCH_MI_BTREE_BITMAP_SHIFT_MAX);
-	BUG_ON(end > 64ULL << m->btree_bitmap_shift);
-
-	for (unsigned bit = start >> m->btree_bitmap_shift;
-	     (u64) bit << m->btree_bitmap_shift < end;
-	     bit++) {
-		__le64 b = cpu_to_le64(BIT_ULL(bit));
-
-		if (!(m->btree_allocated_bitmap & b)) {
-			m->btree_allocated_bitmap |= b;
-			sb_dirty(w);
-		}
-
-		ca->btree_allocated_bitmap_gc |= BIT_ULL(bit);
-	}
+	bch2_btree_bitmap_mark_sectors(&ca->btree_allocated_bitmap_gc,
+				       &ca->btree_allocated_bitmap_gc_shift,
+				       start, sectors);
 }
 
 void bch2_dev_btree_bitmap_mark_locked(struct bch_fs *c, struct bkey_s_c k, struct sb_write *w)
@@ -720,6 +724,22 @@ void bch2_dev_btree_bitmap_mark(struct bch_fs *c, struct bkey_s_c k)
 	bch2_dev_btree_bitmap_mark_locked(c, k, &w);
 }
 
+static void bch2_dev_btree_bitmap_gc_mark(struct bch_fs *c, struct bkey_s_c k)
+{
+	guard(memalloc_flags)(PF_MEMALLOC_NOFS);
+	guard(mutex_noio)(&c->sb_lock);
+	guard(rcu)();
+	bkey_for_each_ptr(bch2_bkey_ptrs_c(k), ptr) {
+		struct bch_dev *ca = bch2_dev_rcu_noerror(c, ptr->dev);
+		if (!ca)
+			continue;
+
+		bch2_btree_bitmap_mark_sectors(&ca->btree_allocated_bitmap_gc,
+					       &ca->btree_allocated_bitmap_gc_shift,
+					       ptr->offset, btree_sectors(c));
+	}
+}
+
 static int btree_bitmap_gc_btree_level(struct btree_trans *trans,
 				       struct progress_indicator *progress,
 				       enum btree_id btree, unsigned level)
@@ -728,8 +748,7 @@ static int btree_bitmap_gc_btree_level(struct btree_trans *trans,
 	CLASS(btree_node_iter, iter)(trans, btree, POS_MIN, 0, level, BTREE_ITER_prefetch);
 
 	try(for_each_btree_key_continue(trans, iter, 0, k, ({
-		if (!bch2_dev_btree_bitmap_marked(c, k))
-			bch2_dev_btree_bitmap_mark(c, k);
+		bch2_dev_btree_bitmap_gc_mark(c, k);
 
 		bch2_progress_update_iter(trans, progress, &iter);
 	})));
@@ -743,8 +762,10 @@ int bch2_btree_bitmap_gc(struct bch_fs *c)
 
 	scoped_guard(mutex_noio, &c->sb_lock) {
 		guard(rcu)();
-		for_each_member_device_rcu(c, ca, NULL)
+		for_each_member_device_rcu(c, ca, NULL) {
 			ca->btree_allocated_bitmap_gc = 0;
+			ca->btree_allocated_bitmap_gc_shift = 0;
+		}
 	}
 
 	{
@@ -759,8 +780,7 @@ int bch2_btree_bitmap_gc(struct bch_fs *c)
 			struct btree *b;
 			try(lockrestart_do(trans, PTR_ERR_OR_ZERO(b = bch2_btree_iter_peek_node(&iter))));
 
-			if (!bch2_dev_btree_bitmap_marked(c, bkey_i_to_s_c(&b->key)))
-				bch2_dev_btree_bitmap_mark(c, bkey_i_to_s_c(&b->key));
+			bch2_dev_btree_bitmap_gc_mark(c, bkey_i_to_s_c(&b->key));
 		}
 	}
 
@@ -772,10 +792,13 @@ int bch2_btree_bitmap_gc(struct bch_fs *c)
 		scoped_guard(rcu)
 			for_each_member_device_rcu(c, ca, NULL) {
 				sectors_marked_old += hweight64(ca->mi.btree_allocated_bitmap) << ca->mi.btree_bitmap_shift;
-				sectors_marked_new += hweight64(ca->btree_allocated_bitmap_gc) << ca->mi.btree_bitmap_shift;
+				sectors_marked_new += hweight64(ca->btree_allocated_bitmap_gc) << ca->btree_allocated_bitmap_gc_shift;
 
 				struct bch_member *m = __bch2_members_v2_get_mut(mi, ca->dev_idx);
 				m->btree_allocated_bitmap = cpu_to_le64(ca->btree_allocated_bitmap_gc);
+				m->btree_bitmap_shift = ca->btree_allocated_bitmap_gc_shift;
+				ca->mi.btree_allocated_bitmap = ca->btree_allocated_bitmap_gc;
+				ca->mi.btree_bitmap_shift = ca->btree_allocated_bitmap_gc_shift;
 			}
 		bch2_write_super(c);
 	}

--- a/fs/sb/members.h
+++ b/fs/sb/members.h
@@ -455,11 +455,19 @@ static inline bool __bch2_dev_btree_bitmap_marked_sectors(struct bch_dev *ca, u6
 	for (unsigned bit = start >> ca->mi.btree_bitmap_shift;
 	     (u64) bit << ca->mi.btree_bitmap_shift < end;
 	     bit++)
-		if (!(BIT_ULL(bit) &
-		      ca->mi.btree_allocated_bitmap &
-		      (with_gc
-		       ? ca->btree_allocated_bitmap_gc
-		       : ~0ULL)))
+		if (!(BIT_ULL(bit) & ca->mi.btree_allocated_bitmap))
+			return false;
+
+	if (!with_gc)
+		return true;
+
+	if (end > 64ULL << ca->btree_allocated_bitmap_gc_shift)
+		return false;
+
+	for (unsigned bit = start >> ca->btree_allocated_bitmap_gc_shift;
+	     (u64) bit << ca->btree_allocated_bitmap_gc_shift < end;
+	     bit++)
+		if (!(BIT_ULL(bit) & ca->btree_allocated_bitmap_gc))
 			return false;
 	return true;
 }

--- a/fs/sb/members.h
+++ b/fs/sb/members.h
@@ -463,11 +463,19 @@ static inline bool __bch2_dev_btree_bitmap_marked_sectors(struct bch_dev *ca, u6
 	for (unsigned bit = start >> ca->mi.btree_bitmap_shift;
 	     (u64) bit << ca->mi.btree_bitmap_shift < end;
 	     bit++)
-		if (!(BIT_ULL(bit) &
-		      ca->mi.btree_allocated_bitmap &
-		      (with_gc
-		       ? ca->btree_allocated_bitmap_gc
-		       : ~0ULL)))
+		if (!(BIT_ULL(bit) & ca->mi.btree_allocated_bitmap))
+			return false;
+
+	if (!with_gc)
+		return true;
+
+	if (end > 64ULL << ca->btree_allocated_bitmap_gc_shift)
+		return false;
+
+	for (unsigned bit = start >> ca->btree_allocated_bitmap_gc_shift;
+	     (u64) bit << ca->btree_allocated_bitmap_gc_shift < end;
+	     bit++)
+		if (!(BIT_ULL(bit) & ca->btree_allocated_bitmap_gc))
 			return false;
 	return true;
 }


### PR DESCRIPTION
`btree_bitmap_gc` rebuilt `btree_allocated_bitmap` while retaining the old
`btree_bitmap_shift`. Once coarse, GC could clear stale bits but still represent
the same oversized range and reschedule itself on the next mount.

Rebuild from exact btree-node pointers into a temporary bitmap/shift pair and
commit both fields together. Normal marking and marked-with-GC checks preserve
the independent persistent and in-flight granularities, so concurrent
allocations are not reinterpreted during GC. This is the correct
`bcachefs-tools` successor to closed wrong-target koverstreet/bcachefs#1170. Addresses
koverstreet/bcachefs#1082; references koverstreet/bcachefs#1111.

Validation: targeted Werror compilation and `git diff --check` passed. A
Linux 7.3-rc1 ktest VM with current head `aca1aa7f` passed the GC regression
scenario: a deliberately coarse, persisted bitmap (64 set bits, shift 17)
was read back before GC; the actual recovery pass reduced its represented
range from 4 GiB to 3 MiB and persisted shift 11. Payload comparisons passed
after GC and after remount, followed by offline fsck. The built kernel
contained `btree_allocated_bitmap_gc_shift`, confirming the candidate code.
