### PR TITLE
doc: set Architectures in the apt sources stanza

### DIFF
--- a/doc/apt.bcachefs.org-README.md
+++ b/doc/apt.bcachefs.org-README.md
@@ -10,6 +10,7 @@ URIs: https://apt.bcachefs.org/unstable/
 # Or replace unstable with your distro's release name
 Suites: bcachefs-tools-release
 Components: main
+Architectures: $(dpkg --print-architecture)
 Signed-By: /etc/apt/keyrings/apt.bcachefs.org.asc
 EOF
 sudo apt update


### PR DESCRIPTION
# doc: set Architectures in the apt sources stanza

The sources stanza in `doc/apt.bcachefs.org-README.md` omits `Architectures:`,
so apt fetches one index per architecture dpkg knows about. On any host that
has added a foreign arch — common with steam/wine adding i386 — every
`apt update` prints:

```
N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository
'https://apt.bcachefs.org/resolute bcachefs-tools-release InRelease' doesn't
support architecture 'i386'
```

This is not specific to resolute. Checked all 12 published suites; none carry
i386:

| Distros | Architectures published |
|---|---|
| unstable, forky, trixie | amd64 arm64 ppc64el |
| resolute, questing, plucky | amd64 arm64 |

Pinning the stanza to `amd64` would silence the note but break arm64 users,
who the CI actively builds for. Instead it auto-detects the native arch, in
the same spirit as the `VERSION_CODENAME` substitution used for the suite:

```
Architectures: $(dpkg --print-architecture)
```

The heredoc is unquoted, so this expands at install time. Verified it renders
to `Architectures: amd64` on an amd64 host.

Note this only narrows the *index fetch* to the running architecture. Anyone
deliberately cross-installing (`apt install bcachefs-tools:arm64`) would need
to widen the list by hand — that seemed the right trade against making the
default copy-paste noisy for everyone.
