### PR TITLE
vfs: fix CONFIG_UNICODE=n casefold alias build

### DIFF
--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -866,6 +866,9 @@ void bch2_dir_casefold_changed(struct dentry *dentry)
 	shrink_dcache_parent(dentry);
 	bch2_dentry_update_casefold_flags(dentry);
 }
+#else
+static void bch2_dentry_set_casefold_ops_locked(struct dentry *dentry,
+						struct inode *vinode) {}
 #endif
 
 static struct dentry *bch2_lookup(struct inode *vdir, struct dentry *dentry,


### PR DESCRIPTION
## Summary

Fixes koverstreet/bcachefs-tools#661.

`bch2_dentry_set_casefold_ops()` and `bch2_dir_casefold_changed()` already have no-op stubs from `fs/vfs/fs.h` when `CONFIG_UNICODE=n`, but the private `bch2_dentry_set_casefold_ops_locked()` helper in `fs/vfs/fs.c` only existed inside the Unicode-enabled block.

That leaves the NFS filehandle alias path calling an undeclared helper when building the module for a kernel without Unicode support.

This keeps the current lookup/create/fileattr behavior unchanged and only adds the matching no-op locked helper for the non-Unicode build. AfoHT's koverstreet/bcachefs-tools#608 identified the same missing casefold guard, but that branch also changed lookup flow; this PR keeps the fix to the missing private helper.

## Validation

- `git diff --check`
- Negative control on unpatched `koverstreet/bcachefs-tools` `origin/master` `b6709ece8d0a98c4e0a6d7f9594ef9fa8895a077`, with `# CONFIG_UNICODE is not set`, failed exactly as reported:

```text
vfs/fs.c:1802:17: error: implicit declaration of function 'bch2_dentry_set_casefold_ops_locked'; did you mean 'bch2_dentry_set_casefold_ops'? [-Wimplicit-function-declaration]
```

- Fixed build, same kernel output and same `# CONFIG_UNICODE is not set`:

```text
OUT=/home/kom/tmp/bcachefs-config-unicode-off-kbuild
make -C /home/kom/proj/kernel-src-7.1-full O="$OUT" M=$PWD/fs BCACHEFS_DKMS=1 BCACHEFS_RUST=0 vfs/fs.o
```

The fixed `vfs/fs.o` build completed successfully.
