### PR TITLE
journal: use atomic64 for flushing_seq

### DIFF
--- a/fs/alloc/discard.c
+++ b/fs/alloc/discard.c
@@ -67,7 +67,8 @@ __cold void bch2_discards_to_text(struct printbuf *out, struct bch_fs *c, struct
 
 	struct journal *j = &c->journal;
 	prt_printf(out, "journal seq:\t%llu\n",			journal_cur_seq(j));
-	prt_printf(out, "journal flushed seq:\t%llu -> %llu\n",	j->flushing_seq, j->flushed_seq_ondisk);
+	prt_printf(out, "journal flushed seq:\t%llu -> %llu\n",
+		   atomic64_read(&j->flushing_seq), j->flushed_seq_ondisk);
 	prt_printf(out, "journal rewind seq:\t%llu -> %llu\n",	j->rewind_seq, j->rewind_seq_ondisk);
 
 	prt_printf(out, "In flight:\n");

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -257,7 +257,7 @@ static inline bool may_alloc_bucket_journal_seq(struct bch_fs *c,
 						u64 journal_seq_empty)
 {
 	if (journal_seq_empty > c->journal.flushed_seq_ondisk) {
-		if (journal_seq_empty > c->journal.flushing_seq)
+		if (journal_seq_empty > atomic64_read(&c->journal.flushing_seq))
 			req->counters.need_journal_commit++;
 		req->counters.skipped_need_journal_commit++;
 		return false;

--- a/fs/journal/journal.c
+++ b/fs/journal/journal.c
@@ -1159,11 +1159,11 @@ int bch2_journal_flush_seq_async(struct journal *j, u64 seq, struct closure *cl)
 	/* if seq was written, but not flushed - flush a newer one instead */
 	seq = max(seq, READ_ONCE(j->in_flight.front));
 
-	u64 old = READ_ONCE(j->flushing_seq);
+	s64 old = atomic64_read(&j->flushing_seq);
 	do {
-		if (old >= seq)
+		if ((u64) old >= seq)
 			break;
-	} while (!try_cmpxchg(&j->flushing_seq, &old, seq));
+	} while (!atomic64_try_cmpxchg(&j->flushing_seq, &old, seq));
 
 	struct closure_waitlist *wait = __bch2_journal_flush_seq_async(j, seq, cl);
 

--- a/fs/journal/types.h
+++ b/fs/journal/types.h
@@ -332,7 +332,7 @@ struct journal {
 	/* seq, last_seq from the most recent journal entry successfully written */
 	u64			seq_ondisk;
 	u64			flushed_seq_ondisk;
-	u64			flushing_seq;
+	atomic64_t		flushing_seq;
 	u64			last_seq_ondisk;
 	u64			err_seq;
 	u64			last_empty_seq;


### PR DESCRIPTION
## Summary

- store `journal.flushing_seq` as `atomic64_t`
- update the max-with-CAS loop to use `atomic64_try_cmpxchg()`
- read the value through `atomic64_read()` in the two status/allocation paths

## Issue

koverstreet/bcachefs-tools#615 reports an i586 build failure from plain `try_cmpxchg()` on the `u64` `journal.flushing_seq` field. Moving this field to the existing `atomic64_t` API avoids relying on plain 64-bit `try_cmpxchg()` support while preserving the monotonic max update.

Fixes koverstreet/bcachefs-tools#615

## Validation

- `git diff --check`
- `BINDGEN=/home/kom/.cargo/bin/bindgen cargo check -q -p bcachefs-tools`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 libbcachefs.a`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
- `make -C /lib/modules/$(uname -r)/build M=$PWD/fs -j32 modules`
- `printf 'int main(void){return 0;}\n' | gcc -m32 -x c - -c -o /tmp/bcachefs_i386_compile_probe.o`

I could not reproduce the exact openSUSE i586 package build locally; this host can compile i386 objects but does not have the 32-bit runtime/linker pieces installed for a full i586 userspace link.
