### PR TITLE
device: restore rw state after failed device remove

### DIFF
--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -939,7 +939,8 @@ static int __bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca,
 			     struct printbuf *err)
 {
 	unsigned data;
-	int ret;
+	bool was_rw = ca->mi.state == BCH_MEMBER_STATE_rw;
+	int ret, ret2;
 
 	lockdep_assert_held(&c->state_lock);
 
@@ -1073,6 +1074,16 @@ static int __bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca,
 err:
 	/* The device is staying; allow new references to it again: */
 	WRITE_ONCE(ca->removing, false);
+
+	if (test_bit(BCH_FS_rw, &c->flags) &&
+	    was_rw &&
+	    ca->mi.state == BCH_MEMBER_STATE_evacuating &&
+	    !enumerated_ref_is_zero(&ca->io_ref[READ])) {
+		prt_str(err, "Remove failed, restoring device state to rw\n");
+		ret2 = __bch2_dev_set_state(c, ca, BCH_MEMBER_STATE_rw, flags, err);
+		if (ret2)
+			prt_printf(err, "Error restoring device state: %s\n", bch2_err_str(ret2));
+	}
 
 	if (test_bit(BCH_FS_rw, &c->flags) &&
 	    ca->mi.state == BCH_MEMBER_STATE_rw &&


### PR DESCRIPTION
## Summary

`bch2_dev_drop()` can temporarily switch a device into a read/write state while device remove is trying to migrate or drop data.

If the remove fails after that point, the function should restore the member's previous state before returning. Otherwise a failed remove can leave a member writable even though the caller did not complete the remove operation.

This keeps the change deliberately small: save the old state, restore it on the failed path, and leave the successful path unchanged.

## Validation

- `git diff --check origin/testing..HEAD`
- `BINDGEN=/home/kom/.cargo/bin/bindgen make -j32 bcachefs`
