### PR TITLE
kvdb: suppress copygc and reconcile in the injection tool's fs instance

### DIFF
--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -437,11 +437,16 @@ fn kvdb(cli: Cli) -> Result<()> {
 
     let mut fs_opts = c::bch_opts::default();
     opt_set!(fs_opts, degraded, bch_degraded_actions::BCH_DEGRADED_very as u8);
-    // An injection tool must not consume its own injections: with this on,
-    // writing WILL_DELETE to a snapshot node kicks the deletion worker in
-    // *this* fs instance, and the state under test is gone (root inode and
-    // all) before fsck ever sees the image.
+    // An injection tool must not consume its own injections: background
+    // workers in *this* fs instance would otherwise act on the state under
+    // test the moment we go read-write. Snapshot deletion reaps a snapshot
+    // node a test marked WILL_DELETE (root inode and all) before fsck ever
+    // sees the image; copygc evacuates fragmented buckets, rewriting
+    // backpointers a test just staged or is about to read; reconcile
+    // consumes pending needs_reconcile state.
     opt_set!(fs_opts, auto_snapshot_deletion, 0);
+    opt_set!(fs_opts, copygc_enabled, 0);
+    opt_set!(fs_opts, reconcile_enabled, 0);
     opt_set!(
         fs_opts,
         errors,


### PR DESCRIPTION
Same reasoning as the auto_snapshot_deletion suppression: an injection tool must not consume its own injections. On a fragmented image copygc starts evacuating buckets as soon as the fs instance goes read-write - a 'list backpointers' session rewrote the fixture out from under the update session that followed it.

----

Note: Implemented mostly for the sake of https://github.com/koverstreet/ktest/pull/95 .