### PR TITLE
btree: retry key cache reclaim flush without rejournal

### DIFF
--- a/fs/btree/key_cache.c
+++ b/fs/btree/key_cache.c
@@ -517,13 +517,44 @@ static int btree_key_cache_flush_pos(struct btree_trans *trans,
 	return 0;
 }
 
+static int btree_key_cache_journal_flush_trans(struct btree_trans *trans,
+					       struct bkey_cached *ck,
+					       u64 seq,
+					       unsigned commit_flags)
+{
+	btree_path_idx_t path_idx;
+	struct bkey_cached_key key;
+	int ret = bch2_btree_node_lock_with_path(trans, &ck->c,
+						 SIX_LOCK_intent, 0, &path_idx);
+	bool do_flush = false;
+
+	if (ret)
+		return ret;
+
+	key = ck->key;
+
+	if (ck->journal.seq != seq ||
+	    !test_bit(BKEY_CACHED_DIRTY, &ck->flags)) {
+		/* raced; nothing to do */
+	} else if (ck->seq != seq) {
+		bch2_journal_pin_update(&trans->c->journal, ck->seq, &ck->journal,
+					bch2_btree_key_cache_journal_flush);
+	} else {
+		do_flush = true;
+	}
+	bch2_btree_node_unlock_with_path(trans, path_idx, 0);
+
+	return do_flush
+		? btree_key_cache_flush_pos(trans, key, seq, commit_flags, false)
+		: 0;
+}
+
 int bch2_btree_key_cache_journal_flush(struct journal *j,
 				struct journal_entry_pin *pin, u64 seq)
 {
 	struct bch_fs *c = container_of(j, struct bch_fs, journal);
 	struct bkey_cached *ck =
 		container_of(pin, struct bkey_cached, journal);
-	struct bkey_cached_key key;
 	int ret = 0;
 
 	guard(srcu)(&c->btree.trans.barrier);
@@ -545,32 +576,28 @@ int bch2_btree_key_cache_journal_flush(struct journal *j,
 	    test_bit(BKEY_CACHED_DIRTY, &ck->flags)) {
 		CLASS(btree_trans, trans)(c);
 
-		ret = lockrestart_do(trans, ({
-			btree_path_idx_t path_idx;
-			int _ret = bch2_btree_node_lock_with_path(trans, &ck->c,
-								  SIX_LOCK_intent, 0, &path_idx);
-			bool do_flush = false;
-
-			if (!_ret) {
-				key = ck->key;
-
-				if (ck->journal.seq != seq ||
-				    !test_bit(BKEY_CACHED_DIRTY, &ck->flags)) {
-					/* raced; nothing to do */
-				} else if (ck->seq != seq) {
-					bch2_journal_pin_update(&c->journal, ck->seq, &ck->journal,
-								bch2_btree_key_cache_journal_flush);
-				} else {
-					do_flush = true;
-				}
-				bch2_btree_node_unlock_with_path(trans, path_idx, 0);
-
-				if (do_flush)
-					_ret = btree_key_cache_flush_pos(trans, key, seq,
-							BCH_TRANS_COMMIT_journal_reclaim, false);
-			}
-			_ret;
-		}));
+		ret = lockrestart_do(trans,
+			btree_key_cache_journal_flush_trans(trans, ck, seq,
+					BCH_TRANS_COMMIT_journal_reclaim));
+		if (bch2_err_matches(ret, BCH_ERR_journal_reclaim_would_deadlock)) {
+			ret = lockrestart_do(trans,
+				btree_key_cache_journal_flush_trans(trans, ck, seq,
+					BCH_TRANS_COMMIT_journal_reclaim|
+					BCH_TRANS_COMMIT_no_journal_res));
+			/*
+			 * no_journal_res only skips taking a fresh journal
+			 * reservation in bch2_trans_commit(); it doesn't clear
+			 * the watermark guard in bch2_btree_update_start() that
+			 * throws this same error for a btree node split/alloc,
+			 * so the retry can still legitimately hit it again.
+			 * Not fatal - the pin stays dirty and reclaim retries
+			 * it next pass - but log it distinctly so it isn't
+			 * indistinguishable from the expected first-attempt case.
+			 */
+			if (bch2_err_matches(ret, BCH_ERR_journal_reclaim_would_deadlock))
+				bch_err_ratelimited(c,
+					"key cache flush: no_journal_res retry also hit journal_reclaim_would_deadlock (btree node split under low-journal-space watermark)");
+		}
 		bch2_fs_fatal_err_on(ret &&
 				     !bch2_err_matches(ret, BCH_ERR_journal_reclaim_would_deadlock) &&
 				     !bch2_journal_error(j), c,

--- a/fs/btree/key_cache.c
+++ b/fs/btree/key_cache.c
@@ -517,13 +517,44 @@ static int btree_key_cache_flush_pos(struct btree_trans *trans,
 	return 0;
 }
 
+static int btree_key_cache_journal_flush_trans(struct btree_trans *trans,
+					       struct bkey_cached *ck,
+					       u64 seq,
+					       unsigned commit_flags)
+{
+	btree_path_idx_t path_idx;
+	struct bkey_cached_key key;
+	int ret = bch2_btree_node_lock_with_path(trans, &ck->c,
+						 SIX_LOCK_intent, 0, &path_idx);
+	bool do_flush = false;
+
+	if (ret)
+		return ret;
+
+	key = ck->key;
+
+	if (ck->journal.seq != seq ||
+	    !test_bit(BKEY_CACHED_DIRTY, &ck->flags)) {
+		/* raced; nothing to do */
+	} else if (ck->seq != seq) {
+		bch2_journal_pin_update(&trans->c->journal, ck->seq, &ck->journal,
+					bch2_btree_key_cache_journal_flush);
+	} else {
+		do_flush = true;
+	}
+	bch2_btree_node_unlock_with_path(trans, path_idx, 0);
+
+	return do_flush
+		? btree_key_cache_flush_pos(trans, key, seq, commit_flags, false)
+		: 0;
+}
+
 int bch2_btree_key_cache_journal_flush(struct journal *j,
 				struct journal_entry_pin *pin, u64 seq)
 {
 	struct bch_fs *c = container_of(j, struct bch_fs, journal);
 	struct bkey_cached *ck =
 		container_of(pin, struct bkey_cached, journal);
-	struct bkey_cached_key key;
 	int ret = 0;
 
 	guard(srcu)(&c->btree.trans.barrier);
@@ -545,32 +576,14 @@ int bch2_btree_key_cache_journal_flush(struct journal *j,
 	    test_bit(BKEY_CACHED_DIRTY, &ck->flags)) {
 		CLASS(btree_trans, trans)(c);
 
-		ret = lockrestart_do(trans, ({
-			btree_path_idx_t path_idx;
-			int _ret = bch2_btree_node_lock_with_path(trans, &ck->c,
-								  SIX_LOCK_intent, 0, &path_idx);
-			bool do_flush = false;
-
-			if (!_ret) {
-				key = ck->key;
-
-				if (ck->journal.seq != seq ||
-				    !test_bit(BKEY_CACHED_DIRTY, &ck->flags)) {
-					/* raced; nothing to do */
-				} else if (ck->seq != seq) {
-					bch2_journal_pin_update(&c->journal, ck->seq, &ck->journal,
-								bch2_btree_key_cache_journal_flush);
-				} else {
-					do_flush = true;
-				}
-				bch2_btree_node_unlock_with_path(trans, path_idx, 0);
-
-				if (do_flush)
-					_ret = btree_key_cache_flush_pos(trans, key, seq,
-							BCH_TRANS_COMMIT_journal_reclaim, false);
-			}
-			_ret;
-		}));
+		ret = lockrestart_do(trans,
+			btree_key_cache_journal_flush_trans(trans, ck, seq,
+					BCH_TRANS_COMMIT_journal_reclaim));
+		if (bch2_err_matches(ret, BCH_ERR_journal_reclaim_would_deadlock))
+			ret = lockrestart_do(trans,
+				btree_key_cache_journal_flush_trans(trans, ck, seq,
+					BCH_TRANS_COMMIT_journal_reclaim|
+					BCH_TRANS_COMMIT_no_journal_res));
 		bch2_fs_fatal_err_on(ret &&
 				     !bch2_err_matches(ret, BCH_ERR_journal_reclaim_would_deadlock) &&
 				     !bch2_journal_error(j), c,


### PR DESCRIPTION
Split out of https://github.com/koverstreet/bcachefs-tools/pull/790 after
https://github.com/koverstreet/bcachefs-tools/pull/790#issuecomment-5017358277
and reworked to follow Kent's review suggestion in
https://github.com/koverstreet/bcachefs-tools/pull/792#issuecomment-5017678001:
retry the flush with the pin transferred to the btree node instead of
re-journalling, rather than treating deadlock-avoidance as a property of the
pin.

A key-cache journal pin flush can return
`BCH_ERR_journal_reclaim_would_deadlock` when the reclaim flush path tries to
re-journal the cached update while the journal is already low on space. That
failure is a property of the flush mode, not of the particular pin.

This patch keeps the existing first attempt, then immediately retries the same
locked/revalidated key-cache flush with `BCH_TRANS_COMMIT_no_journal_res`. The
retry inserts the cached key into the btree leaf using the cached key's existing
pinned journal sequence and transfers the pin to the dirty btree node instead
of consuming journal space for a fresh journal entry.

Races remain handled by the existing revalidation:

- if the cached key is no longer dirty or its journal sequence changed, the
  retry becomes a no-op;
- if the cached key was redirtied onto a later sequence, the pin is updated;
- otherwise the retry flushes the same cached key without a new journal
  reservation.

The retry can still hit `would_deadlock` a second time: if the flush needs to
split/allocate a btree node under the low-journal-space watermark guard in
`bch2_btree_update_start()`, that check is independent of
`no_journal_res` (which only skips the journal reservation in
`bch2_trans_commit()`). That's already handled safely — non-fatal, the pin
stays dirty and reclaim retries it next pass, same as any other
`would_deadlock` — but it's now logged distinctly via `bch_err_ratelimited()`
instead of being silently indistinguishable from the expected first-attempt
case.

Surfaced by the journal-reclaim stalls in
https://github.com/koverstreet/bcachefs-tools/issues/783.

Current head: `ff7725015fa8965766d4d3c871c6ac0006a06530`.

Validation:

- Rebased on current `testing` tip.
- `git diff --check` clean.
- `make -j24 bcachefs` builds clean.
- Prior ktest validation on the pre-rebase tree still applies to this
  unchanged retry logic: `journal_torture` (clean shutdown + fsck) and a
  targeted key-cache/journal-reclaim-pressure run (768M filesystem, journal
  resized to 128 buckets, metadata/xattr/fsync-heavy fsstress), both TEST
  SUCCESS with no journal-stuck/deadlock/hung-task/BUG/WARNING/UBSAN
  signatures in dmesg.
