### PR TITLE
bcachefs: fix bindgen layout for data event

### DIFF
--- a/fs/bcachefs_ioctl.h
+++ b/fs/bcachefs_ioctl.h
@@ -267,7 +267,7 @@ struct bch_ioctl_data_event {
 	struct bch_ioctl_data_progress p;
 	__u64			pad2[15];
 	};
-} __packed __aligned(8);
+} __aligned(8);
 
 struct bch_replicas_usage {
 	__u64			sectors;


### PR DESCRIPTION
Closes koverstreet/bcachefs-tools#377.

`struct bch_ioctl_data_event` contains `struct bch_ioctl_data_progress`. The inner progress struct is explicitly packed and 8-byte aligned; making the outer event struct packed as well gives bindgen a Rust type that contains an aligned field inside a packed wrapper, which is the reported i686 `E0588` failure mode.

The event layout does not need the outer `__packed`: the fixed `pad[6]` already places the union at offset 8, the union keeps the total payload at 120 bytes, and the outer `__aligned(8)` keeps the event alignment/size contract.

Validation:
- `git diff --check`
- `BINDGEN=/home/kom/.cargo/bin/bindgen cargo check -p bch_bindgen`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
- C layout probe before/after: `struct bch_ioctl_data_progress` stays size 56 / align 8, `struct bch_ioctl_data_event` stays size 128 / align 8, and progress remains at offset 8.
- Direct bindgen/rustc probe with `bch_ioctl_data_event` allowlisted compiles on the local host.

I could not run a full i686 Rust target build on this host because only `x86_64-unknown-linux-gnu` is installed in the local Rust sysroot, but the change removes the packed outer wrapper that creates the nested aligned-field shape reported in koverstreet/bcachefs-tools#377.
