### PR TITLE
debian: accept Ubuntu HWE header meta package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -64,6 +64,7 @@ Depends: ${misc:Depends},
 	 openssl,
 	 initramfs-tools | linux-initramfs-tool,
 	 linux-headers-generic (>= 6.16) |
+	 linux-headers-generic-hwe-24.04 (>= 6.16) |
 	 proxmox-headers-6.17 [amd64] |
 	 linux-headers-amd64 (>= 6.16) [amd64] | linux-headers-cloud-amd64 (>= 6.16) [amd64] | linux-headers-rt-amd64 (>= 6.16) [amd64] |
 	 linux-headers-arm64 (>= 6.16) [arm64] | linux-headers-cloud-arm64 (>= 6.16) [arm64] | linux-headers-rt-arm64 (>= 6.16) [arm64] |


### PR DESCRIPTION
## Summary

Allow `bcachefs-kernel-dkms` to satisfy its header dependency through Ubuntu 24.04's HWE generic header meta package.

Ubuntu HWE installs track headers through `linux-headers-generic-hwe-24.04`, while the existing dependency chain only named `linux-headers-generic`, Proxmox headers, Debian arch-specific header packages, and the virtual `linux-headers` fallback. Add the HWE meta package as another alternative next to `linux-headers-generic`.

Fixes koverstreet/bcachefs#1090

## Validation

- `git diff --check`
- `dpkg-parsechangelog -ldebian/changelog`
- `dpkg-gencontrol -pbcachefs-kernel-dkms -Ptmp/pkg-1090 -O -Tdebian/substvars`
