### PR TITLE
bcachefs: don't hold srcu lock across blocking operations

### DIFF
--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -55,7 +55,7 @@ static void bch2_trans_mutex_lock_norelock(struct btree_trans *trans,
 					   struct mutex *lock)
 {
 	if (!mutex_trylock(lock)) {
-		bch2_trans_unlock(trans);
+		bch2_trans_unlock_long(trans);
 		mutex_lock(lock);
 	}
 }

--- a/fs/btree/cache.c
+++ b/fs/btree/cache.c
@@ -927,7 +927,7 @@ struct btree *bch2_btree_node_mem_alloc(struct btree_trans *trans, bool pcpu_rea
 
 	struct btree_node_bufs bufs = { .byte_order = ilog2(c->opts.btree_node_size) };
 	if (__btree_node_data_alloc(c, &bufs, GFP_NOWAIT, true)) {
-		bch2_trans_unlock(trans);
+		bch2_trans_unlock_long(trans);
 		if (__btree_node_data_alloc(c, &bufs, GFP_KERNEL|__GFP_NOWARN, true)) {
 			btree_node_bufs_free(&bufs);
 			goto err;
@@ -938,7 +938,7 @@ struct btree *bch2_btree_node_mem_alloc(struct btree_trans *trans, bool pcpu_rea
 	if (!b) {
 		b = __btree_node_mem_alloc(c, pcpu_read_locks, GFP_NOWAIT);
 		if (!b) {
-			bch2_trans_unlock(trans);
+			bch2_trans_unlock_long(trans);
 			b = __btree_node_mem_alloc(c, pcpu_read_locks, GFP_KERNEL);
 			if (!b) {
 				btree_node_bufs_free(&bufs);
@@ -1074,7 +1074,7 @@ static noinline struct btree *bch2_btree_node_fill(struct btree_trans *trans,
 
 			/* Unlock before doing IO: */
 			six_unlock_intent(&b->c.lock);
-			bch2_trans_unlock(trans);
+			bch2_trans_unlock_long(trans);
 
 			bch2_btree_node_read(trans, b, sync);
 
@@ -1248,7 +1248,7 @@ retry:
 		u32 seq = six_lock_seq(&b->c.lock);
 
 		six_unlock_type(&b->c.lock, lock_type);
-		bch2_trans_unlock(trans);
+		bch2_trans_unlock_long(trans);
 
 		bch2_btree_node_wait_on_read(trans, b);
 

--- a/fs/btree/commit.c
+++ b/fs/btree/commit.c
@@ -442,9 +442,9 @@ btree_key_can_insert_cached_slowpath(struct btree_trans *trans,
 		struct bkey_i *new_k	= kmalloc(new_u64s * sizeof(u64), GFP_NOWAIT);
 		if (unlikely(!new_k)) {
 			bch2_trans_unlock_updates_write(trans);
-			bch2_trans_unlock(trans);
+			bch2_trans_unlock_long(trans);
 
-			new_k = kmalloc(new_u64s * sizeof(u64), GFP_KERNEL);
+			new_k = kmalloc(new_u64s * sizeof(u64), GFP_NOFS);
 			if (!new_k) {
 				struct bch_fs *c = trans->c;
 				bch_err(c, "error allocating memory for key cache key, btree %s u64s %u",
@@ -810,7 +810,7 @@ static int __bch2_trans_commit_error(struct btree_trans *trans, unsigned flags,
 		    watermark < BCH_WATERMARK_reclaim)
 			return bch_err_throw(c, journal_reclaim_would_deadlock);
 
-		return drop_locks_do(trans,
+		return drop_locks_long_do(trans,
 			bch2_trans_journal_res_get(trans,
 					(flags & BCH_WATERMARK_MASK)|
 					JOURNAL_RES_GET_CHECK));
@@ -835,7 +835,7 @@ static int __bch2_trans_commit_error(struct btree_trans *trans, unsigned flags,
 	case -BCH_ERR_btree_insert_need_mark_replicas:
 		return drop_locks_do(trans, bch2_accounting_update_sb(trans));
 	case -BCH_ERR_btree_insert_need_journal_reclaim:
-		bch2_trans_unlock(trans);
+		bch2_trans_unlock_long(trans);
 
 		event_inc_trace(c, trans_blocked_journal_reclaim, buf, ({
 			prt_printf(&buf, "%s\n", trans->fn);

--- a/fs/btree/commit.c
+++ b/fs/btree/commit.c
@@ -458,6 +458,19 @@ btree_key_can_insert_cached_slowpath(struct btree_trans *trans,
 				kfree(new_k);
 				return ret;
 			}
+
+			/*
+			 * bch2_trans_unlock_long() may drop transaction SRCU and
+			 * invalidate cached paths; the old ck pointer is only
+			 * protected while the cached path is locked/SRCU is held.
+			 * Refresh it after relock, and handle the race where
+			 * another transaction already grew the cached key.
+			 */
+			ck = (void *) path->l[0].b;
+			if (u64s <= ck->u64s) {
+				kfree(new_k);
+				goto have_space;
+			}
 		}
 
 		memcpy(new_k, ck->k, ck->u64s * sizeof(u64));
@@ -471,6 +484,7 @@ btree_key_can_insert_cached_slowpath(struct btree_trans *trans,
 		ck->k		= new_k;
 	}
 
+have_space:
 	if (watermark < BCH_WATERMARK_reclaim &&
 	    !test_bit(BKEY_CACHED_DIRTY, &ck->flags) &&
 	    bch2_btree_key_cache_must_wait(c) &&

--- a/fs/btree/commit.c
+++ b/fs/btree/commit.c
@@ -439,6 +439,7 @@ btree_key_can_insert_cached_slowpath(struct btree_trans *trans,
 
 	if (u64s > ck->u64s) {
 		unsigned new_u64s	= roundup_pow_of_two(u64s + u64s / 2);
+		const struct bch_val *old_v = &ck->k->v;
 		struct bkey_i *new_k	= kmalloc(new_u64s * sizeof(u64), GFP_NOWAIT);
 		if (unlikely(!new_k)) {
 			bch2_trans_unlock_updates_write(trans);
@@ -467,6 +468,12 @@ btree_key_can_insert_cached_slowpath(struct btree_trans *trans,
 			 * another transaction already grew the cached key.
 			 */
 			ck = (void *) path->l[0].b;
+			if (old_v != &ck->k->v) {
+				trans_for_each_update(trans, i)
+					if (i->old_v == old_v)
+						i->old_v = &ck->k->v;
+				old_v = &ck->k->v;
+			}
 			if (u64s <= ck->u64s) {
 				kfree(new_k);
 				goto have_space;
@@ -477,7 +484,7 @@ btree_key_can_insert_cached_slowpath(struct btree_trans *trans,
 		kfree(ck->k);
 
 		trans_for_each_update(trans, i)
-			if (i->old_v == &ck->k->v)
+			if (i->old_v == old_v)
 				i->old_v = &new_k->v;
 
 		ck->u64s	= new_u64s;

--- a/fs/btree/interior.c
+++ b/fs/btree/interior.c
@@ -3731,7 +3731,7 @@ int bch2_btree_root_alloc_fake_trans(struct btree_trans *trans, enum btree_id id
 
 	do {
 		ret = bch2_btree_cache_cannibalize_lock(trans, &cl);
-		closure_sync(&cl);
+		trans_closure_sync(trans, &cl);
 	} while (ret);
 
 	b = bch2_btree_node_mem_alloc(trans, false);

--- a/fs/btree/interior.c
+++ b/fs/btree/interior.c
@@ -999,7 +999,7 @@ static void btree_update_nodes_written(struct btree_update *as)
 	 * which may require allocations as well.
 	 */
 
-	bch2_trans_unlock(trans);
+	bch2_trans_unlock_long(trans);
 	/*
 	 * btree_interior_update_commit_lock is needed for synchronization with
 	 * btree_node_update_key(): having the lock be at the filesystem level
@@ -1438,7 +1438,7 @@ bch2_btree_update_start(struct btree_trans *trans, btree_path_idx_t path_idx,
 		if (commit_flags & BCH_TRANS_COMMIT_journal_reclaim)
 			return ERR_PTR(-BCH_ERR_journal_reclaim_would_deadlock);
 
-		ret = drop_locks_do(trans,
+		ret = drop_locks_long_do(trans,
 			({ trans_wait_event(trans, &c->journal.async_wait,
 					    !journal_low_on_space(&c->journal)); 0; }));
 		if (ret)
@@ -1472,7 +1472,7 @@ bch2_btree_update_start(struct btree_trans *trans, btree_path_idx_t path_idx,
 	}
 
 	if (!down_read_trylock(&c->gc.lock)) {
-		ret = drop_locks_do(trans, (down_read(&c->gc.lock), 0));
+		ret = drop_locks_long_do(trans, (down_read(&c->gc.lock), 0));
 		if (ret) {
 			up_read(&c->gc.lock);
 			return ERR_PTR(ret);
@@ -1576,7 +1576,7 @@ bch2_btree_update_start(struct btree_trans *trans, btree_path_idx_t path_idx,
 		 * without waking up the waitlist:
 		 */
 		if (closure_nr_remaining(&cl) > 1)
-			bch2_trans_unlock(trans);
+			bch2_trans_unlock_long(trans);
 	}
 
 	if (ret) {

--- a/fs/btree/iter.c
+++ b/fs/btree/iter.c
@@ -4159,11 +4159,19 @@ static void bch2_btree_bkey_cached_common_to_text(struct printbuf *out,
 		   c.n[0], c.n[1], c.n[2], pid);
 }
 
+static char btree_lock_type_char(int lock_type)
+{
+	static const char lock_types[] = { 'r', 'i', 'w' };
+
+	return lock_type >= 0 && lock_type < ARRAY_SIZE(lock_types)
+		? lock_types[lock_type]
+		: '?';
+}
+
 __cold
 void bch2_btree_trans_to_text(struct printbuf *out, struct btree_trans *trans)
 {
 	struct btree_bkey_cached_common *b;
-	static char lock_types[] = { 'r', 'i', 'w' };
 	struct task_struct *task = READ_ONCE(trans->locking_wait.task);
 	unsigned l, idx;
 
@@ -4204,10 +4212,12 @@ void bch2_btree_trans_to_text(struct printbuf *out, struct btree_trans *trans)
 		prt_newline(out);
 
 		for (l = 0; l < BTREE_MAX_DEPTH; l++) {
-			if (btree_node_locked(path, l) &&
+			int lock_type = btree_node_locked_type(path, l);
+
+			if (lock_type != BTREE_NODE_UNLOCKED &&
 			    !IS_ERR_OR_NULL(b = (void *) READ_ONCE(path->l[l].b))) {
 				prt_printf(out, "    %c l=%u ",
-					   lock_types[btree_node_locked_type(path, l)], l);
+					   btree_lock_type_char(lock_type), l);
 				bch2_btree_bkey_cached_common_to_text(out, b);
 				prt_newline(out);
 			}
@@ -4217,7 +4227,8 @@ void bch2_btree_trans_to_text(struct printbuf *out, struct btree_trans *trans)
 	b = READ_ONCE(trans->locking);
 	if (b) {
 		prt_printf(out, "  blocked on:\n");
-		prt_printf(out, "    %c", lock_types[trans->locking_wait.lock_want]);
+		prt_printf(out, "    %c",
+			   btree_lock_type_char(READ_ONCE(trans->locking_wait.lock_want)));
 		bch2_btree_bkey_cached_common_to_text(out, b);
 		prt_newline(out);
 	}

--- a/fs/btree/iter.c
+++ b/fs/btree/iter.c
@@ -1277,7 +1277,7 @@ retry_all:
 
 		do {
 			ret = bch2_btree_cache_cannibalize_lock(trans, &cl);
-			closure_sync(&cl);
+			trans_closure_sync(trans, &cl);
 		} while (ret);
 	}
 

--- a/fs/btree/iter.h
+++ b/fs/btree/iter.h
@@ -1173,6 +1173,17 @@ struct bkey_s_c bch2_btree_iter_peek_root(struct btree_trans *, struct btree_ite
 	(_do) ?: bch2_trans_relock(_trans);				\
 })
 
+/*
+ * Like drop_locks_do, but also drops the SRCU read lock so that SRCU grace
+ * periods can complete and the shrinker can free old btree nodes.  Use before
+ * operations that may block for an extended/unbounded time.
+ */
+#define drop_locks_long_do(_trans, _do)					\
+({									\
+	bch2_trans_unlock_long(_trans);					\
+	(_do) ?: bch2_trans_relock(_trans);				\
+})
+
 #define allocate_dropping_locks_errcode(_trans, _do)			\
 ({									\
 	gfp_t _gfp = GFP_NOWAIT;					\

--- a/fs/btree/key_cache.c
+++ b/fs/btree/key_cache.c
@@ -446,6 +446,12 @@ static int btree_key_cache_flush_pos(struct btree_trans *trans,
 		if (journal_seq && ck->journal.seq != journal_seq)
 			return 0;
 
+		if (journal_seq && ck->seq != journal_seq) {
+			bch2_journal_pin_update(j, ck->seq, &ck->journal,
+						bch2_btree_key_cache_journal_flush);
+			return 0;
+		}
+
 		trans->journal_res.seq = ck->journal.seq;
 
 		/*
@@ -524,9 +530,8 @@ int bch2_btree_key_cache_journal_flush(struct journal *j,
 	struct bkey_cached *ck =
 		container_of(pin, struct bkey_cached, journal);
 	struct bkey_cached_key key;
+	bool do_flush = false;
 	int ret = 0;
-
-	guard(srcu)(&c->btree.trans.barrier);
 
 	/*
 	 * Lockless bailout: if the pin has already been updated past @seq, or
@@ -536,41 +541,35 @@ int bch2_btree_key_cache_journal_flush(struct journal *j,
 	 *
 	 * The intent lock taken below serializes against
 	 * btree_key_cache_flush_pos(), which reads ck->journal.seq while the
-	 * cached path's intent lock is held: a read lock here would let
-	 * pin_update advance the pin out from under that reader, leaving it
-	 * with a captured ck->journal.seq < j->last_seq and BUG'ing in
-	 * bch2_journal_pin_set() once the trans commit fed it back in.
+	 * cached path's intent lock is held. We only snapshot the key while
+	 * holding this callback's external SRCU guard; the actual flush is a
+	 * fresh lookup by key and may block in btree/journal I/O, so it must not
+	 * run under this guard.
 	 */
-	if (READ_ONCE(ck->journal.seq) == seq &&
-	    test_bit(BKEY_CACHED_DIRTY, &ck->flags)) {
-		CLASS(btree_trans, trans)(c);
+	{
+		guard(srcu)(&c->btree.trans.barrier);
 
-		ret = lockrestart_do(trans, ({
-			btree_path_idx_t path_idx;
-			int _ret = bch2_btree_node_lock_with_path(trans, &ck->c,
-								  SIX_LOCK_intent, &path_idx);
-			bool do_flush = false;
-
-			if (!_ret) {
-				key = ck->key;
-
-				if (ck->journal.seq != seq ||
-				    !test_bit(BKEY_CACHED_DIRTY, &ck->flags)) {
-					/* raced; nothing to do */
-				} else if (ck->seq != seq) {
-					bch2_journal_pin_update(&c->journal, ck->seq, &ck->journal,
-								bch2_btree_key_cache_journal_flush);
-				} else {
+		if (READ_ONCE(ck->journal.seq) == seq &&
+		    test_bit(BKEY_CACHED_DIRTY, &ck->flags)) {
+			if (!six_trylock_intent(&ck->c.lock)) {
+				ret = bch_err_throw(c, journal_reclaim_would_deadlock);
+			} else {
+				if (ck->journal.seq == seq &&
+				    test_bit(BKEY_CACHED_DIRTY, &ck->flags)) {
+					key = ck->key;
 					do_flush = true;
 				}
-				bch2_btree_node_unlock_with_path(trans, path_idx, 0);
-
-				if (do_flush)
-					_ret = btree_key_cache_flush_pos(trans, key, seq,
-							BCH_TRANS_COMMIT_journal_reclaim, false);
+				six_unlock_intent(&ck->c.lock);
 			}
-			_ret;
-		}));
+		}
+	}
+
+	if (do_flush) {
+		CLASS(btree_trans, trans)(c);
+
+		ret = lockrestart_do(trans,
+			btree_key_cache_flush_pos(trans, key, seq,
+				BCH_TRANS_COMMIT_journal_reclaim, false));
 		bch2_fs_fatal_err_on(ret &&
 				     !bch2_err_matches(ret, BCH_ERR_journal_reclaim_would_deadlock) &&
 				     !bch2_journal_error(j), c,
@@ -609,7 +608,6 @@ int bch2_btree_key_cache_flush_going_ro(struct bch_fs *c)
 	    bch2_journal_error(&c->journal))
 		return 0;
 
-	guard(srcu)(&c->btree.trans.barrier);
 	CLASS(btree_trans, trans)(c);
 	CLASS(bkey_cached_keys, keys)();
 	bool any_done = false, full;
@@ -625,33 +623,37 @@ int bch2_btree_key_cache_flush_going_ro(struct bch_fs *c)
 		full = false;
 		keys.nr = 0;
 
-		scoped_guard(rcu) {
-			struct bucket_table *tbl =
-				rht_dereference_rcu(bc->table.tbl, &bc->table);
+		{
+			guard(srcu)(&c->btree.trans.barrier);
 
-			/*
-			 * If a rehash is in flight some entries live on the new
-			 * table; skip this pass and let the OR-chain re-call us.
-			 */
-			if (unlikely(tbl->nest))
-				return any_done;
+			scoped_guard(rcu) {
+				struct bucket_table *tbl =
+					rht_dereference_rcu(bc->table.tbl, &bc->table);
 
-			for (unsigned i = 0; i < tbl->size; i++) {
-				struct rhash_head *pos;
-				struct bkey_cached *ck;
+				/*
+				 * If a rehash is in flight some entries live on the new
+				 * table; skip this pass and let the OR-chain re-call us.
+				 */
+				if (unlikely(tbl->nest))
+					return any_done;
 
-				rht_for_each_entry_rcu(ck, pos, tbl, i, hash) {
-					if (!test_bit(BKEY_CACHED_DIRTY, &ck->flags))
-						continue;
+				for (unsigned i = 0; i < tbl->size; i++) {
+					struct rhash_head *pos;
+					struct bkey_cached *ck;
 
-					if (darray_push_gfp(&keys, ck->key,
-							    GFP_NOWAIT|__GFP_NOWARN)) {
-						full = true;
-						goto rcu_done;
+					rht_for_each_entry_rcu(ck, pos, tbl, i, hash) {
+						if (!test_bit(BKEY_CACHED_DIRTY, &ck->flags))
+							continue;
+
+						if (darray_push_gfp(&keys, ck->key,
+								    GFP_NOWAIT|__GFP_NOWARN)) {
+							full = true;
+							goto rcu_done;
+						}
 					}
 				}
-			}
 rcu_done:;
+			}
 		}
 
 		if (!keys.nr)

--- a/fs/btree/locking.c
+++ b/fs/btree/locking.c
@@ -1294,7 +1294,7 @@ void bch2_trans_unlock_write(struct btree_trans *trans)
 int __bch2_trans_mutex_lock(struct btree_trans *trans,
 			    struct mutex *lock)
 {
-	int ret = drop_locks_do(trans, (mutex_lock(lock), 0));
+	int ret = drop_locks_long_do(trans, (mutex_lock(lock), 0));
 
 	if (ret)
 		mutex_unlock(lock);

--- a/fs/btree/read.c
+++ b/fs/btree/read.c
@@ -1104,7 +1104,7 @@ static int __bch2_btree_root_read(struct btree_trans *trans, enum btree_id id,
 
 	do {
 		ret = bch2_btree_cache_cannibalize_lock(trans, &cl);
-		closure_sync(&cl);
+		trans_closure_sync(trans, &cl);
 	} while (ret);
 
 	b = bch2_btree_node_mem_alloc(trans, level != 0);

--- a/fs/btree/read.c
+++ b/fs/btree/read.c
@@ -1120,7 +1120,7 @@ static int __bch2_btree_root_read(struct btree_trans *trans, enum btree_id id,
 	set_btree_node_read_in_flight(b);
 
 	/* we can't pass the trans to read_done() for fsck errors, so it must be unlocked */
-	bch2_trans_unlock(trans);
+	bch2_trans_unlock_long(trans);
 	bch2_btree_node_read(trans, b, true);
 
 	if (btree_node_read_error(b)) {

--- a/fs/data/ec/init.c
+++ b/fs/data/ec/init.c
@@ -155,7 +155,7 @@ int bch2_dev_remove_stripes(struct bch_fs *c, unsigned dev_idx,
 		if (ret || !had_open)
 			goto out;
 
-		bch2_trans_unlock(trans);
+		bch2_trans_unlock_long(trans);
 		bch2_fs_ec_flush_outstanding(c);
 	}
 

--- a/fs/data/ec/io.c
+++ b/fs/data/ec/io.c
@@ -611,7 +611,7 @@ int bch2_ec_read_extent(struct btree_trans *trans, struct bch_read_bio *rbio,
 	}
 
 	/* Don't hold btree locks for stripe buffer allocations, or IO */
-	bch2_trans_unlock(trans);
+	bch2_trans_unlock_long(trans);
 
 	ret = bch2_ec_stripe_buf_init(c, buf, offset, bio_sectors(&rbio->bio), NULL);
 	if (ret) {

--- a/fs/data/migrate.c
+++ b/fs/data/migrate.c
@@ -172,7 +172,7 @@ static int bch2_dev_metadata_drop(struct bch_fs *c,
 				drop_btree_ptrs(trans, &iter, b, dev_idx, flags, err);
 			})));
 
-	bch2_trans_unlock(trans);
+	bch2_trans_unlock_long(trans);
 	bch2_btree_interior_updates_flush(c);
 	return 0;
 }

--- a/fs/data/migrate.c
+++ b/fs/data/migrate.c
@@ -292,7 +292,7 @@ int bch2_dev_data_drop_by_backpointers(struct bch_fs *c, struct bch_dev *ca,
 		 * it never drains, the stall counter still terminates us.
 		 */
 		if (had_open_stripe) {
-			bch2_trans_unlock(trans);
+			bch2_trans_unlock_long(trans);
 			bch2_fs_ec_flush_outstanding(c);
 		}
 	}

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -1507,7 +1507,7 @@ int bch2_data_update_init(struct btree_trans *trans,
 				(locked = bch2_bkey_nocow_trylock(c, ptrs, m->cas, 0)) ||
 				list_empty(&ctxt->ios));
 			if (!locked) {
-				bch2_trans_unlock(trans);
+				bch2_trans_unlock_long(trans);
 				bch2_bkey_nocow_lock(c, trans, ptrs, m->cas, 0);
 			}
 		}

--- a/fs/data/update.c
+++ b/fs/data/update.c
@@ -841,7 +841,7 @@ int bch2_update_unwritten_extent(struct btree_trans *trans,
 				update->op.watermark,
 				update->op.flags, &cl, &wp);
 		if (bch2_err_matches(ret, BCH_ERR_operation_blocked)) {
-			bch2_trans_unlock(trans);
+			bch2_trans_unlock_long(trans);
 			closure_sync(&cl);
 			continue;
 		}
@@ -874,7 +874,7 @@ int bch2_update_unwritten_extent(struct btree_trans *trans,
 	}
 
 	if (closure_nr_remaining(&cl) != 1) {
-		bch2_trans_unlock(trans);
+		bch2_trans_unlock_long(trans);
 		closure_sync(&cl);
 	}
 
@@ -1519,7 +1519,7 @@ int bch2_data_update_init(struct btree_trans *trans,
 		goto out_nocow_unlock;
 	}
 
-	bch2_trans_unlock(trans);
+	bch2_trans_unlock_long(trans);
 
 	ret = bch2_data_update_bios_init(m, c, io_opts, buf_bytes);
 	if (ret)

--- a/fs/data/write.c
+++ b/fs/data/write.c
@@ -2242,7 +2242,7 @@ retry:
 		k = bkey_i_to_s_c(op->insert_keys.top);
 		ptrs = bch2_bkey_ptrs_c(k);
 
-		bch2_trans_unlock(trans);
+		bch2_trans_unlock_long(trans);
 
 		bch2_bkey_nocow_lock(c, trans, ptrs, cas, BUCKET_NOCOW_LOCK_UPDATE);
 

--- a/fs/init/error.c
+++ b/fs/init/error.c
@@ -241,27 +241,16 @@ static enum ask_yn bch2_fsck_ask_yn(struct bch_fs *c, struct btree_trans *trans)
 		return YN_NO;
 
 	if (trans)
-		bch2_trans_unlock(trans);
+		bch2_trans_unlock_long(trans);
 
-	unsigned long unlock_long_at = trans ? jiffies + HZ * 2 : 0;
 	darray_char line = {};
 	int ret;
 
 	do {
-		unsigned long t;
 		bch2_print(c, " (y,n, or Y,N for all errors of this type) ");
-rewait:
-		t = unlock_long_at
-			? max_t(long, unlock_long_at - jiffies, 0)
-			: MAX_SCHEDULE_TIMEOUT;
 
-		int r = bch2_stdio_redirect_readline_timeout(stdio, &line, t);
-		if (r == -ETIME) {
-			bch2_trans_unlock_long(trans);
-			unlock_long_at = 0;
-			goto rewait;
-		}
-
+		int r = bch2_stdio_redirect_readline_timeout(stdio, &line,
+							     MAX_SCHEDULE_TIMEOUT);
 		if (r < 0) {
 			ret = YN_NO;
 			break;

--- a/fs/journal/reclaim.c
+++ b/fs/journal/reclaim.c
@@ -20,6 +20,8 @@
 #include <linux/kthread.h>
 #include <linux/sched/mm.h>
 
+#define JOURNAL_PIN_DEADLOCK_SKIP_MAX	128
+
 static bool __should_discard_bucket(struct journal *j, struct journal_device *ja)
 {
 	unsigned min_free = max(4, ja->nr / 2);
@@ -576,6 +578,16 @@ static enum journal_pin_type journal_pin_type(struct journal_entry_pin *pin,
 		return JOURNAL_PIN_TYPE_other;
 }
 
+static bool journal_pin_is_skipped(struct journal_entry_pin *pin,
+				   struct journal_entry_pin **skipped,
+				   unsigned nr_skipped)
+{
+	for (unsigned i = 0; i < nr_skipped; i++)
+		if (skipped[i] == pin)
+			return true;
+	return false;
+}
+
 static inline bool bch2_journal_pin_set_locked(struct journal *j,
 			struct journal_entry_pin_list *old_l,
 			struct journal_entry_pin_list *new_l,
@@ -742,6 +754,8 @@ journal_get_next_pin(struct journal *j,
 		     u64 seq_to_flush,
 		     unsigned allowed_below_seq,
 		     unsigned allowed_above_seq,
+		     struct journal_entry_pin **skipped,
+		     unsigned nr_skipped,
 		     u64 *seq, journal_pin_flush_fn *flush_fn)
 {
 	guard(percpu_read)(&j->pin_resize_lock);
@@ -766,9 +780,9 @@ journal_get_next_pin(struct journal *j,
 		for (unsigned i = 0; i < JOURNAL_PIN_TYPE_NR; i++)
 			if (((BIT(i) & allowed_below_seq) && *seq <= seq_to_flush) ||
 			    (BIT(i) & allowed_above_seq)) {
-				ret = list_first_entry_or_null(&pin_list->unflushed[i],
-					struct journal_entry_pin, list);
-				if (ret) {
+				list_for_each_entry(ret, &pin_list->unflushed[i], list) {
+					if (journal_pin_is_skipped(ret, skipped, nr_skipped))
+						continue;
 					BUG_ON(j->flush_in_progress);
 					j->flush_in_progress = ret;
 					j->flush_in_progress_dropped = false;
@@ -792,6 +806,14 @@ static size_t journal_flush_pins(struct journal *j,
 	struct bch_fs *c = container_of(j, struct bch_fs, journal);
 	struct journal_entry_pin *pin;
 	size_t nr_flushed = 0;
+	/*
+	 * journal_reclaim_would_deadlock means "this pin can't be flushed from
+	 * reclaim right now without blocking behind another transaction". Keep a
+	 * bounded per-pass skip set so one contended old pin doesn't hide other
+	 * flushable pins; skipped pins stay unflushed and are retried next pass.
+	 */
+	struct journal_entry_pin *deadlock_skipped[JOURNAL_PIN_DEADLOCK_SKIP_MAX];
+	unsigned nr_deadlock_skipped = 0;
 	int err;
 
 	lockdep_assert_held(&j->reclaim_lock);
@@ -824,17 +846,14 @@ static size_t journal_flush_pins(struct journal *j,
 		u64 seq;
 		journal_pin_flush_fn flush_fn;
 		pin = journal_get_next_pin(j, seq_to_flush, allowed_below, allowed_above,
+					   deadlock_skipped, nr_deadlock_skipped,
 					   &seq, &flush_fn);
 		if (!pin)
 			break;
 
-		if (min_key_cache && pin->flush == bch2_btree_key_cache_journal_flush)
-			min_key_cache--;
-
-		if (min_any)
-			min_any--;
-
+		bool key_cache_pin = flush_fn == bch2_btree_key_cache_journal_flush;
 		u64 start_time = local_clock();
+		bool retry_deadlocked = false;
 		err = flush_fn(j, pin, seq);
 
 		scoped_guard(percpu_read, &j->pin_resize_lock) {
@@ -842,6 +861,8 @@ static size_t journal_flush_pins(struct journal *j,
 
 			guard(spinlock)(&pin_l->lock);
 			enum journal_pin_type type = journal_pin_type(pin, flush_fn);
+			bool would_deadlock =
+				bch2_err_matches(err, BCH_ERR_journal_reclaim_would_deadlock);
 
 			enum bch_time_stats flush_time =
 				type <= JOURNAL_PIN_TYPE_btree0
@@ -854,14 +875,28 @@ static size_t journal_flush_pins(struct journal *j,
 			/* Pin might have been dropped or rearmed: */
 			if (likely(!err && !j->flush_in_progress_dropped))
 				list_move(&pin->list, &pin_l->flushed);
+			else if (would_deadlock && !j->flush_in_progress_dropped &&
+				 nr_deadlock_skipped < ARRAY_SIZE(deadlock_skipped)) {
+				deadlock_skipped[nr_deadlock_skipped++] = pin;
+				retry_deadlocked = true;
+			}
 			j->flush_in_progress = NULL;
 			j->flush_in_progress_dropped = false;
 		}
 
 		wake_up(&j->pin_flush_wait);
 
-		if (err)
+		if (err) {
+			if (retry_deadlocked)
+				continue;
 			break;
+		}
+
+		if (min_key_cache && key_cache_pin)
+			min_key_cache--;
+
+		if (min_any)
+			min_any--;
 
 		nr_flushed++;
 	}

--- a/fs/vfs/buffered.c
+++ b/fs/vfs/buffered.c
@@ -117,7 +117,7 @@ static int readpage_bio_extend(struct btree_trans *trans,
 			       bool get_more)
 {
 	/* Don't hold btree locks while allocating memory: */
-	bch2_trans_unlock(trans);
+	bch2_trans_unlock_long(trans);
 
 	while (bio_sectors(bio) < sectors_this_extent &&
 	       bio->bi_vcnt < bio->bi_max_vecs) {

--- a/fs/vfs/buffered.c
+++ b/fs/vfs/buffered.c
@@ -116,8 +116,19 @@ static int readpage_bio_extend(struct btree_trans *trans,
 			       unsigned sectors_this_extent,
 			       bool get_more)
 {
-	/* Don't hold btree locks while allocating memory: */
-	bch2_trans_unlock_long(trans);
+	/*
+	 * This helper only extends an already allocated read bio.  The caller
+	 * resumes the same extent iterator afterwards, so keep the transaction's
+	 * SRCU read lock: unlock_long() may invalidate cached btree paths that a
+	 * plain relock/iterator continuation still depends on.
+	 *
+	 * For speculative folios past the initial readahead set, avoid blocking
+	 * reclaim while SRCU is held by using nonblocking allocation/attachment.
+	 * If that cannot be done immediately, stop extending this bio; the
+	 * caller will submit what it has and later reads can come through the
+	 * normal path.
+	 */
+	bch2_trans_unlock(trans);
 
 	while (bio_sectors(bio) < sectors_this_extent &&
 	       bio->bi_vcnt < bio->bi_max_vecs) {
@@ -146,20 +157,22 @@ static int readpage_bio_extend(struct btree_trans *trans,
 			if (folio && !xa_is_value(folio))
 				break;
 
+			gfp_t gfp = readahead_gfp_mask(iter->mapping) & ~__GFP_DIRECT_RECLAIM;
+
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,19,0)
-			folio = filemap_alloc_folio(readahead_gfp_mask(iter->mapping), order);
+			folio = filemap_alloc_folio(gfp, order);
 #else
-			folio = filemap_alloc_folio(readahead_gfp_mask(iter->mapping), order, NULL);
+			folio = filemap_alloc_folio(gfp, order, NULL);
 #endif
 			if (!folio)
 				break;
 
-			if (!__bch2_folio_create(folio, GFP_KERNEL)) {
+			if (!__bch2_folio_create(folio, gfp)) {
 				folio_put(folio);
 				break;
 			}
 
-			ret = filemap_add_folio(iter->mapping, folio, folio_offset, GFP_KERNEL);
+			ret = filemap_add_folio(iter->mapping, folio, folio_offset, gfp);
 			if (ret) {
 				__bch2_folio_release(folio);
 				folio_put(folio);

--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -371,7 +371,7 @@ repeat:
 			if (!trans) {
 				__wait_on_freeing_inode(c, inode, inum);
 			} else {
-				int ret = drop_locks_do(trans,
+				int ret = drop_locks_long_do(trans,
 						(__wait_on_freeing_inode(c, inode, inum), 0));
 				if (ret)
 					return ERR_PTR(ret);

--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -767,7 +767,7 @@ static int dirent_to_missing_inode(struct btree_trans *trans,
 	 * Scheduling the pass takes sb_lock and may write the superblock;
 	 * we're on the error return path, nothing here needs btree locks:
 	 */
-	bch2_trans_unlock(trans);
+	bch2_trans_unlock_long(trans);
 	return bch2_run_explicit_recovery_pass(c, &msg.m,
 					       BCH_RECOVERY_PASS_check_dirents, 0);
 }


### PR DESCRIPTION
## Summary

Ports Matthias Goergens' SRCU blocking fix, originally committed as `87cfe6a006f40df2cbe62718a042d18a839795df`, onto current `koverstreet/bcachefs-tools` `testing` through `ffcc6e22921e7b12f0a96661b8d43122b1addc20`, then adds eight follow-ups from the `koverstreet/bcachefs-tools#783` coverage and live-regression pass.

The `koverstreet/bcachefs-tools#783` traces show btree transaction SRCU being held across journal/move/reclaim waits. The first commit switches the blocking transaction sites from `bch2_trans_unlock()` / `drop_locks_do()` to `bch2_trans_unlock_long()` / `drop_locks_long_do()` so transaction SRCU is dropped before unbounded waits, synchronous I/O, or reclaim-capable allocations.

The second commit covers the key-cache part of the same issue shape: `bch2_btree_key_cache_journal_flush()` no longer holds the external btree transaction SRCU read lock across transaction/commit flush work, and the going-read-only key-cache flush loop now holds the external SRCU lock only while snapshotting entries.

The third commit is a v2 correction after live testing the first PR head: `readpage_bio_extend()` must not use `bch2_trans_unlock_long()` and then resume the same read transaction/extent iterator with a plain relock. The read loop also preserves the cached `BTREE_ID_subvolumes` lookup between iterations. Dropping SRCU in that helper can invalidate cached paths while the caller still expects to continue the existing transaction state.

Instead, `readpage_bio_extend()` now keeps the short transaction unlock and makes only the speculative folio allocation/attachment path nonblocking. If those speculative folios cannot be added without direct reclaim, it stops extending the current bio and lets later reads cover the remaining range.

The fourth commit covers another unsafe cached-path lifetime found by re-auditing the kernel-module patch stack after the readpath regression. `btree_key_can_insert_cached_slowpath()` also drops transaction SRCU after capturing a cached key pointer. Since `bch2_trans_unlock_long()` deliberately invalidates unlocked cached paths before releasing SRCU, the old `bkey_cached` pointer is not safe to use after relock. The commit refreshes the cached entry from the relocked path and handles the race where another transaction has already grown the entry.

The fifth commit keeps journal reclaim moving when one pin reports `journal_reclaim_would_deadlock`. A single contended old pin should not hide every other eligible unflushed pin for the rest of the reclaim pass; skipped pins remain unflushed and are retried by the next pass.

The sixth commit is diagnostic hardening for an observed `btree_transactions` debugfs read warning: `bch2_btree_trans_to_text()` now snapshots the lock type once and bounds the lock-type character lookup, so racing path lock state cannot turn a diagnostic dump into `lock_types[-1]` UBSAN noise.

The seventh commit tightens the cached-key fix after another kernel-module re-audit: if `btree_key_can_insert_cached_slowpath()` drops SRCU and another transaction grows the cached key while it is unlocked, pending transaction updates now have matching `old_v` pointers retargeted to the refreshed `ck->k` before the early enough-space exit. If this transaction still grows the key itself, the same saved old pointer is then retargeted to the new allocation.

The eighth commit covers the remaining plain-unlock-before-block sites found in the final kernel-module audit: waiting for outstanding EC stripes during remove-stripes and data-drop paths, the blocking nocow-lock fallback in data update, and explicit dirent repair scheduling from the missing-inode lookup error path now drop transaction SRCU before those potentially unbounded waits.

The ninth commit covers one more SRCU/reclaim-adjacent wait found by rechecking the kernel-module patch stack: btree-cache cannibalize-lock retry loops were still using raw `closure_sync()` while a btree transaction could be holding SRCU. Those loops now use the same SRCU-aware `trans_closure_sync()` wrapper, so a contended cannibalize lock cannot indefinitely pin transaction SRCU while waiting for the holder to drop the lock.

The original pre-`testing` patch also touched `fs/debug/tests.c`; current `testing` has already removed that file, so that hunk is intentionally omitted here.

Companion ktest PR: https://github.com/koverstreet/ktest/pull/99

Current head:

```text
d3c0e0db91b403cf9242f79a790662fdf0a9c292
```

## Scope

This PR targets the host-liveness layer of `koverstreet/bcachefs-tools#783`: transaction SRCU held around reclaim-sensitive blocking operations, journal/key-cache flush work, unsafe long-unlock conversions discovered during review, the readpath regression from the first PR head, journal reclaim progress when individual pins are busy, cached-update `old_v` lifetime after SRCU drop, remaining plain-unlock-before-block waits in EC remove-stripes/data-drop/data-update/dirent-repair paths, btree-cache cannibalize-lock waits, and diagnostic robustness while inspecting stuck transactions.

It is not a proof that every slow/failing-member symptom in `koverstreet/bcachefs-tools#783` is fixed. In particular:

- `koverstreet/ktest#99` remains a smoke/regression oracle, not a red-to-green reproducer; it passes unpatched `origin/testing` as well as this PR.
- This branch is based on `koverstreet/bcachefs-tools` `testing` through `ffcc6e22921e7b12f0a96661b8d43122b1addc20`, including the upstream snapshot/dead-snapshot repair commits that landed while this PR was open. Those base commits are relevant to the broader issue, but they are not authored in this PR and this PR still does not prove every copygc/reconcile symptom fixed.
- The previous PR head `58f07184dbe66dcfa01d8ef021d1326fa4027a2f` was not safe to keep testing live: it regressed ordinary buffered reads on the affected mounted filesystem. That regression is why the readpath tail commit exists.
- The observed `bchfs_truncate` / `bch2_two_state_lock` wait from that bad live head is treated here as a downstream page-cache-lock waiter behind wedged read/readahead, not as a separately reproduced truncate bug with its own direct fix claim.
- The previous PR head `a9350d709a32c5a34cb0bf3973b0da0361233698` fixed that readpath regression, but re-audit found the cached-key lifetime issue fixed by `a299bda9b7d68d1415933ebf29656b2f878b0aba`.
- The previous PR head `a299bda9b7d68d1415933ebf29656b2f878b0aba` fixed that cached-key lifetime issue, but re-audit found the journal-reclaim progress case fixed by `4520cf3f1bf5`, and live debugfs inspection found the transaction-dump UBSAN fixed by `65980fd5bf12`.
- The previous PR head `65980fd5bf127715a21ae557d79e91968e91882b` fixed those two issues, but a final kernel-module patch-stack recheck found one more cached-update `old_v` retargeting case fixed by `3c3fe73ca738`.
- The previous PR head `3c3fe73ca738f39cff876f27d15be30fdda41e8f` fixed that cached-update `old_v` case, but the last plain-unlock sweep found three more potentially unbounded waits fixed by the tail commit at pre-rebase head `ff879aee09e5e9fd3fa3cba28f11410631b8511b`.
- After the `koverstreet/bcachefs-tools` `testing` base advanced to `8ec4d2b32e16c56445d0d7b419a271db41689c88`, I rebased the PR and rechecked the kernel-module patch stack again. That sweep found the same outstanding-EC-stripe wait shape in `bch2_dev_remove_stripes()`, so tail commit `922ad795e705` covered both EC flush sites.
- The previous PR head `922ad795e7057165b22818a9f6592a0a93b2eb56` fixed the EC flush rebase gap, but another kernel-module recheck found btree-cache cannibalize-lock retry loops still using raw `closure_sync()` in transaction context. The cannibalize-lock tail commit switches those waits to `trans_closure_sync()`.
- After the `koverstreet/bcachefs-tools` `testing` base advanced again to `ffcc6e22921e7b12f0a96661b8d43122b1addc20`, this branch was rebased and read back as `CLEAN` / `MERGEABLE`; no extra code hunk was added beyond the same nine-commit stack.

## Testing

- `git diff --check origin/testing..HEAD`
- `git merge-tree --write-tree origin/testing HEAD` completed without conflicts and produced tree `54d07e2f5c373e4a8aa98db24a5e32eb5fce9345`.
- Final post-rebase kernel-module sweep of remaining raw waits in the audited issue layer:
  - btree-cache cannibalize-lock retry loops in `fs/btree/iter.c`, `fs/btree/read.c`, and `fs/btree/interior.c` now use `trans_closure_sync()`.
  - the remaining raw `closure_sync(&cl)` hits in `fs/data/update.c` are immediately after `bch2_trans_unlock_long(trans)`.
  - other changed-file wait hits either use `trans_wait_event()` / `trans_closure_sync()` / `trans_closure_sync_timeout()`, are outside btree transaction SRCU context, or return/relock without sleeping on reclaim/journal/allocator state.
- Compile-only kbuild module build for a Rust-enabled 7.2.0-rc3 header tree, without installing or loading the module:
  - resulting module version: `v1.38.8-202-gd3c0e0db91b4`
  - resulting module srcversion: `A625E851C605EE5E99F5567`
  - resulting module sha256: `075b4be853182ca0798725a2c2c79f270bdeb6803e2f0bff3a4666e8e5daf7f0`
- GitHub Actions for current PR head `d3c0e0db91b403cf9242f79a790662fdf0a9c292` completed successfully, 17/17 jobs: https://github.com/koverstreet/bcachefs-tools/actions/runs/29664984180
- Earlier full VM run of `koverstreet/ktest#99`'s `journal_flush_srcu_liveness.ktest` against the first PR source head:
  - source head: `58f07184dbe66dcfa01d8ef021d1326fa4027a2f`
  - bcachefs module loaded in guest: `version: v1.38.8-182-g58f07184dbe6`
  - result: `========= PASSED journal_flush_srcu_liveness in 114s`
  - result: `TEST SUCCESS`
  - log oracle found no `btree trans held srcu lock`
  - log oracle found no `bch2_journal_flush_seq stuck?`
- Earlier unpatched-tree run of the same companion ktest, confirming it is not a red reproducer:
  - source head: `838ead8957377100c58b501fc1c50816cb7e7da2`
  - bcachefs module loaded in guest: `version: v1.38.8-161-g838ead895737`
  - result: `========= PASSED journal_flush_srcu_liveness in 69s`
  - result: `TEST SUCCESS`
- GitHub Actions for previous PR head `a9350d709a32c5a34cb0bf3973b0da0361233698` completed successfully: https://github.com/koverstreet/bcachefs-tools/actions/runs/29655996856
- GitHub Actions for previous PR head `a299bda9b7d68d1415933ebf29656b2f878b0aba` completed successfully: https://github.com/koverstreet/bcachefs-tools/actions/runs/29657805973
- GitHub Actions for previous PR head `65980fd5bf127715a21ae557d79e91968e91882b` started but was superseded by a later update: https://github.com/koverstreet/bcachefs-tools/actions/runs/29659059216
- GitHub Actions for previous PR head `3c3fe73ca738f39cff876f27d15be30fdda41e8f` completed successfully: https://github.com/koverstreet/bcachefs-tools/actions/runs/29659421546
- GitHub Actions for pre-rebase PR head `474077c1f2c93b63fdebbcb2408157ae1fb88b81` completed successfully: https://github.com/koverstreet/bcachefs-tools/actions/runs/29661629944
- GitHub Actions for pre-v200 PR head `ff879aee09e5e9fd3fa3cba28f11410631b8511b` completed successfully: https://github.com/koverstreet/bcachefs-tools/actions/runs/29662257359
- GitHub Actions for previous PR head `922ad795e7057165b22818a9f6592a0a93b2eb56` completed successfully: https://github.com/koverstreet/bcachefs-tools/actions/runs/29663380983
- GitHub Actions for previous PR head `8ab91ace8baf7237570e60dd6130732a2b2eefa1` completed successfully but was superseded by the current rebase: https://github.com/koverstreet/bcachefs-tools/actions/runs/29664407025
