### PR TITLE
data_update: detect reconcile updates that make no progress

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -605,9 +605,12 @@ If specified,
 must be a subvolume;
 if not specified the snapshot will be of the subvolume containing
 .Ar dest .
+Snapshots are read-only by default.
 .Bl -tag -width Ds
-.It Fl r
-Make snapshot read-only
+.It Fl -rw
+Make snapshot writable
+.It Fl r , Fl -read-only
+Make snapshot read-only (the default; kept for compatibility)
 .El
 .It Ic subvolume list Oo Ar options Oc Ar target
 List subvolumes in a mounted filesystem.

--- a/fs/alloc/disk_groups.c
+++ b/fs/alloc/disk_groups.c
@@ -3,8 +3,6 @@
 
 #include "alloc/disk_groups.h"
 
-#include "data/reconcile/work.h"
-
 #include "init/dev.h"
 
 #include "sb/members.h"
@@ -466,40 +464,56 @@ void bch2_disk_path_to_text_sb(struct printbuf *out, struct bch_sb *sb, unsigned
 	}
 }
 
+/* Resolve a label name to a 1 based group index, creating it if new: */
+static int dev_label_resolve(struct bch_fs *c, const char *name)
+{
+	if (!strlen(name) || !strcmp(name, "none"))
+		return 0;
+
+	int v = bch2_disk_path_find_or_create(&c->disk_sb, name);
+	return v < 0 ? v : v + 1;
+}
+
 int __bch2_dev_group_set(struct bch_fs *c, struct bch_dev *ca, const char *name)
 {
 	lockdep_assert_held(&c->sb_lock);
 
-	if (!strlen(name) || !strcmp(name, "none")) {
-		struct bch_member *mi = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
-		SET_BCH_MEMBER_GROUP(mi, 0);
-	} else {
-		int v = bch2_disk_path_find_or_create(&c->disk_sb, name);
-		if (v < 0)
-			return v;
+	int v = dev_label_resolve(c, name);
+	if (v < 0)
+		return v;
 
-		struct bch_member *mi = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
-		SET_BCH_MEMBER_GROUP(mi, v + 1);
-	}
-
+	SET_BCH_MEMBER_GROUP(bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx), v);
 	return bch2_sb_disk_groups_to_cpu(c);
 }
 
-int bch2_dev_group_set(struct bch_fs *c, struct bch_dev *ca, const char *name)
+int bch2_opt_disk_label_parse(struct bch_fs *c, const char *val, u64 *res,
+			      struct printbuf *err)
 {
-	struct reconcile_scan s = { .type = RECONCILE_SCAN_pending };
+	if (!val)
+		return -EINVAL;
 
-	try(bch2_set_reconcile_needs_scan(c, s, false));
+	if (!c)
+		return -BCH_ERR_option_needs_open_fs;
 
-	/* bch2_reconcile_wakeup_pending goes here */
-	guard(memalloc_flags)(PF_MEMALLOC_NOFS);
 	scoped_guard(mutex, &c->sb_lock) {
-		try(__bch2_dev_group_set(c, ca, name));
-		try(bch2_write_super(c));
+		int v = dev_label_resolve(c, val);
+		if (v < 0)
+			return v;
+		*res = v;
 	}
 
-	try(bch2_set_reconcile_needs_scan(c, s, true));
 	return 0;
+}
+
+void bch2_opt_disk_label_to_text(struct printbuf *out, struct bch_fs *c,
+				 struct bch_sb *sb, u64 v)
+{
+	if (!v)
+		prt_str(out, "none");
+	else if (c)
+		bch2_disk_path_to_text(out, c, v - 1);
+	else
+		bch2_disk_path_to_text_sb(out, sb, v - 1);
 }
 
 int bch2_opt_target_parse(struct bch_fs *c, const char *val, u64 *res,

--- a/fs/alloc/disk_groups.c
+++ b/fs/alloc/disk_groups.c
@@ -67,6 +67,24 @@ static int bch2_sb_disk_groups_validate(struct bch_sb *sb, struct bch_sb_field *
 		}
 	}
 
+	/*
+	 * Parents are walked in bch2_sb_disk_groups_to_cpu() (bounded, so a
+	 * cycle is tolerated) and bch2_disk_path_to_text_sb(): an out of range
+	 * parent reads out of bounds, so reject those. Parents pointing at
+	 * deleted groups are tolerated - chains through deleted groups work.
+	 */
+	for (unsigned i = 0; i < nr_groups; i++) {
+		if (BCH_GROUP_DELETED(&groups->entries[i]))
+			continue;
+
+		u64 parent = BCH_GROUP_PARENT(&groups->entries[i]);
+		if (parent > nr_groups) {
+			prt_printf(err, "label %u has invalid parent %llu (have %u)",
+				   i, parent - 1, nr_groups);
+			return -BCH_ERR_invalid_sb_disk_groups;
+		}
+	}
+
 	struct bch_disk_group *sorted __free(kfree) =
 		kmalloc_array(nr_groups, sizeof(*sorted), GFP_KERNEL);
 	if (!sorted)

--- a/fs/alloc/disk_groups.h
+++ b/fs/alloc/disk_groups.h
@@ -104,10 +104,17 @@ void bch2_opt_target_to_text(struct printbuf *, struct bch_fs *, struct bch_sb *
 	.to_text	= bch2_opt_target_to_text,	\
 }
 
+int bch2_opt_disk_label_parse(struct bch_fs *, const char *, u64 *, struct printbuf *);
+void bch2_opt_disk_label_to_text(struct printbuf *, struct bch_fs *, struct bch_sb *, u64);
+
+#define bch2_opt_disk_label (struct bch_opt_fn) {	\
+	.parse		= bch2_opt_disk_label_parse,	\
+	.to_text	= bch2_opt_disk_label_to_text,	\
+}
+
 int bch2_sb_disk_groups_to_cpu(struct bch_fs *);
 
 int __bch2_dev_group_set(struct bch_fs *, struct bch_dev *, const char *);
-int bch2_dev_group_set(struct bch_fs *, struct bch_dev *, const char *);
 
 const char *bch2_sb_validate_disk_groups(struct bch_sb *,
 					 struct bch_sb_field *);

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -9,6 +9,7 @@
 #include "btree/bkey_buf.h"
 #include "btree/update.h"
 
+#include "data/checksum.h"
 #include "data/compress.h"
 #include "data/copygc.h"
 #include "data/extents.h"
@@ -225,6 +226,60 @@ static void count_data_update_key_fail(struct data_update *u,
 		prt_printf(&buf, "%s\n", msg);
 		data_update_key_to_text(&buf, u, new, wrote, insert);
 	}));
+}
+
+/*
+ * Offending-pointer count for the still-set need_rb bits that are per-ptr
+ * measurable (checksum, compression, target, ec removal): an update that
+ * can't clear a bit outright - e.g. background_target with more replicas
+ * than the target can hold - still makes progress if it shrinks this.
+ *
+ * Bits with no per-ptr measure (data_replicas, ec creation) contribute
+ * nothing, falling back to cleared-or-parked semantics.
+ *
+ * XXX: these are the same per-ptr conformance tests the producer
+ * (bch2_bkey_needs_reconcile()) and consumer (reconcile_set_data_opts())
+ * make - candidates for a shared helper.
+ */
+static unsigned bkey_need_rb_offenders(struct bch_fs *c, struct bkey_s_c k,
+				       const struct bch_extent_reconcile *r,
+				       unsigned need_rb)
+{
+	unsigned csum_type		= bch2_data_checksum_type_rb(c, *r);
+	unsigned compression_type	= bch2_compression_opt_to_type(r->background_compression);
+	unsigned nr = 0;
+
+	guard(rcu)();
+
+	struct bkey_ptrs_c ptrs = bch2_bkey_ptrs_c(k);
+	const union bch_extent_entry *entry;
+	struct extent_ptr_decoded p;
+
+	bkey_for_each_ptr_decode(k.k, ptrs, p, entry) {
+		if (p.ptr.cached)
+			continue;
+
+		if ((need_rb & BIT(BCH_RECONCILE_data_checksum)) &&
+		    p.crc.csum_type != csum_type)
+			nr++;
+
+		if ((need_rb & BIT(BCH_RECONCILE_background_compression)) &&
+		    p.crc.compression_type != compression_type &&
+		    p.crc.compression_type != BCH_COMPRESSION_TYPE_incompressible)
+			nr++;
+
+		if ((need_rb & BIT(BCH_RECONCILE_background_target)) &&
+		    r->background_target &&
+		    !bch2_dev_in_target_rcu(c, p.ptr.dev, r->background_target))
+			nr++;
+
+		if ((need_rb & BIT(BCH_RECONCILE_erasure_code)) &&
+		    !r->erasure_code &&
+		    p.has_ec)
+			nr++;
+	}
+
+	return nr;
 }
 
 static int data_update_index_update_key(struct btree_trans *trans,
@@ -483,6 +538,46 @@ static int data_update_index_update_key(struct btree_trans *trans,
 		prt_str(&buf, "\nnew: ");
 		bch2_bkey_val_to_text(&buf, c, bkey_i_to_s_c(insert));
 	}));
+
+	/*
+	 * Convergence check: a completed reconcile data update must make
+	 * progress on the extent's need_rb set - clear a bit, park it, or
+	 * shrink the count of offending pointers for a divisible bit (a
+	 * partially satisfiable background_target improves placement without
+	 * clearing) - anything else means reconcile will re-queue the
+	 * identical update forever. Skipped when options changed mid-flight
+	 * (the work was computed against old opts), and for stripe-creation
+	 * updates (extra_replicas), whose erasure_code bit legitimately
+	 * clears asynchronously when the stripe pointer is attached.
+	 */
+	if (u->opts.type == BCH_DATA_UPDATE_reconcile &&
+	    !u->opts.extra_replicas &&
+	    u->op.opts.change_cookie == c->opt_change_cookie) {
+		const struct bch_extent_reconcile *r_old = bch2_bkey_reconcile_opts(c, k);
+		const struct bch_extent_reconcile *r_new =
+			bch2_bkey_reconcile_opts(c, bkey_i_to_s_c(insert));
+		unsigned old_rb = r_old ? r_old->need_rb : 0;
+		unsigned new_rb = r_new ? r_new->need_rb : 0;
+
+		if (old_rb && r_new &&
+		    !(old_rb & ~new_rb) &&
+		    !r_new->pending) {
+			/* Both keys measured against the same (new) targets: */
+			unsigned nr_old = bkey_need_rb_offenders(c, k, r_new, old_rb);
+			unsigned nr_new = bkey_need_rb_offenders(c, bkey_i_to_s_c(insert),
+								 r_new, old_rb);
+
+			if (nr_new >= nr_old)
+				event_add_trace(c, data_update_no_progress_fail,
+						insert->k.size, buf, ({
+					prt_printf(&buf, "offending ptrs %u -> %u", nr_old, nr_new);
+					prt_str(&buf, "\nold: ");
+					bch2_bkey_val_to_text(&buf, c, k);
+					prt_str(&buf, "\nnew: ");
+					bch2_bkey_val_to_text(&buf, c, bkey_i_to_s_c(insert));
+				}));
+		}
+	}
 
 	return 0;
 }

--- a/fs/debug/sysfs.c
+++ b/fs/debug/sysfs.c
@@ -224,8 +224,6 @@ read_attribute(filldir64_specialization);
 BCH_PERSISTENT_COUNTERS()
 #undef x
 
-rw_attribute(label);
-
 read_attribute(copy_gc_wait);
 
 read_attribute(reconcile_status);
@@ -1001,12 +999,6 @@ SHOW(bch2_dev)
 	sysfs_print(first_bucket,	ca->mi.first_bucket);
 	sysfs_print(nbuckets,		ca->mi.nbuckets);
 
-	if (attr == &sysfs_label) {
-		if (ca->mi.group)
-			bch2_disk_path_to_text(out, c, ca->mi.group - 1);
-		prt_char(out, '\n');
-	}
-
 	if (attr == &sysfs_has_data) {
 		prt_bitflags(out, __bch2_data_types, bch2_dev_has_data(c, ca));
 		prt_char(out, '\n');
@@ -1065,14 +1057,6 @@ STORE(bch2_dev)
 	struct bch_dev *ca = container_of(kobj, struct bch_dev, kobj);
 	struct bch_fs *c = ca->fs;
 
-	if (attr == &sysfs_label) {
-		char *tmp __free(kfree) = kstrdup(buf, GFP_KERNEL);
-		if (!tmp)
-			return -ENOMEM;
-
-		try(bch2_dev_group_set(c, ca, strim(tmp)));
-	}
-
 	if (attr == &sysfs_io_errors_reset)
 		bch2_dev_errors_reset(ca);
 
@@ -1088,9 +1072,6 @@ struct attribute *bch2_dev_files[] = {
 	&sysfs_uuid,
 	&sysfs_first_bucket,
 	&sysfs_nbuckets,
-
-	/* settings: */
-	&sysfs_label,
 
 	&sysfs_has_data,
 	&sysfs_io_done,

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -1299,8 +1299,12 @@ static int count_inode_keys(struct btree_trans *trans,
 					 inode_pos,
 					 POS(inode_pos.inode, U64_MAX),
 					 0, k, ret) {
-		if (k.k->type == KEY_TYPE_error ||
-		    k.k->type == KEY_TYPE_hash_whiteout)
+		/*
+		 * Error keys count: they're placeholders for unreadable data,
+		 * evidence the inode had contents. Hash whiteouts are just
+		 * tombstones:
+		 */
+		if (k.k->type == KEY_TYPE_hash_whiteout)
 			continue;
 
 		nr_keys++;
@@ -1323,7 +1327,9 @@ int bch2_check_key_has_inode(struct btree_trans *trans,
 {
 	errptr_try(i);
 
-	if (bkey_extent_whiteout(k.k))
+	/* whiteouts and hash whiteouts are tombstones - they need no inode: */
+	if (bkey_extent_whiteout(k.k) ||
+	    k.k->type == KEY_TYPE_hash_whiteout)
 		return 0;
 
 	bool have_inode = i && !i->whiteout;

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1254,9 +1254,11 @@ int bch2_dev_add(struct bch_fs *c, const char *path, struct printbuf *err)
 
 			if (BCH_MEMBER_GROUP(&dev_mi)) {
 				ret = __bch2_dev_group_set(c, ca, label.buf);
-				prt_printf(err, "error creating new label: %s\n", bch2_err_str(ret));
-				if (ret)
+				if (ret) {
+					prt_printf(err, "error creating new label: %s\n",
+						   bch2_err_str(ret));
 					goto err_late;
+				}
 			}
 
 

--- a/fs/opts.c
+++ b/fs/opts.c
@@ -627,6 +627,19 @@ static int opt_hook_io(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum bch_
 		try(reconcile_scan_bracket(c,
 			(struct reconcile_scan) { .type = RECONCILE_SCAN_stripes }, post, scope));
 		break;
+	case Opt_label:
+		/*
+		 * Refresh the cpu label tree before the scan wakes: reconcile
+		 * reads the group devs masks. Errors here (ENOMEM) just leave
+		 * the cpu copy stale until the next superblock swap:
+		 */
+		if (post)
+			scoped_guard(mutex, &c->sb_lock)
+				bch_err_fn(c, bch2_sb_disk_groups_to_cpu(c));
+
+		try(reconcile_scan_bracket(c,
+			(struct reconcile_scan) { .type = RECONCILE_SCAN_pending }, post, scope));
+		break;
 	default:
 		break;
 	}

--- a/fs/opts.h
+++ b/fs/opts.h
@@ -553,6 +553,11 @@ enum fsck_err_opts {
 	  OPT_STR(bch2_member_states),					\
 	  BCH_MEMBER_STATE,		BCH_MEMBER_STATE_rw,		\
 	  "state",	"rw,ro,failed,spare")				\
+	x(label,			u16,				\
+	  OPT_DEVICE|OPT_FORMAT|OPT_RUNTIME,				\
+	  OPT_FN(bch2_opt_disk_label),					\
+	  BCH_MEMBER_GROUP,		0,				\
+	  "(label)",	"Device label: position in the label tree")	\
 	x(bucket_size,			u32,				\
 	  OPT_DEVICE|OPT_HUMAN_READABLE|OPT_SB_FIELD_SECTORS,		\
 	  OPT_UINT(0, S64_MAX),						\

--- a/fs/sb/counters_format.h
+++ b/fs/sb/counters_format.h
@@ -67,6 +67,8 @@ enum bch_counters_flags {
 	  "Failed btree key update sectors")				\
 	x(data_update_useless_write_fail,	128, TYPE_SECTORS,	\
 	  "Useless data update write failures")				\
+	x(data_update_no_progress_fail,		136, TYPE_SECTORS,	\
+	  "Reconcile data updates that cleared no need_rb bits")	\
 	x(data_update_start_fail_obsolete,	39,  TYPE_COUNTER,	\
 	  "Obsolete: data update start failures")			\
 	x(data_update_noop_obsolete,		92,  TYPE_COUNTER,	\

--- a/src/commands/device.rs
+++ b/src/commands/device.rs
@@ -32,11 +32,8 @@ fn device_add_opt_flags() -> u32 {
 fn device_add_cmd() -> Command {
     Command::new("add")
         .about("Add a new device to an existing filesystem")
-        .args(bch_option_args(device_add_opt_flags(), false))
-        .arg(Arg::new("label")
-            .short('l')
-            .long("label")
-            .help("Disk label"))
+        .args(bch_option_args(device_add_opt_flags(), false).into_iter()
+            .map(|a| if a.get_id() == "label" { a.short('l') } else { a }))
         .arg(Arg::new("force")
             .short('f')
             .long("force")
@@ -55,22 +52,20 @@ fn cmd_device_add(argv: Vec<String>) -> Result<()> {
 
     let fs_path = matches.get_one::<String>("filesystem").unwrap();
     let dev_path = matches.get_one::<String>("device").unwrap();
-    let label = matches.get_one::<String>("label");
     let force = matches.get_flag("force");
 
     // Try online first — works for mountpoints, and for block devices
     // or files with a bcachefs superblock if the filesystem is mounted.
     // If the filesystem isn't mounted, fall back to offline add.
     match BcachefsHandle::open(fs_path) {
-        Ok(handle) => cmd_device_add_online(handle, dev_path, label, force, &matches),
-        Err(_) => cmd_device_add_offline(fs_path, dev_path, label, force, &matches),
+        Ok(handle) => cmd_device_add_online(handle, dev_path, force, &matches),
+        Err(_) => cmd_device_add_offline(fs_path, dev_path, force, &matches),
     }
 }
 
 fn cmd_device_add_online(
     handle: BcachefsHandle,
     dev_path: &str,
-    label: Option<&String>,
     force: bool,
     matches: &clap::ArgMatches,
 ) -> Result<()> {
@@ -83,7 +78,7 @@ fn cmd_device_add_online(
             .context("reading btree_node_size from sysfs")?,
     ).context("parsing btree_node_size")?;
 
-    drop(device_add_format(dev_path, label, force, matches,
+    drop(device_add_format(dev_path, force, matches,
         block_size as u32, btree_node_size as u32)?);
     let c_dev_path = path_to_cstr(dev_path);
     handle.disk_add(&c_dev_path)
@@ -96,7 +91,6 @@ fn cmd_device_add_online(
 fn cmd_device_add_offline(
     fs_path: &str,
     dev_path: &str,
-    label: Option<&String>,
     force: bool,
     matches: &clap::ArgMatches,
 ) -> Result<()> {
@@ -114,7 +108,7 @@ fn cmd_device_add_offline(
     let block_size = unsafe { (*fs.raw).opts.block_size as u32 };
     let btree_node_size = unsafe { (*fs.raw).opts.btree_node_size };
 
-    device_add_format(dev_path, label, force, matches,
+    device_add_format(dev_path, force, matches,
         block_size, btree_node_size)?;
 
     fs.dev_add(dev_path)
@@ -129,7 +123,6 @@ fn cmd_device_add_offline(
 
 fn device_add_format(
     dev_path: &str,
-    label: Option<&String>,
     force: bool,
     matches: &clap::ArgMatches,
     block_size: u32,
@@ -138,14 +131,16 @@ fn device_add_format(
     use crate::commands::format_util::DevOpts;
 
     let mut dev_opts = DevOpts::new(CString::new(dev_path)?);
-    dev_opts.label = label.map(|l| CString::new(l.as_str())).transpose()?;
 
     let bch_opts = bch_options_from_matches(matches, device_add_opt_flags());
     for (name, value) in &bch_opts {
         let Some((opt_id, opt)) = bch_opt_lookup(name) else { continue };
-        let val = parse_opt_val(opt, value)?
-            .ok_or_else(|| anyhow!("option {} requires open filesystem", name))?;
-        bcachefs_kernel::opts::opt_set_by_id(&mut dev_opts.opts, opt_id, val);
+        match parse_opt_val(opt, value)? {
+            Some(val) => bcachefs_kernel::opts::opt_set_by_id(&mut dev_opts.opts, opt_id, val),
+            // Values that resolve against a superblock (labels) - the
+            // new device's sb, once format_for_device_add builds it:
+            None => dev_opts.opt_strs.push((opt_id, CString::new(value.as_str())?)),
+        }
     }
 
     if let Some(mpath_dev) = find_multipath_holder(Path::new(dev_path)) {

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -108,7 +108,8 @@ Report bugs to <linux-bcachefs@vger.kernel.org>
 /// Per-device configuration accumulated during parsing.
 struct DevConfig {
     path: String,
-    label: Option<String>,
+    /// Device options that can only be resolved once the sb exists (labels):
+    opt_strs: Vec<(c::bch_opt_id, String)>,
     fs_size: u64,
     opts: c::bch_opts,
 }
@@ -243,7 +244,7 @@ fn parse_format_args(argv: Vec<String>) -> Result<FormatConfig> {
     let mut superblock_size: u32 = SUPERBLOCK_SIZE_DEFAULT;
 
     // Per-device accumulator
-    let mut cur_label: Option<String> = None;
+    let mut cur_dev_opt_strs: Vec<(c::bch_opt_id, String)> = Vec::new();
     let mut cur_fs_size: u64 = 0;
     let mut cur_dev_opts: c::bch_opts = Default::default();
     let mut unconsumed_dev_option = false;
@@ -257,11 +258,21 @@ fn parse_format_args(argv: Vec<String>) -> Result<FormatConfig> {
             // devices until overridden by a new value.
             devices.push(DevConfig {
                 path: $path,
-                label: cur_label.clone(),
+                opt_strs: cur_dev_opt_strs.clone(),
                 fs_size: cur_fs_size,
                 opts: cur_dev_opts,
             });
             unconsumed_dev_option = false;
+        }};
+    }
+
+    // Sticky like cur_dev_opts: a new value for the same option replaces
+    // the old one.
+    macro_rules! push_dev_opt_str {
+        ($id:expr, $val:expr) => {{
+            cur_dev_opt_strs.retain(|(id, _)| *id != $id);
+            cur_dev_opt_strs.push(($id, $val));
+            unconsumed_dev_option = true;
         }};
     }
 
@@ -301,7 +312,16 @@ fn parse_format_args(argv: Vec<String>) -> Result<FormatConfig> {
                     };
 
                     match parse_opt_val(opt, &val_str)? {
-                        None => deferred_opts.push((opt_id, val_str)),
+                        None => {
+                            // Value needs a superblock to resolve against
+                            // (labels, targets); device option values are
+                            // per device, fs option values resolve once:
+                            if opt.flags as u32 & c::opt_flags::OPT_DEVICE as u32 != 0 {
+                                push_dev_opt_str!(opt_id, val_str);
+                            } else {
+                                deferred_opts.push((opt_id, val_str));
+                            }
+                        }
                         Some(v) => {
                             if opt.flags as u32 & c::opt_flags::OPT_DEVICE as u32 != 0 {
                                 bcachefs_kernel::opts::opt_set_by_id(&mut cur_dev_opts, opt_id, v);
@@ -352,10 +372,6 @@ fn parse_format_args(argv: Vec<String>) -> Result<FormatConfig> {
                     let size = parse_human_size(&val)?;
                     superblock_size = (size >> 9) as u32;
                 }
-                "label" => {
-                    cur_label = Some(take_opt_value(inline_val, &argv, &mut i, raw_name)?);
-                    unconsumed_dev_option = true;
-                }
                 "version" => {
                     let val = take_opt_value(inline_val, &argv, &mut i, raw_name)?;
                     format_version = Some(version_parse(&val)?);
@@ -385,8 +401,8 @@ fn parse_format_args(argv: Vec<String>) -> Result<FormatConfig> {
                     fs_label = Some(take_short_value(arg, &argv, &mut i, 'L')?);
                 }
                 b'l' => {
-                    cur_label = Some(take_short_value(arg, &argv, &mut i, 'l')?);
-                    unconsumed_dev_option = true;
+                    let val = take_short_value(arg, &argv, &mut i, 'l')?;
+                    push_dev_opt_str!(c::bch_opt_id::Opt_label, val);
                 }
                 b'U' => {
                     let val = take_short_value(arg, &argv, &mut i, 'U')?;
@@ -530,7 +546,9 @@ fn cmd_format(argv: Vec<String>) -> Result<()> {
     let mut devices: Vec<DevOpts> = cfg.devices.iter()
         .map(|dev| {
             let mut d = DevOpts::new(CString::new(dev.path.as_str())?);
-            d.label = dev.label.as_ref().map(|l| CString::new(l.as_str())).transpose()?;
+            d.opt_strs = dev.opt_strs.iter()
+                .map(|(id, v)| Ok((*id, CString::new(v.as_str())?)))
+                .collect::<Result<_>>()?;
             d.fs_size = dev.fs_size;
             d.opts = dev.opts;
             Ok(d)

--- a/src/commands/format_util.rs
+++ b/src/commands/format_util.rs
@@ -17,7 +17,9 @@ use crate::wrappers::super_io::{die, BCHFS_MAGIC, SUPERBLOCK_SIZE_DEFAULT};
 pub struct DevOpts {
     pub fd: RawFd,
     pub path: CString,
-    pub label: Option<CString>,
+    /// Deferred device options (labels): their values are resolved against
+    /// the superblock being built, after it exists.
+    pub opt_strs: Vec<(c::bch_opt_id, CString)>,
     pub sb_offset: u64,
     pub sb_end: u64,
     pub nbuckets: u64,
@@ -31,7 +33,7 @@ impl DevOpts {
         DevOpts {
             fd: -1,
             path,
-            label: None,
+            opt_strs: Vec::new(),
             sb_offset: 0,
             sb_end: 0,
             nbuckets: 0,
@@ -292,23 +294,24 @@ pub fn format(
         sb.member_mut(idx as u32).unwrap().set_member_rotational_set(1);
     }
 
-    // Disk labels
+    // Deferred device options - labels: resolve against the sb we just built
     for (idx, dev) in dev_slice.iter().enumerate() {
-        let label = match dev.label.as_deref() {
-            Some(l) => l,
-            None => continue,
-        };
+        for (opt_id, val) in &dev.opt_strs {
+            let path_idx = unsafe { c::bch2_disk_path_find_or_create(&mut *sb, val.as_ptr()) };
+            if path_idx < 0 {
+                die(&format!(
+                    "error creating disk path: {}",
+                    std::io::Error::from_raw_os_error(-path_idx)
+                ));
+            }
 
-        let path_idx = unsafe { c::bch2_disk_path_find_or_create(&mut *sb, label.as_ptr()) };
-        if path_idx < 0 {
-            die(&format!(
-                "error creating disk path: {}",
-                std::io::Error::from_raw_os_error(-path_idx)
-            ));
+            // Recompute m after sb modification (memory may have been reallocated)
+            let m = sb.member_mut(idx as u32).unwrap();
+            match *opt_id {
+                c::bch_opt_id::Opt_label => m.set_member_group(path_idx as u64 + 1),
+                _ => die(&format!("can't resolve option {:?} at format time", opt_id)),
+            }
         }
-
-        // Recompute m after sb modification (memory may have been reallocated)
-        sb.member_mut(idx as u32).unwrap().set_member_group(path_idx as u64 + 1);
     }
 
     // Targets

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -988,7 +988,9 @@ fn cmd_image_create(argv: Vec<String>) -> Result<()> {
     let mut d = DevOpts::new(path_cstr);
     d.fs_size = dev_fs_size;
     d.opts = dev_opts;
-    d.label = dev_label_cstr;
+    if let Some(l) = dev_label_cstr {
+        d.opt_strs.push((c::bch_opt_id::Opt_label, l));
+    }
 
     let result = image_create_inner(
         fs_opt_strs,

--- a/src/commands/subvolume.rs
+++ b/src/commands/subvolume.rs
@@ -55,12 +55,17 @@ subvolume boundaries.")]
     #[command(allow_missing_positional = true, visible_aliases = ["snap"],
         long_about = "Creates an instant, COW snapshot of a subvolume. Snapshots \
 initially share all data with the source and only consume additional \
-space as either diverges. Use --read-only for a frozen point-in-time \
-copy.")]
+space as either diverges. Snapshots are read-only by default; use --rw \
+for a writable snapshot.")]
     Snapshot {
-        /// Make snapshot read only
-        #[arg(long, short)]
+        /// Make snapshot writable
+        #[arg(long)]
+        rw: bool,
+
+        /// Make snapshot read only (the default; kept for compatibility)
+        #[arg(long, short, conflicts_with = "rw")]
         read_only: bool,
+
         source:    Option<PathBuf>,
         dest:      PathBuf,
     },
@@ -784,7 +789,7 @@ fn subvolume(cli: Cli) -> Result<()> {
     match cli.subcommands {
         Subcommands::Create { targets }                                         => cmd_create(targets),
         Subcommands::Delete { targets }                                         => cmd_delete(targets),
-        Subcommands::Snapshot { read_only, source, dest }                       => cmd_snapshot(read_only, source, dest),
+        Subcommands::Snapshot { rw, read_only: _, source, dest }               => cmd_snapshot(!rw, source, dest),
         Subcommands::List { json, tree, recursive, snapshots, readonly, sort, target }
                                                                                 => cmd_list(json, tree, recursive, snapshots, readonly, sort, target),
         Subcommands::ListSnapshots { flat, json, readonly, sort, recursive, target }


### PR DESCRIPTION
A completed reconcile data update must make progress on the extent's need_rb set - clear a bit, park it, or shrink the count of offending pointers (a partially satisfiable background_target improves placement without clearing its bit) - anything else means reconcile will re-queue the identical update forever, as with the recent checksum-change livelocks.

Count violations in data_update_no_progress_fail at index update time; the _fail name enrolls it in the CI slowpath checks. Skipped when options changed mid-flight (the work was computed against old opts) and for stripe-creation updates, whose erasure_code bit clears asynchronously. Bits with no per-pointer measure (data_replicas, ec creation) use cleared-or-parked semantics.

----

This is speculative and not a "yes you should pull this"; this catches a reasonably large set of bugs and would have reported several of the recent ones. Also it will happily notify on https://github.com/koverstreet/ktest/pull/93 ; presumably if anyone had encountered that in the wild, they would have found it sooner.

The fact that it reimplements a whole set of checks *again* sucks, and I'm not particularly happy with that; it was necessary for the re-replicate -> park path, which intentionally leaves it in a "not fully on targets" state before adding pending on the next pass. I vaguely recall there was a good reason it had to do it that way and didn't just apply pending immediately; if that were changed, this could be simplified a *lot*.

But it does pass the entire test suite, at least.