### PR TITLE
Speculative support for online `bcachefs list`.

### DIFF
--- a/fs/bcachefs_ioctl.h
+++ b/fs/bcachefs_ioctl.h
@@ -73,6 +73,7 @@
 #define BCH_IOCTL_SUBVOLUME_LIST	_IOWR(0xbc,	31, struct bch_ioctl_subvol_readdir)
 #define BCH_IOCTL_SUBVOLUME_TO_PATH	_IOWR(0xbc,	32, struct bch_ioctl_subvol_to_path)
 #define BCH_IOCTL_SNAPSHOT_TREE		_IOWR(0xbc,	33, struct bch_ioctl_snapshot_tree_query)
+#define BCH_IOCTL_QUERY_BTREE_KEYS	_IOWR(0xbc,	34, struct bch_ioctl_query_btree_keys)
 
 /* ioctl below act on a particular file, not the filesystem as a whole: */
 
@@ -636,6 +637,48 @@ struct bch_ioctl_unpoison {
 	__u64				len;
 	__u32				flags;		/* reserved, must be 0 */
 	__u32				pad;
+};
+
+/*
+ * BCH_IOCTL_QUERY_BTREE_KEYS: read keys from a btree, as text, range query
+ *
+ * Stateless: the cursor lives in userspace and each call is self-contained,
+ * so concurrent callers don't interact and an aborted caller leaves nothing
+ * behind. Modeled on BTRFS_IOC_TREE_SEARCH / FS_IOC_GETFSMAP.
+ *
+ * Keys are formatted by the kernel (bch2_bkey_val_to_text), one per line,
+ * identical to the debugfs btrees/<id>/keys output. Text output carries no
+ * stability promise — this is a debugging interface. @flags is validated so
+ * a packed binary mode can be added later.
+ *
+ * @btree	- btree id
+ * @level	- btree level to read keys from (0 = leaves)
+ * @flags	- BCH_IOCTL_QUERY_BTREE_KEYS_*
+ * @done	- out: nonzero once iteration has reached the end of the range
+ * @start	- in/out: cursor, advanced past the last key returned
+ * @end		- inclusive upper bound
+ * @buf		- pointer to userspace buffer for formatted keys
+ * @buf_size	- size of buffer in bytes
+ * @used	- out: bytes written to buffer
+ *
+ * To iterate: repeat the call, keeping @start from the previous call, until
+ * @done is set. The kernel bounds how much it returns per call, so @used may
+ * be well short of @buf_size while more keys remain.
+ *
+ * Returns -ERANGE if @buf_size is too small to hold even one key.
+ */
+#define BCH_IOCTL_QUERY_BTREE_KEYS_all_snapshots	(1U << 0)
+
+struct bch_ioctl_query_btree_keys {
+	__u32			btree;
+	__u32			level;
+	__u32			flags;
+	__u32			done;
+	struct bpos		start;
+	struct bpos		end;
+	__u64			buf;
+	__u32			buf_size;
+	__u32			used;
 };
 
 #endif /* _BCACHEFS_IOCTL_H */

--- a/fs/errcode.h
+++ b/fs/errcode.h
@@ -378,6 +378,9 @@
 	x(EINVAL,			EINVAL_ioctl_dev_usage_bad_flags)		\
 	x(EINVAL,			EINVAL_ioctl_dev_usage_v2_not_started)		\
 	x(EINVAL,			EINVAL_ioctl_dev_usage_v2_bad_flags)		\
+	x(EINVAL,			EINVAL_ioctl_query_btree_keys_bad_flags)	\
+	x(EINVAL,			EINVAL_ioctl_query_btree_keys_bad_btree)	\
+	x(EINVAL,			EINVAL_ioctl_query_btree_keys_bad_level)	\
 	x(EINVAL,			EINVAL_ioctl_read_super_bad_flags)		\
 	x(EINVAL,			EINVAL_ioctl_disk_get_idx_bad_dev)		\
 	x(EINVAL,			EINVAL_ioctl_disk_resize_bad_flags)		\

--- a/fs/init/chardev.c
+++ b/fs/init/chardev.c
@@ -8,6 +8,9 @@
 #include "alloc/buckets.h"
 #include "alloc/replicas.h"
 
+#include "btree/bkey_methods.h"
+#include "btree/iter.h"
+
 #include "data/move.h"
 
 #include "fs/check.h"
@@ -712,6 +715,91 @@ static long bch2_ioctl_disk_resize_journal_v2(struct bch_fs *c,
 	return bch2_copy_ioctl_err_msg(&arg.err, &err, ret);
 }
 
+static long bch2_ioctl_query_btree_keys(struct bch_fs *c,
+			struct bch_ioctl_query_btree_keys __user *user_arg)
+{
+	struct bch_ioctl_query_btree_keys arg;
+
+	try(copy_from_user_errcode(&arg, user_arg, sizeof(arg)));
+
+	/*
+	 * Exposes all filesystem metadata - dirents, inodes, xattrs - and is
+	 * reachable by any user via the file ioctl path, so admin only:
+	 */
+	if (!capable(CAP_SYS_ADMIN))
+		return bch_err_throw(c, EPERM_non_admin);
+
+	if (arg.flags & ~BCH_IOCTL_QUERY_BTREE_KEYS_all_snapshots)
+		return bch_err_throw(c, EINVAL_ioctl_query_btree_keys_bad_flags);
+
+	if (arg.btree >= BTREE_ID_NR)
+		return bch_err_throw(c, EINVAL_ioctl_query_btree_keys_bad_btree);
+
+	if (arg.level >= BTREE_MAX_DEPTH)
+		return bch_err_throw(c, EINVAL_ioctl_query_btree_keys_bad_level);
+
+	unsigned iter_flags = BTREE_ITER_prefetch;
+	if (arg.flags & BCH_IOCTL_QUERY_BTREE_KEYS_all_snapshots)
+		iter_flags |= BTREE_ITER_all_snapshots;
+
+	/* bound per-call kernel allocation; the caller loops anyways */
+	u32 buf_size = min_t(u32, arg.buf_size, 1U << 20);
+
+	arg.done = 0;
+
+	CLASS(printbuf, out)();
+	out.may_vmalloc = true;
+
+	{
+		CLASS(btree_trans, trans)(c);
+		CLASS(btree_node_iter, iter)(trans, (enum btree_id) arg.btree,
+					     arg.start, 0, arg.level, iter_flags);
+
+		while (1) {
+			bch2_trans_begin(trans);
+
+			struct bkey_s_c k = bch2_btree_iter_peek_max(&iter, &arg.end);
+			int ret = bkey_err(k);
+			if (bch2_err_matches(ret, BCH_ERR_transaction_restart))
+				continue;
+			if (ret)
+				return ret;
+			if (!k.k) {
+				arg.done = 1;
+				break;
+			}
+
+			unsigned prev = out.pos;
+			bch2_bkey_val_to_text(&out, c, k);
+			prt_newline(&out);
+
+			if (out.pos > buf_size) {
+				/* buffer full: this key wasn't returned, resume at it */
+				if (!prev)
+					return -ERANGE;
+				out.pos = prev;
+				arg.start = iter.pos;
+				break;
+			}
+
+			if (!bch2_btree_iter_advance(&iter)) {
+				arg.done = 1;
+				break;
+			}
+			arg.start = iter.pos;
+		}
+	}
+
+	if (out.allocation_failure)
+		return -ENOMEM;
+
+	arg.used = out.pos;
+
+	return copy_to_user_errcode((void __user *)(unsigned long) arg.buf,
+				    out.buf, arg.used) ?:
+		copy_to_user_errcode(user_arg, &arg, sizeof(arg));
+}
+
 #define BCH_IOCTL(_name, _argtype)					\
 do {									\
 	_argtype i;							\
@@ -780,6 +868,8 @@ long bch2_fs_ioctl(struct bch_fs *c, unsigned cmd, void __user *arg)
 		return bch2_ioctl_query_accounting(c, arg);
 	case BCH_IOCTL_QUERY_COUNTERS:
 		return bch2_ioctl_query_counters(c, arg);
+	case BCH_IOCTL_QUERY_BTREE_KEYS:
+		return bch2_err_class(bch2_ioctl_query_btree_keys(c, arg));
 	default:
 		return -ENOTTY;
 	}

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,6 +1,7 @@
+use std::io::Write;
 use std::ops::ControlFlow;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use bcachefs_kernel::{btree_id, c};
 use bcachefs_kernel::btree::bkey::BkeySC;
 use bcachefs_kernel::btree::iter::BtreeIter;
@@ -14,6 +15,7 @@ use clap::Parser;
 use std::io::{stdout, IsTerminal};
 
 use crate::logging;
+use crate::wrappers::handle::BcachefsHandle;
 
 fn list_keys(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let trans = BtreeTrans::new(fs);
@@ -125,6 +127,65 @@ fn list_nodes_ondisk(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// List keys from a mounted filesystem via BCH_IOCTL_QUERY_BTREE_KEYS.
+/// The kernel formats the keys and holds no state between calls: the
+/// cursor lives in `arg.start` and each call is self-contained.
+fn list_keys_online(fs: &BcachefsHandle, opt: &Cli) -> anyhow::Result<()> {
+    let mut flags = 0;
+    if opt.start.snapshot == 0 {
+        flags |= c::BCH_IOCTL_QUERY_BTREE_KEYS_all_snapshots;
+    }
+
+    let mut arg = c::bch_ioctl_query_btree_keys {
+        btree: opt.btree.into(),
+        level: opt.level,
+        flags,
+        start: opt.start,
+        end: opt.end,
+        ..Default::default()
+    };
+
+    let mut buf = vec![0u8; 1 << 20];
+    let mut out = stdout().lock();
+
+    loop {
+        arg.buf = buf.as_mut_ptr() as u64;
+        arg.buf_size = buf.len() as u32;
+
+        match fs.query_btree_keys(&mut arg) {
+            Ok(()) => {}
+            Err(e) if e.0 == libc::ERANGE => {
+                let new_len = buf.len() * 4;
+                buf = vec![0u8; new_len];
+                continue;
+            }
+            Err(e) => bail!("BCH_IOCTL_QUERY_BTREE_KEYS: {}", e),
+        }
+
+        out.write_all(&buf[..arg.used as usize])?;
+
+        if arg.done != 0 {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn list_online(fs: &BcachefsHandle, opt: &Cli) -> anyhow::Result<()> {
+    if !matches!(opt.mode, Mode::Keys) {
+        bail!("only 'keys' mode is supported on a mounted filesystem");
+    }
+    if opt.bkey_type.is_some() {
+        bail!("--bkey-type is not supported on a mounted filesystem");
+    }
+    if opt.fsck {
+        bail!("--fsck requires the filesystem to be unmounted; use 'bcachefs fsck' for online fsck");
+    }
+
+    list_keys_online(fs, opt)
+}
+
 #[derive(Clone, clap::ValueEnum, Debug)]
 enum Mode {
     Keys,
@@ -137,7 +198,9 @@ enum Mode {
 #[derive(Parser, Debug)]
 #[command(long_about = "\
 Lists btree contents in human-readable text. Operates on unmounted \
-devices in read-only mode. Modes: keys (default) prints key/value pairs, \
+devices in read-only mode; if the filesystem is mounted (device, \
+mount point, or UUID), keys are listed via the kernel instead. \
+Modes: keys (default) prints key/value pairs, \
 formats shows btree node packing format, nodes shows btree node keys, \
 nodes-ondisk shows the raw on-disk representation.\n\n\
 Use -b to select a btree (default: extents), -s/-e for start/end \
@@ -186,6 +249,13 @@ pub struct Cli {
 }
 
 fn cmd_list_inner(opt: &Cli) -> anyhow::Result<()> {
+    // A mounted filesystem can't be opened for reading directly, but the
+    // kernel can list keys for us:
+    if let Some(fs) = BcachefsHandle::open_if_mounted(&opt.devices[0])? {
+        log::info!("filesystem is mounted, listing via the kernel");
+        return list_online(&fs, opt);
+    }
+
     let mut fs_opts = c::bch_opts::default();
 
     opt_set!(fs_opts, noexcl, 1);

--- a/src/wrappers/handle.rs
+++ b/src/wrappers/handle.rs
@@ -12,6 +12,7 @@ use bch_bindgen::c::{
     bch_ioctl_disk_resize, bch_ioctl_disk_resize_v2,
     bch_ioctl_disk_resize_journal, bch_ioctl_disk_resize_journal_v2,
     bch_ioctl_subvolume, bch_ioctl_subvolume_v2,
+    bch_ioctl_query_btree_keys,
     BCH_BY_INDEX, BCH_SUBVOL_SNAPSHOT_CREATE,
 };
 use bch_bindgen::accounting::data_type;
@@ -140,12 +141,47 @@ impl BcachefsHandle {
                 .map_err(|e| BchError::from_raw(-e.0));
         }
 
-        // It's a path — open it
-        let path_fd = rustix::fs::open(
+        if let Some(handle) = Self::open_if_mounted(path)? {
+            return Ok(handle);
+        }
+
+        // Fallback: read superblock to get UUID
+        Self::open_via_superblock(path)
+    }
+
+    /// Opens the filesystem a path belongs to, if it's currently mounted:
+    /// a UUID, a path on a mounted filesystem, or a block device that's a
+    /// member of one. Returns Ok(None) — instead of falling back to reading
+    /// the superblock — when the path doesn't resolve to a mounted
+    /// filesystem.
+    ///
+    /// Regular files are never resolved: a filesystem image is not itself a
+    /// mounted filesystem, and an image stored on a mounted bcachefs would
+    /// otherwise resolve to the outer filesystem. Callers treat images as
+    /// offline superblocks.
+    pub(crate) fn open_if_mounted<P: AsRef<Path>>(path: P) -> Result<Option<Self>, BchError> {
+        let path = path.as_ref();
+
+        if let Ok(uuid) = parse_uuid(&path.to_string_lossy()) {
+            // No sysfs dir for the UUID means not mounted
+            return Ok(Self::open_by_name(&path.to_string_lossy(), Some(uuid)).ok());
+        }
+
+        let Ok(path_fd) = rustix::fs::open(
             path,
             rustix::fs::OFlags::RDONLY,
             rustix::fs::Mode::empty(),
-        ).map_err(|e| BchError::from_raw(-e.raw_os_error()))?;
+        ) else {
+            return Ok(None);
+        };
+
+        let stat = rustix::fs::fstat(&path_fd)
+            .map_err(|e| BchError::from_raw(-e.raw_os_error()))?;
+        let file_type = rustix::fs::FileType::from_raw_mode(stat.st_mode);
+
+        if file_type == rustix::fs::FileType::RegularFile {
+            return Ok(None);
+        }
 
         // Try BCH_IOCTL_QUERY_UUID — if it succeeds, it's a mounted fs path
         let mut query_uuid = BchIoctlQueryUuid::default();
@@ -153,17 +189,13 @@ impl BcachefsHandle {
             libc::ioctl(path_fd.as_raw_fd(), BCH_IOCTL_QUERY_UUID, &mut query_uuid)
         };
         if ret == 0 {
-            return Self::open_mounted_path(path_fd, query_uuid.uuid);
+            return Self::open_mounted_path(path_fd, query_uuid.uuid).map(Some);
         }
-
-        // stat the path to distinguish block device vs file
-        let stat = rustix::fs::fstat(&path_fd)
-            .map_err(|e| BchError::from_raw(-e.raw_os_error()))?;
 
         // Drop path_fd — we'll re-open via sysfs/ctl
         drop(path_fd);
 
-        if rustix::fs::FileType::from_raw_mode(stat.st_mode) == rustix::fs::FileType::BlockDevice {
+        if file_type == rustix::fs::FileType::BlockDevice {
             // Block device: try sysfs symlink
             let major = rustix::fs::major(stat.st_rdev);
             let minor = rustix::fs::minor(stat.st_rdev);
@@ -178,13 +210,12 @@ impl BcachefsHandle {
                     let mut handle = Self::open_by_name(uuid_str, uuid)
                         .map_err(|e| BchError::from_raw(-e.0))?;
                     handle.dev_idx = dev_idx;
-                    return Ok(handle);
+                    return Ok(Some(handle));
                 }
             }
         }
 
-        // Fallback: read superblock to get UUID
-        Self::open_via_superblock(path)
+        Ok(None)
     }
 
     /// Open a mounted filesystem path. The fd becomes the ioctl fd.
@@ -456,6 +487,21 @@ impl BcachefsHandle {
                 continue;
             }
             return Err(Errno(err));
+        }
+    }
+
+    /// BCH_IOCTL_QUERY_BTREE_KEYS: fetch one buffer's worth of formatted
+    /// keys from a btree range. The cursor lives in `arg` — the kernel
+    /// advances `arg.start` past the last key returned; loop until
+    /// `arg.done` is set. Returns ERANGE if `arg.buf_size` can't hold even
+    /// a single key.
+    pub(crate) fn query_btree_keys(&self, arg: &mut bch_ioctl_query_btree_keys) -> Result<(), Errno> {
+        let request = bch_ioc_wr::<bch_ioctl_query_btree_keys>(34);
+        let ret = unsafe { libc::ioctl(self.ioctl_fd_raw(), request, arg as *mut _) };
+        if ret == 0 {
+            Ok(())
+        } else {
+            Err(Errno(io::Error::last_os_error().raw_os_error().unwrap_or(libc::EIO)))
         }
     }
 


### PR DESCRIPTION
I've seen a few cases where I *really* want to be able to read keys out of a running filesystem. Well, this should accomplish that. Includes an admin-only ioctl that basically exposes the internal btree search functionality to the outside, and `bcachefs list` will now check for a mounted filesystem and make use of it if there is one.

Implementation just goes through an IOCTL shaped exactly like btree_node_iter; the filesystem returns as much data as it can, then closes the handle. So you don't get a single-transaction list right now, but the kernel also doesn't have to track stateful external iterators. Would've been fine for me, unclear if that's something that should be changed in the long run.

This is speculative; I put it together because I wanted the feature, but it may be that you either think it's badly designed (probably valid) or is a misfeature (I wouldn't agree with that one though :V)

There's currently three different implementations of optionally opening a mounted filesystem, so naturally I've added a fourth; the previous ones (set-fs-option, fsck, device add) are all bespoke and this makes some sense to me as a general-purpose pathway. Again, speculative (but if this gets merged, happy to go and consolidate the other three, or fix this one up to take on functionality that it missed.)