### PR TITLE
device: explain rejected evacuate state changes

### DIFF
--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -861,7 +861,40 @@ bool bch2_dev_state_allowed(struct bch_fs *c, struct bch_dev *ca,
 		struct bch_devs_mask new_rw_devs = c->allocator.rw_devs[0];
 		__clear_bit(ca->dev_idx, new_rw_devs.d);
 
-		return bch2_can_write_fs_with_devs(c, new_rw_devs, flags, err);
+		if (bch2_can_write_fs_with_devs(c, new_rw_devs, flags, err))
+			return true;
+
+		/*
+		 * bch2_can_write_fs_with_devs() has already explained which
+		 * replication constraint failed; add which device/transition
+		 * triggered it, which other devices are why redundancy is
+		 * short, and what the admin can do about it - so the ioctl
+		 * error message that comes back out of this rejection is
+		 * actually actionable instead of a bare EINVAL.
+		 */
+		if (err) {
+			prt_printf(err, "%s: can't leave rw for %s\n",
+				   ca->name, bch2_member_states[new_state]);
+
+			unsigned nr_listed = 0, nr_evacuating = 0;
+			for_each_member_device_rcu(c, ca2, NULL)
+				if (ca2->mi.state != BCH_MEMBER_STATE_rw) {
+					prt_str(err, nr_listed++
+						? ", "
+						: "Other non-writable devices: ");
+					prt_printf(err, "%s (%s)",
+						   ca2->name, bch2_member_states[ca2->mi.state]);
+					nr_evacuating += ca2->mi.state == BCH_MEMBER_STATE_evacuating;
+				}
+			if (nr_listed)
+				prt_newline(err);
+
+			prt_str(err, nr_evacuating
+				? "Wait for the running evacuation to finish before retrying, or add/restore enough writable redundancy\n"
+				: "Add or restore enough writable redundancy before retrying\n");
+		}
+
+		return false;
 	}
 
 	return true;

--- a/src/commands/device.rs
+++ b/src/commands/device.rs
@@ -575,12 +575,12 @@ fn cmd_device_evacuate(cli: EvacuateCli) -> Result<()> {
     if usage.state == BCH_MEMBER_STATE_rw as u8 {
         println!("Setting {} readonly", cli.device);
         handle.disk_set_state(dev_idx, BCH_MEMBER_STATE_ro as u32, BCH_FORCE_IF_DEGRADED)
-            .context("setting device readonly")?;
+            .map_err(|e| evacuate_state_error(&cli.device, "readonly", e))?;
     }
 
     println!("Setting {} evacuating", cli.device);
     handle.disk_set_state(dev_idx, BCH_MEMBER_STATE_evacuating as u32, BCH_FORCE_IF_DEGRADED)
-        .context("setting device evacuating")?;
+        .map_err(|e| evacuate_state_error(&cli.device, "evacuating", e))?;
 
     // Trigger reconcile wakeup so it starts processing the evacuation
     let _ = std::fs::write(sysfs_path.join("internal/trigger_reconcile_wakeup"), "1");
@@ -604,6 +604,47 @@ fn cmd_device_evacuate(cli: EvacuateCli) -> Result<()> {
         }
 
         thread::sleep(Duration::from_secs(1));
+    }
+}
+
+fn evacuate_state_error(device: &str, state: &str, err: errno::Errno) -> anyhow::Error {
+    if err.0 == libc::EINVAL {
+        anyhow!(
+            "setting {device} {state} failed: {err}\n\
+             The kernel rejected this device-state transition because the \
+             filesystem would not remain writable with this member out of rw. \
+             If another device evacuation is already running, wait for that \
+             evacuation to finish before evacuating another required device. \
+             Otherwise, add or restore enough writable redundancy first and \
+             check `bcachefs fs usage` plus member states before retrying."
+        )
+    } else {
+        anyhow!("setting {device} {state} failed: {err}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::evacuate_state_error;
+
+    #[test]
+    fn evacuate_einval_explains_required_writable_member() {
+        let err = evacuate_state_error("/dev/sdc1", "readonly", errno::Errno(libc::EINVAL));
+        let msg = err.to_string();
+
+        assert!(msg.contains("setting /dev/sdc1 readonly failed"));
+        assert!(msg.contains("filesystem would not remain writable"));
+        assert!(msg.contains("another device evacuation is already running"));
+        assert!(msg.contains("bcachefs fs usage"));
+    }
+
+    #[test]
+    fn evacuate_non_einval_keeps_short_error() {
+        let err = evacuate_state_error("/dev/sdc1", "evacuating", errno::Errno(libc::EIO));
+        let msg = err.to_string();
+
+        assert!(msg.contains("setting /dev/sdc1 evacuating failed"));
+        assert!(!msg.contains("another device evacuation"));
     }
 }
 


### PR DESCRIPTION
## Summary

`bcachefs device evacuate` can print a bare `Invalid argument` when the
kernel rejects a device leaving `rw` (koverstreet/bcachefs#568) — typically
because another required device is already mid-evacuation and the
filesystem can't remain writable without this one too.

The previous version of this PR tried to fix that in userspace, wrapping
the `EINVAL` with a hand-written guidance string chosen by pattern-matching
the errno. Kent pointed out the real fix: the `_v2` ioctls already plumb a
kernel-generated error string back to the CLI, so userspace shouldn't be
guessing.

Tracing it, the CLI side turned out to already be fine: `disk_set_state`
calls the `_v2` ioctl and already prints whatever the kernel puts in the
error buffer. The actual gap was on the kernel side: `bch2_dev_state_allowed()`
correctly rejects the transition and its constraint check
(`bch2_can_write_fs_with_devs()`) does put *something* in the error
buffer — but only the bare constraint (e.g. `"No rw user data devices
online"`), with no mention of which device/transition triggered it or that
another device is why redundancy is short.

This PR fills that in at the rejection site instead: which device and
state transition was rejected, which other member devices are currently
non-writable (and whether any of them is evacuating), and what to do about
it — wait for the running evacuation, or restore/add enough writable
redundancy. Same error code as before (`device_state_not_allowed`), just a
useful message behind it.

Fixes koverstreet/bcachefs#568.

## Validation

- `BINDGEN=$HOME/.cargo/bin/bindgen make -j8 bcachefs`
- Verified live in a VM with the patched module: 2-device fs, one member
  evacuating (non-rw), then `bcachefs device set-state evacuating` on the
  other member (which would drop the fs to zero rw devices) was rejected
  with the new message instead of a bare errno:

  ```
  vdc: can't leave rw for evacuating
  Other non-writable devices: vdb (evacuating)
  Wait for the running evacuation to finish before retrying, or add/restore enough writable redundancy
  error=device_state_not_allowed
  ```
