### PR TITLE
opts: accept 2M encoded_extent_max

### DIFF
--- a/fs/opts.c
+++ b/fs/opts.c
@@ -385,20 +385,20 @@ int bch2_opt_validate(const struct bch_option *opt, u64 v, struct printbuf *err)
 	if (opt->max && v >= opt->max) {
 		if (err)
 			prt_printf(err, "%s: too big (max %llu)",
-			       opt->attr.name, opt->max);
+			       opt->attr.name, opt->max - 1);
 		return -BCH_ERR_ERANGE_option_too_big;
-	}
-
-	if ((opt->flags & OPT_SB_FIELD_SECTORS) && (v & 511)) {
-		if (err)
-			prt_printf(err, "%s: not a multiple of 512",
-			       opt->attr.name);
-		return -BCH_ERR_opt_parse_error;
 	}
 
 	if ((opt->flags & OPT_MUST_BE_POW_2) && !is_power_of_2(v)) {
 		if (err)
 			prt_printf(err, "%s: must be a power of two",
+			       opt->attr.name);
+		return -BCH_ERR_opt_parse_error;
+	}
+
+	if ((opt->flags & OPT_SB_FIELD_SECTORS) && (v & 511)) {
+		if (err)
+			prt_printf(err, "%s: not a multiple of 512",
 			       opt->attr.name);
 		return -BCH_ERR_opt_parse_error;
 	}

--- a/fs/opts.h
+++ b/fs/opts.h
@@ -168,7 +168,7 @@ enum fsck_err_opts {
 	x(encoded_extent_max,		u32,				\
 	  OPT_FS|OPT_FORMAT|						\
 	  OPT_HUMAN_READABLE|OPT_MUST_BE_POW_2|OPT_SB_FIELD_SECTORS|OPT_SB_FIELD_ILOG2,\
-	  OPT_UINT(4096, 2U << 20),					\
+	  OPT_UINT(4096, (2U << 20) + 1),				\
 	  BCH_SB_ENCODED_EXTENT_MAX_BITS, 256 << 10,			\
 	  "size",	"Maximum size of checksummed/compressed extents")\
 	x(metadata_checksum,		u8,				\


### PR DESCRIPTION
## Summary

Fix `encoded_extent_max` option parsing so the documented 2 MiB value is
accepted:

- make the exclusive upper bound one byte past 2 MiB
- report the largest accepted value in "too big" diagnostics
- check the power-of-two constraint before the 512-byte sector multiple
  constraint, so `2097151` reports the clearer error

Fixes koverstreet/bcachefs-tools#135.

## Tests

- `git diff --check`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
- `./target/release/bcachefs format --encoded_extent_max=2M --no_initialize --force tmp/encmax-2m.img`
- `./target/release/bcachefs format --encoded_extent_max=2097151 --no_initialize --force tmp/encmax-not-pow2.img`
- `./target/release/bcachefs format --encoded_extent_max=2097153 --no_initialize --force tmp/encmax-too-big.img`
