### PR TITLE
docs: warn about degraded split-brain mounts

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -387,6 +387,17 @@ Mount options provided as a comma-separated list. See user guide for complete li
 .Bl -tag -width Ds -compact
 .It Cm degraded
 Allow mounting with data degraded
+.Pp
+Use degraded read-write mounts for recovery and maintenance when some
+members are temporarily unavailable. Do not mount different subsets of the
+same filesystem read-write, or mount one subset read-write and later mount a
+different subset read-write before the full filesystem has been assembled and
+reconciled. That creates split-brain history: each subset can accept writes
+that the other subset never saw, and when the members are later brought back
+together there may be no single correct value for conflicting files.
+.Pp
+When in doubt, mount degraded filesystems read-only until the missing members
+are available, or assemble the complete filesystem before allowing writes.
 .It Cm verbose
 Extra debugging info during mount/recovery
 .It Cm fsck

--- a/doc/bcachefs.5.rst.tmpl
+++ b/doc/bcachefs.5.rst.tmpl
@@ -128,4 +128,16 @@ of the filesystem.
 Data protection
 ---------------
 
-foo
+Bcachefs can mount with missing devices when the ``degraded`` mount option is
+specified and the available replicas are sufficient. This is intended for
+recovery and maintenance when some members are temporarily unavailable.
+
+Do not mount different subsets of the same filesystem read-write at the same
+time, or mount one subset read-write and later mount a different subset
+read-write before the full filesystem has been assembled and reconciled. That
+creates split-brain history: each subset can accept writes that the other
+subset never saw, and when the members are later brought back together there may
+be no single correct value for the conflicting files.
+
+When in doubt, mount degraded filesystems read-only until the missing members
+are available, or assemble the complete filesystem before allowing writes.


### PR DESCRIPTION
## Summary

- document the split-brain risk when mounting different degraded member subsets read-write
- advise read-only degraded mounts until missing members are available, or assembling the full filesystem before allowing writes
- replace the placeholder `Data protection` text in the user manual template

## Validation

- `git diff --check`
- `python3 - <<'PY' ... publish_doctree(...) ... PY`

`mandoc` is not installed in this environment, so I could not run `mandoc -Tlint bcachefs.8`.

Fixes koverstreet/bcachefs#579.
