### PR TITLE
bcachefs: bound superblock label length

### DIFF
--- a/fs/sb/io.c
+++ b/fs/sb/io.c
@@ -1659,10 +1659,11 @@ __cold void bch2_sb_to_text(struct printbuf *out,
 	prt_printf(out, "Device index:\t%u\n", sb->dev_idx);
 
 	prt_printf(out, "Label:\t");
-	if (!strlen(sb->label))
+	size_t label_len = strnlen(sb->label, sizeof(sb->label));
+	if (!label_len)
 		prt_printf(out, "(none)");
 	else
-		prt_printf(out, "%.*s", (int) sizeof(sb->label), sb->label);
+		prt_printf(out, "%.*s", (int) label_len, sb->label);
 	prt_newline(out);
 
 	prt_printf(out, "Version:\t");


### PR DESCRIPTION
Closes koverstreet/bcachefs-tools#341.

`struct bch_sb::label` is a fixed-size 32-byte field and is not guaranteed to be NUL-terminated when the label fills the field. The superblock text path used `strlen(sb->label)` to decide whether to print `(none)`, so a full-length label could make it read past the label field before the later bounded `%.*s` print.

Use `strnlen(sb->label, sizeof(sb->label))` once, then print exactly that bounded length. This matches the existing bounded label handling in the ioctl label path.

Validation:
- `git diff --check`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
