### PR TITLE
btree: fix inverted condition in bch2_trans_commit_lazy()

### DIFF
--- a/fs/btree/update.h
+++ b/fs/btree/update.h
@@ -346,7 +346,7 @@ static inline int bch2_trans_commit_lazy(struct btree_trans *trans,
 					 u64 *journal_seq,
 					 unsigned flags)
 {
-	if (bch2_trans_has_updates(trans))
+	if (!bch2_trans_has_updates(trans))
 		return 0;
 
 	trans->disk_res		= disk_res;


### PR DESCRIPTION
Commit 435953279e6d ("commit: bch2_trans_commit_lazy() is more precise") rewrote the wrapper from

```c
return bch2_trans_has_updates(trans)
	? (bch2_trans_commit(trans, disk_res, journal_seq, flags) ?:
	   bch_err_throw(trans->c, transaction_restart_commit))
	: 0;
```

to an early return plus `__bch2_trans_commit(..., lazy = true)` — but dropped the negation on the early return. As written it returns 0 without committing exactly when there *are* queued updates, and runs a pointless empty commit when there aren't any.

Every caller queues updates and then relies on this committing them: the str_hash duplicate repair, several check.c fsck repairs, snapshot deletion, reflink, move. All of them currently lose their updates silently (the transaction's updates are reset by the next commit/restart without ever hitting the journal).

Looks like a ternary-to-early-return conversion slip: the ternary's true branch (has updates → commit) became the early `return 0`, so the branches got swapped rather than negated. It survives silently because nothing crashes — the repair paths just quietly don't repair.

This restores the negation, so the semantics match the pre-refactor wrapper: no-op on an empty transaction, commit + `transaction_restart_commit` otherwise (the `lazy` path in `__bch2_trans_commit()` already throws the restart). The empty-transaction check in the wrapper is still needed with the new design — an empty lazy commit would otherwise also throw `transaction_restart_commit` and restart forever.

Found while code-reviewing the reconcile paths.
