### PR TITLE
move: batch internal move journal waits

### DIFF
--- a/fs/data/copygc.c
+++ b/fs/data/copygc.c
@@ -767,6 +767,7 @@ static int bch2_copygc_thread(void *arg)
 	}
 
 	move_buckets_wait(&ctxt, &buckets, true);
+	ret = ret ?: bch2_moving_ctxt_flush_all(&ctxt);
 	bch2_moving_ctxt_exit(&ctxt);
 	bch2_move_stats_exit(&move_stats, c);
 out:

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -192,11 +192,11 @@ void bch2_moving_ctxt_account_noflush_commit(struct moving_context *ctxt, u32 se
 
 static bool bch2_moving_ctxt_needs_flush(struct moving_context *ctxt)
 {
-	struct bch_fs *c = ctxt->trans->c;
-
 	guard(mutex)(&ctxt->lock);
-	return ctxt->noflush_sectors >= c->opts.move_bytes_in_flight >> 9;
+	return ctxt->noflush_sectors >= ctxt->noflush_sectors_limit;
 }
+
+#define MOVE_NOFLUSH_MIN_BYTES			(16U << 20)
 
 void bch2_moving_ctxt_exit(struct moving_context *ctxt)
 {
@@ -240,6 +240,8 @@ void bch2_moving_ctxt_init(struct moving_context *ctxt,
 	ctxt->stats	= stats;
 	ctxt->wp	= wp;
 	ctxt->wait_on_copygc = wait_on_copygc;
+	ctxt->noflush_sectors_limit =
+		max_t(u32, c->opts.move_bytes_in_flight, MOVE_NOFLUSH_MIN_BYTES) >> 9;
 
 	closure_init_stack(&ctxt->cl);
 
@@ -1327,7 +1329,7 @@ static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs 
 		   c->opts.move_bytes_in_flight >> 9);
 	prt_printf(out, "noflush sectors:\t%llu/%llu seq %llu\n",
 		   noflush_sectors,
-		   (u64) c->opts.move_bytes_in_flight >> 9,
+		   ctxt->noflush_sectors_limit,
 		   noflush_seq);
 
 	guard(printbuf_indent)(out);

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -29,6 +29,7 @@
 
 #include "init/error.h"
 
+#include "journal/journal.h"
 #include "journal/reclaim.h"
 
 #include "sb/counters.h"
@@ -151,18 +152,59 @@ void bch2_move_ctxt_wait_for_io(struct moving_context *ctxt)
 		atomic_read(&ctxt->write_sectors) != sectors_pending);
 }
 
-void bch2_moving_ctxt_flush_all(struct moving_context *ctxt)
+int bch2_moving_ctxt_flush_all(struct moving_context *ctxt)
 {
+	struct bch_fs *c = ctxt->trans->c;
+	u64 seq;
+
 	move_ctxt_wait_event(ctxt, list_empty(&ctxt->reads));
 	bch2_trans_unlock_long(ctxt->trans);
 	closure_sync(&ctxt->cl);
+
+	scoped_guard(mutex, &ctxt->lock)
+		seq = ctxt->noflush_seq;
+
+	if (seq) {
+		int ret = bch2_journal_flush_seq(&c->journal, seq, TASK_UNINTERRUPTIBLE);
+		if (ret)
+			return ret;
+
+		scoped_guard(mutex, &ctxt->lock) {
+			if (ctxt->noflush_seq <= seq) {
+				ctxt->noflush_sectors = 0;
+				ctxt->noflush_seq = 0;
+			}
+		}
+	}
+
+	return 0;
+}
+
+void bch2_moving_ctxt_account_noflush_commit(struct moving_context *ctxt, u32 sectors, u64 seq)
+{
+	if (!seq)
+		return;
+
+	guard(mutex)(&ctxt->lock);
+	ctxt->noflush_sectors += sectors;
+	ctxt->noflush_seq = max(ctxt->noflush_seq, seq);
+}
+
+static bool bch2_moving_ctxt_needs_flush(struct moving_context *ctxt)
+{
+	struct bch_fs *c = ctxt->trans->c;
+
+	guard(mutex)(&ctxt->lock);
+	return ctxt->noflush_sectors >= c->opts.move_bytes_in_flight >> 9;
 }
 
 void bch2_moving_ctxt_exit(struct moving_context *ctxt)
 {
 	struct bch_fs *c = ctxt->trans->c;
 
-	bch2_moving_ctxt_flush_all(ctxt);
+	int ret = bch2_moving_ctxt_flush_all(ctxt);
+	if (ret)
+		bch_err_fn(c, ret);
 
 	EBUG_ON(atomic_read(&ctxt->write_sectors));
 	EBUG_ON(atomic_read(&ctxt->write_ios));
@@ -464,13 +506,6 @@ int bch2_move_ratelimit(struct moving_context *ctxt)
 	bool is_kthread = current->flags & PF_KTHREAD;
 	u64 delay;
 
-	if (ctxt->wait_on_copygc && c->copygc.running) {
-		bch2_moving_ctxt_flush_all(ctxt);
-		wait_event_freezable(c->copygc.running_wq,
-				    !c->copygc.running ||
-				    (is_kthread && kthread_should_stop()));
-	}
-
 	do {
 		delay = ctxt->rate ? bch2_ratelimit_delay(ctxt->rate) : 0;
 
@@ -483,10 +518,15 @@ int bch2_move_ratelimit(struct moving_context *ctxt)
 					delay);
 
 		if (unlikely(freezing(current))) {
-			bch2_moving_ctxt_flush_all(ctxt);
+			int ret = bch2_moving_ctxt_flush_all(ctxt);
+			if (ret)
+				return ret;
 			try_to_freeze();
 		}
 	} while (delay);
+
+	if (bch2_moving_ctxt_needs_flush(ctxt))
+		try(bch2_moving_ctxt_flush_all(ctxt));
 
 	/*
 	 * XXX: these limits really ought to be per device, SSDs and hard drives
@@ -794,7 +834,9 @@ int bch2_move_data_phys(struct bch_fs *c,
 		.sector_end	= end,
 	};
 
-	return __bch2_move_data_phys(&ctxt, NULL, &w, data_types, false, pred, arg);
+	int ret = __bch2_move_data_phys(&ctxt, NULL, &w, data_types, false, pred, arg);
+
+	return ret ?: bch2_moving_ctxt_flush_all(&ctxt);
 }
 
 struct evacuate_arg {
@@ -1083,7 +1125,9 @@ int bch2_scrub_journal(struct bch_fs *c, u64 *rewind_seq)
 			}
 		}
 
-		bch2_moving_ctxt_flush_all(&ctxt);
+		ret = bch2_moving_ctxt_flush_all(&ctxt);
+		if (ret)
+			move_ret = ret;
 
 		if (move_ret)
 			bch_err(c, "journal scrub: move error %s in flush range seq %llu-%llu",
@@ -1257,8 +1301,15 @@ __cold void bch2_move_stats_to_text(struct printbuf *out, struct bch_move_stats 
 
 static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs *c, struct moving_context *ctxt)
 {
+	u64 noflush_sectors, noflush_seq;
+
 	if (!out->nr_tabstops)
 		printbuf_tabstop_push(out, 32);
+
+	scoped_guard(mutex, &ctxt->lock) {
+		noflush_sectors = ctxt->noflush_sectors;
+		noflush_seq = ctxt->noflush_seq;
+	}
 
 	bch2_move_stats_to_text(out, ctxt->stats);
 	guard(printbuf_indent)(out);
@@ -1274,6 +1325,10 @@ static __cold void bch2_moving_ctxt_to_text(struct printbuf *out, struct bch_fs 
 		   c->opts.move_ios_in_flight,
 		   atomic_read(&ctxt->write_sectors),
 		   c->opts.move_bytes_in_flight >> 9);
+	prt_printf(out, "noflush sectors:\t%llu/%llu seq %llu\n",
+		   noflush_sectors,
+		   (u64) c->opts.move_bytes_in_flight >> 9,
+		   noflush_seq);
 
 	guard(printbuf_indent)(out);
 

--- a/fs/data/move.h
+++ b/fs/data/move.h
@@ -54,6 +54,7 @@ struct moving_context {
 
 	/* Moved data indexed without FUA; must be ordered by a journal flush. */
 	u64			noflush_sectors;
+	u64			noflush_sectors_limit;
 	u64			noflush_seq;
 
 	wait_queue_head_t	wait;

--- a/fs/data/move.h
+++ b/fs/data/move.h
@@ -52,6 +52,10 @@ struct moving_context {
 	atomic_t		read_ios;
 	atomic_t		write_ios;
 
+	/* Moved data indexed without FUA; must be ordered by a journal flush. */
+	u64			noflush_sectors;
+	u64			noflush_seq;
+
 	wait_queue_head_t	wait;
 };
 
@@ -100,7 +104,8 @@ void bch2_moving_ctxt_init(struct moving_context *, struct bch_fs *,
 			   struct write_point_specifier, bool);
 struct data_update *bch2_moving_ctxt_next_pending_write(struct moving_context *);
 void bch2_moving_ctxt_do_pending_writes(struct moving_context *);
-void bch2_moving_ctxt_flush_all(struct moving_context *);
+int bch2_moving_ctxt_flush_all(struct moving_context *);
+void bch2_moving_ctxt_account_noflush_commit(struct moving_context *, u32, u64);
 void bch2_move_ctxt_wait_for_io(struct moving_context *);
 int bch2_move_ratelimit(struct moving_context *);
 

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1477,7 +1477,9 @@ static CLOSURE_CALLBACK(do_reconcile_phys_thread)
 	struct bbpos work_pos = BBPOS(reconcile_phases[thr->reconcile_phase].btree,
 				      POS(thr->dev, 0));
 
-	while (!bch2_move_ratelimit(&ctxt)) {
+	int ret = 0;
+
+	while (!(ret = bch2_move_ratelimit(&ctxt))) {
 		if (!bch2_reconcile_enabled(c) ||
 		    test_bit(BCH_FS_going_ro, &c->flags))
 			break;
@@ -1490,7 +1492,7 @@ static CLOSURE_CALLBACK(do_reconcile_phys_thread)
 		    k.k->p.inode != thr->dev)
 			break;
 
-		int ret = lockrestart_do(trans,
+		ret = lockrestart_do(trans,
 			do_reconcile_extent_phys(&ctxt, &snapshot_io_opts,
 						 BBPOS(work_pos.btree, k.k->p),
 						 &last_flushed,
@@ -1498,6 +1500,12 @@ static CLOSURE_CALLBACK(do_reconcile_phys_thread)
 		if (ret)
 			break;
 	}
+
+	if (ret > 0)
+		ret = 0;
+	ret = ret ?: bch2_moving_ctxt_flush_all(&ctxt);
+	if (ret)
+		bch_err_fn(c, ret);
 
 	bch2_moving_ctxt_exit(&ctxt);
 	closure_return(cl);
@@ -1739,7 +1747,7 @@ static int do_reconcile(struct moving_context *ctxt)
 	struct bkey_i_cookie pending_cookie;
 	bkey_init(&pending_cookie.k);
 
-	bch2_moving_ctxt_flush_all(ctxt);
+	try(bch2_moving_ctxt_flush_all(ctxt));
 
 	struct wb_maybe_flush last_flushed __cleanup(wb_maybe_flush_exit);
 	wb_maybe_flush_init(&last_flushed);
@@ -1759,10 +1767,12 @@ static int do_reconcile(struct moving_context *ctxt)
 
 	r->running = true;
 
-	while (!bch2_move_ratelimit(ctxt) &&
+	while (!(ret = bch2_move_ratelimit(ctxt)) &&
 	       !test_bit(BCH_FS_going_ro, &c->flags)) {
 		if (!bch2_reconcile_enabled(c)) {
-			bch2_moving_ctxt_flush_all(ctxt);
+			ret = bch2_moving_ctxt_flush_all(ctxt);
+			if (ret)
+				goto out;
 			kthread_wait_freezable(bch2_reconcile_enabled(c) ||
 					       kthread_should_stop());
 			if (kthread_should_stop())
@@ -1799,12 +1809,17 @@ static int do_reconcile(struct moving_context *ctxt)
 			work.nr = 0;
 
 			if (kick != r->kick ||
-			    test_bit(BCH_FS_going_ro, &c->flags) ||
-			    bch2_move_ratelimit(ctxt))
+			    test_bit(BCH_FS_going_ro, &c->flags))
+				break;
+
+			ret = bch2_move_ratelimit(ctxt);
+			if (ret)
 				break;
 
 			/* Drain pending moves before the next phase. */
-			bch2_moving_ctxt_flush_all(ctxt);
+			ret = bch2_moving_ctxt_flush_all(ctxt);
+			if (ret)
+				goto out;
 		}
 
 		/* Completed a clean pass through all phases — we're done. */
@@ -1818,14 +1833,19 @@ out:
 
 	bch2_move_stats_exit(&r->work_stats, c);
 
+	if (ret > 0)
+		ret = 0;
+
 	if (!ret &&
 	    !kthread_should_stop() &&
 	    !atomic64_read(&r->work_stats.sectors_seen) &&
 	    !sectors_scanned &&
 	    kick == r->kick) {
-		bch2_moving_ctxt_flush_all(ctxt);
-		bch2_trans_unlock_long(trans);
-		reconcile_wait(c, kick);
+		ret = bch2_moving_ctxt_flush_all(ctxt);
+		if (!ret) {
+			bch2_trans_unlock_long(trans);
+			reconcile_wait(c, kick);
+		}
 	}
 
 	if (!bch2_err_matches(ret, EROFS))

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -468,10 +468,14 @@ static int data_update_index_update_key(struct btree_trans *trans,
 	try(bch2_trans_update(trans, iter, insert,
 			      BTREE_UPDATE_internal_snapshot_node|
 			      BTREE_TRIGGER_set_needs_reconcile_done));
-	try(bch2_trans_commit(trans, &u->op.res, NULL,
-			      BCH_TRANS_COMMIT_no_check_rw|
-			      BCH_TRANS_COMMIT_no_enospc|
-			      u->opts.commit_flags));
+	bool flush = (u->op.flags & BCH_WRITE_flush) &&
+		bkey_next(insert) == u->op.insert_keys.top;
+
+	try(bch2_trans_commit_flush(trans, &u->op.res, NULL,
+				    flush ? &u->op.cl : NULL,
+				    BCH_TRANS_COMMIT_no_check_rw|
+				    BCH_TRANS_COMMIT_no_enospc|
+				    u->opts.commit_flags));
 
 	bch2_btree_iter_set_pos(iter, next_pos);
 
@@ -1341,6 +1345,7 @@ int bch2_data_update_init(struct btree_trans *trans,
 		BCH_WRITE_pages_owned|
 		BCH_WRITE_data_encoded|
 		BCH_WRITE_move|
+		BCH_WRITE_flush|
 		m->opts.write_flags;
 	m->op.compression_opt	= io_opts->background_compression;
 	m->op.watermark		= max(m->opts.commit_flags & BCH_WATERMARK_MASK,

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -470,12 +470,18 @@ static int data_update_index_update_key(struct btree_trans *trans,
 			      BTREE_TRIGGER_set_needs_reconcile_done));
 	bool flush = (u->op.flags & BCH_WRITE_flush) &&
 		bkey_next(insert) == u->op.insert_keys.top;
+	bool noflush = u->op.flags & BCH_WRITE_move_noflush;
+	u64 journal_seq = 0;
 
-	try(bch2_trans_commit_flush(trans, &u->op.res, NULL,
+	try(bch2_trans_commit_flush(trans, &u->op.res,
+				    noflush ? &journal_seq : NULL,
 				    flush ? &u->op.cl : NULL,
 				    BCH_TRANS_COMMIT_no_check_rw|
 				    BCH_TRANS_COMMIT_no_enospc|
 				    u->opts.commit_flags));
+
+	if (noflush)
+		bch2_moving_ctxt_account_noflush_commit(u->ctxt, new->k.size, journal_seq);
 
 	bch2_btree_iter_set_pos(iter, next_pos);
 
@@ -1345,8 +1351,13 @@ int bch2_data_update_init(struct btree_trans *trans,
 		BCH_WRITE_pages_owned|
 		BCH_WRITE_data_encoded|
 		BCH_WRITE_move|
-		BCH_WRITE_flush|
 		m->opts.write_flags;
+	if (ctxt) {
+		m->op.flags &= ~BCH_WRITE_flush;
+		m->op.flags |= BCH_WRITE_move_noflush;
+	} else {
+		m->op.flags |= BCH_WRITE_flush;
+	}
 	m->op.compression_opt	= io_opts->background_compression;
 	m->op.watermark		= max(m->opts.commit_flags & BCH_WATERMARK_MASK,
 				      BCH_WATERMARK_normal);

--- a/fs/data/write.c
+++ b/fs/data/write.c
@@ -2608,9 +2608,8 @@ err:
 
 		/*
 		 * Internal moves can be issued FUA, making the journal's cache
-		 * flush a no-op for them. Off by default: the per-write FUA
-		 * regresses background-move throughput, and the journal flushes
-		 * every device on commit regardless, so durability is unchanged.
+		 * flush a no-op for them. Otherwise, the data update path
+		 * flushes the journal commit that indexes the moved data.
 		 */
 		if ((op->flags & BCH_WRITE_move) && c->opts.move_writes_fua)
 			bio->bi_opf |= REQ_FUA;

--- a/fs/data/write_types.h
+++ b/fs/data/write_types.h
@@ -26,6 +26,7 @@
 	x(sync)				\
 	x(flush)			\
 	x(move)				\
+	x(move_noflush)			\
 	x(in_worker)			\
 	x(submitted)			\
 	x(convert_unwritten)


### PR DESCRIPTION
Draft split from #704. This is intended to make one part of that integration branch small enough to discuss on its own; it is not meant as a ready-to-merge request yet.

Scope:
- track moved data writes that were indexed without FUA
- record the journal sequence for those noflush move commits
- wait for the relevant journal sequence before too much noflush moved data accumulates
- batch the wait threshold so small moves do not force a journal wait on every move window

Review correction:
- the btree write buffer is not part of this ordering problem; the standalone
  write-buffer flush was removed after maintainer feedback
- this branch now waits on the journal sequence returned by the move data
  commit, preserving the noflush accounting and batching only

Validation so far:
- `git diff --check origin/testing...HEAD`
- `BINDGEN=/home/kom/.cargo/bin/bindgen LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu make -j32 build/fs/data/move.o build/fs/data/update.o build/fs/data/reconcile/work.o build/fs/data/copygc.o`

Needs maintainer/design check before this should leave draft:
- whether this is the right accounting point for moved-data noflush journal ordering
- whether waiting on the journal sequence returned by the data commit matches the intended flush/commit model
- how this should interact with current master/testing background write FUA behavior

Related: #704.
