### PR TITLE
fs: scan reconcile after rename reinherits opts

### DIFF
--- a/fs/fs/namei.c
+++ b/fs/fs/namei.c
@@ -10,6 +10,8 @@
 #include "fs/namei.h"
 #include "fs/xattr.h"
 
+#include "data/reconcile/work.h"
+
 #include "init/fs.h"
 
 #include "snapshots/subvolume.h"
@@ -329,6 +331,29 @@ bool bch2_reinherit_attrs(struct bch_inode_unpacked *dst_u,
 	return ret;
 }
 
+static int bch2_reinherit_attrs_reconcile(struct btree_trans *trans,
+					  struct bch_inode_unpacked *dst_u,
+					  struct bch_inode_unpacked *src_u,
+					  bool *reconcile_changed)
+{
+	struct bch_fs *c = trans->c;
+	struct bch_extent_reconcile old_r = bch2_inode_reconcile_opts_get(c, dst_u);
+
+	if (!bch2_reinherit_attrs(dst_u, src_u))
+		return 0;
+
+	struct bch_extent_reconcile new_r = bch2_inode_reconcile_opts_get(c, dst_u);
+	if (memcmp(&old_r, &new_r, sizeof(new_r))) {
+		try(bch2_set_reconcile_needs_scan_trans(trans,
+				(struct reconcile_scan) {
+					.type = RECONCILE_SCAN_inum,
+					.inum = dst_u->bi_inum }));
+		*reconcile_changed = true;
+	}
+
+	return 1;
+}
+
 static int subvol_update_parent(struct btree_trans *trans, u32 subvol, u32 new_parent)
 {
 	struct bkey_i_subvolume *s =
@@ -347,7 +372,8 @@ int bch2_rename_trans(struct btree_trans *trans,
 		      struct bch_inode_unpacked *dst_inode_u,
 		      const struct qstr *src_name,
 		      const struct qstr *dst_name,
-		      enum bch_rename_mode mode)
+		      enum bch_rename_mode mode,
+		      bool *reconcile_changed)
 {
 	struct bch_fs *c = trans->c;
 	CLASS(btree_iter_uninit, src_dir_iter)(trans);
@@ -357,6 +383,7 @@ int bch2_rename_trans(struct btree_trans *trans,
 	subvol_inum src_inum, dst_inum;
 	u64 src_offset, dst_offset;
 	u64 now = bch2_current_time(c);
+	int ret;
 
 	try(bch2_inode_peek(trans, &src_dir_iter, src_dir_u, src_dir, BTREE_ITER_intent));
 
@@ -431,14 +458,25 @@ int bch2_rename_trans(struct btree_trans *trans,
 	}
 
 	if (!subvol_inum_eq(dst_dir, src_dir)) {
-		if (bch2_reinherit_attrs(src_inode_u, dst_dir_u) &&
-		    S_ISDIR(src_inode_u->bi_mode))
+		int src_attrs_changed = bch2_reinherit_attrs_reconcile(trans, src_inode_u,
+								       dst_dir_u, reconcile_changed);
+		ret = src_attrs_changed < 0 ? src_attrs_changed : 0;
+		if (ret)
+			return ret;
+
+		if (src_attrs_changed && S_ISDIR(src_inode_u->bi_mode))
 			return -EXDEV;
 
-		if (mode == BCH_RENAME_EXCHANGE &&
-		    bch2_reinherit_attrs(dst_inode_u, src_dir_u) &&
-		    S_ISDIR(dst_inode_u->bi_mode))
-			return -EXDEV;
+		if (mode == BCH_RENAME_EXCHANGE) {
+			int dst_attrs_changed = bch2_reinherit_attrs_reconcile(trans, dst_inode_u,
+									       src_dir_u, reconcile_changed);
+			ret = dst_attrs_changed < 0 ? dst_attrs_changed : 0;
+			if (ret)
+				return ret;
+
+			if (dst_attrs_changed && S_ISDIR(dst_inode_u->bi_mode))
+				return -EXDEV;
+		}
 
 		if (is_subdir_for_nlink(src_inode_u)) {
 			src_dir_u->bi_nlink--;

--- a/fs/fs/namei.c
+++ b/fs/fs/namei.c
@@ -10,6 +10,8 @@
 #include "fs/namei.h"
 #include "fs/xattr.h"
 
+#include "data/reconcile/work.h"
+
 #include "init/fs.h"
 
 #include "snapshots/subvolume.h"
@@ -336,6 +338,29 @@ bool bch2_reinherit_attrs(struct bch_inode_unpacked *dst_u,
 	return ret;
 }
 
+static int bch2_reinherit_attrs_reconcile(struct btree_trans *trans,
+					  struct bch_inode_unpacked *dst_u,
+					  struct bch_inode_unpacked *src_u,
+					  bool *reconcile_changed)
+{
+	struct bch_fs *c = trans->c;
+	struct bch_extent_reconcile old_r = bch2_inode_reconcile_opts_get(c, dst_u);
+
+	if (!bch2_reinherit_attrs(dst_u, src_u))
+		return 0;
+
+	struct bch_extent_reconcile new_r = bch2_inode_reconcile_opts_get(c, dst_u);
+	if (memcmp(&old_r, &new_r, sizeof(new_r))) {
+		try(bch2_set_reconcile_needs_scan_trans(trans,
+				(struct reconcile_scan) {
+					.type = RECONCILE_SCAN_inum,
+					.inum = dst_u->bi_inum }));
+		*reconcile_changed = true;
+	}
+
+	return 1;
+}
+
 static int subvol_update_parent(struct btree_trans *trans, u32 subvol, u32 new_parent)
 {
 	struct bkey_i_subvolume *s =
@@ -354,7 +379,8 @@ int bch2_rename_trans(struct btree_trans *trans,
 		      struct bch_inode_unpacked *dst_inode_u,
 		      const struct qstr *src_name,
 		      const struct qstr *dst_name,
-		      enum bch_rename_mode mode)
+		      enum bch_rename_mode mode,
+		      bool *reconcile_changed)
 {
 	struct bch_fs *c = trans->c;
 	CLASS(btree_iter_uninit, src_dir_iter)(trans);
@@ -438,14 +464,25 @@ int bch2_rename_trans(struct btree_trans *trans,
 	}
 
 	if (!subvol_inum_eq(dst_dir, src_dir)) {
-		if (bch2_reinherit_attrs(src_inode_u, dst_dir_u) &&
-		    S_ISDIR(src_inode_u->bi_mode))
+		int src_attrs_changed = bch2_reinherit_attrs_reconcile(trans, src_inode_u,
+								       dst_dir_u, reconcile_changed);
+		int ret = src_attrs_changed < 0 ? src_attrs_changed : 0;
+		if (ret)
+			return ret;
+
+		if (src_attrs_changed && S_ISDIR(src_inode_u->bi_mode))
 			return -EXDEV;
 
-		if (mode == BCH_RENAME_EXCHANGE &&
-		    bch2_reinherit_attrs(dst_inode_u, src_dir_u) &&
-		    S_ISDIR(dst_inode_u->bi_mode))
-			return -EXDEV;
+		if (mode == BCH_RENAME_EXCHANGE) {
+			int dst_attrs_changed = bch2_reinherit_attrs_reconcile(trans, dst_inode_u,
+									       src_dir_u, reconcile_changed);
+			ret = dst_attrs_changed < 0 ? dst_attrs_changed : 0;
+			if (ret)
+				return ret;
+
+			if (dst_attrs_changed && S_ISDIR(dst_inode_u->bi_mode))
+				return -EXDEV;
+		}
 
 		if (is_subdir_for_nlink(src_inode_u)) {
 			src_dir_u->bi_nlink--;

--- a/fs/fs/namei.h
+++ b/fs/fs/namei.h
@@ -38,7 +38,8 @@ int bch2_rename_trans(struct btree_trans *,
 		      struct bch_inode_unpacked *,
 		      const struct qstr *,
 		      const struct qstr *,
-		      enum bch_rename_mode);
+		      enum bch_rename_mode,
+		      bool *);
 
 bool bch2_reinherit_attrs(struct bch_inode_unpacked *,
 			  struct bch_inode_unpacked *);

--- a/fs/fs/namei.h
+++ b/fs/fs/namei.h
@@ -51,7 +51,8 @@ int bch2_rename_trans(struct btree_trans *,
 		      struct bch_inode_unpacked *,
 		      const struct qstr *,
 		      const struct qstr *,
-		      enum bch_rename_mode);
+		      enum bch_rename_mode,
+		      bool *);
 
 bool bch2_reinherit_attrs(struct bch_inode_unpacked *,
 			  struct bch_inode_unpacked *);

--- a/fs/fs/namei.rs
+++ b/fs/fs/namei.rs
@@ -43,6 +43,7 @@ pub fn rename_trans<'a, 't>(
     src_name:    &c::qstr,
     dst_name:    &c::qstr,
     mode:        c::bch_rename_mode,
+    reconcile_changed: &mut bool,
 ) -> Result<TransAttempt<'a, 't>, TransError> {
     let ret = unsafe {
         c::bch2_rename_trans(
@@ -56,6 +57,7 @@ pub fn rename_trans<'a, 't>(
             src_name,
             dst_name,
             mode,
+            reconcile_changed,
         )
     };
     t.result(ret)

--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -1119,6 +1119,7 @@ static int bch2_rename2(struct mnt_idmap *idmap,
 	}
 retry:
 	bch2_trans_begin(trans);
+	reconcile_changed = false;
 
 	ret = bch2_rename_trans(trans,
 				inode_inum(src_dir), &src_dir_u,
@@ -1127,7 +1128,8 @@ retry:
 				&dst_inode_u,
 				&src_dentry->d_name,
 				&dst_dentry->d_name,
-				mode);
+				mode,
+				&reconcile_changed);
 	if (unlikely(ret))
 		goto err_tx_restart;
 
@@ -1178,6 +1180,9 @@ err_tx_restart:
 	if (dst_inode)
 		bch2_inode_update_after_write(trans, dst_inode, &dst_inode_u,
 					      ATTR_CTIME);
+
+	if (reconcile_changed)
+		bch2_reconcile_wakeup(c);
 
 err:
 	bch2_fs_quota_transfer(c, src_inode,

--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -1075,6 +1075,7 @@ static int bch2_rename2(struct mnt_idmap *idmap,
 		: dst_dentry->d_inode
 		? BCH_RENAME_OVERWRITE : BCH_RENAME;
 	bool whiteout = !!(flags & RENAME_WHITEOUT);
+	bool reconcile_changed = false;
 	int ret;
 
 	if (flags & ~(RENAME_NOREPLACE|RENAME_EXCHANGE|RENAME_WHITEOUT))

--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -1240,6 +1240,7 @@ static int bch2_rename2(struct mnt_idmap *idmap,
 		: dst_dentry->d_inode
 		? BCH_RENAME_OVERWRITE : BCH_RENAME;
 	bool whiteout = !!(flags & RENAME_WHITEOUT);
+	bool reconcile_changed = false;
 	int ret;
 
 	if (flags & ~(RENAME_NOREPLACE|RENAME_EXCHANGE|RENAME_WHITEOUT))
@@ -1284,6 +1285,7 @@ static int bch2_rename2(struct mnt_idmap *idmap,
 	}
 retry:
 	bch2_trans_begin(trans);
+	reconcile_changed = false;
 
 	ret = bch2_rename_trans(trans,
 				inode_inum(src_dir), &src_dir_u,
@@ -1292,7 +1294,8 @@ retry:
 				&dst_inode_u,
 				&src_dentry->d_name,
 				&dst_dentry->d_name,
-				mode);
+				mode,
+				&reconcile_changed);
 	if (unlikely(ret))
 		goto err_tx_restart;
 
@@ -1343,6 +1346,9 @@ err_tx_restart:
 	if (dst_inode)
 		bch2_inode_update_after_write(trans, dst_inode, &dst_inode_u,
 					      ATTR_CTIME);
+
+	if (reconcile_changed)
+		bch2_reconcile_wakeup(c);
 
 err:
 	bch2_fs_quota_transfer(c, src_inode,

--- a/src/commands/fusemount.rs
+++ b/src/commands/fusemount.rs
@@ -244,6 +244,7 @@ fn fuse_rename(
     let mut dst_dir_u: c::bch_inode_unpacked = Default::default();
     let mut src_inode_u: c::bch_inode_unpacked = Default::default();
     let mut dst_inode_u: c::bch_inode_unpacked = Default::default();
+    let mut reconcile_changed = false;
 
     btree::iter::trans_commit_do(
         fs,
@@ -261,6 +262,7 @@ fn fuse_rename(
                 &src_qstr,
                 &dst_qstr,
                 c::bch_rename_mode::BCH_RENAME,
+                &mut reconcile_changed,
             )
         },
     )

--- a/src/commands/fusemount.rs
+++ b/src/commands/fusemount.rs
@@ -278,6 +278,7 @@ fn fuse_rename(
     let mut dst_dir_u: c::bch_inode_unpacked = Default::default();
     let mut src_inode_u: c::bch_inode_unpacked = Default::default();
     let mut dst_inode_u: c::bch_inode_unpacked = Default::default();
+    let mut reconcile_changed = false;
 
     btree::iter::trans_commit_do(
         fs,
@@ -295,6 +296,7 @@ fn fuse_rename(
                 &src_qstr,
                 &dst_qstr,
                 c::bch_rename_mode::BCH_RENAME,
+                &mut reconcile_changed,
             )
         },
     )


### PR DESCRIPTION
bch2_reinherit_attrs() can re-inherit IO path options from the destination parent on a cross-directory rename of a regular file, but when that reinheritance changes the inode's effective reconcile options, nothing queued a reconcile scan for it -- leaving existing extents carrying reconcile metadata for the old, no-longer-applicable target set. This queues RECONCILE_SCAN_inum before the rename transaction commits and wakes reconcile after commit whenever reinherit changes the inode's reconcile options; the direct hard-link path already rejects inherited-option changes, but a hardlinked inode can still be reparented by renaming one link and later removing the old one, which is the path behind the failure reported in koverstreet/bcachefs#1173. This is a new reconcile-scan trigger point, and reconcile scheduling is an area that wants review before this is more than a plain bugfix. Validated with a clean build and a FUSE smoke test (cross-directory rename through the changed path, content preserved, clean unmount), but the actual differing-inherited-options branch is untested here: `set-file-option --background_target` returns ENOTSUP over the FUSE backend, and the kernel-module path with real io_path options plumbing wasn't exercised. Companion ktest coverage: koverstreet/ktest#90.
