### PR TITLE
docs: mention mount helper alias

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -374,6 +374,13 @@ for performance testing purposes
 .Sh Mount commands
 .Bl -tag -width Ds
 .It Nm Ic mount Oo Ar options Oc Ar device mountpoint
+The
+.Ic mount Fl t Cm bcachefs
+path invokes the installed
+.Nm mount.bcachefs
+helper; this is the same mount path exposed as
+.Nm Ic mount .
+.Pp
 Mount a filesystem. The
 .Ar device
 can be a device, a colon-separated list of devices, or UUID=<UUID>. The

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -181,7 +181,9 @@ fn cmd_mount_inner(cli: &Cli) -> Result<()> {
 /// Mount a bcachefs filesystem by its UUID.
 #[derive(Parser, Debug)]
 #[command(author, version, about,
-    long_about = "Mounts a bcachefs filesystem. Devices are discovered automatically \
+    long_about = "`mount -t bcachefs` invokes the installed mount.bcachefs helper; \
+this is the same mount path exposed as `bcachefs mount`.\n\n\
+Mounts a bcachefs filesystem. Devices are discovered automatically \
 by scanning for the filesystem UUID---unlike btrfs, this is handled \
 entirely in userspace.\n\n\
 If the filesystem is encrypted, the passphrase will be looked up in \


### PR DESCRIPTION
## Summary

Clarify the mount command docs/help so the section starts by saying
`mount -t bcachefs` invokes the installed `mount.bcachefs` helper and uses the
same path exposed as `bcachefs mount`.

Fixes koverstreet/bcachefs#1124.

## Tests

- `git diff --check`
- `make generate_version`
- `BINDGEN=/home/kom/.cargo/bin/bindgen cargo check -q -p bcachefs-tools`

`mandoc` is not installed locally, so I could not run `mandoc -Tlint bcachefs.8`.
