### PR TITLE
btree: commit_lazy follow-ups — don't mask real commit errors; warn on dropped updates

### DIFF
--- a/fs/btree/commit.c
+++ b/fs/btree/commit.c
@@ -1457,7 +1457,12 @@ out:
 
 	if (!ret)
 		bch2_trans_downgrade(trans);
-	if (lazy)
+	/*
+	 * Lazy commits signal success via transaction_restart_commit; a real
+	 * error must not be masked into a restart, or the caller's restart
+	 * loop retries a failing commit forever:
+	 */
+	if (lazy && !ret)
 		ret = bch_err_throw(trans->c, transaction_restart_commit);
 out_reset:
 	bch2_trans_reset_updates(trans);

--- a/fs/btree/iter.c
+++ b/fs/btree/iter.c
@@ -3757,6 +3757,17 @@ u32 bch2_trans_begin(struct btree_trans *trans)
 	unsigned i;
 	u64 now;
 
+	/*
+	 * Discarding queued updates is correct after a transaction restart
+	 * (the restart loop re-queues them) and on error unwind — but a new
+	 * iteration starting with updates queued and no restart in flight
+	 * means the previous iteration forgot to commit them, and they're
+	 * about to be lost silently:
+	 */
+	WARN_ON_ONCE(IS_ENABLED(CONFIG_BCACHEFS_DEBUG) &&
+		     bch2_trans_has_updates(trans) &&
+		     !trans->restarted && !trans->in_traverse_all);
+
 	bch2_trans_reset_updates(trans);
 
 	trans->restart_count++;


### PR DESCRIPTION
Two follow-ups to the `bch2_trans_commit_lazy()` inversion fix that landed
in `testing` as 83f72cd2 (from #780).

The first commit is the observability that would have caught that bug weeks
earlier. `bch2_trans_begin()` silently discards queued updates — correct
after a transaction restart, where the restart loop re-queues them, but a
new iteration starting with updates queued and no restart in flight means
the previous iteration forgot to commit, and the updates are lost with no
trace. That is exactly what the inverted condition did to every fsck-repair
caller, and nothing crashed and nothing was logged, which is how it
survived for weeks. Under CONFIG_BCACHEFS_DEBUG this now warns once when it
happens.

The second is a correctness fix in the same path: the lazy-commit
conversion to `transaction_restart_commit` at the end of
`__bch2_trans_commit()` ran unconditionally, overwriting real errors from
`bch2_trans_commit_error()` — journal shutdown, EIO,
`journal_reclaim_would_deadlock` — with a restart signal. Every
`bch2_trans_commit_lazy()` caller sits inside a restart loop, so a lazy
commit hitting a persistent error would retry forever, silently. Only
success is converted into the restart signal now.

Both apply on current `testing` (649d646629ef) and the module builds
cleanly with them.
