### PR TITLE
vfs: use anonymous device for vfs superblock

### DIFF
--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -2545,6 +2545,10 @@ static const struct super_operations bch_super_operations = {
 
 static int bch2_set_super(struct super_block *s, struct fs_context *fc)
 {
+	int ret = set_anon_super(s, fc);
+	if (ret)
+		return ret;
+
 	s->s_fs_info = fc->s_fs_info;
 	return 0;
 }
@@ -2691,9 +2695,7 @@ got_sb:
 		for_each_online_member_rcu(c, ca) {
 			struct block_device *bdev = ca->disk_sb.bdev;
 
-			/* XXX: create an anonymous device for multi device filesystems */
 			sb->s_bdev	= bdev;
-			sb->s_dev	= bdev->bd_dev;
 			break;
 		}
 	}
@@ -2767,7 +2769,7 @@ static void bch2_kill_sb(struct super_block *sb)
 {
 	struct bch_fs *c = sb->s_fs_info;
 
-	generic_shutdown_super(sb);
+	kill_anon_super(sb);
 	bch2_fs_exit(c);
 }
 

--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -2665,6 +2665,10 @@ static const struct super_operations bch_super_operations = {
 
 static int bch2_set_super(struct super_block *s, struct fs_context *fc)
 {
+	int ret = set_anon_super(s, fc);
+	if (ret)
+		return ret;
+
 	s->s_fs_info = fc->s_fs_info;
 	return 0;
 }
@@ -2811,9 +2815,7 @@ got_sb:
 		for_each_online_member_rcu(c, ca) {
 			struct block_device *bdev = ca->disk_sb.bdev;
 
-			/* XXX: create an anonymous device for multi device filesystems */
 			sb->s_bdev	= bdev;
-			sb->s_dev	= bdev->bd_dev;
 			break;
 		}
 	}
@@ -2894,7 +2896,7 @@ static void bch2_kill_sb(struct super_block *sb)
 {
 	struct bch_fs *c = sb->s_fs_info;
 
-	generic_shutdown_super(sb);
+	kill_anon_super(sb);
 	bch2_fs_exit(c);
 }
 


### PR DESCRIPTION
bcachefs picks the vfs superblock's `s_dev` from whichever member device happens to be first in the online-member list, and that pick isn't stable across device add/remove. After the mount source moved to `/dev/disk/by-uuid/<fs-uuid>`, the member udev resolves for that symlink doesn't always match the member `bch2_fs_get_tree()` picked for `s_dev`, so quota tooling can see two different device numbers for the same mounted filesystem (koverstreet/bcachefs#1106). This gives the superblock its own anonymous device via `set_anon_super()`/`kill_anon_super()` instead of borrowing a member's `bd_dev`, so `s_dev` stays fixed for the life of the mount. It replaces the rebind approach in koverstreet/bcachefs-tools#758, which fixed the same symptom but changed `st_dev` mid-mount and broke the VFS file-identity contract. The commit is Kent Overstreet's original patch, rebased and carried forward with a Signed-off-by added for the forwarding.

Verified live in a VM with the patched module: formatted and mounted a 2-device filesystem, stat'd a file (`st_dev` reported as anonymous device 32, distinct from either member's block-device number), then evacuated and removed one member while the fs stayed mounted. `st_dev` for the same file was unchanged (still 32) after the member was gone. Without this patch `st_dev` is copied from the first online member's `bdev->bd_dev` at mount time, so it would have pointed at a real, removable member device instead.
