### PR TITLE
bcachefs: port online shrink implementation

### DIFF
--- a/fs/alloc/accounting.c
+++ b/fs/alloc/accounting.c
@@ -1,14 +1,21 @@
 // SPDX-License-Identifier: GPL-2.0
 
+#include "alloc/background.h"
+#include "alloc/format.h"
 #include "bcachefs.h"
+#include "bcachefs_format.h"
 #include "bcachefs_ioctl.h"
+#include "alloc/accounting_format.h"
 
 #include "alloc/accounting.h"
 #include "alloc/buckets.h"
 #include "alloc/replicas.h"
 
+#include "btree/bkey_types.h"
 #include "btree/cache.h"
+#include "btree/iter.h"
 #include "btree/journal_overlay.h"
+#include "btree/types.h"
 #include "btree/update.h"
 #include "btree/write_buffer.h"
 
@@ -1213,7 +1220,55 @@ int bch2_accounting_read(struct bch_fs *c)
 	return accounting_read_mem_fixups(trans);
 }
 
-int bch2_dev_usage_remove(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
+int bch2_dev_truncate_accounting(struct bch_fs *c, struct bch_dev *ca, u64 old_nbuckets, u64 cutoff) {
+	struct bpos start = POS(ca->dev_idx, cutoff);
+	struct bpos end = POS(ca->dev_idx, old_nbuckets);
+
+	CLASS(btree_trans, trans)(c);
+
+	return commit_do(trans, NULL, NULL, 0, ({
+		s64 delta[BCH_DATA_NR][3] = {};
+		s64 keys = 0;
+		struct bkey_s_c k;
+		int ret = 0;
+
+		for_each_btree_key_max_norestart(trans, iter, BTREE_ID_alloc, start, end, BTREE_ITER_prefetch, k, ret) {
+			if (!k.k->type)
+				continue;
+
+			struct bch_alloc_v4 _alloc;
+			const struct bch_alloc_v4 *alloc = bch2_alloc_to_v4(k, &_alloc);
+
+			enum bch_data_type data_type = alloc->data_type;
+
+			delta[data_type][0] -= 1;
+			delta[data_type][1] -= bch2_bucket_sectors(*alloc);
+			delta[data_type][2] -= bch2_bucket_sectors_fragmented(ca, *alloc);
+
+			s64 unstriped = bch2_bucket_sectors_unstriped(*alloc);
+			if (unstriped) {
+				delta[BCH_DATA_unstriped][0] -= 1;
+				delta[BCH_DATA_unstriped][1] -= unstriped;
+			}
+
+			keys++;
+		}
+		if (!ret) {
+			delta[BCH_DATA_free][0] -= (old_nbuckets - cutoff) - keys;
+
+			for (unsigned type = 0; type < BCH_DATA_NR; type++) {
+				ret = bch2_disk_accounting_mod2(trans, false, delta[type], dev_data_type, .dev = ca->dev_idx, .data_type = type);
+
+				if (ret)
+					break;
+			}
+		}
+
+		ret;
+	}));
+}
+
+int bch2_dev_usage_remove(struct bch_fs *c, struct bch_dev *ca)
 {
 	CLASS(btree_trans, trans)(c);
 
@@ -1232,7 +1287,7 @@ int bch2_dev_usage_remove(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
 							 disk_accounting_pos_to_bpos(&start),
 							 disk_accounting_pos_to_bpos(&end),
 							 BTREE_ITER_all_snapshots, k, ret) {
-				if (k.k->type != KEY_TYPE_accounting || k.k->p.offset < cutoff)
+				if (k.k->type != KEY_TYPE_accounting)
 					continue;
 
 				struct disk_accounting_pos acc;

--- a/fs/alloc/accounting.c
+++ b/fs/alloc/accounting.c
@@ -124,7 +124,7 @@ int bch2_disk_accounting_mod(struct btree_trans *trans,
 		     a = (void *) bkey_next(&a->k_i))
 			if (bpos_eq(a->k.p, pos) &&
 			    bch2_accounting_counters(&a->k) == nr) {
-				acc_u64s(a->v.d, d, nr);
+				acc_s64s(a->v.d, d, nr);
 
 				if (bch2_accounting_key_is_zero(accounting_i_to_s_c(a))) {
 					unsigned offset = (u64 *) a -

--- a/fs/alloc/accounting.c
+++ b/fs/alloc/accounting.c
@@ -124,7 +124,7 @@ int bch2_disk_accounting_mod(struct btree_trans *trans,
 		     a = (void *) bkey_next(&a->k_i))
 			if (bpos_eq(a->k.p, pos) &&
 			    bch2_accounting_counters(&a->k) == nr) {
-				acc_s64s(a->v.d, d, nr);
+				acc_u64s(a->v.d, d, nr);
 
 				if (bch2_accounting_key_is_zero(accounting_i_to_s_c(a))) {
 					unsigned offset = (u64 *) a -

--- a/fs/alloc/accounting.c
+++ b/fs/alloc/accounting.c
@@ -1213,7 +1213,7 @@ int bch2_accounting_read(struct bch_fs *c)
 	return accounting_read_mem_fixups(trans);
 }
 
-int bch2_dev_usage_remove(struct bch_fs *c, struct bch_dev *ca)
+int bch2_dev_usage_remove(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
 {
 	CLASS(btree_trans, trans)(c);
 
@@ -1232,7 +1232,7 @@ int bch2_dev_usage_remove(struct bch_fs *c, struct bch_dev *ca)
 							 disk_accounting_pos_to_bpos(&start),
 							 disk_accounting_pos_to_bpos(&end),
 							 BTREE_ITER_all_snapshots, k, ret) {
-				if (k.k->type != KEY_TYPE_accounting)
+				if (k.k->type != KEY_TYPE_accounting || k.k->p.offset < cutoff)
 					continue;
 
 				struct disk_accounting_pos acc;

--- a/fs/alloc/accounting.h
+++ b/fs/alloc/accounting.h
@@ -316,7 +316,7 @@ int bch2_gc_accounting_done(struct bch_fs *);
 
 int bch2_accounting_read(struct bch_fs *);
 
-int bch2_dev_usage_remove(struct bch_fs *, struct bch_dev *);
+int bch2_dev_usage_remove(struct bch_fs *, struct bch_dev *, u64);
 int bch2_dev_usage_init(struct bch_dev *, bool);
 
 void bch2_verify_accounting_clean(struct bch_fs *c);

--- a/fs/alloc/accounting.h
+++ b/fs/alloc/accounting.h
@@ -316,7 +316,10 @@ int bch2_gc_accounting_done(struct bch_fs *);
 
 int bch2_accounting_read(struct bch_fs *);
 
-int bch2_dev_usage_remove(struct bch_fs *, struct bch_dev *, u64);
+
+int bch2_dev_truncate_accounting(struct bch_fs *, struct bch_dev *, u64, u64);
+
+int bch2_dev_usage_remove(struct bch_fs *, struct bch_dev *);
 int bch2_dev_usage_init(struct bch_dev *, bool);
 
 void bch2_verify_accounting_clean(struct bch_fs *c);

--- a/fs/alloc/accounting_format.h
+++ b/fs/alloc/accounting_format.h
@@ -10,7 +10,7 @@
  * Here, the key has considerably more structure than a typical key (bpos); an
  * accounting key is 'struct disk_accounting_pos', which is a union of bpos.
  *
- * More specifically: a key is just a muliword integer (where word endianness
+ * More specifically: a key is just a multiword integer (where word endianness
  * matches native byte order), so we're treating bpos as an opaque 20 byte
  * integer and mapping bch_accounting_key to that.
  *

--- a/fs/alloc/background.c
+++ b/fs/alloc/background.c
@@ -1544,6 +1544,8 @@ int bch2_dev_remove_alloc(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
 {
 	struct bpos start	= POS(ca->dev_idx, cutoff);
 	struct bpos end		= POS(ca->dev_idx, U64_MAX);
+	struct bpos bp_start	= bucket_pos_to_bp_start(ca, start);
+	struct bpos bp_end	= POS(ca->dev_idx + 1, 0);
 	int ret;
 
 	/*
@@ -1556,7 +1558,13 @@ int bch2_dev_remove_alloc(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
 		 : bch2_dev_remove_need_discard(c, ca)) ?:
 		bch2_btree_delete_range(c, BTREE_ID_freespace, start, end,
 					BTREE_TRIGGER_norun) ?:
-		bch2_btree_delete_range(c, BTREE_ID_backpointers, start, end,
+		/*
+		 * Backpointer keys are indexed by device + sector, not device +
+		 * bucket.  A shrink cutoff in bucket space must be translated
+		 * before deleting the truncated tail, otherwise we wipe
+		 * backpointers that still belong to buckets below @cutoff.
+		 */
+		bch2_btree_delete_range(c, BTREE_ID_backpointers, bp_start, bp_end,
 					BTREE_TRIGGER_norun) ?:
 		bch2_dev_remove_bucket_gens(c, ca, cutoff) ?:
 		bch2_btree_delete_range(c, BTREE_ID_alloc, start, end,

--- a/fs/alloc/background.c
+++ b/fs/alloc/background.c
@@ -1693,7 +1693,7 @@ void bch2_dev_allocator_remove(struct bch_fs *c, struct bch_dev *ca)
 	 */
 	bch2_recalc_capacity(c);
 
-	bch2_open_buckets_stop(c, ca, false);
+	bch2_open_buckets_stop(c, ca, false, 0);
 
 	/*
 	 * Wake up threads that were blocked on allocation, so they can notice

--- a/fs/alloc/background.c
+++ b/fs/alloc/background.c
@@ -1491,6 +1491,31 @@ static int bch2_dev_remove_need_discard(struct bch_fs *c, struct bch_dev *ca)
 	}));
 }
 
+int bch2_dev_truncate_alloc(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
+{
+	struct bpos start	= POS(ca->dev_idx, cutoff);
+	struct bpos end		= POS(ca->dev_idx, U64_MAX);
+	int ret;
+
+	/*
+	 * We clear the LRU and need_discard btrees first so that we don't race
+	 * with bch2_do_invalidates() and bch2_do_discards()
+	 */
+	ret =   bch2_dev_truncate_lrus(c, ca, cutoff) ?:
+		bch2_btree_delete_range(c, BTREE_ID_need_discard, start, end,
+					BTREE_TRIGGER_norun) ?:
+		bch2_btree_delete_range(c, BTREE_ID_freespace, start, end,
+					BTREE_TRIGGER_norun) ?:
+		bch2_btree_delete_range(c, BTREE_ID_backpointers, start, end,
+					BTREE_TRIGGER_norun) ?:
+		bch2_btree_delete_range(c, BTREE_ID_bucket_gens, start, end,
+					BTREE_TRIGGER_norun) ?:
+		bch2_btree_delete_range(c, BTREE_ID_alloc, start, end,
+					BTREE_TRIGGER_norun) ?:
+		bch2_dev_usage_remove(c, ca);
+	bch_err_msg_dev(ca, ret, "truncating dev alloc info");
+	return ret;
+}
 int bch2_dev_remove_alloc(struct bch_fs *c, struct bch_dev *ca)
 {
 	struct bpos start	= POS(ca->dev_idx, 0);

--- a/fs/alloc/background.c
+++ b/fs/alloc/background.c
@@ -1523,8 +1523,6 @@ fsck_err:
 
 /* device removal */
 
-<<<<<<< conflict 1 of 2
-+++++++ tkspqttk 8507ca39 "bcachefs: shrink: mark superblock buckets as metadata" (rebase destination)
 static int bch2_dev_remove_need_discard(struct bch_fs *c, struct bch_dev *ca)
 {
 	CLASS(btree_trans, trans)(c);
@@ -1554,8 +1552,7 @@ int bch2_dev_remove_alloc(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
 	 */
 	ret =   bch2_dev_remove_lrus(c, ca, cutoff) ?:
 		(cutoff
-		 ? bch2_btree_delete_range(c, BTREE_ID_need_discard, start, end,
-					   BTREE_TRIGGER_norun)
+		 ? bch2_dev_clear_need_discard(c, ca, cutoff)
 		 : bch2_dev_remove_need_discard(c, ca)) ?:
 		bch2_btree_delete_range(c, BTREE_ID_freespace, start, end,
 					BTREE_TRIGGER_norun) ?:

--- a/fs/alloc/background.c
+++ b/fs/alloc/background.c
@@ -1095,6 +1095,55 @@ int bch2_alloc_read(struct bch_fs *c)
 	return ret;
 }
 
+int bch2_dev_remove_bucket_gens(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
+{
+	unsigned offset;
+	struct bpos pos = alloc_gens_pos(POS(ca->dev_idx, cutoff), &offset);
+	int ret;
+
+	if (!offset)
+		return bch2_btree_delete_range(c, BTREE_ID_bucket_gens,
+					       pos,
+					       POS(ca->dev_idx, U64_MAX),
+					       BTREE_TRIGGER_norun);
+
+	{
+		CLASS(btree_trans, trans)(c);
+		bool need_commit = false;
+
+		ret = lockrestart_do(trans, ({
+			CLASS(btree_iter, iter)(trans, BTREE_ID_bucket_gens, pos, BTREE_ITER_intent);
+			struct bkey_s_c k = bkey_try(bch2_btree_iter_peek_slot(&iter));
+
+			try(bkey_err(k));
+
+			if (k.k->type == KEY_TYPE_bucket_gens) {
+				struct bkey_i_bucket_gens *g =
+					errptr_try(bch2_trans_kmalloc(trans, sizeof(*g)));
+
+				bkey_reassemble(&g->k_i, k);
+				memset(&g->v.gens[offset], 0, sizeof(g->v.gens) - offset);
+				try(bch2_trans_update(trans, &iter, &g->k_i, 0));
+				need_commit = true;
+			}
+			0;
+		}));
+		if (ret)
+			return ret;
+
+		if (need_commit) {
+			ret = bch2_trans_commit(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc);
+			if (ret)
+				return ret;
+		}
+	}
+
+	return bch2_btree_delete_range(c, BTREE_ID_bucket_gens,
+				       bpos_nosnap_successor(pos),
+				       POS(ca->dev_idx, U64_MAX),
+				       BTREE_TRIGGER_norun);
+}
+
 /* Free space/discard btree: */
 
 int bch2_bucket_do_freespace_index(struct btree_trans *trans,
@@ -1512,8 +1561,7 @@ int bch2_dev_remove_alloc(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
 					BTREE_TRIGGER_norun) ?:
 		bch2_btree_delete_range(c, BTREE_ID_backpointers, start, end,
 					BTREE_TRIGGER_norun) ?:
-		bch2_btree_delete_range(c, BTREE_ID_bucket_gens, start, end,
-					BTREE_TRIGGER_norun) ?:
+		bch2_dev_remove_bucket_gens(c, ca, cutoff) ?:
 		bch2_btree_delete_range(c, BTREE_ID_alloc, start, end,
 					BTREE_TRIGGER_norun) ?:
 		(cutoff == 0 ? bch2_dev_usage_remove(c, ca) : 0);

--- a/fs/alloc/background.c
+++ b/fs/alloc/background.c
@@ -1511,8 +1511,7 @@ int bch2_dev_truncate_alloc(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
 		bch2_btree_delete_range(c, BTREE_ID_bucket_gens, start, end,
 					BTREE_TRIGGER_norun) ?:
 		bch2_btree_delete_range(c, BTREE_ID_alloc, start, end,
-					BTREE_TRIGGER_norun) ?:
-		bch2_dev_usage_remove(c, ca);
+					BTREE_TRIGGER_norun);
 	bch_err_msg_dev(ca, ret, "truncating dev alloc info");
 	return ret;
 }

--- a/fs/alloc/background.c
+++ b/fs/alloc/background.c
@@ -1474,6 +1474,8 @@ fsck_err:
 
 /* device removal */
 
+<<<<<<< conflict 1 of 2
++++++++ tkspqttk 8507ca39 "bcachefs: shrink: mark superblock buckets as metadata" (rebase destination)
 static int bch2_dev_remove_need_discard(struct bch_fs *c, struct bch_dev *ca)
 {
 	CLASS(btree_trans, trans)(c);
@@ -1491,7 +1493,7 @@ static int bch2_dev_remove_need_discard(struct bch_fs *c, struct bch_dev *ca)
 	}));
 }
 
-int bch2_dev_truncate_alloc(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
+int bch2_dev_remove_alloc(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
 {
 	struct bpos start	= POS(ca->dev_idx, cutoff);
 	struct bpos end		= POS(ca->dev_idx, U64_MAX);
@@ -1501,32 +1503,13 @@ int bch2_dev_truncate_alloc(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
 	 * We clear the LRU and need_discard btrees first so that we don't race
 	 * with bch2_do_invalidates() and bch2_do_discards()
 	 */
-	ret =   bch2_dev_truncate_lrus(c, ca, cutoff) ?:
-		bch2_btree_delete_range(c, BTREE_ID_need_discard, start, end,
-					BTREE_TRIGGER_norun) ?:
-		bch2_btree_delete_range(c, BTREE_ID_freespace, start, end,
-					BTREE_TRIGGER_norun) ?:
-		bch2_btree_delete_range(c, BTREE_ID_backpointers, start, end,
-					BTREE_TRIGGER_norun) ?:
-		bch2_btree_delete_range(c, BTREE_ID_bucket_gens, start, end,
-					BTREE_TRIGGER_norun) ?:
-		bch2_btree_delete_range(c, BTREE_ID_alloc, start, end,
-					BTREE_TRIGGER_norun);
-	bch_err_msg_dev(ca, ret, "truncating dev alloc info");
-	return ret;
-}
-int bch2_dev_remove_alloc(struct bch_fs *c, struct bch_dev *ca)
-{
-	struct bpos start	= POS(ca->dev_idx, 0);
-	struct bpos end		= POS(ca->dev_idx, U64_MAX);
-	int ret;
-
-	/*
-	 * We clear the LRU and need_discard btrees first so that we don't race
-	 * with bch2_do_invalidates() and bch2_do_discards_async()
-	 */
-	ret =   bch2_dev_remove_lrus(c, ca) ?:
-		bch2_dev_remove_need_discard(c, ca) ?:
+	ret =   (cutoff
+		 ? bch2_dev_truncate_lrus(c, ca, cutoff)
+		 : bch2_dev_remove_lrus(c, ca)) ?:
+		(cutoff
+		 ? bch2_btree_delete_range(c, BTREE_ID_need_discard, start, end,
+					   BTREE_TRIGGER_norun)
+		 : bch2_dev_remove_need_discard(c, ca)) ?:
 		bch2_btree_delete_range(c, BTREE_ID_freespace, start, end,
 					BTREE_TRIGGER_norun) ?:
 		bch2_btree_delete_range(c, BTREE_ID_backpointers, start, end,
@@ -1535,8 +1518,9 @@ int bch2_dev_remove_alloc(struct bch_fs *c, struct bch_dev *ca)
 					BTREE_TRIGGER_norun) ?:
 		bch2_btree_delete_range(c, BTREE_ID_alloc, start, end,
 					BTREE_TRIGGER_norun) ?:
-		bch2_dev_usage_remove(c, ca);
-	bch_err_msg_dev(ca, ret, "removing dev alloc info");
+		bch2_dev_usage_remove(c, ca, cutoff);
+	bch_err_msg_dev(ca, ret, "%s dev alloc info",
+			cutoff ? "truncating" : "removing");
 	return ret;
 }
 

--- a/fs/alloc/background.c
+++ b/fs/alloc/background.c
@@ -1503,9 +1503,7 @@ int bch2_dev_remove_alloc(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
 	 * We clear the LRU and need_discard btrees first so that we don't race
 	 * with bch2_do_invalidates() and bch2_do_discards()
 	 */
-	ret =   (cutoff
-		 ? bch2_dev_truncate_lrus(c, ca, cutoff)
-		 : bch2_dev_remove_lrus(c, ca)) ?:
+	ret =   bch2_dev_remove_lrus(c, ca, cutoff) ?:
 		(cutoff
 		 ? bch2_btree_delete_range(c, BTREE_ID_need_discard, start, end,
 					   BTREE_TRIGGER_norun)
@@ -1518,7 +1516,7 @@ int bch2_dev_remove_alloc(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
 					BTREE_TRIGGER_norun) ?:
 		bch2_btree_delete_range(c, BTREE_ID_alloc, start, end,
 					BTREE_TRIGGER_norun) ?:
-		bch2_dev_usage_remove(c, ca, cutoff);
+		(cutoff == 0 ? bch2_dev_usage_remove(c, ca) : 0);
 	bch_err_msg_dev(ca, ret, "%s dev alloc info",
 			cutoff ? "truncating" : "removing");
 	return ret;

--- a/fs/alloc/background.h
+++ b/fs/alloc/background.h
@@ -306,8 +306,7 @@ int bch2_alloc_key_to_dev_counters(struct btree_trans *, struct bch_dev *,
 				   const struct bch_alloc_v4 *, unsigned);
 int bch2_trigger_alloc(struct btree_trans *, struct btree_trigger_op);
 
-int bch2_dev_truncate_alloc(struct bch_fs *c, struct bch_dev *ca, u64 cutoff);
-int bch2_dev_remove_alloc(struct bch_fs *, struct bch_dev *);
+int bch2_dev_remove_alloc(struct bch_fs *, struct bch_dev *, u64);
 
 void bch2_recalc_capacity(struct bch_fs *);
 unsigned long bch2_fs_ra_pages(struct bch_fs *);

--- a/fs/alloc/background.h
+++ b/fs/alloc/background.h
@@ -306,6 +306,7 @@ int bch2_alloc_key_to_dev_counters(struct btree_trans *, struct bch_dev *,
 				   const struct bch_alloc_v4 *, unsigned);
 int bch2_trigger_alloc(struct btree_trans *, struct btree_trigger_op);
 
+int bch2_dev_truncate_alloc(struct bch_fs *c, struct bch_dev *ca, u64 cutoff);
 int bch2_dev_remove_alloc(struct bch_fs *, struct bch_dev *);
 
 void bch2_recalc_capacity(struct bch_fs *);

--- a/fs/alloc/background.h
+++ b/fs/alloc/background.h
@@ -295,6 +295,7 @@ void bch2_bucket_gens_to_text(struct printbuf *, struct bch_fs *, struct bkey_s_
 })
 
 int bch2_bucket_gens_init(struct bch_fs *);
+int bch2_dev_remove_bucket_gens(struct bch_fs *, struct bch_dev *, u64);
 
 int bch2_alloc_read(struct bch_fs *);
 

--- a/fs/alloc/buckets.c
+++ b/fs/alloc/buckets.c
@@ -579,12 +579,103 @@ static int __trigger_extent(struct btree_trans *trans,
 	return 0;
 }
 
+static int bch2_trigger_extent_same_backpointers(struct btree_trans *trans,
+						 struct btree_trigger_op op,
+						 bool *handled)
+{
+	struct bch_fs *c = trans->c;
+	struct bkey_i_backpointer old_bp[BCH_REPLICAS_MAX * 2];
+	struct bkey_i_backpointer new_bp[BCH_REPLICAS_MAX * 2];
+	struct bkey_ptrs_c ptrs;
+	const union bch_extent_entry *entry;
+	struct extent_ptr_decoded p;
+	unsigned nr_old = 0, nr_new = 0;
+	unsigned i;
+
+	*handled = false;
+	if (op.level)
+		return 0;
+
+	/*
+	 * Reconcile-only updates do not move the extent, they only toggle the
+	 * phys-work flag that is cached in rotational-data backpointers.  Do
+	 * not delete+reinsert those backpointers through the write buffer when
+	 * the key itself is unchanged: update the existing entry in place and
+	 * adjust the reconcile_work_phys bit separately.
+	 */
+	ptrs = bch2_bkey_ptrs_c(op.old);
+	bkey_for_each_ptr_decode(op.old.k, ptrs, p, entry) {
+		BUG_ON(nr_old == ARRAY_SIZE(old_bp));
+		bch2_extent_ptr_to_bp(c, op.btree, op.level, op.old, p, entry, &old_bp[nr_old++]);
+	}
+
+	ptrs = bch2_bkey_ptrs_c(op.new.s_c);
+	bkey_for_each_ptr_decode(op.new.k, ptrs, p, entry) {
+		BUG_ON(nr_new == ARRAY_SIZE(new_bp));
+		bch2_extent_ptr_to_bp(c, op.btree, op.level, op.new.s_c, p, entry, &new_bp[nr_new++]);
+	}
+
+	if (nr_old != nr_new)
+		return 0;
+
+	for (i = 0; i < nr_old; i++) {
+		struct bch_backpointer old_v = old_bp[i].v;
+		struct bch_backpointer new_v = new_bp[i].v;
+
+		SET_BACKPOINTER_RECONCILE_PHYS(&old_v, 0);
+		SET_BACKPOINTER_RECONCILE_PHYS(&new_v, 0);
+
+		if (!bpos_eq(old_bp[i].k.p, new_bp[i].k.p) ||
+		    memcmp(&old_v, &new_v, sizeof(old_v)))
+			return 0;
+	}
+
+	for (i = 0; i < nr_old; i++) {
+		unsigned old_phys = BACKPOINTER_RECONCILE_PHYS(&old_bp[i].v);
+		unsigned new_phys = BACKPOINTER_RECONCILE_PHYS(&new_bp[i].v);
+
+		if (!old_phys && !new_phys)
+			continue;
+
+		if (old_phys)
+			try(bch2_btree_bit_mod_buffered(trans,
+					reconcile_work_phys_btree[old_phys],
+					old_bp[i].k.p, false));
+
+		if (new_phys)
+			try(bch2_btree_bit_mod_buffered(trans,
+					reconcile_work_phys_btree[new_phys],
+					new_bp[i].k.p, true));
+
+		try(bch2_trans_update_buffered(trans,
+				backpointer_btree(&new_bp[i].v),
+				&new_bp[i].k_i));
+	}
+
+	*handled = true;
+	return 0;
+}
+
 int bch2_trigger_extent(struct btree_trans *trans, struct btree_trigger_op op)
 {
 	struct bkey_ptrs_c new_ptrs = bch2_bkey_ptrs_c(op.new.s_c);
 	struct bkey_ptrs_c old_ptrs = bch2_bkey_ptrs_c(op.old);
 	unsigned new_ptrs_bytes = (void *) new_ptrs.end - (void *) new_ptrs.start;
 	unsigned old_ptrs_bytes = (void *) old_ptrs.end - (void *) old_ptrs.start;
+
+	/*
+	 * Reconcile-only updates keep the same physical pointers.  Update
+	 * their backpointer flags in place so buffered delete+insert churn
+	 * cannot drop the key, then let reconcile accounting/work tracking
+	 * see the logical-state change.
+	 */
+	if (op.level == 0) {
+		bool handled;
+
+		try(bch2_trigger_extent_same_backpointers(trans, op, &handled));
+		if (handled)
+			return bch2_trigger_extent_reconcile(trans, op);
+	}
 
 	/* if pointers aren't changing - nothing to do: */
 	if (new_ptrs_bytes == old_ptrs_bytes &&

--- a/fs/alloc/buckets.c
+++ b/fs/alloc/buckets.c
@@ -925,24 +925,34 @@ int __bch2_disk_reservation_add(struct bch_fs *c, struct disk_reservation *res,
 
 /* Startup/shutdown: */
 
+void bch2_dev_buckets_nouse_free(struct bch_fs *c, struct bch_dev *ca)
+{
+	kvfree_rcu_mightsleep(ca->buckets_nouse);
+	ca->buckets_nouse = NULL;
+}
 void bch2_buckets_nouse_free(struct bch_fs *c)
 {
 	for_each_member_device(c, ca) {
-		kvfree_rcu_mightsleep(ca->buckets_nouse);
-		ca->buckets_nouse = NULL;
+		bch2_dev_buckets_nouse_free(c, ca);
 	}
 }
 
+int bch2_dev_buckets_nouse_alloc(struct bch_fs *c, struct bch_dev *ca)
+{
+	BUG_ON(ca->buckets_nouse);
+
+	ca->buckets_nouse = bch2_kvmalloc(BITS_TO_LONGS(ca->mi.nbuckets) *
+				    sizeof(unsigned long),
+				    GFP_KERNEL|__GFP_ZERO);
+	if (!ca->buckets_nouse)
+		return bch_err_throw(c, ENOMEM_buckets_nouse);
+
+	return 0;
+}
 int bch2_buckets_nouse_alloc(struct bch_fs *c)
 {
 	for_each_member_device(c, ca) {
-		BUG_ON(ca->buckets_nouse);
-
-		ca->buckets_nouse = bch2_kvmalloc(BITS_TO_LONGS(ca->mi.nbuckets) *
-					    sizeof(unsigned long),
-					    GFP_KERNEL|__GFP_ZERO);
-		if (!ca->buckets_nouse)
-			return bch_err_throw(c, ENOMEM_buckets_nouse);
+		try(bch2_dev_buckets_nouse_alloc(c, ca));
 	}
 
 	return 0;

--- a/fs/alloc/buckets.c
+++ b/fs/alloc/buckets.c
@@ -1049,6 +1049,28 @@ int bch2_buckets_nouse_alloc(struct bch_fs *c)
 	return 0;
 }
 
+static int bch2_dev_buckets_nouse_resize(struct bch_fs *c, struct bch_dev *ca,
+					 u64 old_size, u64 new_size)
+{
+	if (!ca->buckets_nouse)
+		return 0;
+
+	unsigned long *n = bch2_kvmalloc(BITS_TO_LONGS(new_size) *
+					 sizeof(unsigned long),
+					 GFP_KERNEL|__GFP_ZERO);
+	if (!n)
+		return bch_err_throw(c, ENOMEM_buckets_nouse);
+
+	memcpy(n, ca->buckets_nouse,
+	       BITS_TO_LONGS(min(old_size, new_size)) * sizeof(unsigned long));
+
+	unsigned long *old = ca->buckets_nouse;
+	ca->buckets_nouse = n;
+	kvfree_rcu_mightsleep(old);
+
+	return 0;
+}
+
 static void bucket_gens_free_rcu(struct rcu_head *rcu)
 {
 	struct bucket_gens *buckets =
@@ -1065,9 +1087,6 @@ int bch2_dev_buckets_resize(struct bch_fs *c, struct bch_dev *ca, u64 nbuckets)
 
 	if (resize)
 		lockdep_assert_held(&c->state_lock);
-
-	if (resize && ca->buckets_nouse)
-		return bch_err_throw(c, no_resize_with_buckets_nouse); // TODO: make this work
 
 	bucket_gens = bch2_kvmalloc(struct_size(bucket_gens, b, nbuckets),
 				    GFP_KERNEL|__GFP_ZERO);
@@ -1091,6 +1110,7 @@ int bch2_dev_buckets_resize(struct bch_fs *c, struct bch_dev *ca, u64 nbuckets)
 
 	try(bch2_bucket_bitmap_resize(ca, &ca->bucket_backpointer_mismatch, ca->mi.nbuckets, nbuckets));
 	try(bch2_bucket_bitmap_resize(ca, &ca->bucket_backpointer_empty, ca->mi.nbuckets, nbuckets));
+	try(bch2_dev_buckets_nouse_resize(c, ca, ca->mi.nbuckets, nbuckets));
 
 	rcu_assign_pointer(ca->bucket_gens, bucket_gens);
 	bucket_gens	= old_bucket_gens;

--- a/fs/alloc/buckets.c
+++ b/fs/alloc/buckets.c
@@ -966,7 +966,7 @@ int bch2_dev_buckets_resize(struct bch_fs *c, struct bch_dev *ca, u64 nbuckets)
 		lockdep_assert_held(&c->state_lock);
 
 	if (resize && ca->buckets_nouse)
-		return bch_err_throw(c, no_resize_with_buckets_nouse);
+		return bch_err_throw(c, no_resize_with_buckets_nouse); // TODO: make this work
 
 	bucket_gens = bch2_kvmalloc(struct_size(bucket_gens, b, nbuckets),
 				    GFP_KERNEL|__GFP_ZERO);

--- a/fs/alloc/buckets.h
+++ b/fs/alloc/buckets.h
@@ -432,7 +432,9 @@ static inline u64 avail_factor(u64 r)
 	return div_u64(r << RESERVE_FACTOR, (1 << RESERVE_FACTOR) + 1);
 }
 
+void bch2_dev_buckets_nouse_free(struct bch_fs *, struct bch_dev *);
 void bch2_buckets_nouse_free(struct bch_fs *);
+int bch2_dev_buckets_nouse_alloc(struct bch_fs *, struct bch_dev *);
 int bch2_buckets_nouse_alloc(struct bch_fs *);
 
 static inline bool bch2_bucket_nouse(struct bch_dev *ca, u64 bucket)

--- a/fs/alloc/buckets_types.h
+++ b/fs/alloc/buckets_types.h
@@ -5,6 +5,8 @@
 #include "bcachefs_format.h"
 #include "util/util.h"
 
+#include <linux/rcupdate.h>
+
 #define BUCKET_JOURNAL_SEQ_BITS		16
 
 /*

--- a/fs/alloc/discard.c
+++ b/fs/alloc/discard.c
@@ -380,6 +380,63 @@ static int bch2_discard_one_bucket(struct btree_trans *trans,
 	return ret;
 }
 
+int bch2_dev_clear_need_discard(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
+{
+	struct bpos pos = POS_MIN;
+
+	while (1) {
+		struct bpos next = POS_MAX;
+		bool done = false;
+		int ret = bch2_trans_commit_do(c, NULL, NULL,
+				BCH_WATERMARK_reclaim|
+				BCH_TRANS_COMMIT_no_check_rw|
+				BCH_TRANS_COMMIT_no_enospc, ({
+			int __ret = 0;
+			CLASS(btree_iter, iter)(trans, BTREE_ID_need_discard, pos, 0);
+			struct bkey_s_c k = bch2_btree_iter_peek(&iter);
+			int _ret = bkey_err(k);
+
+			if (_ret) {
+				__ret = _ret;
+			} else if (!k.k) {
+				done = true;
+			} else {
+				struct bpos bucket = u64_to_bucket(k.k->p.offset);
+
+				next = bpos_successor(k.k->p);
+
+				if (bucket.inode == ca->dev_idx &&
+				    bucket.offset >= cutoff) {
+					CLASS(btree_iter, alloc_iter)(trans, BTREE_ID_alloc,
+								      bucket, BTREE_ITER_cached);
+					struct bkey_s_c alloc_k =
+						bch2_btree_iter_peek_slot(&alloc_iter);
+					struct bkey_i_alloc_v4 *a;
+
+					_ret = bkey_err(alloc_k);
+					if (_ret) {
+						__ret = _ret;
+					} else {
+						a = errptr_try(bch2_alloc_to_v4_mut(trans, alloc_k));
+						if (a->v.data_type == BCH_DATA_need_discard) {
+							SET_BCH_ALLOC_V4_NEED_DISCARD(&a->v, false);
+							alloc_data_type_set(&a->v, a->v.data_type);
+							__ret = bch2_trans_update(trans, &alloc_iter,
+										  &a->k_i, 0);
+						}
+					}
+				}
+			}
+			__ret;
+		}));
+		if (ret)
+			return ret;
+		if (done)
+			return 0;
+		pos = next;
+	}
+}
+
 static void calculate_discard_sectors_to_release(struct btree_trans *trans)
 {
 	struct bch_fs *c = trans->c;

--- a/fs/alloc/discard.c
+++ b/fs/alloc/discard.c
@@ -568,33 +568,23 @@ static void bch2_do_discards(struct bch_fs *c)
 								    s, false);
 				if (!__ret)
 					s->seen += bucket_size;
+
+				/*
+				 * Keep the forced restart inside lockrestart_do():
+				 * btree_trans_restart() leaves trans->restarted set
+				 * until the retry loop begins the next transaction.
+				 */
+				if (__ret == -BCH_ERR_max_discards_in_flight ||
+				    (!__ret && READ_ONCE(d->in_flight.nr) > READ_ONCE(d->ref))) {
+					if (!__ret)
+						pos = next;
+					__ret = bch2_discards_complete(trans, s, false, false) ?:
+						btree_trans_restart(trans, BCH_ERR_transaction_restart_nested);
+				} else if (!__ret) {
+					pos = next;
+				}
 				__ret;
 			}));
-			/*
-			 * Reap completed discards as we go: in_flight entries
-			 * are only freed in bch2_discards_complete(), so if we
-			 * never reach DEV_IN_FLIGHT_MAX - the device completes
-			 * discards inline, or doesn't support REQ_OP_DISCARD -
-			 * the in_flight darray would otherwise grow without
-			 * bound and turn the linear scans in
-			 * discard_in_flight_add()/discard_endio() into O(n^2).
-			 * in_flight.nr > ref means there are completed entries
-			 * waiting to be reaped.
-			 *
-			 * On success the bucket's been handled, so advance the
-			 * detached need_discard cursor before the nested restart;
-			 * on -max_discards_in_flight leave it put so we retry the
-			 * bucket after draining.
-			 */
-			if (ret == -BCH_ERR_max_discards_in_flight ||
-			    (!ret && READ_ONCE(d->in_flight.nr) > READ_ONCE(d->ref))) {
-				if (!ret)
-					pos = next;
-				ret = bch2_discards_complete(trans, s, false, false) ?:
-				      btree_trans_restart(trans, BCH_ERR_transaction_restart_nested);
-			} else if (!ret) {
-				pos = next;
-			}
 		}
 
 		ret = bch2_discards_complete(trans, s, false, true) ?: ret;

--- a/fs/alloc/discard.c
+++ b/fs/alloc/discard.c
@@ -403,6 +403,11 @@ int bch2_dev_clear_need_discard(struct bch_fs *c, struct bch_dev *ca, u64 cutoff
 			} else {
 				struct bpos bucket = u64_to_bucket(k.k->p.offset);
 
+				/*
+				 * need_discard is ordered by (journal seq, encoded bucket),
+				 * not by device bucket space, so tail truncation has to
+				 * scan and filter by the decoded bucket position.
+				 */
 				next = bpos_successor(k.k->p);
 
 				if (bucket.inode == ca->dev_idx &&
@@ -524,27 +529,58 @@ static void bch2_do_discards(struct bch_fs *c)
 		struct discard_state *s = &c->discards.s;
 		memset(s, 0, sizeof(*s));
 
+		struct bpos pos = POS_MIN;
 		/*
 		 * Iterate need_discard btree (sorted by journal_seq).
 		 * Stop when we hit a seq beyond rewind_seq_ondisk.
 		 */
-		ret = for_each_btree_key(trans, iter,
-				BTREE_ID_need_discard, POS_MIN, 0, k, ({
-			u64 journal_seq		= k.k->p.inode;
-			struct bpos bucket	= u64_to_bucket(k.k->p.offset);
-			u32 bucket_size		= dev_bucket_size(c, bucket.inode);
+		while (!ret) {
+			struct bpos next = POS_MAX;
+			struct bpos bucket = POS_MAX;
+			u64 journal_seq = 0;
+			u32 bucket_size = 0;
+			bool done = false;
+
+			/*
+			 * Drop the need_discard iterator before we update alloc and
+			 * commit: the discard path removes the corresponding index
+			 * entry, and keeping the original iterator pinned across that
+			 * commit can deadlock against the alloc/freespace updates.
+			 */
+			ret = lockrestart_do(trans, ({
+				int __ret = 0;
+				CLASS(btree_iter, iter)(trans, BTREE_ID_need_discard, pos, 0);
+				struct bkey_s_c k = bch2_btree_iter_peek(&iter);
+				int _ret = bkey_err(k);
+
+				if (_ret) {
+					__ret = _ret;
+				} else if (!k.k) {
+					done = true;
+				} else {
+					journal_seq = k.k->p.inode;
+					bucket = u64_to_bucket(k.k->p.offset);
+					bucket_size = dev_bucket_size(c, bucket.inode);
+					next = bpos_successor(k.k->p);
+					s->pos = next;
+				}
+				__ret;
+			}));
+			if (ret || done)
+				break;
 
 			if (journal_seq >= min(c->journal.rewind_seq_ondisk,
 					       c->journal.flushed_seq_ondisk + 1))
 				break;
 
-			if (!bpos_eq(s->pos, iter.pos))
-				s->seen += bucket_size;
-			s->pos = iter.pos;
-
-			int ret2 = bch2_discard_one_bucket(trans,
-						bucket, bucket_size,
-						s, false);
+			ret = lockrestart_do(trans, ({
+				int __ret = bch2_discard_one_bucket(trans,
+								    bucket, bucket_size,
+								    s, false);
+				if (!__ret)
+					s->seen += bucket_size;
+				__ret;
+			}));
 			/*
 			 * Reap completed discards as we go: in_flight entries
 			 * are only freed in bch2_discards_complete(), so if we
@@ -557,19 +593,20 @@ static void bch2_do_discards(struct bch_fs *c)
 			 * waiting to be reaped.
 			 *
 			 * On success the bucket's been handled, so advance the
-			 * iterator before the nested restart so we don't
-			 * reprocess it; on -max_discards_in_flight leave it put
-			 * so we retry the bucket after draining.
+			 * detached need_discard cursor before the nested restart;
+			 * on -max_discards_in_flight leave it put so we retry the
+			 * bucket after draining.
 			 */
-			if (ret2 == -BCH_ERR_max_discards_in_flight ||
-			    (!ret2 && READ_ONCE(d->in_flight.nr) > READ_ONCE(d->ref))) {
-				if (!ret2)
-					bch2_btree_iter_advance(&iter);
-				ret2 = bch2_discards_complete(trans, s, false, false) ?:
-				btree_trans_restart(trans, BCH_ERR_transaction_restart_nested);
+			if (ret == -BCH_ERR_max_discards_in_flight ||
+			    (!ret && READ_ONCE(d->in_flight.nr) > READ_ONCE(d->ref))) {
+				if (!ret)
+					pos = next;
+				ret = bch2_discards_complete(trans, s, false, false) ?:
+				      btree_trans_restart(trans, BCH_ERR_transaction_restart_nested);
+			} else if (!ret) {
+				pos = next;
 			}
-			ret2;
-		}));
+		}
 
 		ret = bch2_discards_complete(trans, s, false, true) ?: ret;
 

--- a/fs/alloc/discard.c
+++ b/fs/alloc/discard.c
@@ -23,11 +23,14 @@ static u32 dev_bucket_size(struct bch_fs *c, unsigned dev)
 	return ca ? ca->mi.bucket_size : 0;
 }
 
-static bool dev_bucket_nouse(struct bch_fs *c, struct bpos bucket)
+static bool bch2_discard_blocked_by_resize(struct bch_fs *c, struct bpos bucket)
 {
 	guard(rcu)();
 	struct bch_dev *ca = bch2_dev_rcu_noerror(c, bucket.inode);
-	return ca ? bch2_bucket_nouse(ca, bucket.offset) : true;
+
+	return ca &&
+		bch2_dev_is_shrinking(ca) &&
+		bucket.offset >= bch2_dev_resize_target(ca);
 }
 
 #define DEV_IN_FLIGHT_MAX		4
@@ -294,7 +297,7 @@ static int bch2_discard_one_bucket(struct btree_trans *trans,
 {
 	struct bch_fs *c = trans->c;
 
-	if (unlikely(dev_bucket_nouse(c, bucket)))
+	if (unlikely(bch2_discard_blocked_by_resize(c, bucket)))
 		return 0;
 
 	int ret = discard_in_flight_add(c, NULL, bucket, fastpath, true);
@@ -481,16 +484,6 @@ static void calculate_discard_sectors_to_release(struct btree_trans *trans)
 	if (s->r.free < s->r.reserve * 2 &&
 	    s->r.new_rewind_seq > c->journal.rewind_seq)
 		s->r.flush_journal = true;
-}
-
-static bool bch2_discard_blocked_by_resize(struct bch_fs *c, struct bpos bucket)
-{
-	guard(rcu)();
-	struct bch_dev *ca = bch2_dev_rcu_noerror(c, bucket.inode);
-
-	return ca &&
-		bch2_dev_is_shrinking(ca) &&
-		bucket.offset >= bch2_dev_resize_target(ca);
 }
 
 static void bch2_do_discards(struct bch_fs *c)

--- a/fs/alloc/discard.c
+++ b/fs/alloc/discard.c
@@ -382,64 +382,33 @@ static int bch2_discard_one_bucket(struct btree_trans *trans,
 
 int bch2_dev_clear_need_discard(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
 {
-	struct bpos pos = POS_MIN;
+	/*
+	 * Shrink is about to delete the tail's alloc keys entirely, so we only
+	 * need to remove the derived need_discard index entries. Avoid updating
+	 * alloc keys here: that would also fire freespace/reconcile triggers
+	 * while reconcile is still draining the shrinking device, which can
+	 * deadlock with btree node rewrites in the move path.
+	 *
+	 * need_discard is ordered by (journal seq, encoded bucket), not by
+	 * device bucket space, so tail truncation has to scan and filter by the
+	 * decoded bucket position.
+	 */
+	CLASS(btree_trans, trans)(c);
+	unsigned dev_idx = ca->dev_idx;
 
-	while (1) {
-		struct bpos next = POS_MAX;
-		bool done = false;
-		int ret = bch2_trans_commit_do(c, NULL, NULL,
-				BCH_WATERMARK_reclaim|
-				BCH_TRANS_COMMIT_no_check_rw|
-				BCH_TRANS_COMMIT_no_enospc, ({
-			int __ret = 0;
-			CLASS(btree_iter, iter)(trans, BTREE_ID_need_discard, pos, 0);
-			struct bkey_s_c k = bch2_btree_iter_peek(&iter);
-			int _ret = bkey_err(k);
+	return for_each_btree_key_commit(trans, iter,
+			BTREE_ID_need_discard, POS_MIN,
+			BTREE_ITER_intent|BTREE_ITER_prefetch, k,
+			NULL, NULL,
+			BCH_WATERMARK_reclaim|
+			BCH_TRANS_COMMIT_no_check_rw|
+			BCH_TRANS_COMMIT_no_enospc, ({
+		struct bpos bucket = u64_to_bucket(k.k->p.offset);
 
-			if (_ret) {
-				__ret = _ret;
-			} else if (!k.k) {
-				done = true;
-			} else {
-				struct bpos bucket = u64_to_bucket(k.k->p.offset);
-
-				/*
-				 * need_discard is ordered by (journal seq, encoded bucket),
-				 * not by device bucket space, so tail truncation has to
-				 * scan and filter by the decoded bucket position.
-				 */
-				next = bpos_successor(k.k->p);
-
-				if (bucket.inode == ca->dev_idx &&
-				    bucket.offset >= cutoff) {
-					CLASS(btree_iter, alloc_iter)(trans, BTREE_ID_alloc,
-								      bucket, BTREE_ITER_cached);
-					struct bkey_s_c alloc_k =
-						bch2_btree_iter_peek_slot(&alloc_iter);
-					struct bkey_i_alloc_v4 *a;
-
-					_ret = bkey_err(alloc_k);
-					if (_ret) {
-						__ret = _ret;
-					} else {
-						a = errptr_try(bch2_alloc_to_v4_mut(trans, alloc_k));
-						if (a->v.data_type == BCH_DATA_need_discard) {
-							SET_BCH_ALLOC_V4_NEED_DISCARD(&a->v, false);
-							alloc_data_type_set(&a->v, a->v.data_type);
-							__ret = bch2_trans_update(trans, &alloc_iter,
-										  &a->k_i, 0);
-						}
-					}
-				}
-			}
-			__ret;
-		}));
-		if (ret)
-			return ret;
-		if (done)
-			return 0;
-		pos = next;
-	}
+		(bucket.inode == dev_idx && bucket.offset >= cutoff)
+			? bch2_btree_delete_at(trans, &iter, BTREE_TRIGGER_norun)
+			: 0;
+	}));
 }
 
 static void calculate_discard_sectors_to_release(struct btree_trans *trans)
@@ -514,6 +483,16 @@ static void calculate_discard_sectors_to_release(struct btree_trans *trans)
 		s->r.flush_journal = true;
 }
 
+static bool bch2_discard_blocked_by_resize(struct bch_fs *c, struct bpos bucket)
+{
+	guard(rcu)();
+	struct bch_dev *ca = bch2_dev_rcu_noerror(c, bucket.inode);
+
+	return ca &&
+		bch2_dev_is_shrinking(ca) &&
+		bucket.offset >= bch2_dev_resize_target(ca);
+}
+
 static void bch2_do_discards(struct bch_fs *c)
 {
 	struct bch_fs_discards *d = &c->discards;
@@ -572,6 +551,23 @@ static void bch2_do_discards(struct bch_fs *c)
 			if (journal_seq >= min(c->journal.rewind_seq_ondisk,
 					       c->journal.flushed_seq_ondisk + 1))
 				break;
+
+			/*
+			 * need_discard is only advisory trim bookkeeping. If this
+			 * bucket sits in the tail of a device that is currently
+			 * shrinking, leave the entry queued for the tail cleanup
+			 * pass: discard's alloc update can deadlock with
+			 * resize/reconcile on the region being evacuated.
+			 *
+			 * Buckets that remain below the shrink target still need
+			 * discard progress so the allocator can reuse retained
+			 * space on the shrinking device during the long-running
+			 * evacuation.
+			 */
+			if (bch2_discard_blocked_by_resize(c, bucket)) {
+				pos = next;
+				continue;
+			}
 
 			ret = lockrestart_do(trans, ({
 				int __ret = bch2_discard_one_bucket(trans,

--- a/fs/alloc/discard.h
+++ b/fs/alloc/discard.h
@@ -9,6 +9,7 @@ void bch2_fast_discard_bucket_add(struct bch_dev *, u64);
 void bch2_fast_discards_to_text(struct printbuf *, struct bch_dev *);
 
 void bch2_discards_to_text(struct printbuf *, struct bch_fs *, struct discard_state *);
+int  bch2_dev_clear_need_discard(struct bch_fs *, struct bch_dev *, u64);
 
 void bch2_dev_do_discards(struct bch_dev *);
 void bch2_do_discards_going_ro(struct bch_fs *);

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -274,7 +274,9 @@ static struct open_bucket *__try_alloc_bucket(struct bch_fs *c,
 	if (unlikely(is_superblock_bucket(c, ca, bucket)))
 		return NULL;
 
-	if (unlikely(bch2_bucket_nouse(ca, bucket) || (ca->mi.target_nbuckets && bucket >= ca->mi.target_nbuckets))) {
+	if (unlikely(bch2_bucket_nouse(ca, bucket) ||
+		     (bch2_dev_is_shrinking(ca) &&
+		      bucket >= bch2_dev_resize_target(ca)))) {
 		req->counters.skipped_nouse++;
 		return NULL;
 	}

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -1046,20 +1046,21 @@ static int bucket_alloc_set_partial(struct bch_fs *c,
  * @ec:		if true, we're shutting down erasure coding and killing all ec
  *		open_buckets
  *		otherwise, return true
+ * @tail_cutoff: if != 0 only drop buckets after the cutoff
  * Returns: true if we should kill this open_bucket
  *
  * We're killing open_buckets because we're shutting down a device, erasure
  * coding, or the entire filesystem - check if this open_bucket matches:
  */
 static bool should_drop_bucket(struct open_bucket *ob, struct bch_fs *c,
-			       struct bch_dev *ca, bool ec)
+			       struct bch_dev *ca, bool ec, u64 tail_cutoff)
 {
 	struct bch_fs_allocator *a = &c->allocator;
 
 	if (ec) {
 		return ob->ec != NULL;
 	} else if (ca) {
-		bool drop = dev_and_region_matches(ob, ca);
+		bool drop = dev_and_region_matches(ob, ca, tail_cutoff);
 
 		if (!drop && ob->ec) {
 			guard(mutex)(&ob->ec->lock);
@@ -1070,7 +1071,7 @@ static bool should_drop_bucket(struct open_bucket *ob, struct bch_fs *c,
 					continue;
 
 				struct open_bucket *ob2 = a->open_buckets + ob->ec->blocks[i];
-				drop |= dev_and_region_matches(ob2, ca);
+				drop |= dev_and_region_matches(ob2, ca, tail_cutoff);
 			}
 		}
 
@@ -1081,7 +1082,7 @@ static bool should_drop_bucket(struct open_bucket *ob, struct bch_fs *c,
 }
 
 static void bch2_writepoint_stop(struct bch_fs *c, struct bch_dev *ca,
-				 bool ec, struct write_point *wp)
+				 bool ec, struct write_point *wp, u64 tail_cutoff)
 {
 	struct open_buckets ptrs = { .nr = 0 };
 	struct open_bucket *ob;
@@ -1089,27 +1090,27 @@ static void bch2_writepoint_stop(struct bch_fs *c, struct bch_dev *ca,
 
 	guard(mutex)(&wp->lock);
 	open_bucket_for_each(c, &wp->ptrs, ob, i)
-		if (should_drop_bucket(ob, c, ca, ec))
+		if (should_drop_bucket(ob, c, ca, ec, tail_cutoff))
 			bch2_open_bucket_put(c, ob);
 		else
 			ob_push(c, &ptrs, ob);
 	wp->ptrs = ptrs;
 }
 
-/* stop open buckets on @ca. If we're shrinking, only stop buckets in to-be-shrunk region */
+/* stop open buckets on @ca, if tail_cutoff isn't zero, only after the cutoff */
 void bch2_open_buckets_stop(struct bch_fs *c, struct bch_dev *ca,
-			    bool ec)
+			    bool ec, u64 tail_cutoff)
 {
 	struct bch_fs_allocator *a = &c->allocator;
 	unsigned i;
 
 	/* Next, close write points that point to this device or the to-be-shrunk region... */
 	for (i = 0; i < ARRAY_SIZE(a->write_points); i++)
-		bch2_writepoint_stop(c, ca, ec, &a->write_points[i]);
+		bch2_writepoint_stop(c, ca, ec, &a->write_points[i], tail_cutoff);
 
-	bch2_writepoint_stop(c, ca, ec, &c->copygc.write_point);
-	bch2_writepoint_stop(c, ca, ec, &a->reconcile_write_point);
-	bch2_writepoint_stop(c, ca, ec, &a->btree_write_point);
+	bch2_writepoint_stop(c, ca, ec, &c->copygc.write_point, tail_cutoff);
+	bch2_writepoint_stop(c, ca, ec, &a->reconcile_write_point, tail_cutoff);
+	bch2_writepoint_stop(c, ca, ec, &a->btree_write_point, tail_cutoff);
 
 	scoped_guard(mutex, &c->btree.reserve_cache.lock)
 		while (c->btree.reserve_cache.nr) {
@@ -1125,7 +1126,7 @@ void bch2_open_buckets_stop(struct bch_fs *c, struct bch_dev *ca,
 			struct open_bucket *ob =
 				a->open_buckets + a->open_buckets_partial[i];
 
-			if (should_drop_bucket(ob, c, ca, ec)) {
+			if (should_drop_bucket(ob, c, ca, ec, tail_cutoff)) {
 				--a->open_buckets_partial_nr;
 				swap(a->open_buckets_partial[i],
 				     a->open_buckets_partial[a->open_buckets_partial_nr]);
@@ -1143,7 +1144,7 @@ void bch2_open_buckets_stop(struct bch_fs *c, struct bch_dev *ca,
 			}
 		}
 
-	bch2_ec_stop_dev(c, ca);
+	bch2_ec_stop_dev_cutoff(c, ca, tail_cutoff);
 }
 
 static inline struct hlist_head *writepoint_hash(struct bch_fs_allocator *a,

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -274,7 +274,7 @@ static struct open_bucket *__try_alloc_bucket(struct bch_fs *c,
 	if (unlikely(is_superblock_bucket(c, ca, bucket)))
 		return NULL;
 
-	if (unlikely(bch2_bucket_nouse(ca, bucket))) {
+	if (unlikely(bch2_bucket_nouse(ca, bucket) || (ca->mi.target_nbuckets && bucket >= ca->mi.target_nbuckets))) {
 		req->counters.skipped_nouse++;
 		return NULL;
 	}

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -1059,7 +1059,7 @@ static bool should_drop_bucket(struct open_bucket *ob, struct bch_fs *c,
 	if (ec) {
 		return ob->ec != NULL;
 	} else if (ca) {
-		bool drop = ob->dev == ca->dev_idx;
+		bool drop = dev_and_region_matches(ob, ca);
 
 		if (!drop && ob->ec) {
 			guard(mutex)(&ob->ec->lock);
@@ -1070,7 +1070,7 @@ static bool should_drop_bucket(struct open_bucket *ob, struct bch_fs *c,
 					continue;
 
 				struct open_bucket *ob2 = a->open_buckets + ob->ec->blocks[i];
-				drop |= ob2->dev == ca->dev_idx;
+				drop |= dev_and_region_matches(ob2, ca);
 			}
 		}
 
@@ -1096,13 +1096,14 @@ static void bch2_writepoint_stop(struct bch_fs *c, struct bch_dev *ca,
 	wp->ptrs = ptrs;
 }
 
+/* stop open buckets on @ca. If we're shrinking, only stop buckets in to-be-shrunk region */
 void bch2_open_buckets_stop(struct bch_fs *c, struct bch_dev *ca,
 			    bool ec)
 {
 	struct bch_fs_allocator *a = &c->allocator;
 	unsigned i;
 
-	/* Next, close write points that point to this device... */
+	/* Next, close write points that point to this device or the to-be-shrunk region... */
 	for (i = 0; i < ARRAY_SIZE(a->write_points); i++)
 		bch2_writepoint_stop(c, ca, ec, &a->write_points[i]);
 

--- a/fs/alloc/foreground.h
+++ b/fs/alloc/foreground.h
@@ -315,13 +315,12 @@ int bch2_bucket_alloc_set_trans(struct btree_trans *, struct alloc_request *,
 				struct dev_stripe_state *);
 
 /*
- * Returns whether the open bucket's device matches ca, and if we're currently
- * shrinking, whether it falls into the to-be-shrunk region.
+ * Returns whether the open bucket's device matches ca and whether the open
+ * bucket falls behind the cutoff.
  */
-static inline bool dev_and_region_matches(struct open_bucket *ob, struct bch_dev *ca)
+static inline bool dev_and_region_matches(struct open_bucket *ob, struct bch_dev *ca, u64 tail_cutoff)
 {
-	return ob->dev == ca->dev_idx &&
-		(!ca->mi.target_nbuckets || ob->bucket >= ca->mi.target_nbuckets);
+	return ob->dev == ca->dev_idx && ob->bucket >= tail_cutoff;
 }
 
 int bch2_alloc_sectors_req(struct btree_trans *, struct alloc_request *,
@@ -443,7 +442,7 @@ void bch2_alloc_sectors_append_ptrs(struct bch_fs *, struct write_point *,
 				    struct bkey_i *, unsigned, bool);
 void bch2_alloc_sectors_done(struct bch_fs *, struct write_point *);
 
-void bch2_open_buckets_stop(struct bch_fs *c, struct bch_dev *, bool);
+void bch2_open_buckets_stop(struct bch_fs *c, struct bch_dev *, bool, u64 tail_cutoff);
 
 static inline struct write_point_specifier writepoint_hashed(unsigned long v)
 {

--- a/fs/alloc/foreground.h
+++ b/fs/alloc/foreground.h
@@ -314,6 +314,16 @@ enum bch_write_flags;
 int bch2_bucket_alloc_set_trans(struct btree_trans *, struct alloc_request *,
 				struct dev_stripe_state *);
 
+/*
+ * Returns whether the open bucket's device matches ca, and if we're currently
+ * shrinking, whether it falls into the to-be-shrunk region.
+ */
+static inline bool dev_and_region_matches(struct open_bucket *ob, struct bch_dev *ca)
+{
+	return ob->dev == ca->dev_idx &&
+		(!ca->mi.target_nbuckets || ob->bucket >= ca->mi.target_nbuckets);
+}
+
 int bch2_alloc_sectors_req(struct btree_trans *, struct alloc_request *,
 			   struct write_point_specifier,
 			   struct write_point **);

--- a/fs/alloc/lru.c
+++ b/fs/alloc/lru.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
+#include "alloc/backpointers.h"
 #include "bcachefs.h"
 
 #include "alloc/background.h"
@@ -119,7 +120,7 @@ static struct bbpos lru_pos_to_bp(struct bkey_s_c lru_k)
 }
 
 
-int bch2_dev_truncate_lrus(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
+int bch2_dev_remove_lrus(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
 {
 	CLASS(btree_trans, trans)(c);
 	int ret = bch2_btree_write_buffer_flush_sync(trans) ?:
@@ -128,23 +129,6 @@ int bch2_dev_truncate_lrus(struct bch_fs *c, struct bch_dev *ca, u64 cutoff)
 		struct bbpos bp = lru_pos_to_bp(k);
 
 		bp.btree == BTREE_ID_alloc && bp.pos.inode == ca->dev_idx && bp.pos.offset >= cutoff
-		? (bch2_btree_delete_at(trans, &iter, 0) ?:
-		   bch2_trans_commit(trans, NULL, NULL, 0))
-		: 0;
-	}));
-	bch_err_fn(c, ret);
-	return ret;
-}
-
-int bch2_dev_remove_lrus(struct bch_fs *c, struct bch_dev *ca)
-{
-	CLASS(btree_trans, trans)(c);
-	int ret = bch2_btree_write_buffer_flush_sync(trans) ?:
-		for_each_btree_key(trans, iter,
-				 BTREE_ID_lru, POS_MIN, BTREE_ITER_prefetch, k, ({
-		struct bbpos bp = lru_pos_to_bp(k);
-
-		bp.btree == BTREE_ID_alloc && bp.pos.inode == ca->dev_idx
 		? (bch2_btree_delete_at(trans, &iter, 0) ?:
 		   bch2_trans_commit(trans, NULL, NULL, 0))
 		: 0;

--- a/fs/alloc/lru.h
+++ b/fs/alloc/lru.h
@@ -70,6 +70,7 @@ static inline int bch2_lru_change(struct btree_trans *trans,
 		: 0;
 }
 
+int bch2_dev_truncate_lrus(struct bch_fs *c, struct bch_dev *ca, u64 cutoff);
 int bch2_dev_remove_lrus(struct bch_fs *, struct bch_dev *);
 
 struct wb_maybe_flush;

--- a/fs/alloc/lru.h
+++ b/fs/alloc/lru.h
@@ -70,8 +70,7 @@ static inline int bch2_lru_change(struct btree_trans *trans,
 		: 0;
 }
 
-int bch2_dev_truncate_lrus(struct bch_fs *c, struct bch_dev *ca, u64 cutoff);
-int bch2_dev_remove_lrus(struct bch_fs *, struct bch_dev *);
+int bch2_dev_remove_lrus(struct bch_fs *, struct bch_dev *, u64);
 
 struct wb_maybe_flush;
 int bch2_lru_check_set(struct btree_trans *, u16, u64, u64, struct bkey_s_c,

--- a/fs/bcachefs.h
+++ b/fs/bcachefs.h
@@ -33,6 +33,8 @@
 
 #define race_fault(...)			dynamic_fault("bcachefs:race")
 
+struct task_struct;
+
 #include <linux/backing-dev-defs.h>
 #include <linux/bug.h>
 #include <linux/bio.h>
@@ -564,6 +566,11 @@ struct bch_dev {
 	unsigned		nr_btree_reserve;
 
 	struct work_struct	invalidate_work;
+	spinlock_t		resize_lock;
+	u64			resize_seq;
+	wait_queue_head_t	resize_wait;
+	int			resize_status;
+	struct task_struct	*resize_thread;
 
 	struct work_struct	discard_fast_work;
 	darray_u64		discard_fast;

--- a/fs/btree/interior.c
+++ b/fs/btree/interior.c
@@ -183,6 +183,32 @@ static const char * const bch2_btree_update_modes[] = {
 	NULL
 };
 
+static unsigned btree_alloc_target(struct bch_fs *c, unsigned target)
+{
+	target = target ?: c->opts.metadata_target ?: c->opts.foreground_target;
+	if (!target)
+		return 0;
+
+	struct bch_devs_mask devs = target_rw_devs(c, BCH_DATA_btree, target);
+
+	/*
+	 * Shrink needs to keep rewriting btree nodes even when metadata is
+	 * normally pinned to the device being reduced. If every rw member of
+	 * the preferred target is currently shrinking, spill metadata anywhere
+	 * so the shrink can update its own bookkeeping.
+	 */
+	guard(rcu)();
+	unsigned i;
+	for_each_set_bit(i, devs.d, BCH_SB_MEMBERS_MAX) {
+		struct bch_dev *ca = bch2_dev_rcu_noerror(c, i);
+
+		if (ca && !ca->mi.target_nbuckets)
+			return target;
+	}
+
+	return 0;
+}
+
 static __cold void bch2_btree_update_to_text(struct printbuf *, struct btree_update *);
 
 static int bch2_btree_insert_node(struct btree_update *, struct btree_trans *,
@@ -1526,10 +1552,9 @@ bch2_btree_update_start(struct btree_trans *trans, struct btree_path *path,
 		goto err;
 
 	struct bch_devs_list devs_have = (struct bch_devs_list) { 0 };
+	unsigned alloc_target = btree_alloc_target(c, target);
 	req = alloc_request_get(trans,
-				target ?:
-				c->opts.metadata_target ?:
-				c->opts.foreground_target,
+				alloc_target,
 				false,
 				&devs_have,
 				as->disk_res.nr_replicas,

--- a/fs/btree/interior.c
+++ b/fs/btree/interior.c
@@ -202,7 +202,7 @@ static unsigned btree_alloc_target(struct bch_fs *c, unsigned target)
 	for_each_set_bit(i, devs.d, BCH_SB_MEMBERS_MAX) {
 		struct bch_dev *ca = bch2_dev_rcu_noerror(c, i);
 
-		if (ca && !ca->mi.target_nbuckets)
+		if (ca && !bch2_dev_is_shrinking(ca))
 			return target;
 	}
 

--- a/fs/data/ec/create.c
+++ b/fs/data/ec/create.c
@@ -1244,7 +1244,7 @@ static bool may_reuse_stripe(struct bch_fs *c,
 
 	for_each_data_block(i, nr_data)
 		if (stripe_blockcount_get(old, i)) {
-			if (!bch2_dev_bad_or_evacuating(c, old->ptrs[i].dev))
+			if (!bch2_ptr_bad_or_evacuating(c, &old->ptrs[i]))
 				__clear_bit(old->ptrs[i].dev, devs_may_alloc.d);
 			live_data++;
 		}
@@ -1348,7 +1348,7 @@ static void init_new_stripe_from_old(struct bch_fs *c, struct ec_stripe_new *s, 
 
 	for_each_data_block(i, old_nr_data) {
 		if (stripe_blockcount_get(old_v, i)) {
-			if (!bch2_dev_bad_or_evacuating(c, old_v->ptrs[i].dev))
+			if (!bch2_ptr_bad_or_evacuating(c, &old_v->ptrs[i]))
 				__set_bit(s->old_blocks_nr, s->blocks_gotten);
 			else
 				__set_bit(s->old_blocks_nr, s->blocks_moving);
@@ -1808,7 +1808,7 @@ err:
 static bool stripe_degraded(struct bch_fs *c, const struct bch_stripe *s)
 {
 	for (unsigned i = 0; i < s->nr_blocks; i++)
-		if (bch2_dev_bad_or_evacuating(c, s->ptrs[i].dev))
+		if (bch2_ptr_bad_or_evacuating(c, &s->ptrs[i]))
 			return true;
 	return false;
 }

--- a/fs/data/ec/init.c
+++ b/fs/data/ec/init.c
@@ -169,7 +169,7 @@ out:
 
 /* startup/shutdown */
 
-static bool should_cancel_stripe(struct bch_fs *c, struct ec_stripe_new *s, struct bch_dev *ca)
+static bool should_cancel_stripe(struct bch_fs *c, struct ec_stripe_new *s, struct bch_dev *ca, u64 tail_cutoff)
 {
 	if (!ca)
 		return true;
@@ -180,7 +180,7 @@ static bool should_cancel_stripe(struct bch_fs *c, struct ec_stripe_new *s, stru
 		/* Freshly allocated block - check the open_bucket's device: */
 		if (s->blocks[i]) {
 			struct open_bucket *ob = c->allocator.open_buckets + s->blocks[i];
-			if (dev_and_region_matches(ob, ca))
+			if (dev_and_region_matches(ob, ca, tail_cutoff))
 				return true;
 		}
 
@@ -192,34 +192,38 @@ static bool should_cancel_stripe(struct bch_fs *c, struct ec_stripe_new *s, stru
 		 */
 		if (test_bit(i, s->blocks_allocated) &&
 		    v->ptrs[i].dev == ca->dev_idx &&
-		    (!ca->mi.target_nbuckets ||
-		     PTR_BUCKET_NR(ca, &v->ptrs[i]) >= ca->mi.target_nbuckets))
+		    PTR_BUCKET_NR(ca, &v->ptrs[i]) >= tail_cutoff)
 			return true;
 	}
 
 	return false;
 }
 
-static void __bch2_ec_stop(struct bch_fs *c, struct bch_dev *ca)
+static void __bch2_ec_stop(struct bch_fs *c, struct bch_dev *ca, u64 tail_cutoff)
 {
 	struct ec_stripe_head *h;
 
 	guard(mutex)(&c->ec.stripe_head_lock);
 	list_for_each_entry(h, &c->ec.stripe_head_list, list) {
 		guard(mutex)(&h->lock);
-		if (h->s && should_cancel_stripe(c, h->s, ca))
+		if (h->s && should_cancel_stripe(c, h->s, ca, tail_cutoff))
 			bch2_ec_stripe_new_cancel(c, h, -BCH_ERR_erofs_no_writes);
 	}
 }
 
+void bch2_ec_stop_dev_cutoff(struct bch_fs *c, struct bch_dev *ca, u64 tail_cutoff)
+{
+	__bch2_ec_stop(c, ca, tail_cutoff);
+}
+
 void bch2_ec_stop_dev(struct bch_fs *c, struct bch_dev *ca)
 {
-	__bch2_ec_stop(c, ca);
+	__bch2_ec_stop(c, ca, 0);
 }
 
 void bch2_fs_ec_stop(struct bch_fs *c)
 {
-	__bch2_ec_stop(c, NULL);
+	__bch2_ec_stop(c, NULL, 0);
 }
 
 static bool bch2_fs_ec_flush_done(struct bch_fs *c)

--- a/fs/data/ec/init.c
+++ b/fs/data/ec/init.c
@@ -180,7 +180,7 @@ static bool should_cancel_stripe(struct bch_fs *c, struct ec_stripe_new *s, stru
 		/* Freshly allocated block - check the open_bucket's device: */
 		if (s->blocks[i]) {
 			struct open_bucket *ob = c->allocator.open_buckets + s->blocks[i];
-			if (ob->dev == ca->dev_idx)
+			if (dev_and_region_matches(ob, ca))
 				return true;
 		}
 
@@ -191,7 +191,9 @@ static bool should_cancel_stripe(struct bch_fs *c, struct ec_stripe_new *s, stru
 		 * ptrs explicitly for the reuse path.
 		 */
 		if (test_bit(i, s->blocks_allocated) &&
-		    v->ptrs[i].dev == ca->dev_idx)
+		    v->ptrs[i].dev == ca->dev_idx &&
+		    (!ca->mi.target_nbuckets ||
+		     PTR_BUCKET_NR(ca, &v->ptrs[i]) >= ca->mi.target_nbuckets))
 			return true;
 	}
 

--- a/fs/data/ec/init.h
+++ b/fs/data/ec/init.h
@@ -7,6 +7,7 @@ int bch2_invalidate_stripe_to_dev(struct btree_trans *, struct btree_iter *,
 				  unsigned, struct printbuf *, bool *);
 int bch2_dev_remove_stripes(struct bch_fs *, unsigned, unsigned, struct printbuf *);
 
+void bch2_ec_stop_dev_cutoff(struct bch_fs *, struct bch_dev *, u64);
 void bch2_ec_stop_dev(struct bch_fs *, struct bch_dev *);
 void bch2_fs_ec_stop(struct bch_fs *);
 void bch2_fs_ec_flush(struct bch_fs *);
@@ -23,4 +24,3 @@ int bch2_bucket_nr_stripes(struct btree_trans *, struct bpos);
 int bch2_check_stripe_refs(struct btree_trans *);
 
 #endif /* _BCACHEFS_DATA_EC_INIT_H */
-

--- a/fs/data/extents.c
+++ b/fs/data/extents.c
@@ -1507,7 +1507,8 @@ static bool maybe_drop_cached_ptr(struct bch_fs *c, struct bch_inode_opts *opts,
 			return drop_cached_pointer_trace(c, k, ptr, "pointer is stale");
 		if (!ca || ca->mi.state == BCH_MEMBER_STATE_evacuating)
 			return drop_cached_pointer_trace(c, k, ptr, "device bad or evacuating");
-		if (ca->mi.target_nbuckets && ca->mi.target_nbuckets <= sector_to_bucket(ca, ptr->offset))
+		if (bch2_dev_is_shrinking(ca) &&
+		    bch2_dev_resize_target(ca) <= sector_to_bucket(ca, ptr->offset))
 			return drop_cached_pointer_trace(c, k, ptr, "past shrink cutoff");
 
 		unsigned target = opts->promote_target ?: opts->foreground_target;

--- a/fs/data/extents.c
+++ b/fs/data/extents.c
@@ -1357,12 +1357,12 @@ bool bch2_bkey_in_target(struct bch_fs *c, struct bkey_s_c k, unsigned target)
 	return true;
 }
 
-bool bch2_bkey_has_dev_bad_or_evacuating(struct bch_fs *c, struct bkey_s_c k)
+bool bch2_bkey_has_ptr_bad_or_evacuating(struct bch_fs *c, struct bkey_s_c k)
 {
 	guard(rcu)();
 	struct bkey_ptrs_c ptrs = bch2_bkey_ptrs_c(k);
 	bkey_for_each_ptr(ptrs, ptr)
-		if (bch2_dev_bad_or_evacuating_rcu(c, ptr->dev))
+		if (bch2_ptr_bad_or_evacuating_rcu(c, ptr))
 			return true;
 	return false;
 }

--- a/fs/data/extents.c
+++ b/fs/data/extents.c
@@ -1507,6 +1507,8 @@ static bool maybe_drop_cached_ptr(struct bch_fs *c, struct bch_inode_opts *opts,
 			return drop_cached_pointer_trace(c, k, ptr, "pointer is stale");
 		if (!ca || ca->mi.state == BCH_MEMBER_STATE_evacuating)
 			return drop_cached_pointer_trace(c, k, ptr, "device bad or evacuating");
+		if (ca->mi.target_nbuckets && ca->mi.target_nbuckets <= sector_to_bucket(ca, ptr->offset))
+			return drop_cached_pointer_trace(c, k, ptr, "past shrink cutoff");
 
 		unsigned target = opts->promote_target ?: opts->foreground_target;
 		if (target && !bch2_dev_in_target_rcu(c, ptr->dev, target))

--- a/fs/data/extents.h
+++ b/fs/data/extents.h
@@ -642,7 +642,7 @@ bool bch2_bkey_devs_rw(struct bch_fs *, struct bkey_s_c);
 bool bch2_bkey_has_target(struct bch_fs *, struct bkey_s_c, unsigned);
 bool bch2_bkey_in_target(struct bch_fs *, struct bkey_s_c, unsigned);
 
-bool bch2_bkey_has_dev_bad_or_evacuating(struct bch_fs *, struct bkey_s_c);
+bool bch2_bkey_has_ptr_bad_or_evacuating(struct bch_fs *, struct bkey_s_c);
 
 void bch2_bkey_extent_entry_drop_s(const struct bch_fs *, struct bkey_s, union bch_extent_entry *);
 void bch2_bkey_extent_entry_drop(const struct bch_fs *, struct bkey_i *, union bch_extent_entry *);

--- a/fs/data/reconcile/trigger.c
+++ b/fs/data/reconcile/trigger.c
@@ -751,7 +751,14 @@ static int new_needs_rb_allowed(struct btree_trans *trans,
 	if (ret)
 		return min(ret, 0);
 
-	if (new_need_rb == BIT(BCH_RECONCILE_data_replicas)) {
+	/*
+	 * Device scans can add evacuation/rereplicate work on top of existing
+	 * reconcile state, e.g. an extent that was already waiting on
+	 * erasure-code conversion. While that scan cookie is pending, tolerate
+	 * missing data_replicas/hipri state even if other reconcile bits are
+	 * also set; the scan will rewrite the full reconcile entry.
+	 */
+	if (new_need_rb & BIT(BCH_RECONCILE_data_replicas)) {
 		ret = check_dev_reconcile_scan_cookie(trans, k, s ? &s->dev_cookie : NULL);
 		if (ret)
 			return min(ret, 0);

--- a/fs/data/reconcile/trigger.c
+++ b/fs/data/reconcile/trigger.c
@@ -498,7 +498,7 @@ static int bch2_bkey_needs_reconcile(struct btree_trans *trans, struct bkey_s_c 
 		incompressible	|= p.crc.compression_type == BCH_COMPRESSION_TYPE_incompressible;
 		unwritten	|= p.ptr.unwritten;
 
-		bool evacuating = bch2_dev_bad_or_evacuating(c, p.ptr.dev) && !p.has_ec;
+		bool evacuating = bch2_ptr_bad_or_evacuating(c, &p.ptr) && !p.has_ec;
 
 		if (!poisoned &&
 		    !btree &&

--- a/fs/data/reconcile/trigger.c
+++ b/fs/data/reconcile/trigger.c
@@ -730,6 +730,16 @@ static int new_needs_rb_allowed(struct btree_trans *trans,
 	}
 
 	/*
+	 * Shrink/evacuation can mark an extent under-replicated as soon as one
+	 * pointer falls onto a bad/evacuating location, before the device scan
+	 * has rewritten the reconcile entry. That's a transient physical-state
+	 * change, not a missing io-opts propagation cookie.
+	 */
+	if ((new_need_rb & BIT(BCH_RECONCILE_data_replicas)) &&
+	    bch2_bkey_has_ptr_bad_or_evacuating(c, k))
+		return 0;
+
+	/*
 	 * Either the extent data or the extent io options (from
 	 * bch_extent_reconcile) should match the io_opts from the
 	 * inode/filesystem, unless

--- a/fs/data/reconcile/types.h
+++ b/fs/data/reconcile/types.h
@@ -16,7 +16,6 @@ struct bch_fs_reconcile {
 	atomic_t			kick;
 	wait_queue_head_t		wait;
 	atomic_t			completed_kick;
-	atomic64_t			completed_work_units;
 
 	bool				running;
 	u64				wait_iotime_start;

--- a/fs/data/reconcile/types.h
+++ b/fs/data/reconcile/types.h
@@ -2,6 +2,8 @@
 #ifndef _BCACHEFS_REBALANCE_TYPES_H
 #define _BCACHEFS_REBALANCE_TYPES_H
 
+#include <linux/wait.h>
+
 #include "btree/bbpos_types.h"
 #include "data/move_types.h"
 #include "init/progress.h"
@@ -11,7 +13,9 @@
 
 struct bch_fs_reconcile {
 	struct task_struct __rcu	*thread;
-	u32				kick;
+	atomic_t			kick;
+	wait_queue_head_t		wait;
+	atomic_t			completed_kick;
 
 	bool				running;
 	u64				wait_iotime_start;

--- a/fs/data/reconcile/types.h
+++ b/fs/data/reconcile/types.h
@@ -16,6 +16,7 @@ struct bch_fs_reconcile {
 	atomic_t			kick;
 	wait_queue_head_t		wait;
 	atomic_t			completed_kick;
+	atomic64_t			completed_work_units;
 
 	bool				running;
 	u64				wait_iotime_start;

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1383,12 +1383,6 @@ static void reconcile_wait(struct bch_fs *c)
 		r->wait_iotime_start	= now;
 		r->wait_wallclock_start	= ktime_get_real_ns();
 		WRITE_ONCE(r->running, false);
-		/*
-		 * Shrink waits for reconcile to go idle before its final
-		 * journal/key-cache flush, otherwise reconcile can still hold
-		 * cached search paths while it unwinds from the completed kick.
-		 */
-		wake_up_all(&r->wait);
 	}
 
 	bch2_kthread_io_clock_wait_once(clock, r->wait_iotime_end, MAX_SCHEDULE_TIMEOUT);

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1107,12 +1107,27 @@ static int do_reconcile_scan_bps(struct moving_context *ctxt,
 	struct btree_trans *trans = ctxt->trans;
 	struct bch_fs *c = trans->c;
 	struct bch_fs_reconcile *r = &c->reconcile;
+	struct bpos start = POS(s.dev, 0);
+	struct bch_dev *ca;
 
-	r->scan_start	= BBPOS(BTREE_ID_backpointers, POS(s.dev, 0));
+	/*
+	 * Shrink only needs reconcile work for the tail that will be truncated.
+	 * Scanning the whole device requeues metadata below the retained region,
+	 * which can churn btree rewrites for tens of seconds before the resize
+	 * worker ever gets to commit the smaller size.
+	 */
+	scoped_guard(rcu) {
+		ca = bch2_dev_rcu_noerror(c, s.dev);
+		if (ca && bch2_dev_is_shrinking(ca))
+			start = bucket_pos_to_bp_start(ca,
+					POS(s.dev, bch2_dev_resize_target(ca)));
+	}
+
+	r->scan_start	= BBPOS(BTREE_ID_backpointers, start);
 	r->scan_end	= BBPOS(BTREE_ID_backpointers, POS(s.dev, U64_MAX));
 
 	return backpointer_scan_for_each(trans, iter, BTREE_ID_backpointers,
-					 POS(s.dev, 0), POS(s.dev, U64_MAX),
+					 start, POS(s.dev, U64_MAX),
 				  last_flushed, NULL, bp, ({
 		ctxt->stats->pos = BBPOS(BTREE_ID_backpointers, iter.pos);
 
@@ -1364,10 +1379,16 @@ static void reconcile_wait(struct bch_fs *c)
 
 	r->wait_iotime_end		= now + (min_member_capacity >> 6);
 
-	if (r->running) {
+	if (READ_ONCE(r->running)) {
 		r->wait_iotime_start	= now;
 		r->wait_wallclock_start	= ktime_get_real_ns();
-		r->running		= false;
+		WRITE_ONCE(r->running, false);
+		/*
+		 * Shrink waits for reconcile to go idle before its final
+		 * journal/key-cache flush, otherwise reconcile can still hold
+		 * cached search paths while it unwinds from the completed kick.
+		 */
+		wake_up_all(&r->wait);
 	}
 
 	bch2_kthread_io_clock_wait_once(clock, r->wait_iotime_end, MAX_SCHEDULE_TIMEOUT);

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -458,7 +458,7 @@ static int reconcile_set_data_opts(struct btree_trans *trans,
 			guard(rcu)();
 
 			bkey_for_each_ptr(ptrs, ptr) {
-				if (bch2_dev_bad_or_evacuating(c, ptr->dev))
+				if (bch2_ptr_bad_or_evacuating_rcu(c, ptr))
 					data_opts->ptrs_kill |= ptr_bit;
 				ptr_bit <<= 1;
 			}
@@ -476,8 +476,8 @@ static int reconcile_set_data_opts(struct btree_trans *trans,
 			struct bkey_i *n = errptr_try(bch2_bkey_make_mut_noupdate(trans, k));
 			struct bkey_durability cur = durability;
 
-			for (unsigned phase = 0; phase < 2; phase++) {
-				bool online_floor = phase == 1;
+				for (unsigned phase = 0; phase < 2; phase++) {
+					bool online_floor = phase == 1;
 
 				/* phase 0 (hold total) only matters if some durability is offline */
 				if (!online_floor && cur.total == cur.online)
@@ -485,12 +485,12 @@ static int reconcile_set_data_opts(struct btree_trans *trans,
 
 				/* Drop entire pointers? */
 				unsigned ptr_bit = 1;
-				bkey_for_each_ptr(bch2_bkey_ptrs(bkey_i_to_s(n)), ptr) {
-					bool offline = ptr->dev == BCH_SB_MEMBER_INVALID ||
-						       !test_bit(ptr->dev, c->devs_online.d);
+					bkey_for_each_ptr(bch2_bkey_ptrs(bkey_i_to_s(n)), ptr) {
+						bool offline = ptr->dev == BCH_SB_MEMBER_INVALID ||
+							       !test_bit(ptr->dev, c->devs_online.d);
 
-					if (!ptr->cached && (online_floor || offline)) {
-						bool force = bch2_dev_bad_or_evacuating(c, ptr->dev);
+						if (!ptr->cached && (online_floor || offline)) {
+							bool force = bch2_ptr_bad_or_evacuating(c, ptr);
 
 						ptr->cached = true;
 						struct bkey_durability d;
@@ -509,11 +509,11 @@ static int reconcile_set_data_opts(struct btree_trans *trans,
 						 * reads as durability=0, but we drop it once the
 						 * required durability is held by other devices.
 						 */
-						if (have >= r->data_replicas &&
-						    (force || have < was)) {
-							data_opts->ptrs_kill |= ptr_bit;
-							cur = d;
-						} else {
+							if (have >= r->data_replicas &&
+							    (force || have < was)) {
+								data_opts->ptrs_kill |= ptr_bit;
+								cur = d;
+							} else {
 							ptr->cached = false;
 						}
 					}
@@ -541,18 +541,18 @@ static int reconcile_set_data_opts(struct btree_trans *trans,
 					struct bkey_i *m = errptr_try(bch2_bkey_make_mut_noupdate(trans, bkey_i_to_s_c(n)));
 					bch2_bkey_drop_ec_mask(c, m, ec_bits[i]);
 
-					struct bkey_durability d;
-					try(bch2_bkey_durability(trans, bkey_i_to_s_c(m), &d));
+						struct bkey_durability d;
+						try(bch2_bkey_durability(trans, bkey_i_to_s_c(m), &d));
 
-					unsigned have = online_floor ? d.online : d.total;
-					if (have >= r->data_replicas) {
-						data_opts->ptrs_kill_ec |= ec_bits[i];
-						bch2_bkey_drop_ec_mask(c, n, ec_bits[i]);
-						cur = d;
+						unsigned have = online_floor ? d.online : d.total;
+						if (have >= r->data_replicas) {
+							data_opts->ptrs_kill_ec |= ec_bits[i];
+							bch2_bkey_drop_ec_mask(c, n, ec_bits[i]);
+							cur = d;
+						}
 					}
 				}
 			}
-		}
 	}
 
 	if (r->need_rb & BIT(BCH_RECONCILE_erasure_code)) {

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -697,10 +697,17 @@ static int check_reconcile_pending_err(struct btree_trans *trans,
 {
 	struct bch_fs *c = trans->c;
 
-	 if (!bch2_err_matches(err, BCH_ERR_data_update_fail_no_rw_devs) &&
-	     !bch2_err_matches(err, BCH_ERR_insufficient_devices) &&
-	     !bch2_err_matches(err, ENOSPC))
-		 return err;
+	/*
+	 * Reconcile can park transient allocation failures on the pending list
+	 * and retry after space becomes available. The allocator's internal
+	 * no_buckets_found code is the same class of "try again later" failure
+	 * as ENOSPC, but it bypasses the errno-based match.
+	 */
+	if (!bch2_err_matches(err, BCH_ERR_data_update_fail_no_rw_devs) &&
+	    !bch2_err_matches(err, BCH_ERR_insufficient_devices) &&
+	    !bch2_err_matches(err, BCH_ERR_freelist_empty) &&
+	    !bch2_err_matches(err, ENOSPC))
+		return err;
 
 	event_add_trace(c, reconcile_set_pending, k.k->size, buf, ({
 		prt_printf(&buf, "%s\n", bch2_err_str(err));

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1853,9 +1853,6 @@ out:
 	if (!ret &&
 	    pass_complete &&
 	    kick == atomic_read(&r->kick)) {
-		atomic64_set(&r->completed_work_units,
-			     atomic64_read(&r->work_stats.sectors_seen) +
-			     sectors_scanned);
 		atomic_set(&r->completed_kick, kick);
 		wake_up_all(&r->wait);
 	}
@@ -2084,7 +2081,6 @@ int bch2_fs_reconcile_init(struct bch_fs *c)
 	atomic_set(&r->kick, 0);
 	init_waitqueue_head(&r->wait);
 	atomic_set(&r->completed_kick, 0);
-	atomic64_set(&r->completed_work_units, 0);
 	mutex_init(&r->scans_in_flight_lock);
 	try(rhashtable_init(&r->scans_in_flight, &reconcile_scan_in_flight_params));
 	r->scans_in_flight_init_done = true;

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1645,7 +1645,7 @@ static int do_reconcile_phase_iter(struct reconcile_pass *p, u32 kick,
 	while (!bch2_move_ratelimit(ctxt) &&
 	       !test_bit(BCH_FS_going_ro, &c->flags) &&
 	       bch2_reconcile_enabled(c) &&
-	       kick == r->kick) {
+	       kick == atomic_read(&r->kick)) {
 		bch2_trans_begin(trans);
 
 		struct bkey_s_c k = next_reconcile_entry(trans, p->work, &r->work_pos,
@@ -1734,8 +1734,9 @@ static int do_reconcile(struct moving_context *ctxt)
 	struct bch_fs *c = trans->c;
 	struct bch_fs_reconcile *r = &c->reconcile;
 	u64 sectors_scanned = 0;
-	u32 kick = r->kick;
+	u32 kick = atomic_read(&r->kick);
 	u32 copygc_run_count = c->copygc.run_count;
+	bool pass_complete = false;
 	int ret = 0;
 
 	CLASS(darray_reconcile_work, work)();
@@ -1786,7 +1787,7 @@ static int do_reconcile(struct moving_context *ctxt)
 		 * uses this latest value to decide whether anyone is still
 		 * asking for more work.
 		 */
-		kick = r->kick;
+		kick = atomic_read(&r->kick);
 
 		for (r->phase = 0; r->phase < ARRAY_SIZE(reconcile_phases); r->phase++) {
 			reconcile_phase_start(c);
@@ -1807,7 +1808,7 @@ static int do_reconcile(struct moving_context *ctxt)
 
 			work.nr = 0;
 
-			if (kick != r->kick ||
+			if (kick != atomic_read(&r->kick) ||
 			    test_bit(BCH_FS_going_ro, &c->flags) ||
 			    bch2_move_ratelimit(ctxt))
 				break;
@@ -1817,13 +1818,29 @@ static int do_reconcile(struct moving_context *ctxt)
 		}
 
 		/* Completed a clean pass through all phases — we're done. */
-		if (r->phase == ARRAY_SIZE(reconcile_phases))
+		if (r->phase == ARRAY_SIZE(reconcile_phases)) {
+			pass_complete = true;
 			break;
+		}
 	}
 out:
 	if (!ret && !bkey_deleted(&pending_cookie.k))
 		try(bch2_clear_reconcile_needs_scan(trans,
 				pending_cookie.k.p, pending_cookie.v.cookie));
+
+	/*
+	 * A completed kick means reconcile drained every phase for the current
+	 * request generation without being superseded by a newer wakeup.
+	 * Shrink uses this as the point where all scan-generated downstream
+	 * work has been attempted before it decides a tail is still impossible
+	 * to evacuate.
+	 */
+	if (!ret &&
+	    pass_complete &&
+	    kick == atomic_read(&r->kick)) {
+		atomic_set(&r->completed_kick, kick);
+		wake_up_all(&r->wait);
+	}
 
 	bch2_move_stats_exit(&r->work_stats, c);
 
@@ -1831,7 +1848,7 @@ out:
 	    !kthread_should_stop() &&
 	    !atomic64_read(&r->work_stats.sectors_seen) &&
 	    !sectors_scanned &&
-	    kick == r->kick) {
+	    kick == atomic_read(&r->kick)) {
 		bch2_moving_ctxt_flush_all(ctxt);
 		bch2_trans_unlock_long(trans);
 		reconcile_wait(c);
@@ -2046,6 +2063,9 @@ int bch2_fs_reconcile_init(struct bch_fs *c)
 {
 	struct bch_fs_reconcile *r = &c->reconcile;
 
+	atomic_set(&r->kick, 0);
+	init_waitqueue_head(&r->wait);
+	atomic_set(&r->completed_kick, 0);
 	mutex_init(&r->scans_in_flight_lock);
 	try(rhashtable_init(&r->scans_in_flight, &reconcile_scan_in_flight_params));
 	r->scans_in_flight_init_done = true;

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1853,6 +1853,9 @@ out:
 	if (!ret &&
 	    pass_complete &&
 	    kick == atomic_read(&r->kick)) {
+		atomic64_set(&r->completed_work_units,
+			     atomic64_read(&r->work_stats.sectors_seen) +
+			     sectors_scanned);
 		atomic_set(&r->completed_kick, kick);
 		wake_up_all(&r->wait);
 	}
@@ -2081,6 +2084,7 @@ int bch2_fs_reconcile_init(struct bch_fs *c)
 	atomic_set(&r->kick, 0);
 	init_waitqueue_head(&r->wait);
 	atomic_set(&r->completed_kick, 0);
+	atomic64_set(&r->completed_work_units, 0);
 	mutex_init(&r->scans_in_flight_lock);
 	try(rhashtable_init(&r->scans_in_flight, &reconcile_scan_in_flight_params));
 	r->scans_in_flight_init_done = true;

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -349,14 +349,23 @@ static struct bkey_s_c next_reconcile_entry(struct btree_trans *trans,
 	if (work_pos->btree == BTREE_ID_reconcile_scan) {
 		buf->nr = 0;
 
-		int ret = for_each_btree_key_max(trans, iter, work_pos->btree, work_pos->pos, end,
-				   flags, k, ({
-			bkey_reassemble(&darray_top(*buf), k);
-			return bkey_i_to_s_c(&darray_top(*buf));
-			0;
-		}));
+		/*
+		 * Do not return out of a for_each_btree_key_* body here: we want
+		 * the iterator fully dropped before reconcile starts mutating the
+		 * extent that this work item points at. Keeping the reconcile_scan
+		 * path pinned across the later move/rewrite can deadlock against
+		 * alloc/freespace updates from the same transaction.
+		 */
+		CLASS(btree_iter, iter)(trans, work_pos->btree, work_pos->pos, flags);
+		struct bkey_s_c k = bch2_btree_iter_peek(&iter);
 
-		return ret ? bkey_s_c_err(ret) : bkey_s_c_null;
+		if (bkey_err(k))
+			return bkey_s_c_err(bkey_err(k));
+		if (!k.k || bpos_gt(k.k->p, end))
+			return bkey_s_c_null;
+
+		bkey_reassemble(&darray_top(*buf), k);
+		return bkey_i_to_s_c(&darray_top(*buf));
 	}
 
 	if (unlikely(!buf->nr)) {
@@ -1480,6 +1489,15 @@ static CLOSURE_CALLBACK(do_reconcile_phys_thread)
 		    !k.k ||
 		    k.k->p.inode != thr->dev)
 			break;
+
+		/*
+		 * Drop any cached search paths from next_reconcile_entry() before
+		 * we start the actual move work: otherwise reconcile_scan or
+		 * backpointer paths looked up to choose the work item can stay
+		 * pinned in this transaction and deadlock against alloc/freespace
+		 * updates during btree node rewrites.
+		 */
+		bch2_trans_begin(trans);
 
 		int ret = lockrestart_do(trans,
 			do_reconcile_extent_phys(&ctxt, &snapshot_io_opts,

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -895,13 +895,17 @@ static int do_reconcile_extent(struct moving_context *ctxt,
 	struct bch_fs *c = trans->c;
 	struct bbpos data_pos = rb_work_to_data_pos(work.pos);
 
-	/* We require holding an intent lock when calling
-	 * bch2_stripe_handle_tryget(), to avoid racing with the stripe trigger
-	 * deleting the stripe */
-	enum btree_iter_update_trigger_flags flags = data_pos.btree == BTREE_ID_stripes
-		? BTREE_ITER_intent : 0;
+	/*
+	 * Reconcile always mutates the key it is looking at, either by updating
+	 * reconcile state or by queueing a move. Start with an intent iterator
+	 * so we do not pay one transaction restart_upgrade per extent just to
+	 * upgrade the lock during commit. Stripe keys also require intent before
+	 * bch2_stripe_handle_tryget() can safely race with stripe deletion.
+	 */
+	enum btree_iter_update_trigger_flags flags =
+		BTREE_ITER_all_snapshots|BTREE_ITER_intent;
 
-	CLASS(btree_iter, iter)(trans, data_pos.btree, data_pos.pos, BTREE_ITER_all_snapshots|flags);
+	CLASS(btree_iter, iter)(trans, data_pos.btree, data_pos.pos, flags);
 	struct bkey_s_c k = bkey_try(bch2_btree_iter_peek_slot(&iter));
 	if (!k.k)
 		return 0;
@@ -945,11 +949,13 @@ static int do_reconcile_extent_phys(struct moving_context *ctxt,
 	if (bch2_data_update_in_flight(c, &pos, BCH_DATA_UPDATE_reconcile))
 		return 0;
 
-	/* We require holding an intent lock when calling
-	 * bch2_stripe_handle_tryget(), to avoid racing with the stripe trigger
-	 * deleting the stripe */
-	enum btree_iter_update_trigger_flags flags = bp.v->btree_id == BTREE_ID_stripes
-		? BTREE_ITER_intent : 0;
+	/*
+	 * Phys reconcile reaches the owning extent through a backpointer and
+	 * then updates that extent in the same transaction. Take the extent
+	 * iterator in intent mode up front to avoid restart_upgrade churn when
+	 * many adjacent extents are being reprocessed after shrink.
+	 */
+	enum btree_iter_update_trigger_flags flags = BTREE_ITER_intent;
 
 	CLASS(btree_iter_uninit, iter)(trans);
 	struct bkey_s_c k = bkey_try(bch2_backpointer_get_key(trans, bp, &iter, flags, last_flushed));

--- a/fs/data/reconcile/work.h
+++ b/fs/data/reconcile/work.h
@@ -84,6 +84,11 @@ static inline u32 bch2_reconcile_completed_kick(struct bch_fs *c)
 	return atomic_read(&c->reconcile.completed_kick);
 }
 
+static inline u64 bch2_reconcile_completed_work_units(struct bch_fs *c)
+{
+	return atomic64_read(&c->reconcile.completed_work_units);
+}
+
 static inline int bch2_reconcile_pending_wakeup(struct bch_fs *c)
 {
 	return bch2_set_reconcile_needs_scan(c,

--- a/fs/data/reconcile/work.h
+++ b/fs/data/reconcile/work.h
@@ -64,13 +64,24 @@ int bch2_set_fs_needs_reconcile(struct bch_fs *);
 
 int bch2_reconcile_scan_cookie_is_set(struct btree_trans *, u64);
 
-static inline void bch2_reconcile_wakeup(struct bch_fs *c)
+static inline u32 bch2_reconcile_kick(struct bch_fs *c)
 {
-	c->reconcile.kick++;
+	u32 kick = atomic_inc_return(&c->reconcile.kick);
 	guard(rcu)();
 	struct task_struct *p = rcu_dereference(c->reconcile.thread);
 	if (p)
 		wake_up_process(p);
+	return kick;
+}
+
+static inline void bch2_reconcile_wakeup(struct bch_fs *c)
+{
+	bch2_reconcile_kick(c);
+}
+
+static inline u32 bch2_reconcile_completed_kick(struct bch_fs *c)
+{
+	return atomic_read(&c->reconcile.completed_kick);
 }
 
 static inline int bch2_reconcile_pending_wakeup(struct bch_fs *c)

--- a/fs/data/reconcile/work.h
+++ b/fs/data/reconcile/work.h
@@ -84,6 +84,12 @@ static inline u32 bch2_reconcile_completed_kick(struct bch_fs *c)
 	return atomic_read(&c->reconcile.completed_kick);
 }
 
+static inline bool bch2_reconcile_kick_idle(struct bch_fs *c, u32 kick)
+{
+	return bch2_reconcile_completed_kick(c) >= kick &&
+		!READ_ONCE(c->reconcile.running);
+}
+
 static inline int bch2_reconcile_pending_wakeup(struct bch_fs *c)
 {
 	return bch2_set_reconcile_needs_scan(c,

--- a/fs/data/reconcile/work.h
+++ b/fs/data/reconcile/work.h
@@ -84,11 +84,6 @@ static inline u32 bch2_reconcile_completed_kick(struct bch_fs *c)
 	return atomic_read(&c->reconcile.completed_kick);
 }
 
-static inline u64 bch2_reconcile_completed_work_units(struct bch_fs *c)
-{
-	return atomic64_read(&c->reconcile.completed_work_units);
-}
-
 static inline int bch2_reconcile_pending_wakeup(struct bch_fs *c)
 {
 	return bch2_set_reconcile_needs_scan(c,

--- a/fs/data/reconcile/work.h
+++ b/fs/data/reconcile/work.h
@@ -84,12 +84,6 @@ static inline u32 bch2_reconcile_completed_kick(struct bch_fs *c)
 	return atomic_read(&c->reconcile.completed_kick);
 }
 
-static inline bool bch2_reconcile_kick_idle(struct bch_fs *c, u32 kick)
-{
-	return bch2_reconcile_completed_kick(c) >= kick &&
-		!READ_ONCE(c->reconcile.running);
-}
-
 static inline int bch2_reconcile_pending_wakeup(struct bch_fs *c)
 {
 	return bch2_set_reconcile_needs_scan(c,

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -734,12 +734,13 @@ static inline bool should_trace_update_err(struct data_update *u, int ret)
 	    ((u->opts.type == BCH_DATA_UPDATE_reconcile ||
 	      u->opts.type == BCH_DATA_UPDATE_promote) &&
 	     (bch2_err_matches(ret, BCH_ERR_data_update_fail_no_rw_devs) ||
-	      /*
-	       * Reconcile promotes ENOSPC-class write failures to pending work
-	       * and retries after space/stripe availability changes, so don't
-	       * count those transient allocation misses as data update failures.
-	       */
-	      bch2_err_matches(ret, ENOSPC))))
+		      /*
+		       * Reconcile promotes ENOSPC-class write failures to pending work
+		       * and retries after space/stripe availability changes, so don't
+		       * count those transient allocation misses as data update failures.
+		       */
+		      bch2_err_matches(ret, BCH_ERR_freelist_empty) ||
+		      bch2_err_matches(ret, ENOSPC))))
 		return false;
 
 	return true;

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -733,7 +733,13 @@ static inline bool should_trace_update_err(struct data_update *u, int ret)
 	    bch2_err_matches(ret, BCH_ERR_data_update_fail_need_copygc) ||
 	    ((u->opts.type == BCH_DATA_UPDATE_reconcile ||
 	      u->opts.type == BCH_DATA_UPDATE_promote) &&
-	     bch2_err_matches(ret, BCH_ERR_data_update_fail_no_rw_devs)))
+	     (bch2_err_matches(ret, BCH_ERR_data_update_fail_no_rw_devs) ||
+	      /*
+	       * Reconcile promotes ENOSPC-class write failures to pending work
+	       * and retries after space/stripe availability changes, so don't
+	       * count those transient allocation misses as data update failures.
+	       */
+	      bch2_err_matches(ret, ENOSPC))))
 		return false;
 
 	return true;
@@ -1478,8 +1484,24 @@ int bch2_data_update_init(struct btree_trans *trans,
 			goto out;
 		}
 
-		if (!rhltable_insert_key(&c->update_table, &m->pos, &m->hash, bch_update_params))
-			m->on_hashtable = true;
+		/*
+		 * Phys reconcile can queue the same logical extent from multiple
+		 * source devices. The lookup above is only a fast path; another
+		 * mover can still win the race and claim @m->pos before we insert.
+		 * Use the non-list insert helper so only one update owns the key.
+		 */
+		ret = rhashtable_lookup_insert_fast(&c->update_table.ht,
+						    &m->hash.rhead,
+						    bch_update_params);
+		if (ret == -EEXIST) {
+			event_inc(c, data_update_in_flight);
+			ret = bch_err_throw(c, data_update_fail_in_flight);
+			goto out;
+		}
+		if (ret)
+			goto out;
+
+		m->on_hashtable = true;
 	} else {
 		if (unwritten) {
 			ret = bch_err_throw(c, data_update_done_unwritten);

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -1182,7 +1182,8 @@ static int __bch2_can_do_write(struct bch_fs *c,
 		: 0;
 
 	if (btree &&
-	    data_opts->type == BCH_DATA_UPDATE_reconcile)
+	    data_opts->type == BCH_DATA_UPDATE_reconcile &&
+	    !bch2_bkey_has_ptr_bad_or_evacuating(c, k))
 		return bch2_can_do_write_btree(c, opts, data_opts, k, trace);
 
 	if (trace) {

--- a/fs/errcode.h
+++ b/fs/errcode.h
@@ -290,6 +290,7 @@
 	x(EINVAL,			bucket_size_too_small)			\
 	x(EINVAL,			device_size_too_small)			\
 	x(EINVAL,			device_size_too_big)			\
+	x(EINVAL,			device_already_resizing)		\
 	x(EINVAL,			device_not_a_member_of_filesystem)	\
 	x(EINVAL,			device_has_been_removed)		\
 	x(EINVAL,			device_splitbrain)			\

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1489,6 +1489,15 @@ static bool bch2_dev_resize_finish(struct bch_dev *ca, u64 seq, int status)
 	if (is_current)
 		wake_up_all(&ca->resize_wait);
 
+	/*
+	 * Discards are deferred while resize is active to avoid lock/allocator
+	 * deadlocks with reconcile and journal-pin flushing. Kick the worker
+	 * once the latest resize request reaches a terminal state so queued
+	 * need_discard entries can drain again.
+	 */
+	if (is_current)
+		bch2_do_discards_async(ca->fs);
+
 	return is_current;
 }
 
@@ -1829,6 +1838,21 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 			return ret;
 		}
 	};
+
+	ret = bch2_dev_resize_restart_check(ca, seq);
+	if (ret)
+		return ret;
+
+	/*
+	 * Shrink can start while a discard worker from earlier freespace
+	 * churn is still in flight. Drain that work before we begin the
+	 * evacuation/journal-flush path: once shrink has started, later
+	 * discard passes skip the shrinking device, but an already-running
+	 * discard can still race in and deadlock against resize/reconcile's
+	 * allocator and btree rewrite work.
+	 */
+	flush_work(&c->discards.work);
+	flush_work(&ca->discard_fast_work);
 
 	ret = bch2_dev_resize_restart_check(ca, seq);
 	if (ret)

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1672,7 +1672,7 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 int __bch2_dev_resize_alloc(struct bch_dev *ca, u64 old_nbuckets, u64 new_nbuckets)
 {
 	struct bch_fs *c = ca->fs;
-	u64 v[3] = { new_nbuckets - old_nbuckets, 0, 0 };
+	s64 v[3] = { (s64) new_nbuckets - (s64) old_nbuckets, 0, 0 };
 
 	return bch2_trans_commit_do(ca->fs, NULL, NULL, 0,
 			bch2_disk_accounting_mod2(trans, false, v, dev_data_type,

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1835,11 +1835,17 @@ static int bch2_dev_shrink_wait_reconcile(struct bch_dev *ca, u64 seq, u32 kick)
 		if (ret)
 			return ret;
 
-		if (bch2_reconcile_completed_kick(c) >= kick)
+		/*
+		 * A completed kick only says the requested reconcile pass
+		 * drained. Wait for the worker to reach its idle state too, or
+		 * shrink's final journal flush can still race with reconcile's
+		 * cached btree paths and stall behind key-cache pin flushing.
+		 */
+		if (bch2_reconcile_kick_idle(c, kick))
 			return 0;
 
 		ret = wait_event_killable(c->reconcile.wait,
-			bch2_reconcile_completed_kick(c) >= kick ||
+			bch2_reconcile_kick_idle(c, kick) ||
 			bch2_dev_resize_seq(ca) != seq ||
 			kthread_should_stop());
 		if (ret)

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1881,11 +1881,7 @@ static int bch2_dev_shrink_clear_target(struct bch_fs *c, struct bch_dev *ca,
 		try(bch2_dev_resize_update_target(c, ca, 0, err));
 	}
 
-	/*
-	 * Canceling the persisted shrink target lifts the shrink cutoff. Retry
-	 * pending reconcile work so anything that was parked behind the failed
-	 * shrink gets re-evaluated under the restored placement rules.
-	 */
+	/* allocations are now no longer blocked after the cutoff, so there may now be more usable space  */
 	ret = bch2_reconcile_pending_wakeup(c);
 	if (ret)
 		bch_err_fn(c, ret);

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1662,8 +1662,9 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 		}
 
 		/* account disk space */
-		// see __bch2_dev_resize_alloc
-		s64 v[3] = { (s64) new_nbuckets - (s64) old_nbuckets, 0, 0 };
+		// - BCH_DATA_free is somehow still off by 2
+		// - BCH_DATA_sb isn't updated at all yet - should we relocate them or just accept that we have less copies and adjust?
+		s64 v[3] = { -(s64) (old_nbuckets - new_nbuckets), 0, 0 };
 		ret = bch2_trans_commit_do(ca->fs, NULL, NULL, 0,
 				bch2_disk_accounting_mod2(trans, false, v, dev_data_type,
 							  .dev = ca->dev_idx,

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1595,10 +1595,12 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 		bool empty = false;
 		try(tail_is_empty(c, ca, new_nbuckets, err, &empty));
 
+		/* do a definitive check */
 		if (empty) {
-			/* do a definitive check */
-			CLASS(btree_trans, trans)(c);
-			try(bch2_btree_write_buffer_flush_sync(trans));
+			{
+				CLASS(btree_trans, trans)(c);
+				try(bch2_btree_write_buffer_flush_sync(trans));
+			}
 
 			try(tail_is_empty(c, ca, new_nbuckets, err, &empty));
 			if (empty) {
@@ -1649,6 +1651,7 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			return ret;
 		}
 
+		// TODO: make this path shrink-compatible
 		if (ca->mi.freespace_initialized) {
 			ret = __bch2_dev_resize_alloc(ca, old_nbuckets, new_nbuckets);
 			if (ret) {

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1548,6 +1548,87 @@ static int drop_sbs_after_cutoff(struct bch_fs *c, struct bch_dev *ca, u64 cutof
 	return bch2_write_super(c);
 }
 
+static int move_journal_past_cutoff(struct bch_fs *c, struct bch_dev *ca,
+				    u64 cutoff, struct printbuf *err)
+{
+	bool grew = false;
+
+	while (true) {
+		u64 bucket_to_delete = 0;
+		unsigned nr = 0, nr_past_cutoff = 0;
+		bool cur_bucket_past_cutoff = false;
+		int ret;
+
+		scoped_guard(spinlock, &c->journal.lock) {
+			struct journal_device *ja = &ca->journal;
+
+			nr = ja->nr;
+			if (!nr)
+				break;
+
+			cur_bucket_past_cutoff = ja->buckets[ja->cur_idx] >= cutoff;
+
+			for (unsigned i = 0; i < ja->nr; i++) {
+				if (ja->buckets[i] < cutoff)
+					continue;
+
+				nr_past_cutoff++;
+				if (i != ja->cur_idx && !bucket_to_delete)
+					bucket_to_delete = ja->buckets[i];
+			}
+		}
+
+		if (!nr_past_cutoff)
+			return 0;
+
+		if (!grew) {
+			ret = bch2_set_nr_journal_buckets(c, ca, nr + nr_past_cutoff);
+			if (ret) {
+				prt_printf(err, "Failed to relocate journal buckets: %s\n",
+					   bch2_err_str(ret));
+				return ret;
+			}
+			grew = true;
+			continue;
+		}
+
+		if (!bucket_to_delete && cur_bucket_past_cutoff) {
+			scoped_guard(spinlock, &c->journal.lock) {
+				struct journal_device *ja = &ca->journal;
+
+				if (ja->nr &&
+				    ja->buckets[ja->cur_idx] >= cutoff)
+					ja->sectors_free = 0;
+			}
+
+			scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
+				guard(mutex)(&c->sb_lock);
+				ret = bch2_write_super(c);
+			}
+			if (ret) {
+				prt_printf(err, "Failed to advance journal off shrink tail: %s\n",
+					   bch2_err_str(ret));
+				return ret;
+			}
+
+			ret = bch2_journal_flush(&c->journal);
+			if (ret) {
+				prt_printf(err, "Failed to flush relocated journal: %s\n",
+					   bch2_err_str(ret));
+				return ret;
+			}
+			continue;
+		}
+
+		ret = bch2_dev_journal_bucket_delete(ca, bucket_to_delete);
+		if (ret) {
+			prt_printf(err, "Failed to drop journal bucket %llu from shrink tail: %s\n",
+				   bucket_to_delete, bch2_err_str(ret));
+			return ret;
+		}
+	}
+}
+
 // TODO: make sure everything is caught here. Maybe look at bch2_dev_has_data for this
 // Fore example journals and superblocks might need special handling
 static int tail_is_empty(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err, bool *empty) {
@@ -1618,6 +1699,15 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 		}
 	};
 
+	/*
+	 * Move journal buckets out of the tail up front: otherwise the journal
+	 * can keep reintroducing metadata references in the region we're trying
+	 * to evacuate while reconcile is draining backpointers from it.
+	 */
+	ret = move_journal_past_cutoff(c, ca, new_nbuckets, err);
+	if (ret)
+		return ret;
+
 	/*  TODO:
 	 *  When we evacuate data, the original is left in place and marked as cached, just like when moving it for target/compression regions.
 	 *  We need to somehow handle this:
@@ -1653,17 +1743,17 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 		schedule_timeout_killable(HZ/2);
 	}
 
+	/*
+	 * Re-run journal relocation as a final fence before we commit the new
+	 * size: the current journal bucket may have advanced while we were
+	 * waiting for the tail to drain, and we must not expose the smaller
+	 * nbuckets while journal state can still reference the truncated tail.
+	 */
+	ret = move_journal_past_cutoff(c, ca, new_nbuckets, err);
+	if (ret)
+		return ret;
 
 	scoped_guard(rwsem_write, &c->state_lock) {
-		/* zero target_nbuckets */
-		scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
-			guard(mutex)(&c->sb_lock);
-			struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
-			m->target_nbuckets = 0;
-
-			bch2_write_super(c);
-		}
-
 		/* flush interior updates - mirroring dev remove path */
 		bch2_btree_interior_updates_flush(c);
 
@@ -1690,22 +1780,24 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			return -EBUSY;
 		}
 
+		/*
+		 * Buckets in the truncated tail may still be in NEED_DISCARD
+		 * state. Clear that bookkeeping before we drop the alloc range so
+		 * accounting/fsck do not retain tail-only metadata after shrink.
+		 */
+		ret = bch2_dev_clear_need_discard(c, ca, new_nbuckets);
+		if (ret) {
+			prt_printf(err, "error clearing need_discard state: %s\n",
+				   bch2_err_str(ret));
+			return ret;
+		}
+
 		/* drop references to now-truncated superblock copies */
 		ret = drop_sbs_after_cutoff(c, ca, new_nbuckets);
 		if (ret) {
 			prt_printf(err, "Error dropping superblocks after cutoff: %s\n", bch2_err_str(ret));
 			return ret;
 		}
-
-		/* write & commit new_nbuckets */
-		scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
-			guard(mutex)(&c->sb_lock);
-			struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
-			m->nbuckets = cpu_to_le64(new_nbuckets);
-
-			try(bch2_write_super(c));
-		}
-
 
 		/* update accounting info - has to happen before truncating alloc info */
 		ret = bch2_dev_truncate_accounting(c, ca, old_nbuckets, new_nbuckets);
@@ -1719,6 +1811,20 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 		if (ret) {
 			prt_printf(err, "error truncating alloc info: %s\n", bch2_err_str(ret));
 			return ret;
+		}
+
+		/*
+		 * Commit the shrink only after the truncated tail has been
+		 * removed from alloc metadata, so later transactions can't see
+		 * stale tail buckets after the new size is visible.
+		 */
+		scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
+			guard(mutex)(&c->sb_lock);
+			struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
+			m->target_nbuckets = 0;
+			m->nbuckets = cpu_to_le64(new_nbuckets);
+
+			try(bch2_write_super(c));
 		}
 
 		/* resize buckets */

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1660,6 +1660,19 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			prt_printf(err, "error truncating alloc info: %s\n", bch2_err_str(ret));
 			return ret;
 		}
+
+		/* account disk space */
+		// see __bch2_dev_resize_alloc
+		s64 v[3] = { (s64) new_nbuckets - (s64) old_nbuckets, 0, 0 };
+		ret = bch2_trans_commit_do(ca->fs, NULL, NULL, 0,
+				bch2_disk_accounting_mod2(trans, false, v, dev_data_type,
+							  .dev = ca->dev_idx,
+							  .data_type = BCH_DATA_free));
+		if (ret) {
+			prt_printf(err, "error accounting disk space: %s\n", bch2_err_str(ret));
+			return ret;
+		}
+
 		// TODO: figure out what parts of this path still need doing
 		// if (ca->mi.freespace_initialized) {
 		// 	ret = __bch2_dev_resize_alloc(ca, old_nbuckets, new_nbuckets);

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1036,7 +1036,7 @@ static int __bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca,
 	 */
 	__bch2_dev_offline(c, ca);
 
-	ret = bch2_dev_remove_alloc(c, ca);
+	ret = bch2_dev_remove_alloc(c, ca, 0);
 	if (ret) {
 		prt_printf(err, "bch2_dev_remove_alloc() error: %s\n", bch2_err_str(ret));
 		goto err;
@@ -1695,22 +1695,9 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 		}
 
 		/* truncate alloc info */
-		ret = bch2_dev_truncate_alloc(c, ca, new_nbuckets);
+		ret = bch2_dev_remove_alloc(c, ca, new_nbuckets);
 		if (ret) {
 			prt_printf(err, "error truncating alloc info: %s\n", bch2_err_str(ret));
-			return ret;
-		}
-
-		/* account disk space */
-		// - BCH_DATA_free is somehow still off by the amount of superblocks
-		// - BCH_DATA_sb isn't updated at all yet - should we relocate them or just accept that we have less copies and adjust?
-		s64 v[3] = { -(s64) (old_nbuckets - new_nbuckets), 0, 0 };
-		ret = bch2_trans_commit_do(ca->fs, NULL, NULL, 0,
-				bch2_disk_accounting_mod2(trans, false, v, dev_data_type,
-							  .dev = ca->dev_idx,
-							  .data_type = BCH_DATA_free));
-		if (ret) {
-			prt_printf(err, "error accounting disk space: %s\n", bch2_err_str(ret));
 			return ret;
 		}
 

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -203,6 +203,7 @@
  */
 
 #include "alloc/buckets.h"
+#include "asm-generic/bug.h"
 #include "bcachefs.h"
 
 #include "alloc/accounting.h"
@@ -1540,6 +1541,8 @@ static int drop_sbs_after_cutoff(struct bch_fs *c, struct bch_dev *ca, u64 cutof
 		}
 	}
 
+	BUG_ON(i == 0);
+
 	layout->nr_superblocks = i;
 
 	return bch2_write_super(c);
@@ -1615,7 +1618,7 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 		}
 	};
 
-	/* wait for to-be-shrunk reason to be empty */
+	/* wait for to-be-shrunk region to be empty */
 	while (true) {
 		bool empty = false;
 		try(tail_is_empty(c, ca, new_nbuckets, err, &empty));
@@ -1661,6 +1664,20 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			return -EBUSY;
 		}
 
+		/* drop references to now-truncated superblock copies */
+		ret = drop_sbs_after_cutoff(c, ca, new_nbuckets);
+		if (ret) {
+			prt_printf(err, "Error dropping superblocks after cutoff: %s\n", bch2_err_str(ret));
+			return ret;
+		}
+
+		/* mark superblock buckets as metadata - mirroring the grow path. TODO: not sure if this is necessary here */
+		ret = bch2_trans_mark_dev_sb(c, ca, BTREE_TRIGGER_transactional);
+		if (ret) {
+			prt_printf(err, "bch2_trans_mark_dev_sb() error: %s\n", bch2_err_str(ret));
+			return ret;
+		}
+
 		/* write & commit new_nbuckets */
 		scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
 			guard(mutex)(&c->sb_lock);
@@ -1668,13 +1685,6 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			m->nbuckets = new_nbuckets;
 
 			bch2_write_super(c);
-		}
-
-		/* drop references to now-truncated superblock copies */
-		ret = drop_sbs_after_cutoff(c, ca, new_nbuckets);
-		if (ret) {
-			prt_printf(err, "Error dropping superblocks after cutoff: %s\n", bch2_err_str(ret));
-			return ret;
 		}
 
 		/* resize buckets */

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1574,7 +1574,7 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 		}
 
 		/* close open buckets in the to-be-shrunk region */
-		bch2_open_buckets_stop(c, ca, false);
+		bch2_open_buckets_stop(c, ca, false, new_nbuckets);
 		bch2_reset_alloc_cursors(c); // avoid churn
 
 		/* trigger reconcile range scan -> should kick off evacuation from range */

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1443,12 +1443,8 @@ int bch2_dev_offline(struct bch_fs *c, struct bch_dev *ca, int flags, struct pri
 
 static u64 bch2_dev_resize_seq(struct bch_dev *ca)
 {
-	u64 seq;
-
 	scoped_guard(spinlock, &ca->resize_lock)
-		seq = ca->resize_seq;
-
-	return seq;
+		return ca->resize_seq;
 }
 
 static bool bch2_dev_resize_wait_done(struct bch_dev *ca, u64 seq, int *status)
@@ -1486,17 +1482,12 @@ static bool bch2_dev_resize_finish(struct bch_dev *ca, u64 seq, int status)
 			ca->resize_status = status;
 	}
 
-	if (is_current)
+	if (is_current) {
 		wake_up_all(&ca->resize_wait);
 
-	/*
-	 * Discards are deferred while resize is active to avoid lock/allocator
-	 * deadlocks with reconcile and journal-pin flushing. Kick the worker
-	 * once the latest resize request reaches a terminal state so queued
-	 * need_discard entries can drain again.
-	 */
-	if (is_current)
+		/* Discards are deferred during resize to avoid allocator/journal deadlocks, restart them now that we are done */
 		bch2_do_discards_async(ca->fs);
+	}
 
 	return is_current;
 }
@@ -1560,6 +1551,7 @@ static int bch2_dev_resize_update_target(struct bch_fs *c, struct bch_dev *ca,
 {
 	lockdep_assert_held(&c->state_lock);
 
+	/* validate target_nbuckets */
 	u64 old_nbuckets = ca->mi.nbuckets;
 
 	if (target_nbuckets > BCH_MEMBER_NBUCKETS_MAX) {
@@ -1587,6 +1579,7 @@ static int bch2_dev_resize_update_target(struct bch_fs *c, struct bch_dev *ca,
 		return bch_err_throw(c, device_size_too_small);
 	}
 
+	/* commit target_nbuckets */
 	scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
 		guard(mutex)(&c->sb_lock);
 		struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
@@ -1598,7 +1591,6 @@ static int bch2_dev_resize_update_target(struct bch_fs *c, struct bch_dev *ca,
 	return 0;
 }
 
-/* requires write state lock */
 static int __bch2_dev_grow(struct bch_fs *c, struct bch_dev *ca,
 			   u64 new_nbuckets, struct printbuf *err)
 {
@@ -1688,6 +1680,8 @@ static int drop_sbs_after_cutoff(struct bch_fs *c, struct bch_dev *ca, u64 cutof
 		}
 	}
 
+	/* this should never happen, as we only call to this function after checking the cutoff against the minimum fs size,
+	 * which includes at least the first sb copy */
 	BUG_ON(i == 0);
 
 	layout->nr_superblocks = i;

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1650,8 +1650,10 @@ static int tail_is_empty(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets,
 }
 
 
-// TODO: resume shrink on startup
-int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err) {
+static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
+			     u64 new_nbuckets, struct printbuf *err,
+			     bool resuming)
+{
 	u64 old_nbuckets = ca->mi.nbuckets;
 
 	int ret = 0;
@@ -1670,24 +1672,32 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 		}
 
 		if (ca->mi.target_nbuckets) {
-			prt_printf(err, "Device already resizing (current target: %llu, new target: %llu\n", ca->mi.target_nbuckets, new_nbuckets);
-			return bch_err_throw(c, device_already_resizing);
-		}
+			if (!resuming || ca->mi.target_nbuckets != new_nbuckets) {
+				prt_printf(err, "Device already resizing (current target: %llu, new target: %llu)\n",
+					   ca->mi.target_nbuckets, new_nbuckets);
+				return bch_err_throw(c, device_already_resizing);
+			}
+		} else {
+			/* write & commit target_nbuckets - also stops new allocations */
+			scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
+				guard(mutex)(&c->sb_lock);
+				struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
+				m->target_nbuckets = cpu_to_le64(new_nbuckets);
 
-		/* write & commit target_nbuckets - also stops new allocations */
-		scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
-			guard(mutex)(&c->sb_lock);
-			struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
-			m->target_nbuckets = cpu_to_le64(new_nbuckets);
-
-			try(bch2_write_super(c));
+				try(bch2_write_super(c));
+			}
 		}
 
 		/* close open buckets in the to-be-shrunk region */
 		bch2_open_buckets_stop(c, ca, false, new_nbuckets);
 		bch2_reset_alloc_cursors(c); // avoid churn
 
-		/* trigger reconcile range scan -> should kick off evacuation from range */
+		/*
+		 * target_nbuckets persists in the superblock, but the device
+		 * scan's in-memory traversal state does not. Re-queue the
+		 * device scan whenever shrink starts or resumes so reconcile
+		 * reliably rediscovers the tail after a restart.
+		 */
 		struct reconcile_scan s = {
 			.type = RECONCILE_SCAN_device, // TODO(performance): make this range-based
 			.dev = ca->dev_idx,
@@ -1846,6 +1856,20 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 		bch2_recalc_capacity(c);
 	}
 	return 0;
+}
+
+int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
+		    u64 new_nbuckets, struct printbuf *err)
+{
+	return __bch2_dev_shrink(c, ca, new_nbuckets, err, false);
+}
+
+int bch2_dev_shrink_resume(struct bch_fs *c, struct bch_dev *ca,
+			   struct printbuf *err)
+{
+	return ca->mi.target_nbuckets
+		? __bch2_dev_shrink(c, ca, ca->mi.target_nbuckets, err, true)
+		: 0;
 }
 
 /* Resize on mount */

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -2110,7 +2110,7 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 
 		if (pass >= 2) {
 			prt_printf(err,
-				   "Shrink failed: insufficient space or replicas to evacuate data from the shrink tail\n");
+				   "Shrink failed: insufficient space on the filesystem to evacuate data from the shrink tail\n");
 			ret = bch2_dev_shrink_clear_target(c, ca, new_nbuckets, seq, err);
 			if (ret)
 				return ret;

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -262,7 +262,7 @@
 #include "init/fs.h"
 
 #include "linux/bitmap.h"
-#include "linux/byteorder/generic.h"
+#include <linux/byteorder.h>
 #include "linux/kthread.h"
 #include "linux/sched.h"
 #include "linux/sched/signal.h"

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1679,13 +1679,6 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			return ret;
 		}
 
-		/* mark superblock buckets as metadata - mirroring the grow path. TODO: not sure if this is necessary here */
-		ret = bch2_trans_mark_dev_sb(c, ca, BTREE_TRIGGER_transactional);
-		if (ret) {
-			prt_printf(err, "bch2_trans_mark_dev_sb() error: %s\n", bch2_err_str(ret));
-			return ret;
-		}
-
 		/* write & commit new_nbuckets */
 		scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
 			guard(mutex)(&c->sb_lock);

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1682,9 +1682,9 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 		scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
 			guard(mutex)(&c->sb_lock);
 			struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
-			m->nbuckets = new_nbuckets;
 
 			bch2_write_super(c);
+			m->nbuckets = cpu_to_le64(new_nbuckets);
 		}
 
 		/* resize buckets */

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -215,13 +215,16 @@
 #include "alloc/foreground.h"
 
 #include "bcachefs_format.h"
+#include "btree/bkey_methods.h"
 #include "btree/bkey_types.h"
 #include "btree/interior.h"
 
 #include "btree/iter.h"
+#include "btree/update.h"
 #include "btree/types.h"
 #include "btree/write_buffer.h"
 #include "data/ec/init.h"
+#include "data/extents.h"
 #include "data/migrate.h"
 #include "data/reconcile/work.h"
 
@@ -1771,9 +1774,60 @@ static int move_journal_past_cutoff(struct bch_fs *c, struct bch_dev *ca,
 	}
 }
 
+struct shrink_tail_head {
+	struct bpos	bucket;
+	struct bpos	first_bp;
+	unsigned	nr_backpointers;
+};
+
+struct shrink_tail_progress {
+	struct shrink_tail_head	head;
+	u64			nr_backpointers;
+};
+
+static inline bool shrink_tail_head_empty(const struct shrink_tail_head *head)
+{
+	return bpos_eq(head->first_bp, SPOS_MAX);
+}
+
+static bool shrink_tail_head_progressed(const struct shrink_tail_head *old,
+					const struct shrink_tail_head *new)
+{
+	if (shrink_tail_head_empty(new))
+		return true;
+
+	if (shrink_tail_head_empty(old))
+		return false;
+
+	if (!bpos_eq(new->bucket, old->bucket))
+		return bpos_gt(new->bucket, old->bucket);
+
+	if (!bpos_eq(new->first_bp, old->first_bp))
+		return bpos_gt(new->first_bp, old->first_bp);
+
+	return new->nr_backpointers < old->nr_backpointers;
+}
+
+static bool shrink_tail_progressed(const struct shrink_tail_progress *old,
+				   const struct shrink_tail_progress *new)
+{
+	if (shrink_tail_head_empty(&new->head))
+		return true;
+
+	if (shrink_tail_head_empty(&old->head))
+		return false;
+
+	if (new->nr_backpointers < old->nr_backpointers)
+		return true;
+
+	return shrink_tail_head_progressed(&old->head, &new->head);
+}
+
 // TODO: make sure everything is caught here. Maybe look at bch2_dev_has_data for this
 // Fore example journals and superblocks might need special handling
-static int tail_is_empty(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err, bool *empty) {
+static int tail_head_snapshot(struct bch_fs *c, struct bch_dev *ca,
+			      u64 new_nbuckets, struct shrink_tail_head *head)
+{
 	struct bpos bp_start = bucket_pos_to_bp_start(ca, POS(ca->dev_idx, new_nbuckets));
 	struct bpos bp_end = bucket_pos_to_bp_start(ca, POS(ca->dev_idx, ca->mi.nbuckets));
 
@@ -1787,8 +1841,166 @@ static int tail_is_empty(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets,
 
 	try(bkey_err(bp));
 
-	*empty = !bp.k;
+	*head = (struct shrink_tail_head) {
+		.bucket		= SPOS_MAX,
+		.first_bp	= SPOS_MAX,
+	};
+
+	if (!bp.k)
+		return 0;
+
+	head->bucket = bp_pos_to_bucket(ca, bp.k->p);
+	head->first_bp = bp.k->p;
+
+	do {
+		head->nr_backpointers++;
+		bch2_bp_scan_iter_advance(&iter);
+		bp = bch2_bp_scan_iter_peek(trans, &iter, bp_end, &last_flushed);
+		try(bkey_err(bp));
+	} while (bp.k && bpos_eq(bp_pos_to_bucket(ca, bp.k->p), head->bucket));
+
 	return 0;
+}
+
+static int tail_progress_snapshot(struct bch_fs *c, struct bch_dev *ca,
+				  u64 new_nbuckets,
+				  struct shrink_tail_progress *progress)
+{
+	struct bpos bp_start = bucket_pos_to_bp_start(ca, POS(ca->dev_idx, new_nbuckets));
+	struct bpos bp_end = bucket_pos_to_bp_start(ca, POS(ca->dev_idx, ca->mi.nbuckets));
+
+	CLASS(btree_trans, trans)(c);
+	CLASS(backpointer_scan_iter, iter)(BTREE_ID_backpointers, bp_start, NULL);
+
+	struct wb_maybe_flush last_flushed __cleanup(wb_maybe_flush_exit);
+	wb_maybe_flush_init(&last_flushed);
+
+	*progress = (struct shrink_tail_progress) {
+		.head.bucket	= SPOS_MAX,
+		.head.first_bp	= SPOS_MAX,
+	};
+
+	while (true) {
+		struct bkey_s_c_backpointer bp =
+			bch2_bp_scan_iter_peek(trans, &iter, bp_end, &last_flushed);
+
+		try(bkey_err(bp));
+		if (!bp.k)
+			return 0;
+
+		if (shrink_tail_head_empty(&progress->head)) {
+			progress->head.bucket = bp_pos_to_bucket(ca, bp.k->p);
+			progress->head.first_bp = bp.k->p;
+		}
+
+		if (bpos_eq(bp_pos_to_bucket(ca, bp.k->p), progress->head.bucket))
+			progress->head.nr_backpointers++;
+
+		progress->nr_backpointers++;
+		bch2_bp_scan_iter_advance(&iter);
+	}
+}
+
+static int tail_is_empty(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets,
+			 bool *empty)
+{
+	struct shrink_tail_head head;
+
+	try(tail_head_snapshot(c, ca, new_nbuckets, &head));
+	*empty = shrink_tail_head_empty(&head);
+	return 0;
+}
+
+static int bch2_dev_shrink_invalidate_bp(struct btree_trans *trans,
+					 struct bch_dev *ca,
+					 struct bkey_s_c_backpointer bp,
+					 struct wb_maybe_flush *last_flushed)
+{
+	struct bch_fs *c = trans->c;
+
+	CLASS(btree_iter_uninit, iter)(trans);
+	struct bkey_s_c k = bkey_try(bch2_backpointer_get_key(trans, bp, &iter, 0, last_flushed));
+	if (!k.k)
+		return 0;
+
+	struct bkey_i *n = errptr_try(bch2_bkey_make_mut(trans, &iter, &k,
+						BTREE_UPDATE_internal_snapshot_node));
+
+	bch2_bkey_drop_device_noerror(c, bkey_i_to_s(n), ca->dev_idx);
+
+	if (!bch2_bkey_can_read(c, bkey_i_to_s_c(n)))
+		bch2_set_bkey_error(c, n, KEY_TYPE_ERROR_device_removed);
+
+	return 0;
+}
+
+static int bch2_dev_shrink_invalidate_cached_bucket(struct btree_trans *trans,
+						    struct bch_dev *ca,
+						    struct bpos bucket,
+						    u8 gen,
+						    struct wb_maybe_flush *last_flushed)
+{
+	struct bpos bp_start = bucket_pos_to_bp_start(ca, bucket);
+	struct bpos bp_end = bucket_pos_to_bp_end(ca, bucket);
+
+	return for_each_btree_key_max_commit(trans, iter, BTREE_ID_backpointers,
+				      bp_start, bp_end, 0, k,
+				      NULL, NULL,
+				      BCH_WATERMARK_btree|
+				      BCH_TRANS_COMMIT_no_enospc, ({
+		if (k.k->type != KEY_TYPE_backpointer)
+			continue;
+
+		struct bkey_s_c_backpointer bp = bkey_s_c_to_backpointer(k);
+
+		if (bp.v->bucket_gen != gen)
+			continue;
+
+		try(bch2_dev_shrink_invalidate_bp(trans, ca, bp, last_flushed));
+		0;
+	}));
+}
+
+static int bch2_dev_shrink_invalidate_tail_cached(struct bch_fs *c, struct bch_dev *ca,
+						  u64 new_nbuckets, bool *invalidated)
+{
+	struct bpos start = POS(ca->dev_idx, new_nbuckets);
+	struct bpos end = POS(ca->dev_idx, ca->mi.nbuckets - 1);
+	CLASS(btree_trans, trans)(c);
+
+	struct wb_maybe_flush last_flushed __cleanup(wb_maybe_flush_exit);
+	wb_maybe_flush_init(&last_flushed);
+
+	/*
+	 * Shrink evacuation rewrites live data elsewhere but leaves the old
+	 * buckets behind as cached copies. Those cached-only tail buckets don't
+	 * need reconcile, yet they still keep backpointers alive and make
+	 * tail_is_empty() fail. Drop them directly so shrink only waits on
+	 * buckets that still hold durable data or metadata.
+	 */
+	*invalidated = false;
+
+	try(bch2_btree_write_buffer_flush_sync(trans));
+
+	return for_each_btree_key_max_commit(trans, iter, BTREE_ID_alloc,
+				start, end, BTREE_ITER_prefetch, k,
+				NULL, NULL,
+				BCH_WATERMARK_btree|
+				BCH_TRANS_COMMIT_no_enospc, ({
+		struct bch_alloc_v4 a_convert;
+		const struct bch_alloc_v4 *a = bch2_alloc_to_v4(k, &a_convert);
+
+		if (a->data_type != BCH_DATA_cached || !a->cached_sectors)
+			continue;
+
+		if (bch2_bucket_is_open_safe(c, k.k->p.inode, k.k->p.offset))
+			continue;
+
+		try(bch2_dev_shrink_invalidate_cached_bucket(trans, ca, k.k->p,
+							     a->gen, &last_flushed));
+		*invalidated = true;
+		0;
+	}));
 }
 
 static int bch2_dev_shrink_queue_reconcile(struct bch_fs *c, struct bch_dev *ca,
@@ -1829,12 +2041,14 @@ static int bch2_dev_shrink_queue_reconcile(struct bch_fs *c, struct bch_dev *ca,
 
 static int bch2_dev_shrink_wait_reconcile(struct bch_dev *ca, u64 new_nbuckets,
 					  u64 seq, u32 kick,
+					  const struct shrink_tail_head *head_before,
+					  bool *kick_complete,
 					  struct printbuf *err)
 {
 	struct bch_fs *c = ca->fs;
 
 	while (true) {
-		bool empty = false;
+		bool completed;
 		int ret = bch2_dev_resize_restart_check(ca, seq);
 		if (ret)
 			return ret;
@@ -1844,14 +2058,21 @@ static int bch2_dev_shrink_wait_reconcile(struct bch_dev *ca, u64 new_nbuckets,
 		 * actually empty. A kick can continue chewing through unrelated
 		 * global reconcile work for minutes after the truncating region is
 		 * already evacuated, especially with fragmented variable-bucket
-		 * workloads. Poll tail emptiness so shrink can move on as soon as
-		 * the region being truncated is clear.
+		 * workloads. Poll the head of the shrink tail and bound each wait
+		 * to a one-second slice so shrink can rescan its own state instead
+		 * of sitting behind one long reconcile kick.
 		 */
-		try(tail_is_empty(c, ca, new_nbuckets, err, &empty));
+		struct shrink_tail_head head_after;
 
-		if (empty ||
-		    bch2_reconcile_completed_kick(c) >= kick)
+		try(tail_head_snapshot(c, ca, new_nbuckets, &head_after));
+		completed = bch2_reconcile_completed_kick(c) >= kick;
+
+		if (shrink_tail_head_empty(&head_after) ||
+		    shrink_tail_head_progressed(head_before, &head_after) ||
+		    completed) {
+			*kick_complete = completed;
 			return 0;
+		}
 
 		ret = wait_event_killable_timeout(c->reconcile.wait,
 			bch2_reconcile_completed_kick(c) >= kick ||
@@ -1860,6 +2081,10 @@ static int bch2_dev_shrink_wait_reconcile(struct bch_dev *ca, u64 new_nbuckets,
 			HZ);
 		if (ret < 0)
 			return -EINTR;
+		if (!ret) {
+			*kick_complete = false;
+			return 0;
+		}
 	}
 }
 
@@ -1934,7 +2159,7 @@ static int bch2_dev_shrink_finalize(struct bch_fs *c, struct bch_dev *ca,
 		}
 
 		/* re-check that tail is really empty */
-		ret = tail_is_empty(c, ca, new_nbuckets, err, &empty);
+		ret = tail_is_empty(c, ca, new_nbuckets, &empty);
 		if (ret)
 			return ret;
 		if (!empty) {
@@ -2076,45 +2301,75 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 	if (ret)
 		return ret;
 
-	/*  TODO:
-	 *  When we evacuate data, the original is left in place and marked as cached, just like when moving it for target/compression regions.
-	 *  We need to somehow handle this:
-	 *  - Maybe we can just not count it in tail_is_empty() and just shrink it away - but this would likely leave some metadata incorrect
-	 *  - We could just make it completely remove the data if it is evacuating, instead of marking it as cached
-	 *  - We could make passes that check for cached buckets in the tail, and close/remove those - we may actually need to handle buckets anyways
-	 */
-
 	/* wait for to-be-shrunk region to be empty */
+	const unsigned stalled_kicks_limit = 32;
+	struct shrink_tail_progress best_progress = {
+		.head.bucket	= SPOS_MAX,
+		.head.first_bp	= SPOS_MAX,
+	};
+	bool scan_device = true;
+	unsigned stalled_kicks = 0;
+
 	for (unsigned pass = 0; ; pass++) {
-		bool empty = false;
+		bool invalidated_cached = false;
+		bool kick_complete;
+		struct shrink_tail_head head;
+		struct shrink_tail_progress progress;
 		u32 kick;
 
 		ret = bch2_dev_resize_restart_check(ca, seq);
 		if (ret)
 			return ret;
 
-		try(tail_is_empty(c, ca, new_nbuckets, err, &empty));
+		try(tail_head_snapshot(c, ca, new_nbuckets, &head));
 
 		/* do a definitive check */
-		if (empty) {
+		if (shrink_tail_head_empty(&head)) {
 			{
 				CLASS(btree_trans, trans)(c);
 				try(bch2_btree_write_buffer_flush_sync(trans));
 			}
 
-			try(tail_is_empty(c, ca, new_nbuckets, err, &empty));
-			if (empty) {
+			try(tail_head_snapshot(c, ca, new_nbuckets, &head));
+			if (shrink_tail_head_empty(&head)) {
 				break;
 			}
 		}
 
-		if (pass >= 2) {
-			prt_printf(err,
-				   "Shrink failed: insufficient space on the filesystem to evacuate data from the shrink tail\n");
-			ret = bch2_dev_shrink_clear_target(c, ca, new_nbuckets, seq, err);
-			if (ret)
-				return ret;
-			return -ENOSPC;
+		ret = bch2_dev_shrink_invalidate_tail_cached(c, ca, new_nbuckets,
+							     &invalidated_cached);
+		if (ret) {
+			prt_printf(err, "Failed to invalidate cached shrink-tail data: %s\n",
+				   bch2_err_str(ret));
+			return ret;
+		}
+
+		if (invalidated_cached) {
+			{
+				CLASS(btree_trans, trans)(c);
+				try(bch2_btree_write_buffer_flush_sync(trans));
+			}
+
+			try(tail_head_snapshot(c, ca, new_nbuckets, &head));
+			if (shrink_tail_head_empty(&head))
+				break;
+		}
+
+		/*
+		 * Live foreground IO can require several shrink/reconcile passes
+		 * before the leading tail bucket drains, and the head bucket can
+		 * stay put while work elsewhere in the tail is still making
+		 * space for it. Track both the leading bucket and the total tail
+		 * backpointer count, then only fail after many completed
+		 * no-progress reconcile kicks that actually scanned or processed
+		 * shrink work instead of using a wall-clock timeout.
+		 */
+		try(tail_progress_snapshot(c, ca, new_nbuckets, &progress));
+
+		if (shrink_tail_progressed(&best_progress, &progress)) {
+			best_progress = progress;
+			scan_device = false;
+			stalled_kicks = 0;
 		}
 
 		/*
@@ -2123,13 +2378,37 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 		 * requested pass completes or the tail is already empty before we
 		 * decide whether shrink needs another evacuation pass.
 		 */
-		ret = bch2_dev_shrink_queue_reconcile(c, ca, pass == 0, &kick, err);
+		ret = bch2_dev_shrink_queue_reconcile(c, ca, pass == 0 || scan_device,
+						      &kick, err);
 		if (ret)
 			return ret;
 
-		ret = bch2_dev_shrink_wait_reconcile(ca, new_nbuckets, seq, kick, err);
+		ret = bch2_dev_shrink_wait_reconcile(ca, new_nbuckets, seq, kick,
+						     &head, &kick_complete, err);
 		if (ret)
 			return ret;
+
+		try(tail_progress_snapshot(c, ca, new_nbuckets, &progress));
+
+		if (shrink_tail_head_empty(&progress.head))
+			break;
+
+		if (shrink_tail_progressed(&best_progress, &progress)) {
+			best_progress = progress;
+			scan_device = false;
+			stalled_kicks = 0;
+		} else if (kick_complete) {
+			scan_device = !bch2_reconcile_completed_work_units(c);
+			if (bch2_reconcile_completed_work_units(c) &&
+			    ++stalled_kicks >= stalled_kicks_limit) {
+				prt_printf(err,
+					   "Shrink failed: insufficient space on the filesystem to evacuate data from the shrink tail\n");
+				ret = bch2_dev_shrink_clear_target(c, ca, new_nbuckets, seq, err);
+				if (ret)
+					return ret;
+				return -ENOSPC;
+			}
+		}
 	}
 
 	return bch2_dev_shrink_finalize(c, ca, old_nbuckets, new_nbuckets, seq, err);

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1548,7 +1548,7 @@ static int drop_sbs_after_cutoff(struct bch_fs *c, struct bch_dev *ca, u64 cutof
 	return bch2_write_super(c);
 }
 
-// TODO: make sure everything is caught here.
+// TODO: make sure everything is caught here. Maybe look at bch2_dev_has_data for this
 // Fore example journals and superblocks might need special handling
 static int tail_is_empty(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err, bool *empty) {
 	struct bpos bp_start = bucket_pos_to_bp_start(ca, POS(ca->dev_idx, new_nbuckets));
@@ -1662,6 +1662,24 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			m->target_nbuckets = 0;
 
 			bch2_write_super(c);
+		}
+
+		/* flush interior updates - mirroring dev remove path */
+		bch2_btree_interior_updates_flush(c);
+
+		/* flush journal - mirroring dev remove path */
+		bch2_journal_flush_all_pins(&c->journal);
+
+		ret = bch2_journal_flush_device_pins(&c->journal, ca->dev_idx);
+		if (ret) {
+			prt_printf(err, "bch2_journal_flush_device_pins() error: %s\n", bch2_err_str(ret));
+			return ret;
+		}
+
+		ret = bch2_journal_flush(&c->journal);
+		if (ret) {
+			prt_printf(err, "bch2_journal_flush() error: %s\n", bch2_err_str(ret));
+			return ret;
 		}
 
 		/* re-check that tail is really empty */

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -228,7 +228,6 @@
  */
 
 #include "alloc/buckets.h"
-#include "asm-generic/bug.h"
 #include "bcachefs.h"
 
 #include "alloc/accounting.h"

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1520,6 +1520,7 @@ int bch2_dev_grow(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct
 }
 
 
+// TODO: make sure everything is caught here
 static int tail_is_empty(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err, bool *empty) {
 	struct bpos bp_start = bucket_pos_to_bp_start(ca, POS(ca->dev_idx, new_nbuckets));
 	struct bpos bp_end = bucket_pos_to_bp_start(ca, POS(ca->dev_idx, ca->mi.nbuckets));
@@ -1563,7 +1564,7 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			return bch_err_throw(c, device_already_resizing);
 		}
 
-		/* write & commit target_nbuckets */
+		/* write & commit target_nbuckets - also stops new allocations */
 		scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
 			guard(mutex)(&c->sb_lock);
 			struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
@@ -1572,7 +1573,8 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			bch2_write_super(c);
 		}
 
-		/* block allocation - done by setting target_nbuckets */
+		/* close open buckets in the to-be-shrunk region */
+		bch2_open_buckets_stop(c, ca, false);
 		bch2_reset_alloc_cursors(c); // avoid churn
 
 		/* trigger reconcile range scan -> should kick off evacuation from range */
@@ -1605,6 +1607,7 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			}
 		}
 
+		/* make sure reconcile is actually running */
 		bch2_reconcile_wakeup(c);
 
 		if (signal_pending(current))
@@ -1640,13 +1643,16 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 
 			bch2_write_super(c);
 		}
+
 		/* resize in-memory data structures */
+		/* resize buckets */
 		ret = bch2_dev_buckets_resize(c, ca, new_nbuckets);
 		if (ret) {
 			prt_printf(err, "bch2_dev_buckets_resize() error: %s\n", bch2_err_str(ret));
 			return ret;
 		}
 
+		/* resize alloc info - see dev_remove */
 		// TODO: make this path shrink-compatible
 		if (ca->mi.freespace_initialized) {
 			ret = __bch2_dev_resize_alloc(ca, old_nbuckets, new_nbuckets);

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -262,7 +262,6 @@
 #include "init/fs.h"
 
 #include "linux/bitmap.h"
-#include <linux/byteorder.h>
 #include "linux/kthread.h"
 #include "linux/sched.h"
 #include "linux/sched/signal.h"

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -2410,6 +2410,12 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 			 * metadata is still being committed then the set of tail
 			 * blockers is still moving, so rescan from the current
 			 * tail instead of treating the shrink as impossible.
+			 *
+			 * This is intentionally conservative but the signal is
+			 * filesystem-global: unrelated metadata-writing IO can
+			 * advance the journal and keep the heuristic from ever
+			 * counting a stalled pass. A later cleanup should narrow
+			 * this to a shrink-local churn signal.
 			 */
 			if (journal_cur_seq(&c->journal) != journal_seq_before) {
 				scan_device = true;

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -231,6 +231,7 @@
 #include "debug/sysfs.h"
 
 #include "journal/init.h"
+#include "journal/journal.h"
 #include "journal/reclaim.h"
 
 #include "init/dev.h"
@@ -2360,9 +2361,11 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 		 * before the leading tail bucket drains, and the head bucket can
 		 * stay put while work elsewhere in the tail is still making
 		 * space for it. Track both the leading bucket and the total tail
-		 * backpointer count, then only fail after many completed
-		 * no-progress reconcile kicks that actually scanned or processed
-		 * shrink work instead of using a wall-clock timeout.
+		 * backpointer count, but only count no-progress passes after a
+		 * full device rescan on a journal-quiescent state; if the
+		 * journal is still moving then foreground IO or reconcile is
+		 * still mutating metadata and a no-progress pass is not evidence
+		 * that the shrink tail is impossible to evacuate.
 		 */
 		try(tail_progress_snapshot(c, ca, new_nbuckets, &progress));
 
@@ -2378,10 +2381,13 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 		 * requested pass completes or the tail is already empty before we
 		 * decide whether shrink needs another evacuation pass.
 		 */
-		ret = bch2_dev_shrink_queue_reconcile(c, ca, pass == 0 || scan_device,
-						      &kick, err);
+		bool did_scan = pass == 0 || scan_device;
+		u64 journal_seq_before;
+
+		ret = bch2_dev_shrink_queue_reconcile(c, ca, did_scan, &kick, err);
 		if (ret)
 			return ret;
+		journal_seq_before = journal_cur_seq(&c->journal);
 
 		ret = bch2_dev_shrink_wait_reconcile(ca, new_nbuckets, seq, kick,
 						     &head, &kick_complete, err);
@@ -2398,9 +2404,19 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 			scan_device = false;
 			stalled_kicks = 0;
 		} else if (kick_complete) {
-			scan_device = !bch2_reconcile_completed_work_units(c);
-			if (bch2_reconcile_completed_work_units(c) &&
-			    ++stalled_kicks >= stalled_kicks_limit) {
+			/*
+			 * A no-progress pass only counts toward ENOSPC after a
+			 * full device rescan on a quiescent journal state. If
+			 * metadata is still being committed then the set of tail
+			 * blockers is still moving, so rescan from the current
+			 * tail instead of treating the shrink as impossible.
+			 */
+			if (journal_cur_seq(&c->journal) != journal_seq_before) {
+				scan_device = true;
+				stalled_kicks = 0;
+			} else if (!did_scan) {
+				scan_device = true;
+			} else if (++stalled_kicks >= stalled_kicks_limit) {
 				prt_printf(err,
 					   "Shrink failed: insufficient space on the filesystem to evacuate data from the shrink tail\n");
 				ret = bch2_dev_shrink_clear_target(c, ca, new_nbuckets, seq, err);

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1882,7 +1882,7 @@ static int bch2_dev_shrink_clear_target(struct bch_fs *c, struct bch_dev *ca,
 	}
 
 	/* allocations are now no longer blocked after the cutoff, so there may now be more usable space  */
-	ret = bch2_reconcile_pending_wakeup(c);
+	ret = bch2_reconcile_pending_wakeup(c); // TODO: also do this when a user requests a shrink cancel (aka a resize to the current size)
 	if (ret)
 		bch_err_fn(c, ret);
 

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -235,12 +235,15 @@
 
 #include "linux/bitmap.h"
 #include "linux/byteorder/generic.h"
+#include "linux/kthread.h"
 #include "linux/sched.h"
 #include "linux/sched/signal.h"
 #include "sb/io.h"
 #include "sb/members.h"
 #include "sb/members_format.h"
 #include "util/util.h"
+
+static void bch2_dev_resize_thread_stop(struct bch_dev *);
 
 #define x(n)		#n,
 const char * const bch2_dev_read_refs[] = {
@@ -503,6 +506,8 @@ void bch2_dev_free(struct bch_dev *ca)
 	WARN_ON(!enumerated_ref_is_zero(&ca->io_ref[WRITE]));
 	WARN_ON(!enumerated_ref_is_zero(&ca->io_ref[READ]));
 
+	bch2_dev_resize_thread_stop(ca);
+
 	bch2_dev_unlink(ca);
 
 	if (ca->kobj.state_in_sysfs)
@@ -590,6 +595,9 @@ static struct bch_dev *__bch2_dev_alloc(struct bch_fs *c,
 	init_completion(&ca->ref_completion);
 	refcount_set(&ca->ref_outer, 1);
 	init_completion(&ca->ref_outer_completion);
+	spin_lock_init(&ca->resize_lock);
+	init_waitqueue_head(&ca->resize_wait);
+	ca->resize_status = 0;
 
 	INIT_WORK(&ca->io_error_work, bch2_io_error_work);
 
@@ -1433,30 +1441,158 @@ int bch2_dev_offline(struct bch_fs *c, struct bch_dev *ca, int flags, struct pri
 	return 0;
 }
 
-int bch2_dev_resize(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err)
+static u64 bch2_dev_resize_seq(struct bch_dev *ca)
 {
-	u64 old_nbuckets;
+	u64 seq;
 
-	guard(rwsem_write)(&c->state_lock);
+	scoped_guard(spinlock, &ca->resize_lock)
+		seq = ca->resize_seq;
 
-	if (READ_ONCE(ca->removing))
-		return bch_err_throw(c, device_has_been_removed);
+	return seq;
+}
 
-	old_nbuckets = ca->mi.nbuckets;
+static bool bch2_dev_resize_wait_done(struct bch_dev *ca, u64 seq, int *status)
+{
+	bool done;
 
-	if (new_nbuckets > old_nbuckets) {
-		return bch2_dev_grow(c, ca, new_nbuckets, err);
-	} else if (new_nbuckets < old_nbuckets) {
-		return bch2_dev_shrink(c, ca, new_nbuckets, err);
-	} else {
-		return 0;
+	scoped_guard(spinlock, &ca->resize_lock) {
+		done = ca->resize_seq != seq ||
+			ca->resize_status != -EINPROGRESS;
+		if (done)
+			*status = ca->resize_seq != seq
+				? -ECANCELED
+				: ca->resize_status;
 	}
+
+	return done;
+}
+
+static int bch2_dev_resize_wait(struct bch_dev *ca, u64 seq)
+{
+	int status = -EINPROGRESS;
+	int ret = wait_event_killable(ca->resize_wait,
+				      bch2_dev_resize_wait_done(ca, seq, &status));
+
+	return ret ? -EINTR : status;
+}
+
+static bool bch2_dev_resize_finish(struct bch_dev *ca, u64 seq, int status)
+{
+	bool is_current;
+
+	scoped_guard(spinlock, &ca->resize_lock) {
+		is_current = ca->resize_seq == seq;
+		if (is_current)
+			ca->resize_status = status;
+	}
+
+	if (is_current)
+		wake_up_all(&ca->resize_wait);
+
+	return is_current;
+}
+
+static int bch2_dev_resize_restart_check(struct bch_dev *ca, u64 seq)
+{
+	if (kthread_should_stop())
+		return -EINTR;
+
+	return bch2_dev_resize_seq(ca) != seq ? -EAGAIN : 0;
+}
+
+static int bch2_dev_resize_thread(void *arg);
+
+static int bch2_dev_resize_thread_start(struct bch_dev *ca)
+{
+	struct bch_fs *c = ca->fs;
+
+	lockdep_assert_held(&c->state_lock);
+
+	if (ca->resize_thread)
+		return 0;
+
+	struct task_struct *p =
+		kthread_create(bch2_dev_resize_thread, ca,
+			       "bch-resize/%s:%u", c->name, ca->dev_idx);
+	int ret = PTR_ERR_OR_ZERO(p);
+	if (ret)
+		return ret;
+
+	get_task_struct(p);
+	ca->resize_thread = p;
+	wake_up_process(p);
+	return 0;
+}
+
+static void bch2_dev_resize_thread_stop(struct bch_dev *ca)
+{
+	scoped_guard(spinlock, &ca->resize_lock) {
+		ca->resize_seq++;
+		ca->resize_status = -EINTR;
+	}
+
+	if (ca->resize_thread) {
+		kthread_stop(ca->resize_thread);
+		put_task_struct(ca->resize_thread);
+		ca->resize_thread = NULL;
+	}
+
+	wake_up_all(&ca->resize_wait);
+}
+
+void bch2_dev_resize_threads_stop(struct bch_fs *c)
+{
+	for_each_member_device(c, ca)
+		bch2_dev_resize_thread_stop(ca);
+}
+
+static int bch2_dev_resize_update_target(struct bch_fs *c, struct bch_dev *ca,
+					 u64 target_nbuckets, struct printbuf *err)
+{
+	lockdep_assert_held(&c->state_lock);
+
+	u64 old_nbuckets = ca->mi.nbuckets;
+
+	if (target_nbuckets > BCH_MEMBER_NBUCKETS_MAX) {
+		prt_printf(err, "New device size too big (%llu greater than max %u)\n",
+			   target_nbuckets, BCH_MEMBER_NBUCKETS_MAX);
+		return bch_err_throw(c, device_size_too_big);
+	}
+
+	if (target_nbuckets &&
+	    target_nbuckets < old_nbuckets &&
+	    target_nbuckets < ca->mi.first_bucket + BCH_MIN_NR_NBUCKETS) {
+		prt_printf(err, "New device size too small (%llu smaller than min %llu)\n",
+			   target_nbuckets,
+			   (u64) ca->mi.first_bucket + BCH_MIN_NR_NBUCKETS);
+		return bch_err_throw(c, device_size_too_small);
+	}
+
+	if (target_nbuckets > old_nbuckets &&
+	    bch2_dev_is_online(ca) &&
+	    get_capacity(ca->disk_sb.bdev->bd_disk) <
+	    ca->mi.bucket_size * target_nbuckets) {
+		prt_printf(err, "New size %llu larger than device size %llu\n",
+			   ca->mi.bucket_size * target_nbuckets,
+			   get_capacity(ca->disk_sb.bdev->bd_disk));
+		return bch_err_throw(c, device_size_too_small);
+	}
+
+	scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
+		guard(mutex)(&c->sb_lock);
+		struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
+
+		m->target_nbuckets = cpu_to_le64(target_nbuckets);
+		try(bch2_write_super(c));
+	}
+
+	return 0;
 }
 
 /* requires write state lock */
-int bch2_dev_grow(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err)
+static int __bch2_dev_grow(struct bch_fs *c, struct bch_dev *ca,
+			   u64 new_nbuckets, struct printbuf *err)
 {
-	guard(rwsem_write)(&c->state_lock);
 
 	int ret = 0;
 
@@ -1503,6 +1639,8 @@ int bch2_dev_grow(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct
 		guard(mutex)(&c->sb_lock);
 		struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
 		m->nbuckets = cpu_to_le64(new_nbuckets);
+		if (bch2_dev_resize_target(ca) == new_nbuckets)
+			m->target_nbuckets = 0;
 
 		bch2_write_super(c);
 	}
@@ -1651,8 +1789,7 @@ static int tail_is_empty(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets,
 
 
 static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
-			     u64 new_nbuckets, struct printbuf *err,
-			     bool resuming)
+			     u64 new_nbuckets, u64 seq, struct printbuf *err)
 {
 	u64 old_nbuckets = ca->mi.nbuckets;
 
@@ -1661,32 +1798,16 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 	scoped_guard(rwsem_write, &c->state_lock) {
 		/* validate shrink size */
 		if (new_nbuckets >= old_nbuckets) {
-			return 0;
+			return -EAGAIN;
 		}
 
-		u64 first_bucket = ca->mi.first_bucket;
-		if (new_nbuckets < first_bucket + BCH_MIN_NR_NBUCKETS) {
-			prt_printf(err, "New device size too small (%llu smaller than min %llu)\n",
-				   new_nbuckets, first_bucket + BCH_MIN_NR_NBUCKETS);
-			return bch_err_throw(c, device_size_too_small);
-		}
+		ret = bch2_dev_resize_restart_check(ca, seq);
+		if (ret)
+			return ret;
 
-		if (ca->mi.target_nbuckets) {
-			if (!resuming || ca->mi.target_nbuckets != new_nbuckets) {
-				prt_printf(err, "Device already resizing (current target: %llu, new target: %llu)\n",
-					   ca->mi.target_nbuckets, new_nbuckets);
-				return bch_err_throw(c, device_already_resizing);
-			}
-		} else {
-			/* write & commit target_nbuckets - also stops new allocations */
-			scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
-				guard(mutex)(&c->sb_lock);
-				struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
-				m->target_nbuckets = cpu_to_le64(new_nbuckets);
-
-				try(bch2_write_super(c));
-			}
-		}
+		if (bch2_dev_resize_target(ca) != new_nbuckets ||
+		    !bch2_dev_is_shrinking(ca))
+			return -EAGAIN;
 
 		/* close open buckets in the to-be-shrunk region */
 		bch2_open_buckets_stop(c, ca, false, new_nbuckets);
@@ -1709,12 +1830,20 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 		}
 	};
 
+	ret = bch2_dev_resize_restart_check(ca, seq);
+	if (ret)
+		return ret;
+
 	/*
 	 * Move journal buckets out of the tail up front: otherwise the journal
 	 * can keep reintroducing metadata references in the region we're trying
 	 * to evacuate while reconcile is draining backpointers from it.
 	 */
 	ret = move_journal_past_cutoff(c, ca, new_nbuckets, err);
+	if (ret)
+		return ret;
+
+	ret = bch2_dev_resize_restart_check(ca, seq);
 	if (ret)
 		return ret;
 
@@ -1729,6 +1858,11 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 	/* wait for to-be-shrunk region to be empty */
 	while (true) {
 		bool empty = false;
+
+		ret = bch2_dev_resize_restart_check(ca, seq);
+		if (ret)
+			return ret;
+
 		try(tail_is_empty(c, ca, new_nbuckets, err, &empty));
 
 		/* do a definitive check */
@@ -1747,10 +1881,10 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 		/* make sure reconcile is actually running */
 		bch2_reconcile_wakeup(c);
 
-		if (signal_pending(current))
+		if (kthread_should_stop())
 			return -EINTR;
 
-		schedule_timeout_killable(HZ/2);
+		schedule_timeout_interruptible(HZ/2);
 	}
 
 	/*
@@ -1763,7 +1897,19 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 	if (ret)
 		return ret;
 
+	ret = bch2_dev_resize_restart_check(ca, seq);
+	if (ret)
+		return ret;
+
 	scoped_guard(rwsem_write, &c->state_lock) {
+		ret = bch2_dev_resize_restart_check(ca, seq);
+		if (ret)
+			return ret;
+
+		if (bch2_dev_resize_target(ca) != new_nbuckets ||
+		    !bch2_dev_is_shrinking(ca))
+			return -EAGAIN;
+
 		/* flush interior updates - mirroring dev remove path */
 		bch2_btree_interior_updates_flush(c);
 
@@ -1831,8 +1977,9 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 		scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
 			guard(mutex)(&c->sb_lock);
 			struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
-			m->target_nbuckets = 0;
 			m->nbuckets = cpu_to_le64(new_nbuckets);
+			if (bch2_dev_resize_target(ca) == new_nbuckets)
+				m->target_nbuckets = 0;
 
 			try(bch2_write_super(c));
 		}
@@ -1858,18 +2005,112 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 	return 0;
 }
 
-int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
-		    u64 new_nbuckets, struct printbuf *err)
+static int bch2_dev_resize_thread(void *arg)
 {
-	return __bch2_dev_shrink(c, ca, new_nbuckets, err, false);
+	struct bch_dev *ca = arg;
+	struct bch_fs *c = ca->fs;
+	u64 seen_seq = 0;
+
+	set_freezable();
+
+	while (!kthread_should_stop()) {
+		kthread_wait_freezable(kthread_should_stop() ||
+				       bch2_dev_resize_seq(ca) != seen_seq);
+		if (kthread_should_stop())
+			break;
+
+		while (!kthread_should_stop()) {
+			u64 seq = bch2_dev_resize_seq(ca);
+			u64 target = bch2_dev_resize_target(ca);
+			int ret;
+			CLASS(printbuf, err)();
+
+			if (target == ca->mi.nbuckets) {
+				ret = 0;
+			} else if (target > ca->mi.nbuckets) {
+				ret = __bch2_dev_grow(c, ca, target, &err);
+			} else {
+				ret = __bch2_dev_shrink(c, ca, target, seq, &err);
+			}
+
+			if (ret == -EAGAIN)
+				continue;
+
+			if (ret && err.pos)
+				bch_err_dev(ca, "%s", err.buf);
+			else if (ret && ret != -EINTR)
+				bch_err_fn_dev(ca, ret);
+
+			seen_seq = bch2_dev_resize_seq(ca);
+			if (ret == -EINTR)
+				break;
+			if (!bch2_dev_resize_finish(ca, seq, ret))
+				continue;
+			break;
+		}
+	}
+
+	return 0;
 }
 
-int bch2_dev_shrink_resume(struct bch_fs *c, struct bch_dev *ca,
+static int bch2_dev_resize_kick(struct bch_dev *ca)
+{
+	u64 seq;
+
+	scoped_guard(spinlock, &ca->resize_lock) {
+		seq = ++ca->resize_seq;
+		ca->resize_status = -EINPROGRESS;
+	}
+
+	wake_up_process(ca->resize_thread);
+	return bch2_dev_resize_wait(ca, seq);
+}
+
+int bch2_dev_resize(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err)
+{
+	int ret = 0;
+	u64 target_nbuckets;
+
+	scoped_guard(rwsem_write, &c->state_lock) {
+		target_nbuckets = new_nbuckets == ca->mi.nbuckets
+			? 0
+			: new_nbuckets;
+
+		ret = bch2_dev_resize_thread_start(ca);
+		if (ret)
+			return ret;
+
+		ret = bch2_dev_resize_update_target(c, ca, target_nbuckets, err);
+		if (ret)
+			return ret;
+	}
+
+	ret = bch2_dev_resize_kick(ca);
+	if (ret == -ECANCELED)
+		prt_printf(err, "Resize request superseded by a newer target\n");
+	else if (ret && ret != -EINTR && !err->pos)
+		prt_printf(err, "Resize worker failed; see kernel log for details\n");
+	return ret;
+}
+
+int bch2_dev_resize_resume(struct bch_fs *c, struct bch_dev *ca,
 			   struct printbuf *err)
 {
-	return ca->mi.target_nbuckets
-		? __bch2_dev_shrink(c, ca, ca->mi.target_nbuckets, err, true)
-		: 0;
+	int ret = 0;
+
+	if (!bch2_dev_resize_pending(ca))
+		return 0;
+
+	scoped_guard(rwsem_write, &c->state_lock) {
+		ret = bch2_dev_resize_thread_start(ca);
+		if (ret)
+			return ret;
+	}
+
+	ret = bch2_dev_resize_kick(ca);
+	if (ret && ret != -ECANCELED && ret != -EINTR && !err->pos)
+		prt_printf(err, "Resize resume failed; see kernel log for details\n");
+	return ret;
 }
 
 /* Resize on mount */

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1420,10 +1420,9 @@ int bch2_dev_offline(struct bch_fs *c, struct bch_dev *ca, int flags, struct pri
 	return 0;
 }
 
-int bch2_dev_resize(struct bch_fs *c, struct bch_dev *ca, u64 nbuckets, struct printbuf *err)
+int bch2_dev_resize(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err)
 {
 	u64 old_nbuckets;
-	int ret = 0;
 
 	guard(rwsem_write)(&c->state_lock);
 
@@ -1432,32 +1431,48 @@ int bch2_dev_resize(struct bch_fs *c, struct bch_dev *ca, u64 nbuckets, struct p
 
 	old_nbuckets = ca->mi.nbuckets;
 
-	if (nbuckets < ca->mi.nbuckets) {
+	if (new_nbuckets > old_nbuckets) {
+		return bch2_dev_grow(c, ca, new_nbuckets, err);
+	} else if (new_nbuckets < old_nbuckets) {
+		return bch2_dev_shrink(c, ca, new_nbuckets, err);
+	} else {
+		return 0;
+	}
+}
+
+int bch2_dev_grow(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err)
+{
+	int ret = 0;
+
+	u64 old_nbuckets = ca->mi.nbuckets;
+
+	if (new_nbuckets < old_nbuckets) {
 		prt_printf(err, "Cannot shrink yet\n");
 		return bch_err_throw(c, EINVAL_dev_resize_shrink);
 	}
 
-	bool wakeup_reconcile_pending = nbuckets > ca->mi.nbuckets;
+	/* we have more space -> wake up pending */
+	bool wakeup_reconcile_pending = new_nbuckets > old_nbuckets;
 	struct reconcile_scan s = { .type = RECONCILE_SCAN_pending };
 	if (wakeup_reconcile_pending)
 		try(bch2_set_reconcile_needs_scan(c, s, false));
 
-	if (nbuckets > BCH_MEMBER_NBUCKETS_MAX) {
+	if (new_nbuckets > BCH_MEMBER_NBUCKETS_MAX) {
 		prt_printf(err, "New device size too big (%llu greater than max %u)\n",
-			   nbuckets, BCH_MEMBER_NBUCKETS_MAX);
+			   new_nbuckets, BCH_MEMBER_NBUCKETS_MAX);
 		return bch_err_throw(c, device_size_too_big);
 	}
 
 	if (bch2_dev_is_online(ca) &&
 	    get_capacity(ca->disk_sb.bdev->bd_disk) <
-	    ca->mi.bucket_size * nbuckets) {
+	    ca->mi.bucket_size * new_nbuckets) {
 		prt_printf(err, "New size %llu larger than device size %llu\n",
-			   ca->mi.bucket_size * nbuckets,
+			   ca->mi.bucket_size * new_nbuckets,
 			   get_capacity(ca->disk_sb.bdev->bd_disk));
 		return bch_err_throw(c, device_size_too_small);
 	}
 
-	ret = bch2_dev_buckets_resize(c, ca, nbuckets);
+	ret = bch2_dev_buckets_resize(c, ca, new_nbuckets);
 	if (ret) {
 		prt_printf(err, "bch2_dev_buckets_resize() error: %s\n", bch2_err_str(ret));
 		return ret;
@@ -1472,13 +1487,13 @@ int bch2_dev_resize(struct bch_fs *c, struct bch_dev *ca, u64 nbuckets, struct p
 	scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
 		guard(mutex)(&c->sb_lock);
 		struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
-		m->nbuckets = cpu_to_le64(nbuckets);
+		m->nbuckets = cpu_to_le64(new_nbuckets);
 
 		bch2_write_super(c);
 	}
 
 	if (ca->mi.freespace_initialized) {
-		ret = __bch2_dev_resize_alloc(ca, old_nbuckets, nbuckets);
+		ret = __bch2_dev_resize_alloc(ca, old_nbuckets, new_nbuckets);
 		if (ret) {
 			prt_printf(err, "__bch2_dev_resize_alloc() error: %s\n", bch2_err_str(ret));
 			return ret;
@@ -1490,6 +1505,19 @@ int bch2_dev_resize(struct bch_fs *c, struct bch_dev *ca, u64 nbuckets, struct p
 	if (wakeup_reconcile_pending)
 		try(bch2_set_reconcile_needs_scan(c, s, true));
 	return 0;
+}
+
+int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err) {
+	/* validate shrink size */
+	/* write & commit target_nbuckets */
+	/* block allocation (buckets_nouse) */
+	/* trigger reconcile range scan -> should kick off evacuation from range */
+	/* somehow wait for reconcile to finish */
+	/* zero target_nbuckets */
+	/* validate that no pointers are left into to-be-shrunk region */
+	/* write & commit new_nbuckets */
+	/* update free-space accounting */
+	/* resize in-memory data structures */
 }
 
 /* Resize on mount */

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -210,6 +210,7 @@
 #include "alloc/check.h"
 #include "alloc/discard.h"
 #include "alloc/replicas.h"
+#include "alloc/foreground.h"
 
 #include "btree/interior.h"
 
@@ -225,7 +226,9 @@
 #include "init/dev.h"
 #include "init/fs.h"
 
+#include "linux/bitmap.h"
 #include "sb/members.h"
+#include "sb/members_format.h"
 
 #define x(n)		#n,
 const char * const bch2_dev_read_refs[] = {
@@ -1440,15 +1443,17 @@ int bch2_dev_resize(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 	}
 }
 
+/* requires write state lock */
 int bch2_dev_grow(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err)
 {
+	lockdep_assert_held(&c->state_lock);
+
 	int ret = 0;
 
 	u64 old_nbuckets = ca->mi.nbuckets;
 
-	if (new_nbuckets < old_nbuckets) {
-		prt_printf(err, "Cannot shrink yet\n");
-		return bch_err_throw(c, EINVAL_dev_resize_shrink);
+	if (new_nbuckets <= old_nbuckets) {
+		return 0;
 	}
 
 	/* we have more space -> wake up pending */
@@ -1507,15 +1512,52 @@ int bch2_dev_grow(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct
 	return 0;
 }
 
+// TODO: resume shrink on startup
 int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err) {
 	/* validate shrink size */
+	u64 old_nbuckets = ca->mi.nbuckets;
+	if (new_nbuckets >= old_nbuckets) {
+		return 0;
+	}
+
+	u64 first_bucket = ca->mi.first_bucket;
+	if (new_nbuckets < first_bucket + BCH_MIN_NR_NBUCKETS) {
+		prt_printf(err, "New device size too small (%llu smaller than min %llu)\n",
+			   new_nbuckets, first_bucket + BCH_MIN_NR_NBUCKETS);
+		return bch_err_throw(c, device_size_too_small);
+	}
+
 	/* write & commit target_nbuckets */
+	scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
+		guard(mutex)(&c->sb_lock);
+		struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
+		m->target_nbuckets = cpu_to_le64(new_nbuckets);
+
+		bch2_write_super(c);
+	}
+
 	/* block allocation (buckets_nouse) */
+	bitmap_set(ca->buckets_nouse, new_nbuckets, old_nbuckets - new_nbuckets);
+	bch2_reset_alloc_cursors(c);
 	/* trigger reconcile range scan -> should kick off evacuation from range */
 	/* somehow wait for reconcile to finish */
 	/* zero target_nbuckets */
+	scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
+		guard(mutex)(&c->sb_lock);
+		struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
+		m->target_nbuckets = 0;
+
+		bch2_write_super(c);
+	}
 	/* validate that no pointers are left into to-be-shrunk region */
 	/* write & commit new_nbuckets */
+	scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
+		guard(mutex)(&c->sb_lock);
+		struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
+		m->nbuckets = new_nbuckets;
+
+		bch2_write_super(c);
+	}
 	/* update free-space accounting */
 	/* resize in-memory data structures */
 }

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -178,164 +178,37 @@
  * account for the newly available space.
  *
  * \subsubsubsection{Shrinking}
- * Shrinking removes the tail of the device's bucket range, evacuates any data
- * living there, and commits the smaller \texttt{nbuckets}. The truncating region is called the
- * \emph{shrink tail}: buckets \texttt{[target\_nbuckets, nbuckets)}.
+ * Shrinking removes the tail of a device\'s bucket range, evacuates any data
+ * located there, and commits the smaller \texttt{nbuckets}. The truncating
+ * region is called the \emph{shrink tail}: buckets
+ * \texttt{[target\_nbuckets, nbuckets)}.
  *
- * Once \texttt{target\_nbuckets < nbuckets} is persisted, several subsystems
- * react to the pending shrink before the worker has finished evacuation:
+ * Once \texttt{target\_nbuckets < nbuckets} is persisted, the allocator
+ * refuses new allocations in the tail, cached pointers past the cutoff are
+ * treated as stale, and metadata allocation spills to non-shrinking devices
+ * so shrink does not deadlock on its own journal or btree-rewrite needs.
+ * Reconcile is then used to discover and evacuate the remaining data;
+ * its backpointer scans start at the cutoff rather than bucket zero.
  *
- * \begin{itemize}
- * \item The \hyperref[sec:write-points]{allocator} refuses new open-bucket
- *   allocations at or beyond the cutoff.
- * \item Cached extent pointers past the cutoff are treated as stale and
- *   dropped on lookup.
- * \item Metadata allocation (journal buckets, btree node rewrites) falls back
- *   to the full filesystem when the preferred metadata target consists only of
- *   shrinking devices, avoiding a deadlock on metadata writes the shrink
- *   itself needs.
- * \item \hyperref[sec:backpointers]{Backpointer} scans for reconcile start at
- *   the cutoff instead of bucket zero, avoiding needless requeue of work on
- *   the retained region.
- * \end{itemize}
+ * Shrink is executed by a per-device kthread that can be restarted when a
+ * newer request supersedes an in-progress pass. Before draining the tail,
+ * the worker relocates any journal buckets in the truncating region explicitly
+ * (\texttt{move\_journal\_past\_cutoff()}) so journal activity does not keep
+ * reintroducing references into the region being evacuated.
  *
- * These immediate effects are what make the shrink cutoff effective as soon as
- * the target is persisted. They are driven by normalized helper checks
- * (\texttt{bch2\_dev\_is\_shrinking()}) and flip automatically when
- * userspace retargets away from shrink.
+ * Once the tail is empty, the worker finalises under \texttt{state\_lock}:
+ * it flushes journal pins, clears \texttt{NEED\_DISCARD} bookkeeping for
+ * the removed buckets, drops superblock copies and alloc metadata past the
+ * cutoff, then commits \texttt{nbuckets = target\_nbuckets} to the
+ * superblock. If the tail cannot be drained (e.g. insufficient space on
+ * remaining devices), \texttt{target\_nbuckets} is cleared so allocations
+ * are no longer blocked past the old cutoff.
  *
- * \textbf{Worker model.}
- * Each device has a dedicated kthread (\texttt{bch2\_dev\_resize\_thread()})
- * that processes resize requests. On each wakeup it snapshots the current
- * request sequence number and the normalized target, then dispatches to
- * either \texttt{__bch2\_dev\_grow()} or \texttt{__bch2\_dev\_shrink()}.
- * The thread is restartable rather than strictly cancelable---a newer
- * request increments \texttt{resize\_seq} and causes the active pass to
- * return \texttt{-EAGAIN} and restart with the latest target.
- * The common restart check is \texttt{bch2\_dev\_resize\_restart\_check()},
- * which also handles kthread shutdown via \texttt{-EINTR}.
- *
- * \textbf{Shrink algorithm.}
- * Shrink proceeds through four phases:
- *
- * \textbf{Phase 1---Enter shrink mode.}
- * The worker takes \texttt{state\_lock}, validates the target still matches
- * the live request, closes any open buckets in the truncating tail
- * (\texttt{bch2\_open\_buckets\_stop()}), and resets alloc cursors. After
- * dropping the lock, it flushes the discard workqueues so that an older
- * discard pass on the same region does not deadlock the evacuation path.
- *
- * \textbf{Phase 2---Move journal state out of the tail.}
- * \texttt{move\_journal\_past\_cutoff()} runs before the main drain loop.
- * The journal is handled explicitly because journal buckets are not something
- * shrink should wait for reconcile to discover and evacuate indirectly.
- * The function counts journal buckets in the tail, temporarily grows the
- * journal if more journal buckets are needed for relocation, forces the
- * current journal bucket to advance if it still sits in the tail, flushes
- * the journal to persist the relocation, and deletes the now-obsolete journal
- * buckets from the tail. Without this step, journal activity can keep
- * reintroducing metadata references into the very region shrink is trying to
- * empty.
- *
- * \textbf{Phase 3---Drain the tail.}
- * The core loop tracks tail liveness by scanning the backpointer btree in the
- * truncating region. The loop is built around several key helpers:
- *
- * \begin{itemize}
- * \item \texttt{tail\_head\_snapshot()} records the first tail bucket, its
- *   first backpointer, and the number of backpointers in that bucket.
- * \item \texttt{tail\_progress\_snapshot()} records the same head data plus
- *   the total backpointer count across the full tail.
- * \item \texttt{tail\_is\_empty()} performs a definitive emptiness check
- *   after flushing the btree write buffer (to expose buffered updates).
- * \end{itemize}
- *
- * On each pass the loop:
- *
- * \begin{enumerate}
- * \item Snapshots the tail head. If it looks empty, flushes the write buffer
- *   and rechecks before declaring emptiness.
- * \item Invalidates cached-only tail buckets via
- *   \texttt{bch2\_dev\_shrink\_invalidate\_tail\_cached()}. Cached copies in
- *   the tail are not durable data---they can be dropped directly rather than
- *   requiring reconcile to evacuate them.
- * \item Queues reconcile work with
- *   \texttt{bch2\_dev\_shrink\_queue\_reconcile()}: a device backpointer scan
- *   (starting at the cutoff, not bucket zero) plus a pending scan.
- * \item Waits using \texttt{bch2\_dev\_shrink\_wait\_reconcile()}, polling
- *   once per second and returning when the tail is empty, the requested
- *   reconcile kick completes, or head progress is detected. This avoids
- *   waiting for unrelated global reconcile work after the tail is already
- *   empty.
- * \end{enumerate}
- *
- * The progress heuristic tracks two things: the leading tail bucket and its
- * first backpointer, and the total tail backpointer count. A pass that makes
- * progress on either metric resets the stall counter. Passes without progress
- * are counted only after a full device rescan on a journal-quiescent state;
- * if the journal advanced during the pass, the blocker set is still changing
- * and the pass is not evidence of impossibility. After
- * \texttt{stalled\_kicks\_limit} (32) no-progress full rescans on a
- * quiescent journal, shrink declares \texttt{-ENOSPC} and clears the pending
- * target (\texttt{bch2\_dev\_shrink\_clear\_target()}) so allocations are no
- * longer blocked past the old cutoff.
- *
- * The journal-quiescence check is filesystem-global: unrelated
- * metadata-writing IO elsewhere can keep advancing the journal sequence
- * number and suppress the stall counter indefinitely. The intended follow-up
- * is a shrink-local churn signal.
- *
- * \textbf{Phase 4---Finalize the shrink.}
- * \texttt{bch2\_dev\_shrink\_finalize()} runs under \texttt{state\_lock} and
- * commits the truncation. The ordering is critical:
- *
- * \begin{enumerate}
- * \item Revalidate that the live request still matches this pass.
- * \item Flush btree interior updates.
- * \item Flush outstanding journal pins (device-specific, then a flush of
- *   \texttt{journal\_cur\_seq()}---not \texttt{bch2\_journal\_flush\_all\_pins()},
- *   which can wait behind unrelated reconcile or key-cache pins indefinitely).
- * \item Recheck tail emptiness with \texttt{tail\_is\_empty()}.
- * \item Clear \texttt{NEED\_DISCARD} entries for the truncated tail. This must
- *   scan and filter by decoded bucket position because
- *   \texttt{BTREE\_ID\_need\_discard} is keyed by journal sequence, not by
- *   \texttt{(dev, bucket)}.
- * \item Drop superblock copies whose offsets are beyond the cutoff with
- *   \texttt{drop\_sbs\_after\_cutoff()}.
- * \item Truncate accounting with \texttt{bch2\_dev\_truncate\_accounting()}.
- * \item Remove alloc metadata for the tail with
- *   \texttt{bch2\_dev\_remove\_alloc()}.
- * \item Commit \texttt{nbuckets = new\_nbuckets} in the superblock and clear
- *   \texttt{target\_nbuckets} if it still matches the committed target.
- * \item Resize in-memory bucket arrays with
- *   \texttt{bch2\_dev\_buckets\_resize()}.
- * \item Recalculate filesystem capacity.
- * \end{enumerate}
- *
- * The central invariant: shrink may only commit the smaller \texttt{nbuckets}
- * while holding \texttt{state\_lock}, after rechecking that the current
- * normalized target still equals the target used by this pass and is still a
- * shrink target. This prevents an obsolete pass from truncating the device
- * after userspace has already requested a different target or cancellation.
- * After finalization completes, \texttt{bch2\_dev\_resize\_finish()} wakes
- * waiters and restarts async discards on the device (which were deferred
- * during the shrink to avoid deadlocks with the evacuation path).
- *
- * \textbf{Recovery and remount behavior.}
- * A pending shrink that was persisted to the superblock but interrupted
- * (e.g., by a crash or unmount) resumes automatically on the next read-write
- * mount. \texttt{bch2\_fs\_resize\_on\_mount()} detects devices whose
- * normalized target still differs from \texttt{nbuckets} once the btree and
- * reconcile infrastructure is running, and calls
- * \texttt{bch2\_dev\_resize\_resume()} for each such device. No userspace
- * reissue is required.
- *
- * \textbf{Shutdown ordering.}
- * Resize workers are stopped in \texttt{bch2\_fs\_read\_only()} via
- * \texttt{bch2\_dev\_resize\_threads\_stop()}, before the filesystem enters
- * clean shutdown. This ordering matters because a persisted shrink may still
- * be performing transactional alloc/accounting work; if the filesystem starts
- * going read-only first, the worker's writes can trip write-path assertions.
+ * A pending shrink persisted to the superblock resumes automatically on the
+ * next read-write mount without requiring userspace to reissue the ioctl.
+ * Resize workers are stopped in \texttt{bch2\_fs\_read\_only()} before the
+ * filesystem enters clean shutdown, so that in-flight transactional work
+ * does not trip write-path assertions.
  *
  *
  * \texttt{bcachefs device resize-journal} adjusts the per-device journal size

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1849,8 +1849,11 @@ static bool shrink_tail_progressed(const struct shrink_tail_progress *old,
 	return shrink_tail_head_progressed(&old->head, &new->head);
 }
 
-// TODO: make sure everything is caught here. Maybe look at bch2_dev_has_data for this
-// Fore example journals and superblocks might need special handling
+/*
+ * Make sure everything is caught here: this snapshots backpointer-visible tail
+ * data. Journal buckets and superblock copies in the shrink tail are handled by
+ * move_journal_past_cutoff() and drop_sbs_after_cutoff().
+ */
 static int tail_head_snapshot(struct bch_fs *c, struct bch_dev *ca,
 			      u64 new_nbuckets, struct shrink_tail_head *head)
 {
@@ -2253,15 +2256,6 @@ static int bch2_dev_shrink_finalize(struct bch_fs *c, struct bch_dev *ca,
 				   bch2_err_str(ret));
 			return ret;
 		}
-
-		// TODO: figure out what parts of this path still need doing
-		// if (ca->mi.freespace_initialized) {
-		// 	ret = __bch2_dev_resize_alloc(ca, old_nbuckets, new_nbuckets);
-		// 	if (ret) {
-		// 		prt_printf(err, "__bch2_dev_resize_alloc() error: %s\n", bch2_err_str(ret));
-		// 		return ret;
-		// 	}
-		// }
 
 		bch2_recalc_capacity(c);
 	}

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1599,7 +1599,7 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
 			m->target_nbuckets = cpu_to_le64(new_nbuckets);
 
-			bch2_write_super(c);
+			try(bch2_write_super(c));
 		}
 
 		/* close open buckets in the to-be-shrunk region */
@@ -1617,6 +1617,14 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			return ret;
 		}
 	};
+
+	/*  TODO:
+	 *  When we evacuate data, the original is left in place and marked as cached, just like when moving it for target/compression regions.
+	 *  We need to somehow handle this:
+	 *  - Maybe we can just not count it in tail_is_empty() and just shrink it away - but this would likely leave some metadata incorrect
+	 *  - We could just make it completely remove the data if it is evacuating, instead of marking it as cached
+	 *  - We could make passes that check for cached buckets in the tail, and close/remove those - we may actually need to handle buckets anyways
+	 */
 
 	/* wait for to-be-shrunk region to be empty */
 	while (true) {

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -233,8 +233,10 @@
 #include "init/fs.h"
 
 #include "linux/bitmap.h"
+#include "linux/byteorder/generic.h"
 #include "linux/sched.h"
 #include "linux/sched/signal.h"
+#include "sb/io.h"
 #include "sb/members.h"
 #include "sb/members_format.h"
 #include "util/util.h"
@@ -1519,6 +1521,29 @@ int bch2_dev_grow(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct
 	return 0;
 }
 
+static int drop_sbs_after_cutoff(struct bch_fs *c, struct bch_dev *ca, u64 cutoff) {
+	u64 cutoff_sector = bucket_to_sector(ca, cutoff);
+
+	guard(memalloc_flags)(PF_MEMALLOC_NOFS);
+	guard(mutex)(&c->sb_lock);
+
+	struct bch_sb_layout *layout = &ca->disk_sb.sb->layout;
+
+	u64 max_sectors = 1 << layout->sb_max_size_bits;
+
+	u8 i;
+	/* offsets are sorted in ascending order, see validate_sb_layout() overlapping checks for evidence */
+	for (i = 0; i < layout->nr_superblocks; i++) {
+		u64 offset = le64_to_cpu(layout->sb_offset[i]);
+		if (offset + max_sectors > cutoff_sector) {
+			break;
+		}
+	}
+
+	layout->nr_superblocks = i;
+
+	return bch2_write_super(c);
+}
 
 // TODO: make sure everything is caught here.
 // Fore example journals and superblocks might need special handling
@@ -1645,7 +1670,12 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			bch2_write_super(c);
 		}
 
-		/* resize in-memory data structures */
+		/* drop references to now-truncated superblock copies */
+		ret = drop_sbs_after_cutoff(c, ca, new_nbuckets);
+		if (ret) {
+			prt_printf(err, "Error dropping superblocks after cutoff: %s\n", bch2_err_str(ret));
+			return ret;
+		}
 
 		/* resize buckets */
 		ret = bch2_dev_buckets_resize(c, ca, new_nbuckets);
@@ -1662,7 +1692,7 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 		}
 
 		/* account disk space */
-		// - BCH_DATA_free is somehow still off by 2
+		// - BCH_DATA_free is somehow still off by the amount of superblocks
 		// - BCH_DATA_sb isn't updated at all yet - should we relocate them or just accept that we have less copies and adjust?
 		s64 v[3] = { -(s64) (old_nbuckets - new_nbuckets), 0, 0 };
 		ret = bch2_trans_commit_do(ca->fs, NULL, NULL, 0,

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1682,15 +1682,16 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 		scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
 			guard(mutex)(&c->sb_lock);
 			struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
-
-			bch2_write_super(c);
 			m->nbuckets = cpu_to_le64(new_nbuckets);
+
+			try(bch2_write_super(c));
 		}
 
-		/* resize buckets */
-		ret = bch2_dev_buckets_resize(c, ca, new_nbuckets);
+
+		/* update accounting info - has to happen before truncating alloc info */
+		ret = bch2_dev_truncate_accounting(c, ca, old_nbuckets, new_nbuckets);
 		if (ret) {
-			prt_printf(err, "bch2_dev_buckets_resize() error: %s\n", bch2_err_str(ret));
+			prt_printf(err, "error updating accounting info: %s\n", bch2_err_str(ret));
 			return ret;
 		}
 
@@ -1698,6 +1699,13 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 		ret = bch2_dev_remove_alloc(c, ca, new_nbuckets);
 		if (ret) {
 			prt_printf(err, "error truncating alloc info: %s\n", bch2_err_str(ret));
+			return ret;
+		}
+
+		/* resize buckets */
+		ret = bch2_dev_buckets_resize(c, ca, new_nbuckets);
+		if (ret) {
+			prt_printf(err, "bch2_dev_buckets_resize() error: %s\n", bch2_err_str(ret));
 			return ret;
 		}
 

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1943,6 +1943,7 @@ static int bch2_dev_shrink_invalidate_bp(struct btree_trans *trans,
 					 struct bkey_s_c_backpointer bp,
 					 struct wb_maybe_flush *last_flushed)
 {
+	u32 restart_count = trans->restart_count;
 	struct bch_fs *c = trans->c;
 
 	CLASS(btree_iter_uninit, iter)(trans);
@@ -1958,7 +1959,7 @@ static int bch2_dev_shrink_invalidate_bp(struct btree_trans *trans,
 	if (!bch2_bkey_can_read(c, bkey_i_to_s_c(n)))
 		bch2_set_bkey_error(c, n, KEY_TYPE_ERROR_device_removed);
 
-	return 0;
+	return trans_was_restarted(trans, restart_count);
 }
 
 static int bch2_dev_shrink_invalidate_cached_bucket(struct btree_trans *trans,
@@ -1967,6 +1968,7 @@ static int bch2_dev_shrink_invalidate_cached_bucket(struct btree_trans *trans,
 						    u8 gen,
 						    struct wb_maybe_flush *last_flushed)
 {
+	u32 restart_count = trans->restart_count;
 	struct bpos bp_start = bucket_pos_to_bp_start(ca, bucket);
 	struct bpos bp_end = bucket_pos_to_bp_end(ca, bucket);
 
@@ -1983,9 +1985,8 @@ static int bch2_dev_shrink_invalidate_cached_bucket(struct btree_trans *trans,
 		if (bp.v->bucket_gen != gen)
 			continue;
 
-		try(bch2_dev_shrink_invalidate_bp(trans, ca, bp, last_flushed));
-		0;
-	}));
+		bch2_dev_shrink_invalidate_bp(trans, ca, bp, last_flushed);
+	})) ?: trans_was_restarted(trans, restart_count);
 }
 
 static int bch2_dev_shrink_invalidate_tail_cached(struct bch_fs *c, struct bch_dev *ca,
@@ -2023,10 +2024,11 @@ static int bch2_dev_shrink_invalidate_tail_cached(struct bch_fs *c, struct bch_d
 		if (bch2_bucket_is_open_safe(c, k.k->p.inode, k.k->p.offset))
 			continue;
 
-			try(bch2_dev_shrink_invalidate_cached_bucket(trans, ca, k.k->p,
-								     a->generation, &last_flushed));
-		*invalidated = true;
-		0;
+		int ret = bch2_dev_shrink_invalidate_cached_bucket(trans, ca, k.k->p,
+								   a->generation, &last_flushed);
+		if (!ret)
+			*invalidated = true;
+		ret;
 	}));
 }
 

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1581,6 +1581,10 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			.dev = ca->dev_idx,
 		};
 		ret = bch2_set_reconcile_needs_scan(c, s, true);
+		if (ret) {
+			prt_printf(err, "Failed to run device reconcile scan: %s\n", bch2_err_str(ret));
+			return ret;
+		}
 	};
 
 	/* wait for to-be-shrunk reason to be empty */
@@ -1637,7 +1641,7 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			bch2_write_super(c);
 		}
 		/* resize in-memory data structures */
-		int ret = bch2_dev_buckets_resize(c, ca, new_nbuckets);
+		ret = bch2_dev_buckets_resize(c, ca, new_nbuckets);
 		if (ret) {
 			prt_printf(err, "bch2_dev_buckets_resize() error: %s\n", bch2_err_str(ret));
 			return ret;

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1826,29 +1826,38 @@ static int bch2_dev_shrink_queue_reconcile(struct bch_fs *c, struct bch_dev *ca,
 	return 0;
 }
 
-static int bch2_dev_shrink_wait_reconcile(struct bch_dev *ca, u64 seq, u32 kick)
+static int bch2_dev_shrink_wait_reconcile(struct bch_dev *ca, u64 new_nbuckets,
+					  u64 seq, u32 kick,
+					  struct printbuf *err)
 {
 	struct bch_fs *c = ca->fs;
 
 	while (true) {
+		bool empty = false;
 		int ret = bch2_dev_resize_restart_check(ca, seq);
 		if (ret)
 			return ret;
 
 		/*
-		 * A completed kick only says the requested reconcile pass
-		 * drained. Wait for the worker to reach its idle state too, or
-		 * shrink's final journal flush can still race with reconcile's
-		 * cached btree paths and stall behind key-cache pin flushing.
+		 * We only need reconcile to keep running until the shrink tail is
+		 * actually empty. A kick can continue chewing through unrelated
+		 * global reconcile work for minutes after the truncating region is
+		 * already evacuated, especially with fragmented variable-bucket
+		 * workloads. Poll tail emptiness so shrink can move on as soon as
+		 * the region being truncated is clear.
 		 */
-		if (bch2_reconcile_kick_idle(c, kick))
+		try(tail_is_empty(c, ca, new_nbuckets, err, &empty));
+
+		if (empty ||
+		    bch2_reconcile_completed_kick(c) >= kick)
 			return 0;
 
-		ret = wait_event_killable(c->reconcile.wait,
-			bch2_reconcile_kick_idle(c, kick) ||
+		ret = wait_event_killable_timeout(c->reconcile.wait,
+			bch2_reconcile_completed_kick(c) >= kick ||
 			bch2_dev_resize_seq(ca) != seq ||
-			kthread_should_stop());
-		if (ret)
+			kthread_should_stop(),
+			HZ);
+		if (ret < 0)
 			return -EINTR;
 	}
 }
@@ -1883,12 +1892,147 @@ static int bch2_dev_shrink_clear_target(struct bch_fs *c, struct bch_dev *ca,
 	return 0;
 }
 
+static int bch2_dev_shrink_finish(struct bch_fs *c, struct bch_dev *ca,
+				  u64 old_nbuckets, u64 new_nbuckets,
+				  u64 seq, struct printbuf *err)
+{
+	int ret;
+
+	/*
+	 * Re-run journal relocation as a final fence before we commit the new
+	 * size: the current journal bucket may have advanced while we were
+	 * waiting for the tail to drain, and we must not expose the smaller
+	 * nbuckets while journal state can still reference the truncated tail.
+	 */
+	ret = move_journal_past_cutoff(c, ca, new_nbuckets, err);
+	if (ret)
+		return ret;
+
+	ret = bch2_dev_resize_restart_check(ca, seq);
+	if (ret)
+		return ret;
+
+	scoped_guard(rwsem_write, &c->state_lock) {
+		bool empty = false;
+
+		ret = bch2_dev_resize_restart_check(ca, seq);
+		if (ret)
+			return ret;
+
+		if (bch2_dev_resize_target(ca) != new_nbuckets ||
+		    !bch2_dev_is_shrinking(ca))
+			return -EAGAIN;
+
+		/* flush interior updates - mirroring dev remove path */
+		bch2_btree_interior_updates_flush(c);
+
+		/* flush journal - mirroring dev remove path */
+		bch2_journal_flush_all_pins(&c->journal);
+
+		ret = bch2_journal_flush_device_pins(&c->journal, ca->dev_idx);
+		if (ret) {
+			prt_printf(err, "bch2_journal_flush_device_pins() error: %s\n",
+				   bch2_err_str(ret));
+			return ret;
+		}
+
+		ret = bch2_journal_flush(&c->journal);
+		if (ret) {
+			prt_printf(err, "bch2_journal_flush() error: %s\n",
+				   bch2_err_str(ret));
+			return ret;
+		}
+
+		/* re-check that tail is really empty */
+		ret = tail_is_empty(c, ca, new_nbuckets, err, &empty);
+		if (ret)
+			return ret;
+		if (!empty) {
+			prt_printf(err, "Shrink failed: still has data\n");
+			return -EBUSY;
+		}
+
+		/*
+		 * Buckets in the truncated tail may still be in NEED_DISCARD
+		 * state. Clear that bookkeeping before we drop the alloc range so
+		 * accounting/fsck do not retain tail-only metadata after shrink.
+		 */
+		ret = bch2_dev_clear_need_discard(c, ca, new_nbuckets);
+		if (ret) {
+			prt_printf(err, "error clearing need_discard state: %s\n",
+				   bch2_err_str(ret));
+			return ret;
+		}
+
+		/* drop references to now-truncated superblock copies */
+		ret = drop_sbs_after_cutoff(c, ca, new_nbuckets);
+		if (ret) {
+			prt_printf(err, "Error dropping superblocks after cutoff: %s\n",
+				   bch2_err_str(ret));
+			return ret;
+		}
+
+		/* update accounting info - has to happen before truncating alloc info */
+		ret = bch2_dev_truncate_accounting(c, ca, old_nbuckets, new_nbuckets);
+		if (ret) {
+			prt_printf(err, "error updating accounting info: %s\n",
+				   bch2_err_str(ret));
+			return ret;
+		}
+
+		/* truncate alloc info */
+		ret = bch2_dev_remove_alloc(c, ca, new_nbuckets);
+		if (ret) {
+			prt_printf(err, "error truncating alloc info: %s\n",
+				   bch2_err_str(ret));
+			return ret;
+		}
+
+		/*
+		 * Commit the shrink only after the truncated tail has been
+		 * removed from alloc metadata, so later transactions can't see
+		 * stale tail buckets after the new size is visible.
+		 */
+		scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
+			guard(mutex)(&c->sb_lock);
+			struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
+			m->nbuckets = cpu_to_le64(new_nbuckets);
+			if (bch2_dev_resize_target(ca) == new_nbuckets)
+				m->target_nbuckets = 0;
+
+			ret = bch2_write_super(c);
+			if (ret)
+				return ret;
+		}
+
+		/* resize buckets */
+		ret = bch2_dev_buckets_resize(c, ca, new_nbuckets);
+		if (ret) {
+			prt_printf(err, "bch2_dev_buckets_resize() error: %s\n",
+				   bch2_err_str(ret));
+			return ret;
+		}
+
+		// TODO: figure out what parts of this path still need doing
+		// if (ca->mi.freespace_initialized) {
+		// 	ret = __bch2_dev_resize_alloc(ca, old_nbuckets, new_nbuckets);
+		// 	if (ret) {
+		// 		prt_printf(err, "__bch2_dev_resize_alloc() error: %s\n", bch2_err_str(ret));
+		// 		return ret;
+		// 	}
+		// }
+
+		bch2_recalc_capacity(c);
+	}
+
+	return 0;
+}
+
 
 static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 			     u64 new_nbuckets, u64 seq, struct printbuf *err)
 {
 	u64 old_nbuckets = ca->mi.nbuckets;
-
 	int ret = 0;
 
 	scoped_guard(rwsem_write, &c->state_lock) {
@@ -1985,135 +2129,20 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 
 		/*
 		 * A consumed scan cookie only means reconcile observed the scan
-		 * request and queued downstream work. Wait for a completed pass
-		 * so the scan-generated normal and pending work has been
-		 * attempted before we decide the tail still cannot drain.
+		 * request and queued downstream work. Wait until either the
+		 * requested pass completes or the tail is already empty before we
+		 * decide whether shrink needs another evacuation pass.
 		 */
 		ret = bch2_dev_shrink_queue_reconcile(c, ca, pass == 0, &kick, err);
 		if (ret)
 			return ret;
 
-		ret = bch2_dev_shrink_wait_reconcile(ca, seq, kick);
+		ret = bch2_dev_shrink_wait_reconcile(ca, new_nbuckets, seq, kick, err);
 		if (ret)
 			return ret;
 	}
 
-	/*
-	 * Re-run journal relocation as a final fence before we commit the new
-	 * size: the current journal bucket may have advanced while we were
-	 * waiting for the tail to drain, and we must not expose the smaller
-	 * nbuckets while journal state can still reference the truncated tail.
-	 */
-	ret = move_journal_past_cutoff(c, ca, new_nbuckets, err);
-	if (ret)
-		return ret;
-
-	ret = bch2_dev_resize_restart_check(ca, seq);
-	if (ret)
-		return ret;
-
-	scoped_guard(rwsem_write, &c->state_lock) {
-		ret = bch2_dev_resize_restart_check(ca, seq);
-		if (ret)
-			return ret;
-
-		if (bch2_dev_resize_target(ca) != new_nbuckets ||
-		    !bch2_dev_is_shrinking(ca))
-			return -EAGAIN;
-
-		/* flush interior updates - mirroring dev remove path */
-		bch2_btree_interior_updates_flush(c);
-
-		/* flush journal - mirroring dev remove path */
-		bch2_journal_flush_all_pins(&c->journal);
-
-		ret = bch2_journal_flush_device_pins(&c->journal, ca->dev_idx);
-		if (ret) {
-			prt_printf(err, "bch2_journal_flush_device_pins() error: %s\n", bch2_err_str(ret));
-			return ret;
-		}
-
-		ret = bch2_journal_flush(&c->journal);
-		if (ret) {
-			prt_printf(err, "bch2_journal_flush() error: %s\n", bch2_err_str(ret));
-			return ret;
-		}
-
-		/* re-check that tail is really empty */
-		bool empty = false;
-		try(tail_is_empty(c, ca, new_nbuckets, err, &empty));
-		if (!empty) {
-			prt_printf(err, "Shrink failed: still has data\n");
-			return -EBUSY;
-		}
-
-		/*
-		 * Buckets in the truncated tail may still be in NEED_DISCARD
-		 * state. Clear that bookkeeping before we drop the alloc range so
-		 * accounting/fsck do not retain tail-only metadata after shrink.
-		 */
-		ret = bch2_dev_clear_need_discard(c, ca, new_nbuckets);
-		if (ret) {
-			prt_printf(err, "error clearing need_discard state: %s\n",
-				   bch2_err_str(ret));
-			return ret;
-		}
-
-		/* drop references to now-truncated superblock copies */
-		ret = drop_sbs_after_cutoff(c, ca, new_nbuckets);
-		if (ret) {
-			prt_printf(err, "Error dropping superblocks after cutoff: %s\n", bch2_err_str(ret));
-			return ret;
-		}
-
-		/* update accounting info - has to happen before truncating alloc info */
-		ret = bch2_dev_truncate_accounting(c, ca, old_nbuckets, new_nbuckets);
-		if (ret) {
-			prt_printf(err, "error updating accounting info: %s\n", bch2_err_str(ret));
-			return ret;
-		}
-
-		/* truncate alloc info */
-		ret = bch2_dev_remove_alloc(c, ca, new_nbuckets);
-		if (ret) {
-			prt_printf(err, "error truncating alloc info: %s\n", bch2_err_str(ret));
-			return ret;
-		}
-
-		/*
-		 * Commit the shrink only after the truncated tail has been
-		 * removed from alloc metadata, so later transactions can't see
-		 * stale tail buckets after the new size is visible.
-		 */
-		scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
-			guard(mutex)(&c->sb_lock);
-			struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
-			m->nbuckets = cpu_to_le64(new_nbuckets);
-			if (bch2_dev_resize_target(ca) == new_nbuckets)
-				m->target_nbuckets = 0;
-
-			try(bch2_write_super(c));
-		}
-
-		/* resize buckets */
-		ret = bch2_dev_buckets_resize(c, ca, new_nbuckets);
-		if (ret) {
-			prt_printf(err, "bch2_dev_buckets_resize() error: %s\n", bch2_err_str(ret));
-			return ret;
-		}
-
-		// TODO: figure out what parts of this path still need doing
-		// if (ca->mi.freespace_initialized) {
-		// 	ret = __bch2_dev_resize_alloc(ca, old_nbuckets, new_nbuckets);
-		// 	if (ret) {
-		// 		prt_printf(err, "__bch2_dev_resize_alloc() error: %s\n", bch2_err_str(ret));
-		// 		return ret;
-		// 	}
-		// }
-
-		bch2_recalc_capacity(c);
-	}
-	return 0;
+	return bch2_dev_shrink_finish(c, ca, old_nbuckets, new_nbuckets, seq, err);
 }
 
 static int bch2_dev_resize_thread(void *arg)

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1520,7 +1520,8 @@ int bch2_dev_grow(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct
 }
 
 
-// TODO: make sure everything is caught here
+// TODO: make sure everything is caught here.
+// Fore example journals and superblocks might need special handling
 static int tail_is_empty(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err, bool *empty) {
 	struct bpos bp_start = bucket_pos_to_bp_start(ca, POS(ca->dev_idx, new_nbuckets));
 	struct bpos bp_end = bucket_pos_to_bp_start(ca, POS(ca->dev_idx, ca->mi.nbuckets));
@@ -1645,6 +1646,7 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 		}
 
 		/* resize in-memory data structures */
+
 		/* resize buckets */
 		ret = bch2_dev_buckets_resize(c, ca, new_nbuckets);
 		if (ret) {
@@ -1652,15 +1654,20 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			return ret;
 		}
 
-		/* resize alloc info - see dev_remove */
-		// TODO: make this path shrink-compatible
-		if (ca->mi.freespace_initialized) {
-			ret = __bch2_dev_resize_alloc(ca, old_nbuckets, new_nbuckets);
-			if (ret) {
-				prt_printf(err, "__bch2_dev_resize_alloc() error: %s\n", bch2_err_str(ret));
-				return ret;
-			}
+		/* truncate alloc info */
+		ret = bch2_dev_truncate_alloc(c, ca, new_nbuckets);
+		if (ret) {
+			prt_printf(err, "error truncating alloc info: %s\n", bch2_err_str(ret));
+			return ret;
 		}
+		// TODO: figure out what parts of this path still need doing
+		// if (ca->mi.freespace_initialized) {
+		// 	ret = __bch2_dev_resize_alloc(ca, old_nbuckets, new_nbuckets);
+		// 	if (ret) {
+		// 		prt_printf(err, "__bch2_dev_resize_alloc() error: %s\n", bch2_err_str(ret));
+		// 		return ret;
+		// 	}
+		// }
 
 		bch2_recalc_capacity(c);
 	}

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1453,18 +1453,18 @@ static u64 bch2_dev_resize_seq(struct bch_dev *ca)
 
 static bool bch2_dev_resize_wait_done(struct bch_dev *ca, u64 seq, int *status)
 {
-	bool done;
-
 	scoped_guard(spinlock, &ca->resize_lock) {
-		done = ca->resize_seq != seq ||
-			ca->resize_status != -EINPROGRESS;
-		if (done)
-			*status = ca->resize_seq != seq
-				? -ECANCELED
-				: ca->resize_status;
+		if (ca->resize_seq != seq) {
+			*status = -ECANCELED;
+			return true;
+		}
+		if (ca->resize_status != -EINPROGRESS) {
+			*status = ca->resize_status;
+			return true;
+		}
 	}
 
-	return done;
+	return false;
 }
 
 static int bch2_dev_resize_wait(struct bch_dev *ca, u64 seq)

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1572,15 +1572,8 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			bch2_write_super(c);
 		}
 
-		/* block allocation */
-		ret = bch2_dev_buckets_nouse_alloc(c, ca);
-		if (ret) {
-			prt_printf(err, "error allocating buckets_nouse for dev %u: %s\n", ca->dev_idx, bch2_err_str(ret));
-			return ret;
-		}
-
-		bitmap_set(ca->buckets_nouse, new_nbuckets, old_nbuckets - new_nbuckets);
-		bch2_reset_alloc_cursors(c);
+		/* block allocation - done by setting target_nbuckets */
+		bch2_reset_alloc_cursors(c); // avoid churn
 
 		/* trigger reconcile range scan -> should kick off evacuation from range */
 		struct reconcile_scan s = {
@@ -1644,7 +1637,6 @@ int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 			bch2_write_super(c);
 		}
 		/* resize in-memory data structures */
-		bch2_dev_buckets_nouse_free(c, ca);
 		int ret = bch2_dev_buckets_resize(c, ca, new_nbuckets);
 		if (ret) {
 			prt_printf(err, "bch2_dev_buckets_resize() error: %s\n", bch2_err_str(ret));

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -2024,8 +2024,8 @@ static int bch2_dev_shrink_invalidate_tail_cached(struct bch_fs *c, struct bch_d
 		if (bch2_bucket_is_open_safe(c, k.k->p.inode, k.k->p.offset))
 			continue;
 
-		try(bch2_dev_shrink_invalidate_cached_bucket(trans, ca, k.k->p,
-							     a->gen, &last_flushed));
+			try(bch2_dev_shrink_invalidate_cached_bucket(trans, ca, k.k->p,
+								     a->generation, &last_flushed));
 		*invalidated = true;
 		0;
 	}));
@@ -2102,13 +2102,11 @@ static int bch2_dev_shrink_wait_reconcile(struct bch_dev *ca, u64 new_nbuckets,
 			return 0;
 		}
 
-		ret = wait_event_killable_timeout(c->reconcile.wait,
+		ret = wait_event_timeout(c->reconcile.wait,
 			bch2_reconcile_completed_kick(c) >= kick ||
 			bch2_dev_resize_seq(ca) != seq ||
 			kthread_should_stop(),
 			HZ);
-		if (ret < 0)
-			return -EINTR;
 		if (!ret) {
 			*kick_complete = false;
 			return 0;

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1926,8 +1926,15 @@ static int bch2_dev_shrink_finish(struct bch_fs *c, struct bch_dev *ca,
 		/* flush interior updates - mirroring dev remove path */
 		bch2_btree_interior_updates_flush(c);
 
-		/* flush journal - mirroring dev remove path */
-		bch2_journal_flush_all_pins(&c->journal);
+		/*
+		 * Only flush pins that were already outstanding when shrink
+		 * entered the final commit path. Reconcile can continue
+		 * generating unrelated key-cache journal pins on newer
+		 * sequences while the tail is already empty; waiting for every
+		 * future pin here can turn shrink into an unbounded global
+		 * journal drain.
+		 */
+		bch2_journal_flush_outstanding_pins(&c->journal);
 
 		ret = bch2_journal_flush_device_pins(&c->journal, ca->dev_idx);
 		if (ret) {

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1893,7 +1893,7 @@ static int bch2_dev_shrink_clear_target(struct bch_fs *c, struct bch_dev *ca,
 	return 0;
 }
 
-static int bch2_dev_shrink_finish(struct bch_fs *c, struct bch_dev *ca,
+static int bch2_dev_shrink_finalize(struct bch_fs *c, struct bch_dev *ca,
 				  u64 old_nbuckets, u64 new_nbuckets,
 				  u64 seq, struct printbuf *err)
 {
@@ -2136,7 +2136,7 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 			return ret;
 	}
 
-	return bch2_dev_shrink_finish(c, ca, old_nbuckets, new_nbuckets, seq, err);
+	return bch2_dev_shrink_finalize(c, ca, old_nbuckets, new_nbuckets, seq, err);
 }
 
 static int bch2_dev_resize_thread(void *arg)

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -202,6 +202,7 @@
  * remaining devices automatically.
  */
 
+#include "alloc/buckets.h"
 #include "bcachefs.h"
 
 #include "alloc/accounting.h"
@@ -212,8 +213,13 @@
 #include "alloc/replicas.h"
 #include "alloc/foreground.h"
 
+#include "bcachefs_format.h"
+#include "btree/bkey_types.h"
 #include "btree/interior.h"
 
+#include "btree/iter.h"
+#include "btree/types.h"
+#include "btree/write_buffer.h"
 #include "data/ec/init.h"
 #include "data/migrate.h"
 #include "data/reconcile/work.h"
@@ -227,8 +233,11 @@
 #include "init/fs.h"
 
 #include "linux/bitmap.h"
+#include "linux/sched.h"
+#include "linux/sched/signal.h"
 #include "sb/members.h"
 #include "sb/members_format.h"
+#include "util/util.h"
 
 #define x(n)		#n,
 const char * const bch2_dev_read_refs[] = {
@@ -927,8 +936,6 @@ int bch2_dev_set_state(struct bch_fs *c, struct bch_dev *ca,
 		       enum bch_member_state new_state, int flags,
 		       struct printbuf *err)
 {
-	guard(rwsem_write)(&c->state_lock);
-
 	if (READ_ONCE(ca->removing))
 		return bch_err_throw(c, device_has_been_removed);
 
@@ -1446,7 +1453,7 @@ int bch2_dev_resize(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, stru
 /* requires write state lock */
 int bch2_dev_grow(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err)
 {
-	lockdep_assert_held(&c->state_lock);
+	guard(rwsem_write)(&c->state_lock);
 
 	int ret = 0;
 
@@ -1512,54 +1519,147 @@ int bch2_dev_grow(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct
 	return 0;
 }
 
+
+static int tail_is_empty(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err, bool *empty) {
+	struct bpos bp_start = bucket_pos_to_bp_start(ca, POS(ca->dev_idx, new_nbuckets));
+	struct bpos bp_end = bucket_pos_to_bp_start(ca, POS(ca->dev_idx, ca->mi.nbuckets));
+
+	CLASS(btree_trans, trans)(c);
+	CLASS(backpointer_scan_iter, iter)(BTREE_ID_backpointers, bp_start, NULL);
+
+	struct wb_maybe_flush last_flushed __cleanup(wb_maybe_flush_exit);
+	wb_maybe_flush_init(&last_flushed);
+
+	struct bkey_s_c_backpointer bp = bch2_bp_scan_iter_peek(trans, &iter, bp_end, &last_flushed);
+
+	try(bkey_err(bp));
+
+	*empty = !bp.k;
+	return 0;
+}
+
+
 // TODO: resume shrink on startup
 int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets, struct printbuf *err) {
-	/* validate shrink size */
 	u64 old_nbuckets = ca->mi.nbuckets;
-	if (new_nbuckets >= old_nbuckets) {
-		return 0;
+
+	int ret = 0;
+
+	scoped_guard(rwsem_write, &c->state_lock) {
+		/* validate shrink size */
+		if (new_nbuckets >= old_nbuckets) {
+			return 0;
+		}
+
+		u64 first_bucket = ca->mi.first_bucket;
+		if (new_nbuckets < first_bucket + BCH_MIN_NR_NBUCKETS) {
+			prt_printf(err, "New device size too small (%llu smaller than min %llu)\n",
+				   new_nbuckets, first_bucket + BCH_MIN_NR_NBUCKETS);
+			return bch_err_throw(c, device_size_too_small);
+		}
+
+		if (ca->mi.target_nbuckets) {
+			prt_printf(err, "Device already resizing (current target: %llu, new target: %llu\n", ca->mi.target_nbuckets, new_nbuckets);
+			return bch_err_throw(c, device_already_resizing);
+		}
+
+		/* write & commit target_nbuckets */
+		scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
+			guard(mutex)(&c->sb_lock);
+			struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
+			m->target_nbuckets = cpu_to_le64(new_nbuckets);
+
+			bch2_write_super(c);
+		}
+
+		/* block allocation */
+		ret = bch2_dev_buckets_nouse_alloc(c, ca);
+		if (ret) {
+			prt_printf(err, "error allocating buckets_nouse for dev %u: %s\n", ca->dev_idx, bch2_err_str(ret));
+			return ret;
+		}
+
+		bitmap_set(ca->buckets_nouse, new_nbuckets, old_nbuckets - new_nbuckets);
+		bch2_reset_alloc_cursors(c);
+
+		/* trigger reconcile range scan -> should kick off evacuation from range */
+		struct reconcile_scan s = {
+			.type = RECONCILE_SCAN_device, // TODO(performance): make this range-based
+			.dev = ca->dev_idx,
+		};
+		ret = bch2_set_reconcile_needs_scan(c, s, true);
+	};
+
+	/* wait for to-be-shrunk reason to be empty */
+	while (true) {
+		bool empty = false;
+		try(tail_is_empty(c, ca, new_nbuckets, err, &empty));
+
+		if (empty) {
+			/* do a definitive check */
+			CLASS(btree_trans, trans)(c);
+			try(bch2_btree_write_buffer_flush_sync(trans));
+
+			try(tail_is_empty(c, ca, new_nbuckets, err, &empty));
+			if (empty) {
+				break;
+			}
+		}
+
+		bch2_reconcile_wakeup(c);
+
+		if (signal_pending(current))
+			return -EINTR;
+
+		schedule_timeout_killable(HZ/2);
 	}
 
-	u64 first_bucket = ca->mi.first_bucket;
-	if (new_nbuckets < first_bucket + BCH_MIN_NR_NBUCKETS) {
-		prt_printf(err, "New device size too small (%llu smaller than min %llu)\n",
-			   new_nbuckets, first_bucket + BCH_MIN_NR_NBUCKETS);
-		return bch_err_throw(c, device_size_too_small);
+
+	scoped_guard(rwsem_write, &c->state_lock) {
+		/* zero target_nbuckets */
+		scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
+			guard(mutex)(&c->sb_lock);
+			struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
+			m->target_nbuckets = 0;
+
+			bch2_write_super(c);
+		}
+
+		/* re-check that tail is really empty */
+		bool empty = false;
+		try(tail_is_empty(c, ca, new_nbuckets, err, &empty));
+		if (!empty) {
+			prt_printf(err, "Shrink failed: still has data\n");
+			return -EBUSY;
+		}
+
+		/* write & commit new_nbuckets */
+		scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
+			guard(mutex)(&c->sb_lock);
+			struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
+			m->nbuckets = new_nbuckets;
+
+			bch2_write_super(c);
+		}
+		/* resize in-memory data structures */
+		bch2_dev_buckets_nouse_free(c, ca);
+		int ret = bch2_dev_buckets_resize(c, ca, new_nbuckets);
+		if (ret) {
+			prt_printf(err, "bch2_dev_buckets_resize() error: %s\n", bch2_err_str(ret));
+			return ret;
+		}
+
+		if (ca->mi.freespace_initialized) {
+			ret = __bch2_dev_resize_alloc(ca, old_nbuckets, new_nbuckets);
+			if (ret) {
+				prt_printf(err, "__bch2_dev_resize_alloc() error: %s\n", bch2_err_str(ret));
+				return ret;
+			}
+		}
+
+		bch2_recalc_capacity(c);
 	}
-
-	/* write & commit target_nbuckets */
-	scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
-		guard(mutex)(&c->sb_lock);
-		struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
-		m->target_nbuckets = cpu_to_le64(new_nbuckets);
-
-		bch2_write_super(c);
-	}
-
-	/* block allocation (buckets_nouse) */
-	bitmap_set(ca->buckets_nouse, new_nbuckets, old_nbuckets - new_nbuckets);
-	bch2_reset_alloc_cursors(c);
-	/* trigger reconcile range scan -> should kick off evacuation from range */
-	/* somehow wait for reconcile to finish */
-	/* zero target_nbuckets */
-	scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
-		guard(mutex)(&c->sb_lock);
-		struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
-		m->target_nbuckets = 0;
-
-		bch2_write_super(c);
-	}
-	/* validate that no pointers are left into to-be-shrunk region */
-	/* write & commit new_nbuckets */
-	scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
-		guard(mutex)(&c->sb_lock);
-		struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
-		m->nbuckets = new_nbuckets;
-
-		bch2_write_super(c);
-	}
-	/* update free-space accounting */
-	/* resize in-memory data structures */
+	return 0;
 }
 
 /* Resize on mount */

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -170,6 +170,9 @@
  * \texttt{bcachefs device resize} resizes a device to use more or less space.
  * If no size is specified, the device grows to
  * fill its underlying block device. Resize works online---no unmount required.
+ * Resize is executed by a per-device kthread, which is restarted when a
+ * newer request overwrites an in-progress resize, automatically cancelling the old resize.
+ * Resizes are persisted as \texttt{target\_nbuckets} and will be automatically resumed across restarts.
  *
  * \subsubsubsection{Growing}
  * The new size is subject to a maximum bucket count
@@ -178,21 +181,16 @@
  * account for the newly available space.
  *
  * \subsubsubsection{Shrinking}
- * Shrinking removes the tail of a device\'s bucket range, evacuates any data
- * located there, and commits the smaller \texttt{nbuckets}. The truncating
- * region is called the \emph{shrink tail}: buckets
- * \texttt{[target\_nbuckets, nbuckets)}.
+ * Shrinking removes the tail region of a device and evacuates any data
+ * located there. If this is not possible, the operation will fail with \texttt{-ENOSPC}.
  *
  * Once \texttt{target\_nbuckets < nbuckets} is persisted, the allocator
  * refuses new allocations in the tail, cached pointers past the cutoff are
  * treated as stale, and metadata allocation spills to non-shrinking devices
  * so shrink does not deadlock on its own journal or btree-rewrite needs.
- * Reconcile is then used to discover and evacuate the remaining data;
- * its backpointer scans start at the cutoff rather than bucket zero.
+ * Reconcile is then used to discover and evacuate the remaining data.
  *
- * Shrink is executed by a per-device kthread that can be restarted when a
- * newer request supersedes an in-progress pass. Before draining the tail,
- * the worker relocates any journal buckets in the truncating region explicitly
+ * Before draining the tail, the worker relocates any journal buckets in the truncating region explicitly
  * (\texttt{move\_journal\_past\_cutoff()}) so journal activity does not keep
  * reintroducing references into the region being evacuated.
  *
@@ -200,16 +198,7 @@
  * it flushes journal pins, clears \texttt{NEED\_DISCARD} bookkeeping for
  * the removed buckets, drops superblock copies and alloc metadata past the
  * cutoff, then commits \texttt{nbuckets = target\_nbuckets} to the
- * superblock. If the tail cannot be drained (e.g. insufficient space on
- * remaining devices), \texttt{target\_nbuckets} is cleared so allocations
- * are no longer blocked past the old cutoff.
- *
- * A pending shrink persisted to the superblock resumes automatically on the
- * next read-write mount without requiring userspace to reissue the ioctl.
- * Resize workers are stopped in \texttt{bch2\_fs\_read\_only()} before the
- * filesystem enters clean shutdown, so that in-flight transactional work
- * does not trip write-path assertions.
- *
+ * superblock.
  *
  * \texttt{bcachefs device resize-journal} adjusts the per-device journal size
  * independently of the data area.

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1790,6 +1790,93 @@ static int tail_is_empty(struct bch_fs *c, struct bch_dev *ca, u64 new_nbuckets,
 	return 0;
 }
 
+static int bch2_dev_shrink_queue_reconcile(struct bch_fs *c, struct bch_dev *ca,
+					   bool scan_device, u32 *kick,
+					   struct printbuf *err)
+{
+	if (scan_device) {
+		struct reconcile_scan s = {
+			.type = RECONCILE_SCAN_device, // TODO(performance): make this range-based
+			.dev = ca->dev_idx,
+		};
+
+		int ret = bch2_set_reconcile_needs_scan(c, s, false);
+		if (ret) {
+			prt_printf(err, "Failed to queue device reconcile scan: %s\n",
+				   bch2_err_str(ret));
+			return ret;
+		}
+	}
+
+	/*
+	 * Shrink waits for a completed reconcile pass, not just for the device
+	 * scan cookie to disappear. Queue the pending phase alongside the scan
+	 * so the same pass also retries any work that evacuation demoted to the
+	 * pending list.
+	 */
+	int ret = bch2_set_reconcile_needs_scan(c,
+		(struct reconcile_scan) { .type = RECONCILE_SCAN_pending }, false);
+	if (ret) {
+		prt_printf(err, "Failed to queue pending reconcile scan: %s\n",
+			   bch2_err_str(ret));
+		return ret;
+	}
+
+	*kick = bch2_reconcile_kick(c);
+	return 0;
+}
+
+static int bch2_dev_shrink_wait_reconcile(struct bch_dev *ca, u64 seq, u32 kick)
+{
+	struct bch_fs *c = ca->fs;
+
+	while (true) {
+		int ret = bch2_dev_resize_restart_check(ca, seq);
+		if (ret)
+			return ret;
+
+		if (bch2_reconcile_completed_kick(c) >= kick)
+			return 0;
+
+		ret = wait_event_killable(c->reconcile.wait,
+			bch2_reconcile_completed_kick(c) >= kick ||
+			bch2_dev_resize_seq(ca) != seq ||
+			kthread_should_stop());
+		if (ret)
+			return -EINTR;
+	}
+}
+
+static int bch2_dev_shrink_clear_target(struct bch_fs *c, struct bch_dev *ca,
+					u64 new_nbuckets, u64 seq,
+					struct printbuf *err)
+{
+	int ret = 0;
+
+	scoped_guard(rwsem_write, &c->state_lock) {
+		ret = bch2_dev_resize_restart_check(ca, seq);
+		if (ret)
+			return ret;
+
+		if (bch2_dev_resize_target(ca) != new_nbuckets ||
+		    !bch2_dev_is_shrinking(ca))
+			return -EAGAIN;
+
+		try(bch2_dev_resize_update_target(c, ca, 0, err));
+	}
+
+	/*
+	 * Canceling the persisted shrink target lifts the shrink cutoff. Retry
+	 * pending reconcile work so anything that was parked behind the failed
+	 * shrink gets re-evaluated under the restored placement rules.
+	 */
+	ret = bch2_reconcile_pending_wakeup(c);
+	if (ret)
+		bch_err_fn(c, ret);
+
+	return 0;
+}
+
 
 static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 			     u64 new_nbuckets, u64 seq, struct printbuf *err)
@@ -1815,22 +1902,6 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 		/* close open buckets in the to-be-shrunk region */
 		bch2_open_buckets_stop(c, ca, false, new_nbuckets);
 		bch2_reset_alloc_cursors(c); // avoid churn
-
-		/*
-		 * target_nbuckets persists in the superblock, but the device
-		 * scan's in-memory traversal state does not. Re-queue the
-		 * device scan whenever shrink starts or resumes so reconcile
-		 * reliably rediscovers the tail after a restart.
-		 */
-		struct reconcile_scan s = {
-			.type = RECONCILE_SCAN_device, // TODO(performance): make this range-based
-			.dev = ca->dev_idx,
-		};
-		ret = bch2_set_reconcile_needs_scan(c, s, true);
-		if (ret) {
-			prt_printf(err, "Failed to run device reconcile scan: %s\n", bch2_err_str(ret));
-			return ret;
-		}
 	};
 
 	ret = bch2_dev_resize_restart_check(ca, seq);
@@ -1874,8 +1945,9 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 	 */
 
 	/* wait for to-be-shrunk region to be empty */
-	while (true) {
+	for (unsigned pass = 0; ; pass++) {
 		bool empty = false;
+		u32 kick;
 
 		ret = bch2_dev_resize_restart_check(ca, seq);
 		if (ret)
@@ -1896,13 +1968,28 @@ static int __bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
 			}
 		}
 
-		/* make sure reconcile is actually running */
-		bch2_reconcile_wakeup(c);
+		if (pass >= 2) {
+			prt_printf(err,
+				   "Shrink failed: insufficient space or replicas to evacuate data from the shrink tail\n");
+			ret = bch2_dev_shrink_clear_target(c, ca, new_nbuckets, seq, err);
+			if (ret)
+				return ret;
+			return -ENOSPC;
+		}
 
-		if (kthread_should_stop())
-			return -EINTR;
+		/*
+		 * A consumed scan cookie only means reconcile observed the scan
+		 * request and queued downstream work. Wait for a completed pass
+		 * so the scan-generated normal and pending work has been
+		 * attempted before we decide the tail still cannot drain.
+		 */
+		ret = bch2_dev_shrink_queue_reconcile(c, ca, pass == 0, &kick, err);
+		if (ret)
+			return ret;
 
-		schedule_timeout_interruptible(HZ/2);
+		ret = bch2_dev_shrink_wait_reconcile(ca, seq, kick);
+		if (ret)
+			return ret;
 	}
 
 	/*

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -167,13 +167,176 @@
  *
  * \subsubsection{Resize}
  *
- * \texttt{bcachefs device resize} grows a device to use additional space
- * (shrinking is not yet supported). If no size is specified, the device grows to
+ * \texttt{bcachefs device resize} resizes a device to use more or less space.
+ * If no size is specified, the device grows to
  * fill its underlying block device. Resize works online---no unmount required.
+ *
+ * \subsubsubsection{Growing}
  * The new size is subject to a maximum bucket count
  * (\texttt{BCH\_MEMBER\_NBUCKETS\_MAX}); resize will fail if the requested size
  * would exceed this limit. After resize, the reconcile subsystem is notified to
  * account for the newly available space.
+ *
+ * \subsubsubsection{Shrinking}
+ * Shrinking removes the tail of the device's bucket range, evacuates any data
+ * living there, and commits the smaller \texttt{nbuckets}. The truncating region is called the
+ * \emph{shrink tail}: buckets \texttt{[target\_nbuckets, nbuckets)}.
+ *
+ * Once \texttt{target\_nbuckets < nbuckets} is persisted, several subsystems
+ * react to the pending shrink before the worker has finished evacuation:
+ *
+ * \begin{itemize}
+ * \item The \hyperref[sec:write-points]{allocator} refuses new open-bucket
+ *   allocations at or beyond the cutoff.
+ * \item Cached extent pointers past the cutoff are treated as stale and
+ *   dropped on lookup.
+ * \item Metadata allocation (journal buckets, btree node rewrites) falls back
+ *   to the full filesystem when the preferred metadata target consists only of
+ *   shrinking devices, avoiding a deadlock on metadata writes the shrink
+ *   itself needs.
+ * \item \hyperref[sec:backpointers]{Backpointer} scans for reconcile start at
+ *   the cutoff instead of bucket zero, avoiding needless requeue of work on
+ *   the retained region.
+ * \end{itemize}
+ *
+ * These immediate effects are what make the shrink cutoff effective as soon as
+ * the target is persisted. They are driven by normalized helper checks
+ * (\texttt{bch2\_dev\_is\_shrinking()}) and flip automatically when
+ * userspace retargets away from shrink.
+ *
+ * \textbf{Worker model.}
+ * Each device has a dedicated kthread (\texttt{bch2\_dev\_resize\_thread()})
+ * that processes resize requests. On each wakeup it snapshots the current
+ * request sequence number and the normalized target, then dispatches to
+ * either \texttt{__bch2\_dev\_grow()} or \texttt{__bch2\_dev\_shrink()}.
+ * The thread is restartable rather than strictly cancelable---a newer
+ * request increments \texttt{resize\_seq} and causes the active pass to
+ * return \texttt{-EAGAIN} and restart with the latest target.
+ * The common restart check is \texttt{bch2\_dev\_resize\_restart\_check()},
+ * which also handles kthread shutdown via \texttt{-EINTR}.
+ *
+ * \textbf{Shrink algorithm.}
+ * Shrink proceeds through four phases:
+ *
+ * \textbf{Phase 1---Enter shrink mode.}
+ * The worker takes \texttt{state\_lock}, validates the target still matches
+ * the live request, closes any open buckets in the truncating tail
+ * (\texttt{bch2\_open\_buckets\_stop()}), and resets alloc cursors. After
+ * dropping the lock, it flushes the discard workqueues so that an older
+ * discard pass on the same region does not deadlock the evacuation path.
+ *
+ * \textbf{Phase 2---Move journal state out of the tail.}
+ * \texttt{move\_journal\_past\_cutoff()} runs before the main drain loop.
+ * The journal is handled explicitly because journal buckets are not something
+ * shrink should wait for reconcile to discover and evacuate indirectly.
+ * The function counts journal buckets in the tail, temporarily grows the
+ * journal if more journal buckets are needed for relocation, forces the
+ * current journal bucket to advance if it still sits in the tail, flushes
+ * the journal to persist the relocation, and deletes the now-obsolete journal
+ * buckets from the tail. Without this step, journal activity can keep
+ * reintroducing metadata references into the very region shrink is trying to
+ * empty.
+ *
+ * \textbf{Phase 3---Drain the tail.}
+ * The core loop tracks tail liveness by scanning the backpointer btree in the
+ * truncating region. The loop is built around several key helpers:
+ *
+ * \begin{itemize}
+ * \item \texttt{tail\_head\_snapshot()} records the first tail bucket, its
+ *   first backpointer, and the number of backpointers in that bucket.
+ * \item \texttt{tail\_progress\_snapshot()} records the same head data plus
+ *   the total backpointer count across the full tail.
+ * \item \texttt{tail\_is\_empty()} performs a definitive emptiness check
+ *   after flushing the btree write buffer (to expose buffered updates).
+ * \end{itemize}
+ *
+ * On each pass the loop:
+ *
+ * \begin{enumerate}
+ * \item Snapshots the tail head. If it looks empty, flushes the write buffer
+ *   and rechecks before declaring emptiness.
+ * \item Invalidates cached-only tail buckets via
+ *   \texttt{bch2\_dev\_shrink\_invalidate\_tail\_cached()}. Cached copies in
+ *   the tail are not durable data---they can be dropped directly rather than
+ *   requiring reconcile to evacuate them.
+ * \item Queues reconcile work with
+ *   \texttt{bch2\_dev\_shrink\_queue\_reconcile()}: a device backpointer scan
+ *   (starting at the cutoff, not bucket zero) plus a pending scan.
+ * \item Waits using \texttt{bch2\_dev\_shrink\_wait\_reconcile()}, polling
+ *   once per second and returning when the tail is empty, the requested
+ *   reconcile kick completes, or head progress is detected. This avoids
+ *   waiting for unrelated global reconcile work after the tail is already
+ *   empty.
+ * \end{enumerate}
+ *
+ * The progress heuristic tracks two things: the leading tail bucket and its
+ * first backpointer, and the total tail backpointer count. A pass that makes
+ * progress on either metric resets the stall counter. Passes without progress
+ * are counted only after a full device rescan on a journal-quiescent state;
+ * if the journal advanced during the pass, the blocker set is still changing
+ * and the pass is not evidence of impossibility. After
+ * \texttt{stalled\_kicks\_limit} (32) no-progress full rescans on a
+ * quiescent journal, shrink declares \texttt{-ENOSPC} and clears the pending
+ * target (\texttt{bch2\_dev\_shrink\_clear\_target()}) so allocations are no
+ * longer blocked past the old cutoff.
+ *
+ * The journal-quiescence check is filesystem-global: unrelated
+ * metadata-writing IO elsewhere can keep advancing the journal sequence
+ * number and suppress the stall counter indefinitely. The intended follow-up
+ * is a shrink-local churn signal.
+ *
+ * \textbf{Phase 4---Finalize the shrink.}
+ * \texttt{bch2\_dev\_shrink\_finalize()} runs under \texttt{state\_lock} and
+ * commits the truncation. The ordering is critical:
+ *
+ * \begin{enumerate}
+ * \item Revalidate that the live request still matches this pass.
+ * \item Flush btree interior updates.
+ * \item Flush outstanding journal pins (device-specific, then a flush of
+ *   \texttt{journal\_cur\_seq()}---not \texttt{bch2\_journal\_flush\_all\_pins()},
+ *   which can wait behind unrelated reconcile or key-cache pins indefinitely).
+ * \item Recheck tail emptiness with \texttt{tail\_is\_empty()}.
+ * \item Clear \texttt{NEED\_DISCARD} entries for the truncated tail. This must
+ *   scan and filter by decoded bucket position because
+ *   \texttt{BTREE\_ID\_need\_discard} is keyed by journal sequence, not by
+ *   \texttt{(dev, bucket)}.
+ * \item Drop superblock copies whose offsets are beyond the cutoff with
+ *   \texttt{drop\_sbs\_after\_cutoff()}.
+ * \item Truncate accounting with \texttt{bch2\_dev\_truncate\_accounting()}.
+ * \item Remove alloc metadata for the tail with
+ *   \texttt{bch2\_dev\_remove\_alloc()}.
+ * \item Commit \texttt{nbuckets = new\_nbuckets} in the superblock and clear
+ *   \texttt{target\_nbuckets} if it still matches the committed target.
+ * \item Resize in-memory bucket arrays with
+ *   \texttt{bch2\_dev\_buckets\_resize()}.
+ * \item Recalculate filesystem capacity.
+ * \end{enumerate}
+ *
+ * The central invariant: shrink may only commit the smaller \texttt{nbuckets}
+ * while holding \texttt{state\_lock}, after rechecking that the current
+ * normalized target still equals the target used by this pass and is still a
+ * shrink target. This prevents an obsolete pass from truncating the device
+ * after userspace has already requested a different target or cancellation.
+ * After finalization completes, \texttt{bch2\_dev\_resize\_finish()} wakes
+ * waiters and restarts async discards on the device (which were deferred
+ * during the shrink to avoid deadlocks with the evacuation path).
+ *
+ * \textbf{Recovery and remount behavior.}
+ * A pending shrink that was persisted to the superblock but interrupted
+ * (e.g., by a crash or unmount) resumes automatically on the next read-write
+ * mount. \texttt{bch2\_fs\_resize\_on\_mount()} detects devices whose
+ * normalized target still differs from \texttt{nbuckets} once the btree and
+ * reconcile infrastructure is running, and calls
+ * \texttt{bch2\_dev\_resize\_resume()} for each such device. No userspace
+ * reissue is required.
+ *
+ * \textbf{Shutdown ordering.}
+ * Resize workers are stopped in \texttt{bch2\_fs\_read\_only()} via
+ * \texttt{bch2\_dev\_resize\_threads\_stop()}, before the filesystem enters
+ * clean shutdown. This ordering matters because a persisted shrink may still
+ * be performing transactional alloc/accounting work; if the filesystem starts
+ * going read-only first, the worker's writes can trip write-path assertions.
+ *
  *
  * \texttt{bcachefs device resize-journal} adjusts the per-device journal size
  * independently of the data area.

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1899,20 +1899,6 @@ static int bch2_dev_shrink_finish(struct bch_fs *c, struct bch_dev *ca,
 {
 	int ret;
 
-	/*
-	 * Re-run journal relocation as a final fence before we commit the new
-	 * size: the current journal bucket may have advanced while we were
-	 * waiting for the tail to drain, and we must not expose the smaller
-	 * nbuckets while journal state can still reference the truncated tail.
-	 */
-	ret = move_journal_past_cutoff(c, ca, new_nbuckets, err);
-	if (ret)
-		return ret;
-
-	ret = bch2_dev_resize_restart_check(ca, seq);
-	if (ret)
-		return ret;
-
 	scoped_guard(rwsem_write, &c->state_lock) {
 		bool empty = false;
 

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1492,6 +1492,7 @@ static bool bch2_dev_resize_finish(struct bch_dev *ca, u64 seq, int status)
 	return is_current;
 }
 
+/* checks for kthread interruption, and resize seq having changed */
 static int bch2_dev_resize_restart_check(struct bch_dev *ca, u64 seq)
 {
 	if (kthread_should_stop())

--- a/fs/init/dev.h
+++ b/fs/init/dev.h
@@ -40,6 +40,7 @@ int bch2_dev_offline(struct bch_fs *, struct bch_dev *, int, struct printbuf *);
 int bch2_dev_resize(struct bch_fs *, struct bch_dev *, u64, struct printbuf *);
 int bch2_dev_grow(struct bch_fs *, struct bch_dev *, u64, struct printbuf *);
 int bch2_dev_shrink(struct bch_fs *, struct bch_dev *, u64, struct printbuf *);
+int bch2_dev_shrink_resume(struct bch_fs *, struct bch_dev *, struct printbuf *);
 
 int __bch2_dev_resize_alloc(struct bch_dev *, u64, u64);
 

--- a/fs/init/dev.h
+++ b/fs/init/dev.h
@@ -38,9 +38,8 @@ int bch2_dev_add(struct bch_fs *, const char *, struct printbuf *);
 int bch2_dev_online(struct bch_fs *, const char *, struct printbuf *);
 int bch2_dev_offline(struct bch_fs *, struct bch_dev *, int, struct printbuf *);
 int bch2_dev_resize(struct bch_fs *, struct bch_dev *, u64, struct printbuf *);
-int bch2_dev_grow(struct bch_fs *, struct bch_dev *, u64, struct printbuf *);
-int bch2_dev_shrink(struct bch_fs *, struct bch_dev *, u64, struct printbuf *);
-int bch2_dev_shrink_resume(struct bch_fs *, struct bch_dev *, struct printbuf *);
+int bch2_dev_resize_resume(struct bch_fs *, struct bch_dev *, struct printbuf *);
+void bch2_dev_resize_threads_stop(struct bch_fs *);
 
 int __bch2_dev_resize_alloc(struct bch_dev *, u64, u64);
 

--- a/fs/init/dev.h
+++ b/fs/init/dev.h
@@ -38,6 +38,8 @@ int bch2_dev_add(struct bch_fs *, const char *, struct printbuf *);
 int bch2_dev_online(struct bch_fs *, const char *, struct printbuf *);
 int bch2_dev_offline(struct bch_fs *, struct bch_dev *, int, struct printbuf *);
 int bch2_dev_resize(struct bch_fs *, struct bch_dev *, u64, struct printbuf *);
+int bch2_dev_grow(struct bch_fs *, struct bch_dev *, u64, struct printbuf *);
+int bch2_dev_shrink(struct bch_fs *, struct bch_dev *, u64, struct printbuf *);
 
 int __bch2_dev_resize_alloc(struct bch_dev *, u64, u64);
 

--- a/fs/init/fs.c
+++ b/fs/init/fs.c
@@ -408,6 +408,15 @@ void bch2_fs_read_only(struct bch_fs *c)
 	bch_verbose(c, "going read-only");
 
 	/*
+	 * Close write points before stopping background data movers. Shrink can
+	 * leave copygc waiting on allocator space from its dedicated
+	 * write_point; dropping those open buckets first breaks that dependency
+	 * so kthread_stop() does not hang behind a move write that's blocked in
+	 * the allocator.
+	 */
+	bch2_open_buckets_stop(c, NULL, true, 0);
+
+	/*
 	 * Stop background data movers before disabling writes globally:
 	 * reconcile/copygc move writes don't hold c->writes refs, but they do
 	 * still need journal/btree write access to finish their final index

--- a/fs/init/fs.c
+++ b/fs/init/fs.c
@@ -321,7 +321,8 @@ static void __bch2_fs_read_only(struct bch_fs *c)
 
 	bch2_maybe_schedule_btree_bitmap_gc_stop(c);
 	bch2_fs_ec_stop(c);
-	bch2_open_buckets_stop(c, NULL, true);
+	bch2_open_buckets_stop(c, NULL, true, 0);
+	bch2_reconcile_stop(c);
 	bch2_copygc_stop(c);
 	bch2_btree_write_buffer_stop(c);
 	bch2_fs_ec_flush(c);

--- a/fs/init/fs.c
+++ b/fs/init/fs.c
@@ -1568,40 +1568,78 @@ static bool bch2_fs_will_resize_on_mount(struct bch_fs *c)
 
 int bch2_fs_resize_on_mount(struct bch_fs *c)
 {
-	for_each_online_member(c, ca, BCH_DEV_READ_REF_fs_resize_on_mount) {
-		if (bch2_dev_will_resize_on_mount(ca)) {
-			u64 old_nbuckets = ca->mi.nbuckets;
-			u64 new_nbuckets = div64_u64(get_capacity(ca->disk_sb.bdev->bd_disk),
-						     ca->mi.bucket_size);
+	scoped_guard(rwsem_write, &c->state_lock) {
+		for_each_online_member(c, ca, BCH_DEV_READ_REF_fs_resize_on_mount) {
+			if (bch2_dev_will_resize_on_mount(ca)) {
+				u64 old_nbuckets = ca->mi.nbuckets;
+				u64 new_nbuckets = div64_u64(get_capacity(ca->disk_sb.bdev->bd_disk),
+							     ca->mi.bucket_size);
 
-			bch_info_dev(ca, "resizing to size %llu", new_nbuckets * ca->mi.bucket_size);
-			int ret = bch2_dev_buckets_resize(c, ca, new_nbuckets);
-			bch_err_fn_dev(ca, ret);
-			if (ret) {
-				enumerated_ref_put(&ca->io_ref[READ],
-						   BCH_DEV_READ_REF_fs_resize_on_mount);
-				return ret;
-			}
-
-			scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
-				guard(mutex)(&c->sb_lock);
-				struct bch_member *m =
-					bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
-				m->nbuckets = cpu_to_le64(new_nbuckets);
-				SET_BCH_MEMBER_RESIZE_ON_MOUNT(m, false);
-
-				c->disk_sb.sb->features[0] &= ~cpu_to_le64(BIT_ULL(BCH_FEATURE_small_image));
-				bch2_write_super(c);
-			}
-
-			if (ca->mi.freespace_initialized) {
-				ret = __bch2_dev_resize_alloc(ca, old_nbuckets, new_nbuckets);
+				bch_info_dev(ca, "resizing to size %llu", new_nbuckets * ca->mi.bucket_size);
+				int ret = bch2_dev_buckets_resize(c, ca, new_nbuckets);
+				bch_err_fn_dev(ca, ret);
 				if (ret) {
 					enumerated_ref_put(&ca->io_ref[READ],
-							BCH_DEV_READ_REF_fs_resize_on_mount);
+							   BCH_DEV_READ_REF_fs_resize_on_mount);
 					return ret;
 				}
+
+				scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
+					guard(mutex)(&c->sb_lock);
+					struct bch_member *m =
+						bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
+					m->nbuckets = cpu_to_le64(new_nbuckets);
+					SET_BCH_MEMBER_RESIZE_ON_MOUNT(m, false);
+
+					c->disk_sb.sb->features[0] &= ~cpu_to_le64(BIT_ULL(BCH_FEATURE_small_image));
+					bch2_write_super(c);
+				}
+
+				if (ca->mi.freespace_initialized) {
+					ret = __bch2_dev_resize_alloc(ca, old_nbuckets, new_nbuckets);
+					if (ret) {
+						enumerated_ref_put(&ca->io_ref[READ],
+								BCH_DEV_READ_REF_fs_resize_on_mount);
+						return ret;
+					}
+				}
 			}
+		}
+	}
+
+	/*
+	 * A pending shrink needs reconcile_scan and backpointer btree access.
+	 * The early resize-on-mount hook runs before btree roots are read so it
+	 * can handle grow-on-mount image expansion; defer shrink resume until a
+	 * later call once BCH_FS_btree_running is set.
+	 */
+	if (!test_bit(BCH_FS_btree_running, &c->flags))
+		return 0;
+
+	if (c->opts.read_only ||
+	    (c->sb.features & (BIT_ULL(BCH_FEATURE_small_image) |
+			       BIT_ULL(BCH_FEATURE_no_default_sb))))
+		return 0;
+
+	for_each_online_member(c, ca, BCH_DEV_READ_REF_fs_resize_on_mount) {
+		if (!ca->mi.target_nbuckets)
+			continue;
+
+		CLASS(printbuf, err)();
+		int ret;
+
+		bch_info_dev(ca, "resuming shrink to size %llu",
+			     ca->mi.target_nbuckets * ca->mi.bucket_size);
+		ret = bch2_dev_shrink_resume(c, ca, &err);
+		if (ret) {
+			if (err.pos)
+				bch_err_dev(ca, "%s", err.buf);
+			else
+				bch_err_fn_dev(ca, ret);
+
+			enumerated_ref_put(&ca->io_ref[READ],
+					   BCH_DEV_READ_REF_fs_resize_on_mount);
+			return ret;
 		}
 	}
 	return 0;

--- a/fs/init/fs.c
+++ b/fs/init/fs.c
@@ -417,6 +417,14 @@ void bch2_fs_read_only(struct bch_fs *c)
 	bch2_open_buckets_stop(c, NULL, true, 0);
 
 	/*
+	 * Stop per-device resize workers while writes are still available.
+	 * A pending resize may be in the middle of transactional alloc/accounting
+	 * updates; if it survives into clean shutdown it can trip write-path
+	 * assertions while the filesystem is already going read-only.
+	 */
+	bch2_dev_resize_threads_stop(c);
+
+	/*
 	 * Stop background data movers before disabling writes globally:
 	 * reconcile/copygc move writes don't hold c->writes refs, but they do
 	 * still need journal/btree write access to finish their final index
@@ -1622,15 +1630,15 @@ int bch2_fs_resize_on_mount(struct bch_fs *c)
 		return 0;
 
 	for_each_online_member(c, ca, BCH_DEV_READ_REF_fs_resize_on_mount) {
-		if (!ca->mi.target_nbuckets)
+		if (!bch2_dev_resize_pending(ca))
 			continue;
 
 		CLASS(printbuf, err)();
 		int ret;
 
-		bch_info_dev(ca, "resuming shrink to size %llu",
-			     ca->mi.target_nbuckets * ca->mi.bucket_size);
-		ret = bch2_dev_shrink_resume(c, ca, &err);
+		bch_info_dev(ca, "resuming resize to size %llu",
+			     bch2_dev_resize_target(ca) * ca->mi.bucket_size);
+		ret = bch2_dev_resize_resume(c, ca, &err);
 		if (ret) {
 			if (err.pos)
 				bch_err_dev(ca, "%s", err.buf);

--- a/fs/init/fs.c
+++ b/fs/init/fs.c
@@ -320,10 +320,7 @@ static void __bch2_fs_read_only(struct bch_fs *c)
 	u64 seq = 0;
 
 	bch2_maybe_schedule_btree_bitmap_gc_stop(c);
-	bch2_fs_ec_stop(c);
 	bch2_open_buckets_stop(c, NULL, true, 0);
-	bch2_reconcile_stop(c);
-	bch2_copygc_stop(c);
 	bch2_btree_write_buffer_stop(c);
 	bch2_fs_ec_flush(c);
 	cancel_delayed_work_sync(&c->maybe_schedule_btree_bitmap_gc);
@@ -409,6 +406,17 @@ void bch2_fs_read_only(struct bch_fs *c)
 	BUG_ON(test_bit(BCH_FS_write_disable_complete, &c->flags));
 
 	bch_verbose(c, "going read-only");
+
+	/*
+	 * Stop background data movers before disabling writes globally:
+	 * reconcile/copygc move writes don't hold c->writes refs, but they do
+	 * still need journal/btree write access to finish their final index
+	 * updates. If we shut off writes first they'll trip -EROFS during
+	 * shutdown and spuriously account data_update failures.
+	 */
+	bch2_fs_ec_stop(c);
+	bch2_reconcile_stop(c);
+	bch2_copygc_stop(c);
 
 	/*
 	 * Block new foreground-end write operations from starting - any new

--- a/fs/init/recovery.c
+++ b/fs/init/recovery.c
@@ -756,8 +756,7 @@ use_clean:
 
 	try(journal_replay_early(c, clean));
 
-	scoped_guard(rwsem_write, &c->state_lock)
-		try(bch2_fs_resize_on_mount(c));
+	try(bch2_fs_resize_on_mount(c));
 
 	if (c->sb.features & BIT_ULL(BCH_FEATURE_small_image)) {
 		bch_info(c, "filesystem is an unresized image file, mounting ro");
@@ -887,6 +886,8 @@ use_clean:
 	 */
 	set_bit(BCH_FS_may_go_rw, &c->flags);
 	clear_bit(BCH_FS_in_fsck, &c->flags);
+
+	try(bch2_fs_resize_on_mount(c));
 
 	/* in case we don't run journal replay, i.e. norecovery mode */
 	set_bit(BCH_FS_accounting_replay_done, &c->flags);

--- a/fs/journal/init.c
+++ b/fs/journal/init.c
@@ -219,37 +219,53 @@ int bch2_dev_journal_bucket_delete(struct bch_dev *ca, u64 b)
 		&new_buckets[pos + 1],
 		(ja->nr - 1 - pos) * sizeof(new_buckets[0]));
 
-	int ret = bch2_journal_buckets_to_sb(c, ca, ja->buckets, ja->nr - 1) ?:
-		bch2_write_super(c);
+	int ret;
+
+	scoped_guard(journal_block, &c->journal) {
+		ret = bch2_journal_buckets_to_sb(c, ca, new_buckets, ja->nr - 1) ?:
+			bch2_write_super(c);
+		if (ret)
+			break;
+
+		scoped_guard(spinlock, &j->lock) {
+			if (pos < ja->discard_idx)
+				--ja->discard_idx;
+			if (pos < ja->dirty_idx_ondisk)
+				--ja->dirty_idx_ondisk;
+			if (pos < ja->dirty_idx)
+				--ja->dirty_idx;
+			if (pos < ja->cur_idx)
+				--ja->cur_idx;
+
+			ja->nr--;
+
+			memmove(&ja->buckets[pos],
+				&ja->buckets[pos + 1],
+				(ja->nr - pos) * sizeof(ja->buckets[0]));
+
+			memmove(&ja->bucket_seq[pos],
+				&ja->bucket_seq[pos + 1],
+				(ja->nr - pos) * sizeof(ja->bucket_seq[0]));
+
+			bch2_journal_space_available(j);
+		}
+	}
+
 	if (ret) {
 		kfree(new_buckets);
 		return ret;
 	}
 
-	scoped_guard(spinlock, &j->lock) {
-		if (pos < ja->discard_idx)
-			--ja->discard_idx;
-		if (pos < ja->dirty_idx_ondisk)
-			--ja->dirty_idx_ondisk;
-		if (pos < ja->dirty_idx)
-			--ja->dirty_idx;
-		if (pos < ja->cur_idx)
-			--ja->cur_idx;
+	kfree(new_buckets);
 
-		ja->nr--;
-
-		memmove(&ja->buckets[pos],
-			&ja->buckets[pos + 1],
-			(ja->nr - pos) * sizeof(ja->buckets[0]));
-
-		memmove(&ja->bucket_seq[pos],
-			&ja->bucket_seq[pos + 1],
-			(ja->nr - pos) * sizeof(ja->bucket_seq[0]));
-
-		bch2_journal_space_available(j);
+	{
+		CLASS(btree_trans, trans)(c);
+		ret = commit_do(trans, NULL, NULL, 0,
+			bch2_trans_mark_metadata_bucket(trans, ca, b,
+							BCH_DATA_free, 0,
+							BTREE_TRIGGER_transactional));
 	}
 
-	kfree(new_buckets);
 	return 0;
 }
 

--- a/fs/journal/write.c
+++ b/fs/journal/write.c
@@ -23,8 +23,35 @@
 
 #include "sb/clean.h"
 #include "sb/counters.h"
+#include "sb/members.h"
 
 #include <linux/ioprio.h>
+
+static unsigned journal_alloc_target(struct bch_fs *c)
+{
+	unsigned target = c->opts.metadata_target ?: c->opts.foreground_target;
+	if (!target)
+		return 0;
+
+	struct bch_devs_mask devs = target_rw_devs(c, BCH_DATA_journal, target);
+
+	/*
+	 * Shrink can temporarily make the preferred metadata target unusable
+	 * for new journal buckets. If every rw member of that target is
+	 * shrinking, allocate from the full filesystem until the shrink
+	 * finishes so journal progress doesn't deadlock on target preference.
+	 */
+	guard(rcu)();
+	unsigned i;
+	for_each_set_bit(i, devs.d, BCH_SB_MEMBERS_MAX) {
+		struct bch_dev *ca = bch2_dev_rcu_noerror(c, i);
+
+		if (ca && !ca->mi.target_nbuckets)
+			return target;
+	}
+
+	return 0;
+}
 
 static void journal_advance_devs_to_next_bucket(struct journal *j,
 						struct dev_alloc_list *devs,
@@ -116,8 +143,7 @@ static int journal_write_alloc(struct journal *j, struct journal_buf *w,
 	struct bch_devs_mask devs;
 	struct dev_alloc_list devs_sorted;
 	unsigned sectors = vstruct_sectors(w->data, c->block_bits);
-	unsigned target = c->opts.metadata_target ?:
-		c->opts.foreground_target;
+	unsigned target = journal_alloc_target(c);
 	unsigned replicas_want = READ_ONCE(c->opts.metadata_replicas);
 	bool advance_done = false;
 

--- a/fs/journal/write.c
+++ b/fs/journal/write.c
@@ -46,7 +46,7 @@ static unsigned journal_alloc_target(struct bch_fs *c)
 	for_each_set_bit(i, devs.d, BCH_SB_MEMBERS_MAX) {
 		struct bch_dev *ca = bch2_dev_rcu_noerror(c, i);
 
-		if (ca && !ca->mi.target_nbuckets)
+		if (ca && !bch2_dev_is_shrinking(ca))
 			return target;
 	}
 

--- a/fs/sb/members.c
+++ b/fs/sb/members.c
@@ -205,17 +205,26 @@ static int validate_member(struct printbuf *err,
 		return -BCH_ERR_invalid_sb_members;
 	}
 
-	if (le64_to_cpu(m.target_nbuckets) && le64_to_cpu(m.target_nbuckets) > BCH_MEMBER_NBUCKETS_MAX) {
-		prt_printf(err, "device %u: too many target buckets (got %llu, max %u)",
-			   i, le64_to_cpu(m.target_nbuckets), BCH_MEMBER_NBUCKETS_MAX);
-		return -BCH_ERR_invalid_sb_members;
-	}
+	u64 target_nbuckets = le64_to_cpu(m.target_nbuckets);
 
-	if (le64_to_cpu(m.target_nbuckets) && le64_to_cpu(m.target_nbuckets) -
-	    le16_to_cpu(m.first_bucket) < BCH_MIN_NR_NBUCKETS) {
-		prt_printf(err, "device %u: not enough target buckets (got %llu, max %u)",
-			   i, le64_to_cpu(m.target_nbuckets), BCH_MIN_NR_NBUCKETS);
-		return -BCH_ERR_invalid_sb_members;
+	if (target_nbuckets) {
+		if (target_nbuckets >= nbuckets) {
+			prt_printf(err, "device %u: target buckets >= buckets (got %llu, nbuckets %llu)",
+				   i, target_nbuckets, nbuckets);
+			return -BCH_ERR_invalid_sb_members;
+		}
+
+		if (target_nbuckets < first_bucket) {
+			prt_printf(err, "device %u: target buckets starts before first bucket (got %llu, first %u)",
+				   i, target_nbuckets, first_bucket);
+			return -BCH_ERR_invalid_sb_members;
+		}
+
+		if (target_nbuckets - first_bucket < BCH_MIN_NR_NBUCKETS) {
+			prt_printf(err, "device %u: not enough target buckets (got %llu, min %u)",
+				   i, target_nbuckets - first_bucket, BCH_MIN_NR_NBUCKETS);
+			return -BCH_ERR_invalid_sb_members;
+		}
 	}
 
 	return 0;

--- a/fs/sb/members.c
+++ b/fs/sb/members.c
@@ -205,6 +205,19 @@ static int validate_member(struct printbuf *err,
 		return -BCH_ERR_invalid_sb_members;
 	}
 
+	if (le64_to_cpu(m.target_nbuckets) && le64_to_cpu(m.target_nbuckets) > BCH_MEMBER_NBUCKETS_MAX) {
+		prt_printf(err, "device %u: too many target buckets (got %llu, max %u)",
+			   i, le64_to_cpu(m.target_nbuckets), BCH_MEMBER_NBUCKETS_MAX);
+		return -BCH_ERR_invalid_sb_members;
+	}
+
+	if (le64_to_cpu(m.target_nbuckets) && le64_to_cpu(m.target_nbuckets) -
+	    le16_to_cpu(m.first_bucket) < BCH_MIN_NR_NBUCKETS) {
+		prt_printf(err, "device %u: not enough target buckets (got %llu, max %u)",
+			   i, le64_to_cpu(m.target_nbuckets), BCH_MIN_NR_NBUCKETS);
+		return -BCH_ERR_invalid_sb_members;
+	}
+
 	return 0;
 }
 
@@ -216,6 +229,7 @@ __cold void bch2_member_to_text(struct printbuf *out,
 {
 	u64 bucket_size = le16_to_cpu(m->bucket_size);
 	u64 device_size = le64_to_cpu(m->nbuckets) * bucket_size;
+	u64 target_device_size = le64_to_cpu(m->target_nbuckets) * bucket_size;
 
 	prt_printf(out, "Label:\t");
 	if (BCH_MEMBER_GROUP(m))
@@ -233,6 +247,10 @@ __cold void bch2_member_to_text(struct printbuf *out,
 	prt_units_u64(out, device_size << 9);
 	prt_newline(out);
 
+	prt_printf(out, "Target size:\t");
+	prt_units_u64(out, target_device_size << 9);
+	prt_newline(out);
+
 	for (unsigned i = 0; i < BCH_MEMBER_ERROR_NR; i++)
 		prt_printf(out, "%s errors:\t%llu\n", bch2_member_error_strs[i], le64_to_cpu(m->errors[i]));
 
@@ -245,6 +263,7 @@ __cold void bch2_member_to_text(struct printbuf *out,
 
 	prt_printf(out, "First bucket:\t%u\n", le16_to_cpu(m->first_bucket));
 	prt_printf(out, "Buckets:\t%llu\n", le64_to_cpu(m->nbuckets));
+	prt_printf(out, "Target buckets:\t%llu\n", le64_to_cpu(m->target_nbuckets));
 
 	prt_printf(out, "Last mount:\t");
 	if (m->last_mount)

--- a/fs/sb/members.c
+++ b/fs/sb/members.c
@@ -208,21 +208,22 @@ static int validate_member(struct printbuf *err,
 	u64 target_nbuckets = le64_to_cpu(m.target_nbuckets);
 
 	if (target_nbuckets) {
-		if (target_nbuckets >= nbuckets) {
-			prt_printf(err, "device %u: target buckets >= buckets (got %llu, nbuckets %llu)",
-				   i, target_nbuckets, nbuckets);
-			return -BCH_ERR_invalid_sb_members;
-		}
-
 		if (target_nbuckets < first_bucket) {
 			prt_printf(err, "device %u: target buckets starts before first bucket (got %llu, first %u)",
 				   i, target_nbuckets, first_bucket);
 			return -BCH_ERR_invalid_sb_members;
 		}
 
-		if (target_nbuckets - first_bucket < BCH_MIN_NR_NBUCKETS) {
+		if (target_nbuckets < nbuckets &&
+		    target_nbuckets - first_bucket < BCH_MIN_NR_NBUCKETS) {
 			prt_printf(err, "device %u: not enough target buckets (got %llu, min %u)",
 				   i, target_nbuckets - first_bucket, BCH_MIN_NR_NBUCKETS);
+			return -BCH_ERR_invalid_sb_members;
+		}
+
+		if (target_nbuckets > BCH_MEMBER_NBUCKETS_MAX) {
+			prt_printf(err, "device %u: target buckets too big (got %llu, max %u)",
+				   i, target_nbuckets, BCH_MEMBER_NBUCKETS_MAX);
 			return -BCH_ERR_invalid_sb_members;
 		}
 	}

--- a/fs/sb/members.c
+++ b/fs/sb/members.c
@@ -248,7 +248,11 @@ __cold void bch2_member_to_text(struct printbuf *out,
 	prt_newline(out);
 
 	prt_printf(out, "Target size:\t");
-	prt_units_u64(out, target_device_size << 9);
+	if (target_device_size) {
+		prt_units_u64(out, target_device_size << 9);
+	} else {
+		prt_printf(out, "Inactive");
+	}
 	prt_newline(out);
 
 	for (unsigned i = 0; i < BCH_MEMBER_ERROR_NR; i++)
@@ -263,7 +267,14 @@ __cold void bch2_member_to_text(struct printbuf *out,
 
 	prt_printf(out, "First bucket:\t%u\n", le16_to_cpu(m->first_bucket));
 	prt_printf(out, "Buckets:\t%llu\n", le64_to_cpu(m->nbuckets));
-	prt_printf(out, "Target buckets:\t%llu\n", le64_to_cpu(m->target_nbuckets));
+
+	prt_printf(out, "Target buckets:\t");
+	if (target_device_size) {
+		prt_printf(out, "%llu", le64_to_cpu(m->target_nbuckets));
+	} else {
+		prt_printf(out, "Inactive");
+	}
+	prt_newline(out);
 
 	prt_printf(out, "Last mount:\t");
 	if (m->last_mount)

--- a/fs/sb/members.h
+++ b/fs/sb/members.h
@@ -279,10 +279,35 @@ static inline bool bch2_dev_bad_or_evacuating(struct bch_fs *c, unsigned dev)
 	return bch2_dev_bad_or_evacuating_rcu(c, dev);
 }
 
+static inline u64 bch2_dev_resize_target(const struct bch_dev *ca)
+{
+	u64 target = READ_ONCE(ca->mi.target_nbuckets);
+
+	return target ?: READ_ONCE(ca->mi.nbuckets);
+}
+
+static inline bool bch2_dev_resize_pending(const struct bch_dev *ca)
+{
+	return bch2_dev_resize_target(ca) != READ_ONCE(ca->mi.nbuckets);
+}
+
+static inline bool bch2_dev_is_shrinking(const struct bch_dev *ca)
+{
+	return bch2_dev_resize_target(ca) < READ_ONCE(ca->mi.nbuckets);
+}
+
+static inline bool bch2_dev_is_growing(const struct bch_dev *ca)
+{
+	return bch2_dev_resize_target(ca) > READ_ONCE(ca->mi.nbuckets);
+}
+
 static inline bool bch2_ptr_bad_or_evacuating_rcu(struct bch_fs *c, const struct bch_extent_ptr *ptr) {
 	struct bch_dev *ca = bch2_dev_rcu_noerror(c, ptr->dev);
 
-	return !ca || bch2_dev_bad_or_evacuating_rcu(c, ptr->dev) || (ca->mi.target_nbuckets && ca->mi.target_nbuckets <= div_u64(ptr->offset, ca->mi.bucket_size));
+	return !ca ||
+		bch2_dev_bad_or_evacuating_rcu(c, ptr->dev) ||
+		(bch2_dev_is_shrinking(ca) &&
+		 bch2_dev_resize_target(ca) <= div_u64(ptr->offset, ca->mi.bucket_size));
 }
 
 static inline bool bch2_ptr_bad_or_evacuating(struct bch_fs *c, const struct bch_extent_ptr *ptr) {

--- a/fs/sb/members.h
+++ b/fs/sb/members.h
@@ -279,6 +279,18 @@ static inline bool bch2_dev_bad_or_evacuating(struct bch_fs *c, unsigned dev)
 	return bch2_dev_bad_or_evacuating_rcu(c, dev);
 }
 
+static inline bool bch2_ptr_bad_or_evacuating_rcu(struct bch_fs *c, const struct bch_extent_ptr *ptr) {
+	struct bch_dev *ca = bch2_dev_rcu_noerror(c, ptr->dev);
+
+	return !ca || bch2_dev_bad_or_evacuating_rcu(c, ptr->dev) || (ca->mi.target_nbuckets && ca->mi.target_nbuckets <= div_u64(ptr->offset, ca->mi.bucket_size));
+}
+
+static inline bool bch2_ptr_bad_or_evacuating(struct bch_fs *c, const struct bch_extent_ptr *ptr) {
+	guard(rcu)();
+	return bch2_ptr_bad_or_evacuating_rcu(c, ptr);
+}
+
+
 int bch2_dev_missing_bkey_msg(struct bch_fs *, struct bkey_s_c, unsigned, struct printbuf *out);
 int bch2_dev_missing_bkey(struct bch_fs *, struct bkey_s_c, unsigned);
 

--- a/fs/sb/members.h
+++ b/fs/sb/members.h
@@ -301,16 +301,22 @@ static inline bool bch2_dev_is_growing(const struct bch_dev *ca)
 	return bch2_dev_resize_target(ca) > READ_ONCE(ca->mi.nbuckets);
 }
 
-static inline bool bch2_ptr_bad_or_evacuating_rcu(struct bch_fs *c, const struct bch_extent_ptr *ptr) {
+static inline bool bch2_ptr_bad_or_evacuating_rcu(struct bch_fs *c, const struct bch_extent_ptr *ptr)
+{
 	struct bch_dev *ca = bch2_dev_rcu_noerror(c, ptr->dev);
+	u64 resize_target;
 
-	return !ca ||
-		bch2_dev_bad_or_evacuating_rcu(c, ptr->dev) ||
-		(bch2_dev_is_shrinking(ca) &&
-		 bch2_dev_resize_target(ca) <= div_u64(ptr->offset, ca->mi.bucket_size));
+	if (!ca || bch2_dev_bad_or_evacuating_rcu(c, ptr->dev))
+		return true;
+
+	resize_target = bch2_dev_resize_target(ca);
+
+	return resize_target < READ_ONCE(ca->mi.nbuckets) &&
+		ptr->offset >= resize_target * ca->mi.bucket_size;
 }
 
-static inline bool bch2_ptr_bad_or_evacuating(struct bch_fs *c, const struct bch_extent_ptr *ptr) {
+static inline bool bch2_ptr_bad_or_evacuating(struct bch_fs *c, const struct bch_extent_ptr *ptr)
+{
 	guard(rcu)();
 	return bch2_ptr_bad_or_evacuating_rcu(c, ptr);
 }

--- a/fs/sb/members.h
+++ b/fs/sb/members.h
@@ -426,13 +426,14 @@ static inline struct bch_member_cpu bch2_mi_to_cpu(struct bch_member *mi)
 		.durability	= BCH_MEMBER_DURABILITY(mi)
 			? BCH_MEMBER_DURABILITY(mi) - 1
 			: 1,
-		.freespace_initialized = BCH_MEMBER_FREESPACE_INITIALIZED(mi),
+		.freespace_initialized	= BCH_MEMBER_FREESPACE_INITIALIZED(mi),
 		.initialized		= BCH_MEMBER_INITIALIZED(mi),
 		.resize_on_mount	= BCH_MEMBER_RESIZE_ON_MOUNT(mi),
 		.rotational		= BCH_MEMBER_ROTATIONAL(mi),
 		.valid			= bch2_member_alive(mi),
 		.btree_bitmap_shift	= mi->btree_bitmap_shift,
 		.btree_allocated_bitmap = le64_to_cpu(mi->btree_allocated_bitmap),
+		.target_nbuckets	= le64_to_cpu(mi->target_nbuckets),
 	};
 }
 

--- a/fs/sb/members_format.h
+++ b/fs/sb/members_format.h
@@ -76,7 +76,7 @@ struct bch_member {
 	__u8			device_model[64] __nonstring;
 	__le64			flush_errors;
 	__u8			device_serial[64] __nonstring;
-	__le64			target_nbuckets; /* 0 => no pending resize */
+	__le64			target_nbuckets; /* 0 => no pending resize, (first_bucket + BCH_MIN_NR_NBUCKETS)..nbuckets => shrink, other => illegal */
 };
 
 /*

--- a/fs/sb/members_format.h
+++ b/fs/sb/members_format.h
@@ -76,6 +76,7 @@ struct bch_member {
 	__u8			device_model[64] __nonstring;
 	__le64			flush_errors;
 	__u8			device_serial[64] __nonstring;
+	__le64			target_nbuckets; /* 0 => no pending resize */
 };
 
 /*

--- a/fs/sb/members_format.h
+++ b/fs/sb/members_format.h
@@ -76,7 +76,7 @@ struct bch_member {
 	__u8			device_model[64] __nonstring;
 	__le64			flush_errors;
 	__u8			device_serial[64] __nonstring;
-	__le64			target_nbuckets; /* 0 => no pending resize, (first_bucket + BCH_MIN_NR_NBUCKETS)..nbuckets => shrink, other => illegal */
+	__le64			target_nbuckets; /* 0 => idle, nbuckets => idle, < nbuckets => shrink target, > nbuckets => grow target */
 };
 
 /*

--- a/fs/sb/members_types.h
+++ b/fs/sb/members_types.h
@@ -19,7 +19,7 @@ struct bch_member_cpu {
 	u8			valid;
 	u8			btree_bitmap_shift;
 	u64			btree_allocated_bitmap;
-	u64 			target_nbuckets; /* 0 => no pending resize, [first_bucket + BCH_MIN_NR_NBUCKETS, nbuckets) => shrink, other => illegal */
+	u64 			target_nbuckets; /* 0 => idle, nbuckets => idle, < nbuckets => shrink target, > nbuckets => grow target */
 };
 
 #endif /* _BCACHEFS_SB_MEMBERS_H */

--- a/fs/sb/members_types.h
+++ b/fs/sb/members_types.h
@@ -19,6 +19,7 @@ struct bch_member_cpu {
 	u8			valid;
 	u8			btree_bitmap_shift;
 	u64			btree_allocated_bitmap;
+	u64 			target_nbuckets; /* (!= 0) => pending resize */
 };
 
 #endif /* _BCACHEFS_SB_MEMBERS_H */

--- a/fs/sb/members_types.h
+++ b/fs/sb/members_types.h
@@ -19,7 +19,7 @@ struct bch_member_cpu {
 	u8			valid;
 	u8			btree_bitmap_shift;
 	u64			btree_allocated_bitmap;
-	u64 			target_nbuckets; /* (!= 0) => pending resize */
+	u64 			target_nbuckets; /* 0 => no pending resize, [first_bucket + BCH_MIN_NR_NBUCKETS, nbuckets) => shrink, other => illegal */
 };
 
 #endif /* _BCACHEFS_SB_MEMBERS_H */

--- a/fs/util/util.h
+++ b/fs/util/util.h
@@ -704,6 +704,16 @@ static inline void percpu_u64_set(u64 __percpu *dst, u64 src)
 	this_cpu_write(*dst, src);
 }
 
+static inline void acc_s64s(u64 *acc, const s64 *src, unsigned nr)
+{
+	for (unsigned i = 0; i < nr; i++)
+		if (src[i] >= 0) {
+			acc[i] += src[i];
+		} else {
+			acc[i] -= abs(src[i]);
+		}
+}
+
 static inline void acc_u64s(u64 *acc, const u64 *src, unsigned nr)
 {
 	for (unsigned i = 0; i < nr; i++)

--- a/fs/util/util.h
+++ b/fs/util/util.h
@@ -704,16 +704,6 @@ static inline void percpu_u64_set(u64 __percpu *dst, u64 src)
 	this_cpu_write(*dst, src);
 }
 
-static inline void acc_s64s(u64 *acc, const s64 *src, unsigned nr)
-{
-	for (unsigned i = 0; i < nr; i++)
-		if (src[i] >= 0) {
-			acc[i] += src[i];
-		} else {
-			acc[i] -= abs(src[i]);
-		}
-}
-
 static inline void acc_u64s(u64 *acc, const u64 *src, unsigned nr)
 {
 	for (unsigned i = 0; i < nr; i++)

--- a/src/commands/device.rs
+++ b/src/commands/device.rs
@@ -415,10 +415,6 @@ fn cmd_device_resize(cli: ResizeCli) -> Result<()> {
                 .context("querying device usage")?;
             let nbuckets = size_sectors / usage.bucket_size as u64;
 
-            if nbuckets < usage.nr_buckets {
-                return Err(anyhow!("Shrinking not supported yet"));
-            }
-
             println!("resizing {} to {} buckets", cli.device, nbuckets);
             handle.disk_resize(dev_idx, nbuckets)
                 .context("resizing device")?;


### PR DESCRIPTION
## Summary

- port the online device shrink implementation from the kernel-side `koverstreet/bcachefs#1073` work to `bcachefs-tools/testing`
- preserve the original Jul Lang / Codex commit stack instead of squashing the port, with bcachefs-tools-specific adaptations split into separate Komzpa commits
- allow online `bcachefs device resize` requests with smaller target sizes to reach the resize worker
- keep and resize the tools-only `buckets_nouse` bitmap that current Rust migration code still depends on
- add `target_nbuckets` resize state, resize worker restart/resume handling, allocator/discard/reconcile/journal handling for a shrinking tail
- fix restart handling found by the local shrink suite in discard retry and cached-tail invalidation paths

## Status

Draft/WIP. This is the bcachefs-tools-targeted artifact for the online shrink issue cluster. It now has local destructive shrink-suite proof against the companion ktest branch, but should still be treated as experimental until maintainer review and CI settle on the current head.

Companion draft ktest coverage is at `koverstreet/ktest#85`.

## Provenance

This is based on the online shrink work from:

- `koverstreet/bcachefs#1073`
- `koverstreet/bcachefs#781`
- `koverstreet/bcachefs#1056`
- `koverstreet/bcachefs-tools#268`

Credit for the original implementation belongs to Jul Lang. The branch keeps the imported commit authors/messages where practical; bcachefs-tools-specific fixes are separate Komzpa commits at the tail of the branch.

Recent tail commits on this PR:

- `8a3e030bb` `bcachefs: keep discard restart inside retry loop`
- `d432f6894` `bcachefs: bubble shrink invalidation restarts`

## Validation

Current head: `d432f6894649123cc1e6fde2157b967f2662094e`

- `git diff --check`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
- `./target/release/bcachefs device resize --help`
- `make -C /lib/modules/$(uname -r)/build M=$PWD/fs -j32 modules`
- local full shrink suite using `koverstreet/ktest#85` head `0bdec5d426122b740faefbda88c5d2fcbfe1f7e5` and a local ktest kernel/root pair with host-mount support: all 15 tests passed, `TEST SUCCESS`

GitHub CI is green for the current head: 17/17 visible checks passed, and the PR is merge-clean.

