### PR TITLE
device: refresh udev after device add

### DIFF
--- a/src/commands/device.rs
+++ b/src/commands/device.rs
@@ -88,6 +88,7 @@ fn cmd_device_add_online(
     let c_dev_path = path_to_cstr(dev_path);
     handle.disk_add(&c_dev_path)
         .map_err(|e| anyhow!("adding device '{}': {}", dev_path, e))?;
+    crate::commands::format_util::trigger_udev_for_paths(&[dev_path]);
 
     Ok(())
 }
@@ -118,6 +119,7 @@ fn cmd_device_add_offline(
 
     fs.dev_add(dev_path)
         .map_err(|e| anyhow!("adding device '{}': {}", dev_path, e))?;
+    crate::commands::format_util::trigger_udev_for_paths(&[dev_path]);
 
     fs.start()
         .map_err(|e| anyhow!("starting filesystem: {}", e))?;

--- a/src/commands/format_util.rs
+++ b/src/commands/format_util.rs
@@ -372,15 +372,22 @@ pub fn format(
         crate::wrappers::super_io::bch2_super_write(fd, sb.sb);
     }
 
-    // udevadm trigger --settle <devices>
-    let mut udevadm = std::process::Command::new("udevadm");
-    udevadm.args(["trigger", "--settle"]);
-    for dev in dev_slice.iter() {
-        udevadm.arg(dev.path.to_str().unwrap_or(""));
-    }
-    let _ = udevadm.status();
+    let paths: Vec<&str> = dev_slice
+        .iter()
+        .map(|dev| dev.path.to_str().unwrap_or(""))
+        .collect();
+    trigger_udev_for_paths(&paths);
 
     sb.sb
+}
+
+pub fn trigger_udev_for_paths(paths: &[&str]) {
+    let mut udevadm = std::process::Command::new("udevadm");
+    udevadm.args(["trigger", "--settle"]);
+    for path in paths {
+        udevadm.arg(path);
+    }
+    let _ = udevadm.status();
 }
 
 /// Format a single device for addition to an existing filesystem.


### PR DESCRIPTION
Summary:
- refresh the udev database for the newly added device after online `bcachefs device add` succeeds
- do the same after the offline `fs.dev_add()` path rewrites the added device into the existing filesystem
- share the existing best-effort `udevadm trigger --settle` behavior with normal format so missing/failing udev does not make device add fail

Why:
`device add` first formats the new device as a standalone bcachefs member, then the add path rewrites the member into the existing filesystem. In koverstreet/bcachefs-tools#267, the on-disk UUID becomes correct after add, but udev can keep the temporary pre-add `ID_FS_UUID`, so a later mount by one member or filesystem UUID discovers too few devices and hits `insufficient_devices_to_start`.

Refreshing udev after the final add step makes the udev cache observe the final filesystem UUID, matching what plain `format` already does after writing superblocks.

Validation:
- `git diff --check`
- `make generate_version`
- `cargo check -q -p bcachefs-tools`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`

Closes koverstreet/bcachefs-tools#267.
