### PR TITLE
wait-devices: bound dev_idx by nr_devices, not the live device count

### DIFF
--- a/src/commands/wait_devices.rs
+++ b/src/commands/wait_devices.rs
@@ -107,8 +107,18 @@ impl WaitInitialized {
             return Ok(());
         }
         let dev_idx = sb.dev_idx;
-	if u32::from(dev_idx) >= sb.number_of_devices() {
-	    warn!("superblock with invalid dev_idx: {dev_idx} >= {}", sb.number_of_devices());
+        // dev_idx indexes the member array, which is sb.nr_devices long.
+        // number_of_devices() counts only *live* members, and that is smaller
+        // whenever a device has been removed: the slot is left behind as a
+        // tombstone and the array never shrinks. Bounding an index by that
+        // count therefore rejects every device whose slot sits past it, so a
+        // filesystem that has ever had a device replaced could never be seen
+        // as fully initialized and we would wait forever.
+        if u32::from(dev_idx) >= sb.nr_devices as u32 {
+            warn!(
+                "superblock with invalid dev_idx: {dev_idx} >= {}",
+                sb.nr_devices
+            );
             return Ok(());
         }
 


### PR DESCRIPTION
cmd_wait_devices() silently discarded valid devices, so on some filesystems it could never observe every device and would wait forever.

add() bounds-checks the superblock's dev_idx before recording a device:

	if u32::from(dev_idx) >= sb.number_of_devices() {

but dev_idx is an index into the member array, whose length is sb->nr_devices, while bch2_sb_nr_devices() counts only the members that are alive:

	unsigned bch2_sb_nr_devices(const struct bch_sb *sb)
	{
		unsigned nr = 0;

		for (unsigned i = 0; i < sb->nr_devices; i++)
			nr += bch2_member_exists((struct bch_sb *) sb, i);
		return nr;
	}

Removing a device leaves its slot behind as a tombstone and the member array never shrinks, so on any filesystem that has ever had a device removed or replaced the live count is smaller than the array length, and every device whose slot sits at or past that count is rejected with "superblock with invalid dev_idx". Those devices are then missing from the set every_device_is_initialized() compares against number_of_devices(), the counts can never match, and the command blocks indefinitely.

For example, a filesystem whose member array is three slots long with the middle slot freed reports two live devices, so the device in slot 2 is rejected and only one is ever recorded. Since bcachefs-wait-devices@.service is meant to gate a mount, that stalls the boot until the unit times out.

Bound dev_idx by sb->nr_devices, the actual length of the array it indexes.