### PR TITLE
bcachefs: mark hot-removed devices read-only

### DIFF
--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -532,6 +532,39 @@ void __bch2_dev_offline(struct bch_fs *c, struct bch_dev *ca)
 	bch2_dev_journal_exit(ca);
 }
 
+static int bch2_dev_mark_ro_after_offline(struct bch_fs *c, struct bch_dev *ca,
+					  struct printbuf *err)
+{
+	lockdep_assert_held(&c->state_lock);
+
+	if (ca->mi.state != BCH_MEMBER_STATE_rw)
+		return 0;
+
+	bch_notice_dev(ca, "%s", bch2_member_states[BCH_MEMBER_STATE_ro]);
+	ca->mi.state = BCH_MEMBER_STATE_ro;
+
+	scoped_guard(mutex, &c->sb_lock) {
+		struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
+
+		SET_BCH_MEMBER_STATE(m, BCH_MEMBER_STATE_ro);
+
+		int ret = bch2_write_super(c);
+		if (ret) {
+			prt_printf(err, "bch2_write_super() error marking device ro: %s\n",
+				   bch2_err_str(ret));
+			return ret;
+		}
+	}
+
+	int ret = bch2_set_reconcile_needs_scan(c,
+		(struct reconcile_scan) { .type = RECONCILE_SCAN_stripes }, false);
+	if (ret)
+		prt_printf(err, "error scheduling stripe scan after device offline: %s\n",
+			   bch2_err_str(ret));
+
+	return ret;
+}
+
 #ifndef CONFIG_BCACHEFS_DEBUG
 static void bch2_dev_ref_complete(struct percpu_ref *ref)
 {
@@ -1592,6 +1625,11 @@ static void bch2_fs_bdev_mark_dead(struct block_device *bdev, bool surprise)
 		}
 
 		__bch2_dev_offline(c, ca);
+		if (dev) {
+			int ret = bch2_dev_mark_ro_after_offline(c, ca, &buf);
+			if (ret)
+				print = true;
+		}
 
 		if (print)
 			bch2_print_str(c, KERN_ERR, buf.buf);


### PR DESCRIPTION
## Summary

Fixes the hot-remove path behind koverstreet/bcachefs#142.

When the block layer reports a mounted member dead, `bch2_fs_bdev_mark_dead()` already stops IO refs and unlinks the block device, but the member state can remain `rw`. That leaves later allocator/reconcile decisions able to treat the disappeared member as a writable target again.

This patch marks a safely-offlined hot-removed `rw` member as `ro` after the dead block device has been removed from the online mask, then writes the updated superblock to the surviving devices and queues the same stripe-scan follow-up used by other `rw -> non-rw` transitions.

## Companion coverage

Companion coverage is in koverstreet/ktest#89.

## Validation

- `make -j32`
- Negative control: the companion ktest on upstream `koverstreet/bcachefs-tools` `b6709ece8d0a98c4e0a6d7f9594ef9fa8895a077` reproduced the bug: after `offline from block layer`, dev-1 remained `[rw]` and writes logged `vdc io: BLK_STS_REMOVED`.
- Fixed run: `ktest_deps_dir=/home/kom/proj/ktest-deps-hot-remove-offline ./ktest run -S -k /home/kom/.ktest/kernels/local/7.1/x86_64/7.1-ktest-gcc15-virtiofs-20260630 -o tmp/ktest-hot-remove-final -T tmp/ktest-hot-remove-final-work /home/kom/proj/ktest-hot-remove-offline/tests/fs/bcachefs/replication.ktest device_hot_remove_offlines_dead_dev`
  - loaded bcachefs module `v1.38.6-101-g12a7af3305c9`
  - hot-removed dev-1 moved from `[rw]` to `rw [ro] evacuating spare`
  - after the post-remove 64 MiB write, `fs usage` showed dev-1 `ro` unchanged while vdb/vdd grew
  - degraded remount verified both `before-hot-remove` and `after-hot-remove` checksums
  - printed `TEST SUCCESS`
