### PR TITLE
reconcile: park target work that can't improve placement

### DIFF
--- a/fs/btree/interior.c
+++ b/fs/btree/interior.c
@@ -23,6 +23,7 @@
 #include "data/extents.h"
 #include "data/keylist.h"
 #include "data/reconcile/trigger.h"
+#include "data/reconcile/work.h"
 #include "data/write.h"
 
 #include "init/error.h"
@@ -871,15 +872,20 @@ static int btree_update_nodes_written_trans(struct btree_trans *trans,
 						  BKEY_BTREE_PTR_U64s_MAX,
 						  SET_NEEDS_RECONCILE_foreground, 0));
 
+		bch2_reconcile_maybe_park_new_node(c, &i->key);
+
 		/*
 		 * This is not strictly the best way of doing this, what we
 		 * really want is a flag for 'did
-		 * bch2_bkey_set_needs_reconcile() change anything, and do we
-		 * need to update the node key'; there's no reason we couldn't
-		 * be calling bch2_bkey_set_needs_reconcile() at node allocation
-		 * time to better handle the case where we have to pad with
-		 * invalid pointers because we don't currently have devices
-		 * available to meet the desired replication level.
+		 * bch2_bkey_set_needs_reconcile() or
+		 * bch2_reconcile_maybe_park_new_node() change anything, and do
+		 * we need to update the node key' - note that the latter can
+		 * set pending when the former changed nothing; there's no
+		 * reason we couldn't be calling
+		 * bch2_bkey_set_needs_reconcile() at node allocation time to
+		 * better handle the case where we have to pad with invalid
+		 * pointers because we don't currently have devices available
+		 * to meet the desired replication level.
 		 */
 
 		if (bkey_has_reconcile(c, bkey_i_to_s_c(&i->key))) {

--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -75,11 +75,13 @@ static void move_write_done(struct bch_write_op *op)
 	atomic_dec(&ctxt->write_ios);
 
 	/*
-	 * EC allocation failed — the write never happened but the extent
-	 * still needs erasure coding. Mark it pending so reconcile retries
-	 * from the pending list instead of the main scan.
+	 * Allocation failed outright (EC stripe, or a reconcile write on a
+	 * full target): park it so reconcile retries from the pending list
+	 * instead of the main scan.
 	 */
-	if (bch2_err_matches(op->error, BCH_ERR_ec_alloc_failed))
+	if (bch2_err_matches(op->error, BCH_ERR_ec_alloc_failed) ||
+	    (u->opts.type == BCH_DATA_UPDATE_reconcile &&
+	     bch2_err_matches(op->error, BCH_ERR_freelist_empty)))
 		bch2_data_update_ec_alloc_failed(u);
 
 	bch2_data_update_exit(u, op->error);

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -650,6 +650,31 @@ static void bkey_reconcile_pending_mod(struct bch_fs *c, struct bkey_i *k, bool 
 	r->pending = set;
 }
 
+/*
+ * Called on a btree node key about to be committed by an interior update.
+ * The node was just allocated with target preference (all btree node
+ * allocation goes through the effective metadata target,
+ * bch2_btree_update_start()), so its placement is the allocator's best
+ * current effort: if the key still wants target placement, a rewrite
+ * through the same allocator can't do better right now. Park it - btree
+ * node allocation falls back off target rather than failing, so the
+ * data update path never generates the error that parks extents, and an
+ * unparked key would be rewritten to the same placement forever.
+ *
+ * Only target-only keys park: anything with a replicas component (hipri:
+ * degraded, evacuating) must stay live.
+ *
+ * There's still a potential problem if other BCH_RECONCILE flags are spinning; they will all wait for the others to be done before parking.
+ */
+void bch2_reconcile_maybe_park_new_node(struct bch_fs *c, struct bkey_i *k)
+{
+	struct bch_extent_reconcile *r = (struct bch_extent_reconcile *)
+		bch2_bkey_reconcile_opts(c, bkey_i_to_s_c(k));
+
+	if (r && r->need_rb == BIT(BCH_RECONCILE_background_target))
+		r->pending = true;
+}
+
 int bch2_extent_reconcile_pending_mod(struct btree_trans *trans, struct btree_iter *iter,
 				      unsigned level, struct bkey_s_c k, bool set)
 {

--- a/fs/data/reconcile/work.h
+++ b/fs/data/reconcile/work.h
@@ -81,6 +81,7 @@ static inline int bch2_reconcile_pending_wakeup(struct bch_fs *c)
 
 int bch2_extent_reconcile_pending_mod(struct btree_trans *, struct btree_iter *,
 				      unsigned, struct bkey_s_c, bool);
+void bch2_reconcile_maybe_park_new_node(struct bch_fs *, struct bkey_i *);
 
 void bch2_reconcile_status_to_text(struct printbuf *, struct bch_fs *);
 void bch2_reconcile_scan_pending_to_text(struct printbuf *, struct bch_fs *);


### PR DESCRIPTION
A target with less total durability than data_replicas can never satisfy the target goal, and the data update path can't be relied on to fail in that case: btree node allocation falls back off target rather than failing, so the rewrite succeeds - still off target - and the trigger re-queues it. Reconcile then spins forever; observed in the field as months of ~300 btree node rewrites/sec with no net progress.

Instead, only kill an off-target pointer if the resulting write request (data_replicas minus durability kept) fits what the target can absorb right now - the write path is all-or-nothing, so an oversized request places nothing. When no goal on a key can make progress, park it on the pending list, which device add/remove/state changes already kick for re-evaluation. The parking check must consider all outstanding goals together: per-goal checks would let stuck combinations (e.g. target + erasure_code) defer to each other forever.

This converges to best-possible placement: as much as fits lands on the target, the remainder parks, and reconcile goes idle instead of spinning.

Tests live in https://github.com/koverstreet/ktest/pull/91.