### PR TITLE
bcachefs: avoid unused owner state in six trylock

### DIFF
--- a/fs/util/six.c
+++ b/fs/util/six.c
@@ -204,7 +204,7 @@ static int __do_six_trylock(struct six_lock *lock, enum six_lock_type type,
 		}
 	}
 
-	if (ret > 0)
+	if (ret > 0 && type == SIX_LOCK_intent)
 		six_set_owner(lock, type, old, task);
 
 	EBUG_ON(type == SIX_LOCK_write && try && ret <= 0 &&


### PR DESCRIPTION
Closes koverstreet/bcachefs-tools#208.

`old` in `__do_six_trylock()` is only needed when acquiring `SIX_LOCK_intent`, because `six_set_owner()` immediately returns for read/write locks. The write/percpu-reader path can succeed without ever assigning `old`, but the old code still passed it to `six_set_owner()`.

Only call `six_set_owner()` for intent locks. That avoids evaluating an uninitialized value and keeps the owner-state update on the only lock type that uses it.

Validation:
- `git diff --check`
- `make -j32 build/fs/util/six.o`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
