### PR TITLE
bcachefs: retry stale allocator waiters after global wakeups

### DIFF
--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -84,9 +84,7 @@ void bch2_alloc_wake_dev(struct bch_dev *ca)
 
 void bch2_alloc_wake_all(struct bch_fs *c)
 {
-	guard(rcu)();
-	for_each_member_device_rcu(c, ca, NULL)
-		atomic_inc(&ca->alloc_wake_counter);
+	atomic_inc(&c->allocator.wake_all_counter);
 	closure_wake_up(&c->allocator.freelist_wait);
 }
 
@@ -1511,6 +1509,7 @@ int bch2_alloc_sectors_req(struct btree_trans *trans,
 	BUG_ON(!req->nr_replicas);
 retry:
 	req->ca				= NULL;
+	req->wake_all_counter_snapshot	= atomic_read(&c->allocator.wake_all_counter);
 	req->will_retry_all_devices	= req->target && !(req->flags & BCH_WRITE_only_specified_devs);
 	req->will_retry_target_devices	= !(req->flags & BCH_WRITE_alloc_nowait);
 	req->copygc_can_make_progress	= false;
@@ -2149,6 +2148,15 @@ static noinline void bch2_print_allocator_stuck(struct bch_fs *c, struct alloc_r
  */
 static bool alloc_wait_advanced(struct bch_fs *c, struct alloc_request *req)
 {
+	/*
+	 * A global wake means allocation eligibility may have changed outside
+	 * the devices recorded in this request's trace (for example, a newly
+	 * added device).  Force a full allocator retry in that case.
+	 */
+	if (atomic_read(&c->allocator.wake_all_counter) !=
+	    req->wake_all_counter_snapshot)
+		return true;
+
 	if (unlikely(req->trace_alloc_failed))
 		return true;
 
@@ -2191,6 +2199,17 @@ void __bch2_wait_on_allocator(struct btree_trans *trans,
 	bch2_trans_unlock(trans);
 
 	while (1) {
+		/*
+		 * A wake may race with closure_wait() before our closure is on
+		 * the waitlist.  Check the snapshots before sleeping; unpark is
+		 * required to remove our closure from the llist on this path.
+		 */
+		if (bch2_err_matches(err, BCH_ERR_bucket_alloc_blocked) &&
+		    alloc_wait_advanced(c, req)) {
+			bch2_alloc_waiters_unpark(c);
+			return;
+		}
+
 		long t = until - jiffies;
 
 		if (t > 0 && trans_closure_sync_timeout(trans, cl, t)) {

--- a/fs/alloc/foreground.h
+++ b/fs/alloc/foreground.h
@@ -41,6 +41,7 @@ typedef struct {
 
 struct alloc_request {
 	struct closure		*cl;
+	u32			wake_all_counter_snapshot;
 	u8			nr_replicas;
 	u8			ec_replicas;
 	u8			ec_max_data_blocks;	/* 0 = no cap */
@@ -351,6 +352,7 @@ static inline struct alloc_request *alloc_request_get(struct btree_trans *trans,
 
 	req->ca				= NULL;
 	req->cl				= cl;
+	req->wake_all_counter_snapshot	= atomic_read(&trans->c->allocator.wake_all_counter);
 	req->nr_replicas		= nr_replicas;
 	req->nr_effective		= 0;
 	req->ec_replicas		= ec_replicas;

--- a/fs/alloc/types.h
+++ b/fs/alloc/types.h
@@ -164,6 +164,7 @@ struct bch_fs_capacity {
 struct bch_fs_allocator {
 	struct bch_devs_mask	rw_devs[BCH_DATA_NR];
 	unsigned long		rw_devs_change_count;
+	atomic_t		wake_all_counter;
 
 	spinlock_t		freelist_lock;
 	struct closure_waitlist	freelist_wait;


### PR DESCRIPTION
## Summary

Allocator waiters currently filter filesystem-wide wakeups through the
per-device counters recorded in the failed allocation trace. If a device
becomes newly eligible after that trace was built, it is absent from the trace
and the waiter can re-park without rebuilding the eligible device set.

Add a filesystem-wide allocator wake generation. `bch2_alloc_wake_all()` now
advances that generation, and allocation requests compare it with the snapshot
taken before device selection. A changed generation forces a full allocator
retry while ordinary per-device wakes keep the existing selective filtering.

Also check allocator progress before the first closure sync. This closes the
lost-wakeup window where progress occurs after the counter snapshot but before
the closure is visible on `freelist_wait`.

## Reported failure

In the recurrence documented in
[koverstreet/bcachefs-tools#628](https://github.com/koverstreet/bcachefs-tools/issues/628#issuecomment-4940045386),
a blocked two-replica btree allocation retained a trace of the old eligible
devices. Adding and relabelling an empty btree/journal member made it eligible,
and new allocations used it, but the old waiters remained parked even after an
explicit filesystem-wide allocator wake.

## Validation

- `make -j32 bcachefs`
- external module build against Debian `7.1.3+deb14-amd64` headers
- the same change carried onto the deployed composite and loaded without
  reboot on the reported filesystem; clean-shutdown recovery completed,
  allocator waitlists remained empty, and the journal continued advancing

The PR is draft while a focused ktest reproducer for the stale-trace topology
change is being finalized.

References: koverstreet/bcachefs-tools#628
