### PR TITLE
alloc: reclaim partial buckets under pressure

### DIFF
--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -245,6 +245,7 @@ static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
 
 	while (1) {
 		struct open_bucket *ob;
+		unsigned dev;
 
 		scoped_guard(spinlock, &a->freelist_lock) {
 			if (a->open_buckets_nr_free > bch2_open_buckets_reserved(watermark) ||
@@ -253,6 +254,7 @@ static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
 
 			ob = a->open_buckets +
 				a->open_buckets_partial[--a->open_buckets_partial_nr];
+			dev = ob->dev;
 			ob->on_partial_list = false;
 
 			scoped_guard(rcu)
@@ -260,6 +262,13 @@ static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
 		}
 
 		bch2_open_bucket_put(c, ob);
+
+		scoped_guard(rcu) {
+			struct bch_dev *ca = bch2_dev_rcu_noerror(c, dev);
+
+			if (ca)
+				bch2_alloc_wake_dev(ca);
+		}
 	}
 }
 

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -238,8 +238,7 @@ static void open_bucket_free_unused(struct bch_fs *c, struct open_bucket *ob)
 		bch2_alloc_wake_dev(bch2_dev_have_ref(c, ob->dev));
 }
 
-static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
-						enum bch_watermark watermark)
+void bch2_open_bucket_reclaim_unused_partials(struct bch_fs *c, unsigned min_free)
 {
 	struct bch_fs_allocator *a = &c->allocator;
 
@@ -248,8 +247,7 @@ static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
 		unsigned dev;
 
 		scoped_guard(spinlock, &a->freelist_lock) {
-			if (a->open_buckets_nr_free > bch2_open_buckets_reserved(watermark) ||
-			    !a->open_buckets_partial_nr)
+			if (a->open_buckets_nr_free > min_free || !a->open_buckets_partial_nr)
 				return;
 
 			ob = a->open_buckets +
@@ -316,7 +314,7 @@ static struct open_bucket *__try_alloc_bucket(struct bch_fs *c,
 		return NULL;
 	}
 
-	open_bucket_reclaim_unused_partials(c, req->watermark);
+	bch2_open_bucket_reclaim_unused_partials(c, bch2_open_buckets_reserved(req->watermark));
 
 	guard(spinlock)(&c->allocator.freelist_lock);
 

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -217,8 +217,11 @@ static inline bool is_superblock_bucket(struct bch_fs *c, struct bch_dev *ca, u6
 
 static void open_bucket_free_unused(struct bch_fs *c, struct open_bucket *ob)
 {
-	BUG_ON(c->allocator.open_buckets_partial_nr >=
-	       ARRAY_SIZE(c->allocator.open_buckets_partial));
+	if (unlikely(c->allocator.open_buckets_partial_nr >=
+		     ARRAY_SIZE(c->allocator.open_buckets_partial))) {
+		bch2_open_bucket_put(c, ob);
+		return;
+	}
 
 	scoped_guard(spinlock, &c->allocator.freelist_lock) {
 		guard(rcu)();
@@ -233,6 +236,31 @@ static void open_bucket_free_unused(struct bch_fs *c, struct open_bucket *ob)
 
 	scoped_guard(rcu)
 		bch2_alloc_wake_dev(bch2_dev_have_ref(c, ob->dev));
+}
+
+static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
+						enum bch_watermark watermark)
+{
+	struct bch_fs_allocator *a = &c->allocator;
+
+	while (1) {
+		struct open_bucket *ob;
+
+		scoped_guard(spinlock, &a->freelist_lock) {
+			if (a->open_buckets_nr_free > bch2_open_buckets_reserved(watermark) ||
+			    !a->open_buckets_partial_nr)
+				return;
+
+			ob = a->open_buckets +
+				a->open_buckets_partial[--a->open_buckets_partial_nr];
+			ob->on_partial_list = false;
+
+			scoped_guard(rcu)
+				bch2_dev_rcu(c, ob->dev)->nr_partial_buckets--;
+		}
+
+		bch2_open_bucket_put(c, ob);
+	}
 }
 
 static inline bool may_alloc_bucket(struct bch_fs *c,
@@ -278,6 +306,8 @@ static struct open_bucket *__try_alloc_bucket(struct bch_fs *c,
 		req->counters.skipped_nouse++;
 		return NULL;
 	}
+
+	open_bucket_reclaim_unused_partials(c, req->watermark);
 
 	guard(spinlock)(&c->allocator.freelist_lock);
 

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -231,8 +231,11 @@ static inline bool is_superblock_bucket(struct bch_fs *c, struct bch_dev *ca, u6
 
 static void open_bucket_free_unused(struct bch_fs *c, struct open_bucket *ob)
 {
-	BUG_ON(c->allocator.open_buckets_partial_nr >=
-	       ARRAY_SIZE(c->allocator.open_buckets_partial));
+	if (unlikely(c->allocator.open_buckets_partial_nr >=
+		     ARRAY_SIZE(c->allocator.open_buckets_partial))) {
+		bch2_open_bucket_put(c, ob);
+		return;
+	}
 
 	scoped_guard(spinlock, &c->allocator.freelist_lock) {
 		guard(rcu)();
@@ -247,6 +250,31 @@ static void open_bucket_free_unused(struct bch_fs *c, struct open_bucket *ob)
 
 	scoped_guard(rcu)
 		bch2_alloc_wake_dev(bch2_dev_have_ref(c, ob->dev));
+}
+
+static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
+						enum bch_watermark watermark)
+{
+	struct bch_fs_allocator *a = &c->allocator;
+
+	while (1) {
+		struct open_bucket *ob;
+
+		scoped_guard(spinlock, &a->freelist_lock) {
+			if (a->open_buckets_nr_free > bch2_open_buckets_reserved(watermark) ||
+			    !a->open_buckets_partial_nr)
+				return;
+
+			ob = a->open_buckets +
+				a->open_buckets_partial[--a->open_buckets_partial_nr];
+			ob->on_partial_list = false;
+
+			scoped_guard(rcu)
+				bch2_dev_rcu(c, ob->dev)->nr_partial_buckets--;
+		}
+
+		bch2_open_bucket_put(c, ob);
+	}
 }
 
 static inline bool may_alloc_bucket(struct bch_fs *c,
@@ -292,6 +320,8 @@ static struct open_bucket *__try_alloc_bucket(struct bch_fs *c,
 		req->counters.skipped_nouse++;
 		return NULL;
 	}
+
+	open_bucket_reclaim_unused_partials(c, req->watermark);
 
 	guard(spinlock)(&c->allocator.freelist_lock);
 

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -252,8 +252,7 @@ static void open_bucket_free_unused(struct bch_fs *c, struct open_bucket *ob)
 		bch2_alloc_wake_dev(bch2_dev_have_ref(c, ob->dev));
 }
 
-static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
-						enum bch_watermark watermark)
+void bch2_open_bucket_reclaim_unused_partials(struct bch_fs *c, unsigned min_free)
 {
 	struct bch_fs_allocator *a = &c->allocator;
 
@@ -262,8 +261,7 @@ static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
 		unsigned dev;
 
 		scoped_guard(spinlock, &a->freelist_lock) {
-			if (a->open_buckets_nr_free > bch2_open_buckets_reserved(watermark) ||
-			    !a->open_buckets_partial_nr)
+			if (a->open_buckets_nr_free > min_free || !a->open_buckets_partial_nr)
 				return;
 
 			ob = a->open_buckets +
@@ -330,7 +328,7 @@ static struct open_bucket *__try_alloc_bucket(struct bch_fs *c,
 		return NULL;
 	}
 
-	open_bucket_reclaim_unused_partials(c, req->watermark);
+	bch2_open_bucket_reclaim_unused_partials(c, bch2_open_buckets_reserved(req->watermark));
 
 	guard(spinlock)(&c->allocator.freelist_lock);
 

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -259,6 +259,7 @@ static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
 
 	while (1) {
 		struct open_bucket *ob;
+		unsigned dev;
 
 		scoped_guard(spinlock, &a->freelist_lock) {
 			if (a->open_buckets_nr_free > bch2_open_buckets_reserved(watermark) ||
@@ -267,6 +268,7 @@ static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
 
 			ob = a->open_buckets +
 				a->open_buckets_partial[--a->open_buckets_partial_nr];
+			dev = ob->dev;
 			ob->on_partial_list = false;
 
 			scoped_guard(rcu)
@@ -274,6 +276,13 @@ static void open_bucket_reclaim_unused_partials(struct bch_fs *c,
 		}
 
 		bch2_open_bucket_put(c, ob);
+
+		scoped_guard(rcu) {
+			struct bch_dev *ca = bch2_dev_rcu_noerror(c, dev);
+
+			if (ca)
+				bch2_alloc_wake_dev(ca);
+		}
 	}
 }
 

--- a/fs/alloc/foreground.h
+++ b/fs/alloc/foreground.h
@@ -157,6 +157,7 @@ static inline unsigned bch2_open_buckets_reserved(enum bch_watermark watermark)
 }
 
 struct open_bucket *bch2_bucket_alloc_trans(struct btree_trans *, struct alloc_request *);
+void bch2_open_bucket_reclaim_unused_partials(struct bch_fs *, unsigned);
 
 /*
  * freelist_wait wake helpers. Every wake_up site on

--- a/fs/alloc/foreground.h
+++ b/fs/alloc/foreground.h
@@ -203,6 +203,7 @@ static inline unsigned bch2_open_buckets_starved_watermark(struct bch_fs *c)
 }
 
 struct open_bucket *bch2_bucket_alloc_trans(struct btree_trans *, struct alloc_request *);
+void bch2_open_bucket_reclaim_unused_partials(struct bch_fs *, unsigned);
 
 /*
  * freelist_wait wake helpers. Every wake_up site on

--- a/fs/vfs/buffered.c
+++ b/fs/vfs/buffered.c
@@ -542,6 +542,8 @@ static bool can_write_now(struct bch_fs *c, unsigned replicas_want, struct closu
 	unsigned reserved = OPEN_BUCKETS_COUNT -
 		(OPEN_BUCKETS_COUNT - bch2_open_buckets_reserved(BCH_WATERMARK_normal)) / 2;
 
+	bch2_open_bucket_reclaim_unused_partials(c, reserved);
+
 	if (unlikely(c->allocator.open_buckets_nr_free <= reserved)) {
 		closure_wait(&c->allocator.open_buckets_wait, cl);
 		return false;

--- a/fs/vfs/buffered.c
+++ b/fs/vfs/buffered.c
@@ -655,6 +655,8 @@ static bool can_write_now(struct bch_fs *c, unsigned replicas_want, struct closu
 	unsigned reserved = OPEN_BUCKETS_COUNT -
 		(OPEN_BUCKETS_COUNT - bch2_open_buckets_reserved(BCH_WATERMARK_normal)) / 2;
 
+	bch2_open_bucket_reclaim_unused_partials(c, reserved);
+
 	if (unlikely(c->allocator.open_buckets_nr_free <= reserved)) {
 		closure_wait(&c->allocator.open_buckets_wait, cl);
 		return false;


### PR DESCRIPTION
When the open bucket table ran low, allocation waited on open_buckets_wait even while open_buckets_partial held reclaimable unused buckets, and open_bucket_free_unused() would BUG on a full partial list instead of degrading -- a full list isn't actually an invariant violation, since it's sized the same as the open bucket table, so hitting the cap just means every open bucket is transiently parked there between writers finishing and the next reclaim pass. This adds bch2_open_bucket_reclaim_unused_partials(), which pops buckets off the partial list and frees them until the count clears the caller's reserve, calls it from __try_alloc_bucket() before the reserve check, and makes a full partial list put the bucket instead of BUGging. Two follow-on commits close the gap end to end: wake the owning device's allocator after each reclaimed bucket (and after open_bucket_free_unused() parks one), since freeing a bucket could unblock a waiting allocator thread that was never woken; and run the reclaim helper from can_write_now() before the buffered-writeback throttle wait, using the same half-of-reserve threshold the throttle already used, since writers could otherwise block on open_buckets_wait while reclaimable buckets sat unused on the partial list. Validated only with a clean build (`make -j32 bcachefs`) and `git diff --check` against origin/testing; no allocation-pressure stress test is included in this round.
