### PR TITLE
bcachefs: metadata-only checksum reconcile + nodecode read flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -150,6 +150,7 @@ dependencies = [
  "owo-colors",
  "rustc-demangle",
  "rustix",
+ "rustyline",
  "serde",
  "serde_json",
  "strum",
@@ -378,6 +379,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +447,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,7 +474,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -524,6 +557,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "httpdate"
@@ -609,7 +651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -679,7 +721,16 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -858,6 +909,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,7 +998,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -945,6 +1006,28 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustyline"
+version = "17.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1123,7 +1206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1223,6 +1306,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1312,7 +1407,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1382,6 +1477,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1395,14 +1508,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1412,10 +1542,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1424,10 +1566,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1436,10 +1590,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1448,10 +1614,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ tiny_http = "0.12.0"
 rustc-demangle = "0.1"
 chrono = { version = "0.4.43", default-features = false, features = ["clock"] }
 fuser = { version = "0.17", optional = true }
+# rustyline 18 requires home 0.5.12, which requires rustc 1.88 (> our 1.85 MSRV)
+rustyline = "17.0.2"
 
 [dependencies.env_logger]
 version = "0.10"

--- a/bcachefs-shim/src/wrapper.h
+++ b/bcachefs-shim/src/wrapper.h
@@ -6,6 +6,7 @@
 #include "include/linux/idr.h"
 #include "include/linux/kernel.h"
 #include "include/linux/llist.h"
+#include "include/linux/local_lock.h"
 #include "include/linux/percpu-refcount.h"
 #include "include/linux/percpu-rwsem.h"
 #include "include/linux/ratelimit.h"

--- a/bch_bindgen/build.rs
+++ b/bch_bindgen/build.rs
@@ -375,8 +375,17 @@ impl bindgen::callbacks::ParseCallbacks for Fix753 {
 fn watch_dir(dir: &str) {
     let Ok(entries) = std::fs::read_dir(dir) else { return };
     for entry in entries.flatten() {
+        // file_type() reads the dirent directly - unlike Path::is_dir() it does
+        // NOT follow symlinks. This crate only walks bounded source dirs so it
+        // wasn't the one that stalled, but the shared shape follows the same
+        // trap: a symlink (e.g. ktest-out/kernel) into a large tree would
+        // stat-storm over virtiofs. Keep both watchers symlink-safe.
+        let Ok(file_type) = entry.file_type() else { continue };
         let path = entry.path();
-        if path.is_dir() {
+        if file_type.is_dir() {
+            if matches!(entry.file_name().to_str(), Some("target" | "ktest-out" | ".git")) {
+                continue;
+            }
             watch_dir(&path.to_string_lossy());
         } else if path.extension().is_some_and(|ext| ext == "h" || ext == "c") {
             println!("cargo:rerun-if-changed={}", path.display());

--- a/doc/bcachefs-principles-of-operation.tex
+++ b/doc/bcachefs-principles-of-operation.tex
@@ -608,6 +608,10 @@ be unique). This gives us ways of referring to multiple devices in target
 options: If we specify ssd in a target option, that will refer to all devices
 with the label ssd or labels that start with ssd. (e.g. ssd.ssd1, ssd.ssd2).
 
+Device labels are used only for targeting. How replicas are spread across
+devices to survive hardware failures is a separate, per-device property; see
+\hyperref[sec:failure-domains]{Failure domains}.
+
 Four target options exist. All may be set at the filesystem level (at format
 time, at mount time, or at runtime via sysfs). All except
 \texttt{metadata\_target} may also be set on a particular file or directory:
@@ -1657,6 +1661,11 @@ the filesystem.
 \subsection{Allocator}
 
 \bchdoc{allocator}
+
+\subsection{Failure domains}
+\label{sec:failure-domains}
+
+\bchdoc{failure-domains}
 
 \subsection{Subvolumes and snapshots}
 \label{sec:snapshots}

--- a/doc/bcachefs-principles-of-operation.tex
+++ b/doc/bcachefs-principles-of-operation.tex
@@ -1645,6 +1645,11 @@ not recover from and need attention from the developers, this makes it possible
 to send the developers only the required metadata. Encrypted filesystems must
 first be unlocked with \texttt{bcachefs remove-passphrase}.
 
+\subsection{kvdb: the btree REPL}
+\label{sec:kvdb}
+
+\bchdoc{kvdb}
+
 \section{Subsystem details}
 
 \subsection{Data paths}

--- a/doc/docgen/src/main.rs
+++ b/doc/docgen/src/main.rs
@@ -155,10 +155,39 @@ fn walk_c_files(dir: &Path, f: &mut dyn FnMut(&Path)) {
         let path = entry.path();
         if path.is_dir() {
             walk_c_files(&path, f);
-        } else if matches!(path.extension().and_then(|e| e.to_str()), Some("h" | "c")) {
+        } else if matches!(path.extension().and_then(|e| e.to_str()), Some("h" | "c" | "rs")) {
             f(&path);
         }
     }
+}
+
+/// Parse a Rust string literal starting at the first `"` in @text: returns
+/// the unescaped contents and the byte length consumed through the closing
+/// quote. Handles \n, \t, \", \\, and \<newline> line continuations (which,
+/// like rustc, skip all following whitespace).
+fn parse_rust_string_literal(text: &str) -> Option<(String, usize)> {
+    let start = text.find('"')?;
+    let mut out = String::new();
+    let mut chars = text[start + 1..].char_indices().peekable();
+    while let Some((i, ch)) = chars.next() {
+        match ch {
+            '"' => return Some((out, start + 1 + i + ch.len_utf8())),
+            '\\' => match chars.next()?.1 {
+                'n' => out.push('\n'),
+                't' => out.push('\t'),
+                '\\' => out.push('\\'),
+                '"' => out.push('"'),
+                '\n' => {
+                    while chars.peek().is_some_and(|&(_, c)| c.is_whitespace()) {
+                        chars.next();
+                    }
+                }
+                other => out.push(other),
+            },
+            _ => out.push(ch),
+        }
+    }
+    None
 }
 
 fn extract_doc_blocks_from(path: &Path, source: &str, blocks: &mut Vec<DocBlock>) {
@@ -166,6 +195,26 @@ fn extract_doc_blocks_from(path: &Path, source: &str, blocks: &mut Vec<DocBlock>
     let mut i = 0;
     while i < lines.len() {
         let trimmed = lines[i].trim();
+        // DOC_STRING(key) — the following Rust string literal (typically a
+        // helptext constant, so one text serves --help and the PoO),
+        // converted like a DOC() block.
+        if let Some(rest) = trimmed.strip_prefix("// DOC_STRING(") {
+            if let Some(key) = rest.strip_suffix(')') {
+                let remaining = lines[i + 1..].join("\n");
+                if let Some((content, consumed)) = parse_rust_string_literal(&remaining) {
+                    blocks.push(DocBlock {
+                        raw_latex: false,
+                        key: key.trim().to_string(),
+                        content: content.trim().to_string(),
+                        file: path.to_path_buf(),
+                        line: i + 2,
+                    });
+                    i += remaining[..consumed].matches('\n').count() + 1;
+                }
+            }
+            i += 1;
+            continue;
+        }
         // DOC_LATEX(key) — raw LaTeX, passed through verbatim
         // DOC(key)       — simple markup, converted to LaTeX
         let (rest, raw_latex) = if let Some(rest) = trimmed.strip_prefix("/* DOC_LATEX(") {
@@ -326,8 +375,30 @@ fn markup_to_latex(content: &str) -> String {
     #[derive(PartialEq)]
     enum ListState { None, Itemize, Description }
     let mut list_state = ListState::None;
+    let mut in_verbatim = false;
 
     for line in content.lines() {
+        // Lines indented four or more spaces form a verbatim block -
+        // command tables, examples - emitted raw:
+        if line.starts_with("    ") {
+            if !in_verbatim {
+                match list_state {
+                    ListState::Itemize => out.push_str("\\end{itemize}\n"),
+                    ListState::Description => out.push_str("\\end{description}\n"),
+                    ListState::None => {}
+                }
+                list_state = ListState::None;
+                out.push_str("\\begin{verbatim}\n");
+                in_verbatim = true;
+            }
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        }
+        if in_verbatim {
+            out.push_str("\\end{verbatim}\n");
+            in_verbatim = false;
+        }
         if line.is_empty() {
             match list_state {
                 ListState::Itemize => {
@@ -383,8 +454,8 @@ fn markup_to_latex(content: &str) -> String {
                 out.push_str(&convert_inline(line));
                 out.push('\n');
             }
-        } else if line.starts_with("  ") && list_state == ListState::Description {
-            // Continuation of previous description item
+        } else if line.starts_with("  ") && list_state != ListState::None {
+            // Continuation of the previous item
             out.push_str(&convert_inline(line.trim_start()));
             out.push('\n');
         } else {
@@ -399,6 +470,9 @@ fn markup_to_latex(content: &str) -> String {
             out.push_str(&convert_inline(line));
             out.push('\n');
         }
+    }
+    if in_verbatim {
+        out.push_str("\\end{verbatim}\n");
     }
     match list_state {
         ListState::Itemize => out.push_str("\\end{itemize}\n"),
@@ -984,9 +1058,10 @@ fn main() {
     let mut available_keys = HashSet::new();
     let mut errors = 0;
 
-    // --- DOC() blocks from C sources ---
+    // --- DOC() blocks from C and Rust sources ---
     let mut doc_blocks = extract_doc_blocks(&root.join("fs"));
     doc_blocks.append(&mut extract_doc_blocks(&root.join("c_src")));
+    doc_blocks.append(&mut extract_doc_blocks(&root.join("src")));
 
     for block in &doc_blocks {
         let latex = if block.raw_latex {

--- a/fs/Makefile
+++ b/fs/Makefile
@@ -16,6 +16,10 @@ ifneq ($(bcachefs-version),)
 ifeq ($(shell $(CONFIG_SHELL) $(src)/scripts/fetch-module.sh '$(KERNELRELEASE)' '$(bcachefs-version)' '$(obj)/bcachefs.ko' && echo hit),hit)
 CONFIG_BCACHEFS_FS :=
 endif
+else
+# No version means no lookup key — say so rather than silently compiling:
+# the missing file is the tell that this tree wasn't staged the supported way.
+$(warning bcachefs: no version in $(src)/version.h - not looking for a prebuilt module (version.h is staged by bcachefs-tools 'make install_dkms'; a hand-copied kernel fs/bcachefs/ tree lacks it))
 endif
 endif
 
@@ -216,7 +220,14 @@ ifndef BCACHEFS_DKMS
 endif
 
 ifdef BCACHEFS_DKMS
+ifneq ($(wildcard $(src)/module-version.c),)
 	bcachefs-y += module-version.o
+else
+# Staged by bcachefs-tools 'make install_dkms'; a hand-copied kernel
+# fs/bcachefs/ tree lacks it. Degrade rather than fail with a bare
+# "no rule to make target" (field report: CRCinAU, 2026-07-23).
+$(warning bcachefs: $(src)/module-version.c missing - module will carry no MODULE_VERSION)
+endif
 endif
 
 # Rust support — optional, gated on CONFIG_RUST. The C side owns the module

--- a/fs/alloc/accounting.c
+++ b/fs/alloc/accounting.c
@@ -508,6 +508,30 @@ void __bch2_accounting_maybe_kill(struct bch_fs *c, struct bpos pos)
 	bch2_write_super(c);
 }
 
+/*
+ * Read accounting counters from the accounting btree - for types excluded
+ * from the mem table (bch2_accounting_is_mem()), where
+ * bch2_accounting_mem_read() would silently return zeros. Deltas buffer
+ * through the btree write buffer: callers that need current values must
+ * flush it first, hoisted out of their loops.
+ */
+int bch2_accounting_btree_read(struct btree_trans *trans, struct bpos p,
+			       u64 *v, unsigned nr)
+{
+	memset(v, 0, sizeof(*v) * nr);
+
+	CLASS(btree_iter, iter)(trans, BTREE_ID_accounting, p, 0);
+	struct bkey_s_c k = bkey_try(bch2_btree_iter_peek_slot(&iter));
+
+	if (k.k->type != KEY_TYPE_accounting)
+		return 0;
+
+	struct bkey_s_c_accounting a = bkey_s_c_to_accounting(k);
+	memcpy(v, a.v->d,
+	       min_t(unsigned, nr, bch2_accounting_counters(a.k)) * sizeof(u64));
+	return 0;
+}
+
 void bch2_accounting_mem_gc(struct bch_fs *c)
 {
 	struct bch_accounting_mem *acc = &c->accounting;

--- a/fs/alloc/accounting.c
+++ b/fs/alloc/accounting.c
@@ -98,9 +98,9 @@ static inline void accounting_key_init(struct bkey_i *k, struct disk_accounting_
 
 static int bch2_accounting_update_sb_one(struct bch_fs *, struct bpos);
 
-int bch2_disk_accounting_mod(struct btree_trans *trans,
+int bch2_disk_accounting_mod_normal(struct btree_trans *trans,
 			     struct disk_accounting_pos *k,
-			     s64 *d, unsigned nr, bool gc)
+			     s64 *d, unsigned nr)
 {
 	BUG_ON(nr > BCH_ACCOUNTING_MAX_COUNTERS);
 
@@ -115,46 +115,67 @@ int bch2_disk_accounting_mod(struct btree_trans *trans,
 	}
 
 	struct bpos pos = disk_accounting_pos_to_bpos(k);
+	struct bkey_i_accounting *a;
 
-	if (likely(!gc)) {
-		struct bkey_i_accounting *a;
+	for (a = btree_trans_subbuf_base(trans, &trans->accounting);
+	     a != btree_trans_subbuf_top(trans, &trans->accounting);
+	     a = (void *) bkey_next(&a->k_i))
+		if (bpos_eq(a->k.p, pos) &&
+		    bch2_accounting_counters(&a->k) == nr) {
+			acc_u64s(a->v.d, d, nr);
 
-		for (a = btree_trans_subbuf_base(trans, &trans->accounting);
-		     a != btree_trans_subbuf_top(trans, &trans->accounting);
-		     a = (void *) bkey_next(&a->k_i))
-			if (bpos_eq(a->k.p, pos) &&
-			    bch2_accounting_counters(&a->k) == nr) {
-				acc_u64s(a->v.d, d, nr);
+			if (bch2_accounting_key_is_zero(accounting_i_to_s_c(a))) {
+				unsigned offset = (u64 *) a -
+					(u64 *) btree_trans_subbuf_base(trans, &trans->accounting);
 
-				if (bch2_accounting_key_is_zero(accounting_i_to_s_c(a))) {
-					unsigned offset = (u64 *) a -
-						(u64 *) btree_trans_subbuf_base(trans, &trans->accounting);
-
-					trans->accounting.u64s -= a->k.u64s;
-					memmove_u64s_down(a,
-							  bkey_next(&a->k_i),
-							  trans->accounting.u64s - offset);
-				}
-				return 0;
+				trans->accounting.u64s -= a->k.u64s;
+				memmove_u64s_down(a,
+						  bkey_next(&a->k_i),
+						  trans->accounting.u64s - offset);
 			}
+			return 0;
+		}
 
-		unsigned u64s = sizeof(*a) / sizeof(u64) + nr;
-		a = errptr_try(bch2_trans_subbuf_alloc(trans, &trans->accounting, u64s));
+	unsigned u64s = sizeof(*a) / sizeof(u64) + nr;
+	a = errptr_try(bch2_trans_subbuf_alloc(trans, &trans->accounting, u64s));
 
-		__accounting_key_init(&a->k_i, pos, d, nr);
-		return 0;
-	} else {
-		struct { __BKEY_PADDED(k, BCH_ACCOUNTING_MAX_COUNTERS); } k_i;
+	__accounting_key_init(&a->k_i, pos, d, nr);
+	return 0;
+}
 
-		__accounting_key_init(&k_i.k, pos, d, nr);
+int bch2_disk_accounting_mod_gc(struct btree_trans *trans,
+			     struct disk_accounting_pos *k,
+			     s64 *d, unsigned nr)
+{
+	BUG_ON(nr > BCH_ACCOUNTING_MAX_COUNTERS);
 
-		int ret = bch2_accounting_mem_add(trans, bkey_i_to_s_c_accounting(&k_i.k), true);
-		if (ret == -BCH_ERR_btree_insert_need_mark_replicas)
-			ret = drop_locks_do(trans,
-				bch2_accounting_update_sb_one(trans->c, disk_accounting_pos_to_bpos(k))) ?:
-				bch2_accounting_mem_add(trans, bkey_i_to_s_c_accounting(&k_i.k), true);
-		return ret;
+	BUG_ON(k->type >= BCH_DISK_ACCOUNTING_TYPE_NR);
+	EBUG_ON(nr != bch2_accounting_type_nr_counters[k->type]);
+
+	/* Normalize: */
+	switch (k->type) {
+	case BCH_DISK_ACCOUNTING_replicas:
+		bubble_sort(k->replicas.devs, k->replicas.nr_devs, u8_cmp);
+		break;
 	}
+
+	struct { __BKEY_PADDED(k, BCH_ACCOUNTING_MAX_COUNTERS); } k_i;
+
+	__accounting_key_init(&k_i.k, disk_accounting_pos_to_bpos(k), d, nr);
+
+	int ret = 0;
+
+	while (true) {
+		ret = bch2_accounting_mem_add(trans, bkey_i_to_s_c_accounting(&k_i.k), true);
+		if (likely(ret != -BCH_ERR_btree_insert_need_mark_replicas))
+			break;
+
+		ret = drop_locks_do(trans, bch2_accounting_update_sb_one(trans->c, k_i.k.k.p));
+		if (ret)
+			break;
+	}
+
+	return ret;
 }
 
 int bch2_mod_dev_cached_sectors(struct btree_trans *trans,

--- a/fs/alloc/accounting.c
+++ b/fs/alloc/accounting.c
@@ -98,6 +98,12 @@ static inline void accounting_key_init(struct bkey_i *k, struct disk_accounting_
 
 static int bch2_accounting_update_sb_one(struct bch_fs *, struct bpos);
 
+int bch2_accounting_mem_add(struct btree_trans *trans, struct bkey_s_c_accounting a,
+			    enum bch_accounting_mode mode, bool write_locked)
+{
+	return bch2_accounting_mem_add_inlined(trans, a, mode, write_locked);
+}
+
 int bch2_disk_accounting_mod_normal(struct btree_trans *trans,
 			     struct disk_accounting_pos *k,
 			     s64 *d, unsigned nr)
@@ -166,7 +172,11 @@ int bch2_disk_accounting_mod_gc(struct btree_trans *trans,
 	int ret = 0;
 
 	while (true) {
-		ret = bch2_accounting_mem_add(trans, bkey_i_to_s_c_accounting(&k_i.k), true);
+		scoped_guard(percpu_read_noio, &trans->c->capacity.mark_lock)
+			ret = bch2_accounting_mem_add_inlined(trans,
+						bkey_i_to_s_c_accounting(&k_i.k),
+						BCH_ACCOUNTING_gc,
+						false);
 		if (likely(ret != -BCH_ERR_btree_insert_need_mark_replicas))
 			break;
 
@@ -769,7 +779,7 @@ int bch2_gc_accounting_done(struct bch_fs *c)
 					struct { __BKEY_PADDED(k, BCH_ACCOUNTING_MAX_COUNTERS); } k_i;
 
 					accounting_key_init(&k_i.k, &acc_k, src_v, nr);
-					bch2_accounting_mem_mod_locked(trans,
+					bch2_accounting_mem_add(trans,
 								bkey_i_to_s_c_accounting(&k_i.k),
 								BCH_ACCOUNTING_normal, true);
 

--- a/fs/alloc/accounting.h
+++ b/fs/alloc/accounting.h
@@ -259,6 +259,19 @@ static inline void bch2_accounting_mem_read_locked(struct bch_fs *c, struct bpos
 {
 	percpu_rwsem_assert_held(&c->capacity.mark_lock.lock);
 
+	/*
+	 * Types not in the mem table read back as zeros - not an error, a
+	 * silently wrong answer: bch2_snapshot_node_check_no_data()'s empty
+	 * check read zeros from the day it was added, licensing no_keys
+	 * transitions that stranded live keys. Non-mem types must be read
+	 * from the accounting btree.
+	 */
+	EBUG_ON(({
+		struct disk_accounting_pos acc_k;
+		bpos_to_disk_accounting_pos(&acc_k, p);
+		!bch2_accounting_is_mem(&acc_k);
+	}));
+
 	struct bch_accounting_mem *acc = &c->accounting;
 	unsigned idx = eytzinger0_find(acc->k.data, acc->k.nr, sizeof(acc->k.data[0]),
 				       accounting_pos_cmp, &p);

--- a/fs/alloc/accounting.h
+++ b/fs/alloc/accounting.h
@@ -182,10 +182,11 @@ static inline bool bch2_bkey_is_accounting_mem(struct bkey *k)
  * Update in memory counters so they match the btree update we're doing; called
  * from transaction commit path
  */
-static inline int bch2_accounting_mem_mod_locked(struct btree_trans *trans,
-						 struct bkey_s_c_accounting a,
-						 enum bch_accounting_mode mode,
-						 bool write_locked)
+static __always_inline
+int bch2_accounting_mem_add_inlined(struct btree_trans *trans,
+				   struct bkey_s_c_accounting a,
+				   enum bch_accounting_mode mode,
+				   bool write_locked)
 {
 	struct bch_fs *c = trans->c;
 	struct bch_accounting_mem *acc = &c->accounting;
@@ -243,11 +244,8 @@ static inline int bch2_accounting_mem_mod_locked(struct btree_trans *trans,
 	return 0;
 }
 
-static inline int bch2_accounting_mem_add(struct btree_trans *trans, struct bkey_s_c_accounting a, bool gc)
-{
-	guard(percpu_read_noio)(&trans->c->capacity.mark_lock);
-	return bch2_accounting_mem_mod_locked(trans, a, gc ? BCH_ACCOUNTING_gc : BCH_ACCOUNTING_normal, false);
-}
+int bch2_accounting_mem_add(struct btree_trans *, struct bkey_s_c_accounting,
+			    enum bch_accounting_mode, bool);
 
 static inline void bch2_accounting_mem_read_counters(struct bch_accounting_mem *acc,
 						     unsigned idx, u64 *v, unsigned nr, bool gc)
@@ -317,7 +315,7 @@ static inline int bch2_accounting_trans_commit_hook(struct btree_trans *trans,
 	EBUG_ON(bversion_zero(a->k.bversion));
 
 	return likely(!(commit_flags & BCH_TRANS_COMMIT_skip_accounting_apply))
-		? bch2_accounting_mem_mod_locked(trans, accounting_i_to_s_c(a), BCH_ACCOUNTING_normal, false)
+		? bch2_accounting_mem_add_inlined(trans, accounting_i_to_s_c(a), BCH_ACCOUNTING_normal, false)
 		: 0;
 }
 
@@ -329,7 +327,7 @@ static inline void bch2_accounting_trans_commit_revert(struct btree_trans *trans
 		struct bkey_s_accounting a = accounting_i_to_s(a_i);
 
 		bch2_accounting_neg(a);
-		bch2_accounting_mem_mod_locked(trans, a.c, BCH_ACCOUNTING_normal, false);
+		bch2_accounting_mem_add(trans, a.c, BCH_ACCOUNTING_normal, false);
 		bch2_accounting_neg(a);
 	}
 }

--- a/fs/alloc/accounting.h
+++ b/fs/alloc/accounting.h
@@ -164,7 +164,6 @@ int bch2_accounting_btree_read(struct btree_trans *, struct bpos, u64 *, unsigne
 static inline bool bch2_accounting_is_mem(struct disk_accounting_pos *acc)
 {
 	return acc->type < BCH_DISK_ACCOUNTING_TYPE_NR &&
-		acc->type != BCH_DISK_ACCOUNTING_snapshot &&
 		acc->type != BCH_DISK_ACCOUNTING_inum;
 }
 

--- a/fs/alloc/accounting.h
+++ b/fs/alloc/accounting.h
@@ -97,8 +97,19 @@ static inline struct bpos disk_accounting_pos_to_bpos(struct disk_accounting_pos
 	return p;
 }
 
-int bch2_disk_accounting_mod(struct btree_trans *, struct disk_accounting_pos *,
-			     s64 *, unsigned, bool);
+int bch2_disk_accounting_mod_normal(struct btree_trans *, struct disk_accounting_pos *,
+			     s64 *, unsigned);
+int bch2_disk_accounting_mod_gc(struct btree_trans *, struct disk_accounting_pos *,
+			     s64 *, unsigned);
+
+static inline int bch2_disk_accounting_mod(struct btree_trans *trans,
+			     struct disk_accounting_pos *k,
+			     s64 *d, unsigned nr, bool gc)
+{
+	return likely(!gc)
+		? bch2_disk_accounting_mod_normal(trans, k, d, nr)
+		: bch2_disk_accounting_mod_gc(trans, k, d, nr);
+}
 
 #define disk_accounting_key_init(_k, _type, ...)			\
 do {									\

--- a/fs/alloc/accounting.h
+++ b/fs/alloc/accounting.h
@@ -148,6 +148,8 @@ int bch2_accounting_mem_insert(struct bch_fs *, struct bkey_s_c_accounting, enum
 int bch2_accounting_mem_insert_locked(struct bch_fs *, struct bkey_s_c_accounting, enum bch_accounting_mode);
 void bch2_accounting_mem_gc(struct bch_fs *);
 
+int bch2_accounting_btree_read(struct btree_trans *, struct bpos, u64 *, unsigned);
+
 static inline bool bch2_accounting_is_mem(struct disk_accounting_pos *acc)
 {
 	return acc->type < BCH_DISK_ACCOUNTING_TYPE_NR &&

--- a/fs/alloc/backpointers.c
+++ b/fs/alloc/backpointers.c
@@ -1228,7 +1228,8 @@ int bch2_check_bucket_backpointer_mismatch(struct btree_trans *trans,
 			BCH_RECOVERY_PASS_check_extents_to_backpointers,
 			nr < allowed ? RUN_RECOVERY_PASS_ratelimit : 0);
 
-	bch2_print_str(c, KERN_ERR, buf.buf);
+	if (!bch2_ratelimit(c))
+		bch2_print_str(c, KERN_ERR, buf.buf);
 	return 0;
 }
 

--- a/fs/alloc/buckets.c
+++ b/fs/alloc/buckets.c
@@ -314,6 +314,22 @@ static int __mark_pointer(struct btree_trans *trans, struct bch_dev *ca,
 	return 0;
 }
 
+static noinline int
+trigger_pointer_dev_missing(struct btree_trans *trans,
+			    struct bkey_s_c k, unsigned dev,
+			    bool insert)
+{
+	struct bch_fs *c = trans->c;
+	int ret = insert
+		? bch_err_throw(c, trigger_pointer)
+		: 0;
+
+	CLASS(bch_log_msg_ratelimited, msg)(c);
+	prt_printf(&msg.m, "Error while %s key:\n", insert ? "inserting" : "deleting");
+	ret = bch2_dev_missing_bkey_msg(c, k, dev, &msg.m);
+	return ret;
+}
+
 static int bch2_trigger_pointer(struct btree_trans *trans,
 			enum btree_id btree_id, unsigned level,
 			struct bkey_s_c k, struct extent_ptr_decoded p,
@@ -342,19 +358,8 @@ static int bch2_trigger_pointer(struct btree_trans *trans,
 	}
 
 	CLASS(bch2_dev_tryget_noerror, ca)(c, p.ptr.dev);
-	if (unlikely(!ca)) {
-		int ret = insert
-			? bch_err_throw(c, trigger_pointer)
-			: 0;
-
-		if (p.ptr.dev != BCH_SB_MEMBER_INVALID) {
-			CLASS(bch_log_msg_ratelimited, msg)(c);
-			prt_printf(&msg.m, "Error while %s key:\n", insert ? "inserting" : "deleting");
-			ret = bch2_dev_missing_bkey_msg(c, k, p.ptr.dev, &msg.m);
-		}
-
-		return ret;
-	}
+	if (unlikely(!ca))
+		return trigger_pointer_dev_missing(trans, k, p.ptr.dev, insert);
 
 	struct bpos bucket = PTR_BUCKET_POS(ca, &p.ptr);
 	if (!bucket_valid(ca, bucket.offset)) {
@@ -372,13 +377,7 @@ static int bch2_trigger_pointer(struct btree_trans *trans,
 	}
 
 	if (flags & BTREE_TRIGGER_gc) {
-		CLASS(printbuf, buf)();
 		struct bucket *g = gc_bucket(ca, bucket.offset);
-		if (bch2_fs_inconsistent_on(!g, c, "reference to invalid bucket on device %u\n  %s",
-					    p.ptr.dev,
-					    (bch2_bkey_val_to_text(&buf, c, k), buf.buf)))
-			return bch_err_throw(c, trigger_pointer);
-
 		struct bch_alloc_v4 old, new;
 
 		scoped_guard(bucket_lock, g) {

--- a/fs/alloc/check.c
+++ b/fs/alloc/check.c
@@ -125,7 +125,7 @@ int bch2_need_discard_or_freespace_err(struct btree_trans *trans,
 
 	bch2_bkey_val_to_text(&buf, c, alloc_k);
 
-	int ret = __bch2_fsck_err(NULL, trans, flags, err_id,
+	int ret = __bch2_fsck_err(NULL, trans, POS_MIN, flags, err_id,
 				  "bucket incorrectly %sset in %s btree\n%s",
 				  set ? "" : "un",
 				  bch2_btree_id_str(btree),

--- a/fs/alloc/disk_groups.c
+++ b/fs/alloc/disk_groups.c
@@ -212,6 +212,77 @@ const struct bch_devs_mask *bch2_target_to_mask(struct bch_fs *c, unsigned targe
 	}
 }
 
+/* Interned failure domain id of a device, 0 = unset. Caller holds rcu. */
+static inline u16 dev_failure_domain(struct bch_fs *c, unsigned dev)
+{
+	struct bch_dev *ca = bch2_dev_rcu_noerror(c, dev);
+	return ca ? ca->mi.failure_domain : 0;
+}
+
+/*
+ * Spreading key for a candidate device: the number of already-chosen replicas
+ * in its failure domain. Sorting candidates by this ascending fills empty
+ * domains first, then doubles up - the failure-domain preference for
+ * replicated data. A device with no failure domain (id 0) always keys 0: it
+ * never shares a domain, so it sorts first and is never excluded.
+ *
+ * Called in batches - caller holds the rcu read lock.
+ */
+u64 bch2_dev_domain_key(struct bch_fs *c,
+			const struct bch_devs_mask *chosen, unsigned dev)
+{
+	u16 d = dev_failure_domain(c, dev);
+	if (!d)
+		return 0;
+
+	u64 key = 0;
+	unsigned i;
+	for_each_set_bit(i, chosen->d, BCH_SB_MEMBERS_MAX)
+		key += dev_failure_domain(c, i) == d;
+
+	return key;
+}
+
+/*
+ * Number of distinct failure domains @devs spans: each set domain counted
+ * once, each device with no domain counted as its own. This caps stripe width
+ * when failure domains are a hard requirement - a stripe can't have more
+ * blocks than domains to spread them across.
+ */
+unsigned bch2_target_nr_domains(struct bch_fs *c,
+				const struct bch_devs_mask *devs)
+{
+	unsigned nr = 0;
+
+	guard(rcu)();
+
+	unsigned i;
+	for_each_set_bit(i, devs->d, BCH_SB_MEMBERS_MAX) {
+		u16 d = dev_failure_domain(c, i);
+
+		/* no failure domain - a domain of its own: */
+		if (!d) {
+			nr++;
+			continue;
+		}
+
+		/* count each domain at its first device: */
+		bool first = true;
+		unsigned j;
+		for_each_set_bit(j, devs->d, BCH_SB_MEMBERS_MAX) {
+			if (j >= i)
+				break;
+			if (dev_failure_domain(c, j) == d) {
+				first = false;
+				break;
+			}
+		}
+		nr += first;
+	}
+
+	return nr;
+}
+
 bool bch2_dev_in_target_rcu(struct bch_fs *c, unsigned dev, unsigned target)
 {
 	if (dev == BCH_SB_MEMBER_INVALID)

--- a/fs/alloc/disk_groups.c
+++ b/fs/alloc/disk_groups.c
@@ -1,4 +1,62 @@
 // SPDX-License-Identifier: GPL-2.0
+
+/* DOC_LATEX(failure-domains)
+ * A \emph{failure domain} is a set of devices expected to fail together: a
+ * shared controller, host, or rack. Spreading a filesystem's replicas across
+ * failure domains is what lets it survive one failing --- losing a whole
+ * domain then costs at most one replica of any extent.
+ *
+ * Each device may be given a failure domain: a free-form string, set with the
+ * \texttt{failure\_domain} device option at format time, at device add time,
+ * or at runtime. Two devices are in the same failure domain when their strings
+ * are equal; a device with no failure domain set is a domain of its own.
+ *
+ * This is a flat, intrinsic device property with no relationship to the disk
+ * label tree used for \hyperref[sec:io-path-options]{targeting}: a device's
+ * label positions it for target options, its failure domain describes physical
+ * fault isolation, and the two need not agree --- devices labeled by
+ * performance class (\texttt{ssd}, \texttt{hdd}) may sit in racks that cut
+ * across those classes.
+ *
+ * \subsubsection{Spreading replicas}
+ *
+ * When allocating, candidate devices are sorted by how many replicas of the
+ * current write already sit in each device's failure domain, so each replica
+ * goes to the least occupied domain, ties broken by the usual free space round
+ * robin. The journal spreads its replicas the same way.
+ *
+ * For replicated data this is a preference, not a requirement: if every
+ * remaining domain already holds a replica --- too few domains for the
+ * replication level, or the empty ones are full --- replicas double up rather
+ * than failing the allocation. Data sharing a domain with another of its
+ * replicas is still intact; it just isn't protected against that domain's loss.
+ *
+ * \subsubsection{Erasure coding}
+ *
+ * For erasure coding, distinct failure domains are a hard requirement rather
+ * than a preference: a stripe survives losing a domain only if no more than
+ * \texttt{nr\_redundant} of its blocks are in it, and a stripe that loses too
+ * many blocks cannot be reconstructed --- landing poorly is not merely
+ * unprotected, as for replicated data, but unrecoverable. So stripe block
+ * allocation excludes devices sharing an already-placed block's domain, and
+ * stripe width is capped at the number of failure domains with allocatable
+ * devices: if a domain becomes unavailable, new stripes are allocated narrower
+ * rather than doubling up.
+ *
+ * \subsubsection{Checking failure domains}
+ *
+ * \texttt{bcachefs fs failure-domains} shows the failure domains and what
+ * losing each would cost, computed from the replicas accounting: for each
+ * domain, the data that would be lost if it failed --- too few copies or stripe
+ * blocks left to reconstruct --- and the data that would survive degraded.
+ * Nonzero lost data means failure domain separation is being violated. With no
+ * failure domains configured each device is its own domain, so this becomes the
+ * per device view.
+ *
+ * Existing data is not rewritten when failure domains change: the report shows
+ * what a future rewrite pass would need to move.
+ */
+
 #include "bcachefs.h"
 
 #include "alloc/disk_groups.h"

--- a/fs/alloc/disk_groups.h
+++ b/fs/alloc/disk_groups.h
@@ -57,6 +57,8 @@ static inline struct target target_decode(unsigned target)
 }
 
 const struct bch_devs_mask *bch2_target_to_mask(struct bch_fs *, unsigned);
+u64 bch2_dev_domain_key(struct bch_fs *, const struct bch_devs_mask *, unsigned);
+unsigned bch2_target_nr_domains(struct bch_fs *, const struct bch_devs_mask *);
 
 static inline struct bch_devs_mask target_rw_devs(struct bch_fs *c,
 						  enum bch_data_type data_type,

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -41,6 +41,7 @@
 #include "init/error.h"
 
 #include "journal/journal.h"
+#include "journal/reclaim.h"
 
 #include "sb/counters.h"
 
@@ -842,6 +843,19 @@ err:
 
 	if (!ret) {
 		ob->data_type = req->data_type;
+
+		/*
+		 * We just consumed an open bucket. If the pool is getting low, poke
+		 * the journal watermark: it factors in open-bucket usage and will
+		 * throttle new journal-reserving work before the reclaim path starves
+		 * (see bch2_journal_set_watermark()). freelist_lock has been dropped
+		 * by now, so taking j->lock here doesn't nest the two.
+		 */
+		if (unlikely(READ_ONCE(c->allocator.open_buckets_nr_free) <
+			     bch2_open_buckets_journal_reserved())) {
+			guard(spinlock)(&c->journal.lock);
+			bch2_journal_set_watermark(&c->journal);
+		}
 
 		event_inc_trace(c, bucket_alloc, buf,
 			bucket_alloc_to_text(&buf, c, req, ob));

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -920,10 +920,20 @@ static void dev_stripe_state_sync(struct dev_stripe_state *stripe,
 	stripe->cached_devs = *devs;
 }
 
-void bch2_dev_alloc_list(struct bch_fs *c,
-			 struct dev_stripe_state *stripe,
-			 struct bch_devs_mask *devs,
-			 struct dev_alloc_list *ret)
+/*
+ * Devices are ordered by failure domain occupancy first - so replicas
+ * spread across failure domains - with the free space round robin breaking
+ * ties:
+ */
+#define dev_alloc_cmp(l, r)						\
+	((domain_keys ? cmp_int(domain_keys[l], domain_keys[r]) : 0) ?:\
+	 __dev_stripe_cmp(stripe, l, r))
+
+static void __dev_alloc_list(struct bch_fs *c,
+			     struct dev_stripe_state *stripe,
+			     struct bch_devs_mask *devs,
+			     const u64 *domain_keys,
+			     struct dev_alloc_list *ret)
 {
 	dev_stripe_state_sync(stripe, devs);
 
@@ -933,7 +943,60 @@ void bch2_dev_alloc_list(struct bch_fs *c,
 	for_each_set_bit(i, devs->d, BCH_SB_MEMBERS_MAX)
 		ret->data[ret->nr++] = i;
 
-	bubble_sort(ret->data, ret->nr, dev_stripe_cmp);
+	bubble_sort(ret->data, ret->nr, dev_alloc_cmp);
+}
+
+/*
+ * Refresh req->domain_keys for every device we may allocate from - one rcu
+ * section per batch. Recomputed whenever devs_chosen changes (each pick
+ * changes the occupancy the next pick should avoid):
+ */
+static void bch2_dev_domain_keys_update(struct bch_fs *c, struct alloc_request *req)
+{
+	unsigned i;
+	scoped_guard(rcu)
+		for_each_set_bit(i, req->devs_may_alloc.d, BCH_SB_MEMBERS_MAX)
+			req->domain_keys[i] = bch2_dev_domain_key(c, &req->devs_chosen, i);
+
+	/*
+	 * For erasure coding failure domains are a hard requirement, not a
+	 * preference: exclude every device sharing a domain with an
+	 * already-chosen block (domain_key > 0) so the allocation fails, or
+	 * narrows, rather than doubling up.
+	 */
+	if (req->failure_domains_required)
+		for_each_set_bit(i, req->devs_may_alloc.d, BCH_SB_MEMBERS_MAX)
+			if (req->domain_keys[i])
+				__clear_bit(i, req->devs_may_alloc.d);
+}
+
+/*
+ * The journal's device selection: domain keys live in the caller's scratch
+ * buffer rather than an alloc_request:
+ */
+void bch2_dev_alloc_list_devs(struct bch_fs *c,
+			      struct dev_stripe_state *stripe,
+			      struct bch_devs_mask *devs,
+			      const struct bch_devs_mask *devs_chosen,
+			      u64 *domain_keys,
+			      struct dev_alloc_list *ret)
+{
+	unsigned i;
+	scoped_guard(rcu)
+		for_each_set_bit(i, devs->d, BCH_SB_MEMBERS_MAX)
+			domain_keys[i] = bch2_dev_domain_key(c, devs_chosen, i);
+
+	__dev_alloc_list(c, stripe, devs, domain_keys, ret);
+}
+
+void bch2_dev_alloc_list(struct bch_fs *c,
+			 struct dev_stripe_state *stripe,
+			 struct alloc_request *req)
+{
+	bch2_dev_domain_keys_update(c, req);
+
+	__dev_alloc_list(c, stripe, &req->devs_may_alloc,
+			 req->domain_keys, &req->devs_sorted);
 }
 
 static const u64 stripe_clock_hand_rescale	= 1ULL << 62; /* trigger rescale at */
@@ -1012,6 +1075,7 @@ static int add_new_bucket(struct bch_fs *c,
 	BUG_ON(req->nr_effective >= req->nr_replicas && durability);
 
 	__clear_bit(ob->dev, req->devs_may_alloc.d);
+	__set_bit(ob->dev, req->devs_chosen.d);
 	req->nr_effective	+= durability;
 
 	ob_push(c, &req->ptrs, ob);
@@ -1032,38 +1096,59 @@ int bch2_bucket_alloc_set_trans(struct btree_trans *trans,
 {
 	struct bch_fs *c = trans->c;
 	int ret = 0;
+	bool progress;
 
 	BUG_ON(req->nr_effective >= req->nr_replicas);
 
-	bch2_dev_alloc_list(c, stripe, &req->devs_may_alloc, &req->devs_sorted);
+	bch2_dev_alloc_list(c, stripe, req);
 
+	/*
+	 * Evaluated once, on the full candidate list: this classifies the
+	 * whole allocation for tracing/bailing, and must not flip as the
+	 * list shrinks below.
+	 */
 	if (req->devs_sorted.nr <= 1)
 		req->will_retry_target_devices = false;
 
-	darray_for_each(req->devs_sorted, i) {
-		req->ca = bch2_dev_tryget_noerror(c, *i);
-		if (!req->ca)
-			continue;
+	do {
+		progress = false;
 
-		req->will_retry_set_devices =
-			i + 1 < req->devs_sorted.data + req->devs_sorted.nr;
+		darray_for_each(req->devs_sorted, i) {
+			req->ca = bch2_dev_tryget_noerror(c, *i);
+			if (!req->ca)
+				continue;
 
-		struct open_bucket *ob = bch2_bucket_alloc_trans(trans, req);
-		if (!IS_ERR(ob))
-			bch2_dev_stripe_increment_inlined(req->ca, stripe, &req->usage);
+			req->will_retry_set_devices =
+				i + 1 < req->devs_sorted.data + req->devs_sorted.nr;
 
-		bch2_dev_put(req->ca);
-		req->ca = NULL;
+			struct open_bucket *ob = bch2_bucket_alloc_trans(trans, req);
+			if (!IS_ERR(ob))
+				bch2_dev_stripe_increment_inlined(req->ca, stripe, &req->usage);
 
-		if (IS_ERR(ob)) { /* don't squash error */
-			ret = PTR_ERR(ob);
-			if (bch2_err_matches(ret, BCH_ERR_transaction_restart) ||
-			    bch2_err_matches(ret, BCH_ERR_operation_blocked) ||
-			    bch2_err_matches(ret, BCH_ERR_open_buckets_empty))
-				return ret;
-		} else if (add_new_bucket(c, req, ob))
-			return 0;
-	}
+			bch2_dev_put(req->ca);
+			req->ca = NULL;
+
+			if (IS_ERR(ob)) { /* don't squash error */
+				ret = PTR_ERR(ob);
+				if (bch2_err_matches(ret, BCH_ERR_transaction_restart) ||
+				    bch2_err_matches(ret, BCH_ERR_operation_blocked) ||
+				    bch2_err_matches(ret, BCH_ERR_open_buckets_empty))
+					return ret;
+			} else if (add_new_bucket(c, req, ob)) {
+				return 0;
+			} else {
+				progress = true;
+				break;
+			}
+		}
+
+		/*
+		 * Each allocation changes which failure domains the next
+		 * replica should avoid - re-sort and go again:
+		 */
+		if (progress)
+			bch2_dev_alloc_list(c, stripe, req);
+	} while (progress);
 
 	return ret ?: alloc_trace_add(req, BCH_SB_MEMBER_INVALID,
 			bch_err_throw(c, insufficient_devices), 0, 0, false);
@@ -1087,7 +1172,7 @@ static int bucket_alloc_from_stripe(struct btree_trans *trans,
 	if (!h)
 		return 0;
 
-	bch2_dev_alloc_list(c, &req->wp->stripe, &req->devs_may_alloc, &req->devs_sorted);
+	bch2_dev_alloc_list(c, &req->wp->stripe, req);
 
 	darray_for_each(req->devs_sorted, i)
 		for (unsigned ec_idx = 0; ec_idx < ec_stripe_new_nr_data(h->s); ec_idx++) {
@@ -1180,23 +1265,43 @@ static int bucket_alloc_set_partial(struct bch_fs *c,
 
 	guard(spinlock)(&a->freelist_lock);
 
-	if (!a->open_buckets_partial_nr)
-		return 0;
+	/*
+	 * Pick the domain-best usable candidate each round, not the first
+	 * match: on a steady-state filesystem most allocations are satisfied
+	 * here, and first-fit would undo the failure domain spreading
+	 * bch2_bucket_alloc_set_trans() does for fresh buckets. Each pick
+	 * updates devs_chosen (via add_new_bucket), so the keys are
+	 * recomputed per round - same shape as the fresh-bucket re-sort loop.
+	 */
+	while (a->open_buckets_partial_nr) {
+		int best = -1;
+		u64 best_key = U64_MAX;
 
-	for (int i = a->open_buckets_partial_nr - 1; i >= 0; --i) {
-		struct open_bucket *ob = a->open_buckets + a->open_buckets_partial[i];
+		bch2_dev_domain_keys_update(c, req);
 
-		if (want_bucket(c, req, ob)) {
-			struct bch_dev *ca = ob_dev(c, ob);
-			u64 avail;
+		for (int i = a->open_buckets_partial_nr - 1; i >= 0; --i) {
+			struct open_bucket *ob = a->open_buckets + a->open_buckets_partial[i];
 
-			bch2_dev_usage_read_fast(ca, &req->usage);
-			avail = __dev_buckets_free(ca, req->usage, req->watermark) + ca->nr_partial_buckets;
-			if (!avail)
+			if (!want_bucket(c, req, ob))
 				continue;
 
-			try(partial_bucket_alloc(c, req, i));
+			struct bch_dev *ca = ob_dev(c, ob);
+
+			bch2_dev_usage_read_fast(ca, &req->usage);
+			if (!(__dev_buckets_free(ca, req->usage, req->watermark) +
+			      ca->nr_partial_buckets))
+				continue;
+
+			if (req->domain_keys[ob->dev] < best_key) {
+				best		= i;
+				best_key	= req->domain_keys[ob->dev];
+			}
 		}
+
+		if (best < 0)
+			return 0;
+
+		try(partial_bucket_alloc(c, req, best));
 	}
 
 	return 0;
@@ -1562,12 +1667,21 @@ retry:
 				  cached_devs.d, BCH_SB_MEMBERS_MAX);
 		}
 
-		/* Don't allocate from devices we already have pointers to: */
-		darray_for_each(*req->devs_have, i)
-			__clear_bit(*i, req->devs_may_alloc.d);
+		/*
+		 * Don't allocate from devices we already have pointers to -
+		 * and spread away from their failure domains:
+		 */
+		memset(&req->devs_chosen, 0, sizeof(req->devs_chosen));
 
-		open_bucket_for_each(c, &req->ptrs, ob, i)
+		darray_for_each(*req->devs_have, i) {
+			__clear_bit(*i, req->devs_may_alloc.d);
+			__set_bit(*i, req->devs_chosen.d);
+		}
+
+		open_bucket_for_each(c, &req->ptrs, ob, i) {
 			__clear_bit(ob->dev, req->devs_may_alloc.d);
+			__set_bit(ob->dev, req->devs_chosen.d);
+		}
 
 		ret =   bucket_alloc_set_writepoint(c, req) ?:
 			bucket_alloc_set_partial(c, req) ?:

--- a/fs/alloc/foreground.h
+++ b/fs/alloc/foreground.h
@@ -53,6 +53,8 @@ struct alloc_request {
 	bool			will_retry_set_devices:1;
 	bool			copygc_can_make_progress:1;
 	bool			trace_alloc_failed:1;
+	/* failure domains are a hard requirement, not a preference (erasure coding): */
+	bool			failure_domains_required:1;
 	enum bch_watermark	watermark;
 	enum bch_write_flags	flags;
 	enum bch_data_type	data_type;
@@ -64,8 +66,16 @@ struct alloc_request {
 	unsigned		nr_effective;	/* sum of @ptrs durability */
 	struct bch_devs_mask	devs_may_alloc;
 
+	/*
+	 * Devices already holding a replica of what we're allocating for -
+	 * devs_have plus buckets allocated so far - for spreading replicas
+	 * across failure domains, see bch2_dev_domain_key():
+	 */
+	struct bch_devs_mask	devs_chosen;
+
 	/* bch2_bucket_alloc_set_trans(): */
 	struct dev_alloc_list	devs_sorted;
+	u64			domain_keys[BCH_SB_MEMBERS_MAX];
 	struct bch_dev_usage	usage;
 
 	/* bch2_bucket_alloc_trans(): */
@@ -140,10 +150,15 @@ static inline int alloc_trace_add(struct alloc_request *req,
 	return err;
 }
 
+void bch2_dev_alloc_list_devs(struct bch_fs *,
+			      struct dev_stripe_state *,
+			      struct bch_devs_mask *,
+			      const struct bch_devs_mask *,
+			      u64 *,
+			      struct dev_alloc_list *);
 void bch2_dev_alloc_list(struct bch_fs *,
 			 struct dev_stripe_state *,
-			 struct bch_devs_mask *,
-			 struct dev_alloc_list *);
+			 struct alloc_request *);
 void bch2_dev_stripe_increment(struct bch_dev *, struct dev_stripe_state *);
 
 static inline struct bch_dev *ob_dev(struct bch_fs *c, struct open_bucket *ob)
@@ -380,12 +395,14 @@ static inline struct alloc_request *alloc_request_get(struct btree_trans *trans,
 	req->will_retry_target_devices	= false;
 	req->will_retry_set_devices	= false;
 	req->copygc_can_make_progress	= false;
+	req->failure_domains_required	= false;
 	req->trace_alloc_failed		= false;
 	req->target_frac			= 0;
 	req->devs_sorted.nr		= 0;
-	/* bch2_alloc_sectors_req() overwrites this; bch2_bucket_alloc_trans()
-	 * callers (e.g. journal resize) don't, so zero it here for them: */
+	/* bch2_alloc_sectors_req() overwrites these; bch2_bucket_alloc_trans()
+	 * callers (e.g. journal resize) don't, so zero them here for them: */
 	memset(&req->devs_may_alloc, 0, sizeof(req->devs_may_alloc));
+	memset(&req->devs_chosen, 0, sizeof(req->devs_chosen));
 	darray_init(&req->trace);
 	return req;
 }

--- a/fs/alloc/foreground.h
+++ b/fs/alloc/foreground.h
@@ -168,6 +168,18 @@ static inline unsigned bch2_open_buckets_reserved(enum bch_watermark watermark)
 	}
 }
 
+/*
+ * Free open buckets we keep in reserve for the reclaim path (write-buffer flush
+ * -> journal -> writeback), which both frees open buckets and needs them to make
+ * progress. When free drops below this, bch2_journal_set_watermark() raises the
+ * journal watermark so new journal-reserving work throttles at reservation time,
+ * before it can drain the pool below the reclaim reserve (BCH_WATERMARK_reclaim).
+ */
+static inline unsigned bch2_open_buckets_journal_reserved(void)
+{
+	return OPEN_BUCKETS_COUNT / 4;
+}
+
 struct open_bucket *bch2_bucket_alloc_trans(struct btree_trans *, struct alloc_request *);
 
 /*

--- a/fs/bcachefs.h
+++ b/fs/bcachefs.h
@@ -376,6 +376,9 @@ BCH_DEBUG_PARAMS_ALL()
 	x(blocked_journal_low_on_pin,					\
 	  "Blocked: journal pins (dirty btree nodes, "			\
 	  "key cache entries) not flushed fast enough")			\
+	x(blocked_journal_low_on_open_buckets,				\
+	  "Blocked: open buckets running low, throttling new "		\
+	  "journal work so reclaim can free them")			\
 	x(blocked_journal_max_in_flight,				\
 	  "Blocked: too many journal writes in flight")			\
 	x(blocked_journal_max_open,					\

--- a/fs/bcachefs.h
+++ b/fs/bcachefs.h
@@ -1019,8 +1019,11 @@ struct bch_log_msg {
 
 static inline void bch2_log_msg_exit(struct bch_log_msg *msg)
 {
-	if (!msg->m.suppress)
+	if (!msg->m.suppress) {
+		/* elastic tabstops: align any raw \t/\r columns */
+		bch2_printbuf_tabstop_align(&msg->m);
 		bch2_print_str_loglevel(msg->c, msg->loglevel, msg->m.buf);
+	}
 	printbuf_exit(&msg->m);
 }
 

--- a/fs/bcachefs_ioctl.h
+++ b/fs/bcachefs_ioctl.h
@@ -691,6 +691,7 @@ struct bch_ioctl_unpoison {
 #define BCH_IOCTL_QUERY_BTREE_KEYS_slots		(1U << 0)
 #define BCH_IOCTL_QUERY_BTREE_KEYS_prev			(1U << 1)
 #define BCH_IOCTL_QUERY_BTREE_KEYS_all_snapshots	(1U << 2)
+#define BCH_IOCTL_QUERY_BTREE_KEYS_nofilter_whiteouts	(1U << 3)
 
 struct bch_ioctl_query_btree_keys {
 	__u32			btree;

--- a/fs/btree/bkey.rs
+++ b/fs/btree/bkey.rs
@@ -279,6 +279,14 @@ impl<'a> BkeySC<'a> {
         }
     }
 
+    /// Key only - type, pos, size - without rendering the value.
+    #[cfg(feature = "std")]
+    pub fn to_text_key(&self) -> BkeySCKeyToText<'a> {
+        BkeySCKeyToText {
+            k: BkeySC { k: self.k, v: self.v, iter: PhantomData },
+        }
+    }
+
     pub fn v(&self) -> BkeyValSC<'a> {
         unsafe { BkeyValSC::from_raw(self.k, self.v) }
     }
@@ -393,6 +401,18 @@ impl fmt::Display for BkeySCToText<'_, '_> {
                 c::bch2_bkey_val_to_text(buf, self.fs.raw, self.k.to_raw())
             })
         }
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct BkeySCKeyToText<'a> {
+    k: BkeySC<'a>,
+}
+
+#[cfg(feature = "std")]
+impl fmt::Display for BkeySCKeyToText<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unsafe { printbuf_to_formatter(f, |buf| c::bch2_bkey_to_text(buf, self.k.k)) }
     }
 }
 

--- a/fs/btree/bkey_methods.h
+++ b/fs/btree/bkey_methods.h
@@ -83,7 +83,14 @@ static inline int bch2_key_trigger(struct btree_trans *trans,
 		? ops->trigger(trans, op)
 		: 0;
 
-	return ret ?: bch2_trigger_snapshot_nr_keys(trans, op);
+	/*
+	 * Gate matches the trans-commit dispatch: only snapshotted btrees get
+	 * per-snapshot key counts. Snapshot-field btrees (reconcile_pending)
+	 * carry a snapshot in their bpos but must not be counted.
+	 */
+	return ret ?: (btree_type_has_snapshots(op.btree)
+		       ? bch2_trigger_snapshot_nr_keys(trans, op)
+		       : 0);
 }
 
 static inline int bch2_key_trigger_old(struct btree_trans *trans,

--- a/fs/btree/cache.c
+++ b/fs/btree/cache.c
@@ -395,8 +395,21 @@ int bch2_btree_node_transition_state_locked(struct bch_fs_btree_cache *bc, struc
 	 * The dirty bit is what makes the cache_state DIRTY, so a FREEABLE
 	 * node with the bit set is an inconsistent state — and consumers that
 	 * need to scrub dirty nodes can rely on walking only live[].dirty.
+	 * Warn with the node dumped — the flags identify which path leaked
+	 * the dirty bit (write_blocked/never_write/noevict/need_write) — then
+	 * clear it and carry on: the state bookkeeping below handles the
+	 * DIRTY exit either way.
 	 */
-	EBUG_ON(!btree_node_state_hashed(new) && btree_node_dirty(b));
+	if (WARN_ONCE(!btree_node_state_hashed(new) && btree_node_dirty(b),
+		      "bcachefs: dirty node in unhashed state transition")) {
+		struct bch_fs *c = container_of(bc, struct bch_fs, btree.cache);
+		CLASS(bch_log_msg, msg)(c);
+		prt_printf(&msg.m, "dirty node in unhashed state transition %u -> %u\n",
+			   old, new);
+		prt_printf(&msg.m, "btree=%u level=%u cache_state=%u flags=0x%lx hash_val=0x%llx\n",
+			   b->c.btree_id, b->c.level, b->cache_state, b->flags, b->hash_val);
+		clear_btree_node_dirty(b);
+	}
 
 	if (old == new)
 		return 0;
@@ -1646,6 +1659,21 @@ static void btree_cache_exit_drain_node(struct bch_fs *c,
 		btree_cache_exit_locked_dump(c, b, "write held");
 		BUG();
 	}
+
+	/*
+	 * Dirty nodes can survive to exit on a dead journal: the going-RO
+	 * path's bch2_btree_cancel_all_writes() only catches nodes dirty at
+	 * that instant, and the window between going-RO and unmount can
+	 * redirty a node (btree node reads wanting a rewrite, interior
+	 * update teardown). With the journal dead they can never be written;
+	 * cancel here too. Dirty at exit with a live journal is a bug, but
+	 * we're freeing everything regardless — warn, don't die.
+	 */
+	if (btree_node_dirty(b)) {
+		WARN_ON_ONCE(!bch2_journal_error(&c->journal));
+		clear_btree_node_dirty(b);
+	}
+
 	bch2_btree_node_transition_state_locked(bc, b, BTREE_NODE_CACHE_FREED);
 	six_unlock_write(&b->c.lock);
 	six_unlock_intent(&b->c.lock);

--- a/fs/btree/commit.c
+++ b/fs/btree/commit.c
@@ -968,7 +968,10 @@ retry:
 			goto fatal_err;
 	}
 
-	event_inc_trace(c, transaction_commit, buf, prt_str(&buf, trans->fn));
+	event_inc_trace(c, transaction_commit, buf, ({
+		prt_printf(&buf, "%s\nseq %llu\n", trans->fn, trans->journal_res.seq);
+		bch2_trans_updates_to_text(&buf, trans);
+	}));
 
 	return 0;
 fatal_err:
@@ -1053,7 +1056,10 @@ static int trans_commit_merge(struct btree_trans *trans,
 noinline __cold
 static void transaction_commit_trace(struct btree_trans *trans)
 {
-	__event_trace(trans->c, transaction_commit, buf, prt_str(&buf, trans->fn));
+	__event_trace(trans->c, transaction_commit, buf, ({
+		prt_printf(&buf, "%s\nseq %llu\n", trans->fn, trans->journal_res.seq);
+		bch2_trans_updates_to_text(&buf, trans);
+	}));
 }
 
 static inline bool update_is_noop(struct btree_insert_entry *i, enum bch_trans_commit_flags flags)
@@ -1200,6 +1206,8 @@ bch2_trans_commit_write_locked(struct btree_trans *trans,
 		btree_insert_entry_checks(trans, i);
 	}
 #endif
+
+	event_inc_trace_fn(c, transaction_commit, transaction_commit_trace(trans));
 
 	if (likely(!(flags & BCH_TRANS_COMMIT_no_journal_res))) {
 		struct journal *j = &c->journal;
@@ -1471,7 +1479,6 @@ retry:
 		goto err;
 
 	trans->commit_count++;
-	event_inc_trace_fn(c, transaction_commit, transaction_commit_trace(trans));
 out:
 	if (likely(!(flags & BCH_TRANS_COMMIT_no_check_rw)))
 		enumerated_ref_put(&c->writes, BCH_WRITE_REF_trans);

--- a/fs/btree/commit.c
+++ b/fs/btree/commit.c
@@ -260,11 +260,24 @@ static int __btree_node_flush(struct journal *j, struct journal_entry_pin *pin,
 	unsigned long old, new;
 	unsigned idx = w - b->writes;
 
+	/*
+	 * The journal pin doesn't pin the node: another thread can write the
+	 * node and drop the pin while we run, and reclaim can then reuse the
+	 * node's memory. Snapshot the identity to arm the reuse check: gone
+	 * already (unhashed nodes can't be dirty), or going while we'd sleep
+	 * on the lock (aborting the attempt), means the pinned write is done
+	 * and there's nothing to flush.
+	 */
+	u64 hash_val = READ_ONCE(b->hash_val);
+	if (!hash_val)
+		return 0;
+
 	CLASS(btree_trans, trans)(c);
-	return lockrestart_do(trans, ({
+	int ret = lockrestart_do(trans, ({
 		btree_path_idx_t path_idx;
-		int ret = bch2_btree_node_lock_with_path(trans, &b->c, SIX_LOCK_read, &path_idx);
-		if (!ret) {
+		int _ret = bch2_btree_node_lock_with_path(trans, &b->c, SIX_LOCK_read,
+							  hash_val, &path_idx);
+		if (!_ret) {
 			old = READ_ONCE(b->flags);
 			do {
 				new = old;
@@ -282,8 +295,10 @@ static int __btree_node_flush(struct journal *j, struct journal_entry_pin *pin,
 			__bch2_btree_node_write(trans, b, BTREE_WRITE_only_if_need);
 			bch2_btree_node_unlock_with_path(trans, path_idx, b->c.level);
 		}
-		ret;
+		_ret;
 	}));
+
+	return bch2_err_matches(ret, BCH_ERR_no_btree_node_reused) ? 0 : ret;
 }
 
 int bch2_btree_node_flush0(struct journal *j, struct journal_entry_pin *pin, u64 seq)

--- a/fs/btree/commit.c
+++ b/fs/btree/commit.c
@@ -935,8 +935,8 @@ retry:
 	     accounting != btree_trans_subbuf_top(trans, &trans->accounting);
 	     accounting = bkey_next(accounting)) {
 		ret = likely(!(flags & BCH_TRANS_COMMIT_skip_accounting_apply))
-			? bch2_accounting_mem_mod_locked(trans, bkey_i_to_s_c_accounting(accounting),
-							 BCH_ACCOUNTING_normal, false)
+			? bch2_accounting_mem_add(trans, bkey_i_to_s_c_accounting(accounting),
+						  BCH_ACCOUNTING_normal, false)
 			: 0;
 		if (ret)
 			goto revert_fs_usage;

--- a/fs/btree/interior.c
+++ b/fs/btree/interior.c
@@ -967,10 +967,29 @@ static void btree_update_nodes_written(struct btree_update *as)
 	darray_for_each(as->old_nodes, i) {
 		bool seq_matches = false;
 
+		/*
+		 * i->b is a stale pointer: this update deleted the node, so
+		 * btree_node_reclaim may have reused its memory — e.g. as
+		 * another update's prealloc node, whose owner holds it
+		 * intent+write while possibly blocked on the allocator. The
+		 * open buckets the allocator is waiting on are released by
+		 * this workqueue (bch2_open_bucket_put below), so sleeping on
+		 * the node here closes the loop and deadlocks. Arm the
+		 * identity check with the old key's hash: if we'd sleep on a
+		 * node that's no longer ours, the lock attempt aborts.
+		 *
+		 * An abort means no wait is owed. Sustained write locks on an
+		 * unhashed node come only from reclaim (which requires
+		 * write_in_flight clear before grabbing) or the write
+		 * completion path (which runs after the bio finished) — either
+		 * way the IO this wait guards against is already done.
+		 */
 		ret = lockrestart_do(trans, ({
 			btree_path_idx_t path_idx;
 			int _ret = bch2_btree_node_lock_with_path(trans, &i->b->c,
-								  SIX_LOCK_read, &path_idx);
+								  SIX_LOCK_read,
+								  btree_ptr_hash_val(&i->key),
+								  &path_idx);
 			if (!_ret) {
 				seq_matches = btree_node_seq_matches(i->b, i->seq);
 				bch2_btree_node_unlock_with_path(trans, path_idx,
@@ -1063,8 +1082,17 @@ static void btree_update_nodes_written(struct btree_update *as)
 		 */
 		lockrestart_do(trans, ({
 			btree_path_idx_t path_idx;
+			/*
+			 * Unarmed take: this block owns clearing b's
+			 * write_blocked (the list_del below), which is what
+			 * makes b unreclaimable - so the reuse race can't
+			 * reach it, and skipping on a spurious abort would
+			 * leak write_blocked and leave b unwritable forever.
+			 * The reparent race is handled by the as->b recheck
+			 * under interior_updates.lock.
+			 */
 			int _ret = bch2_btree_node_lock_with_path(trans, &b->c,
-							SIX_LOCK_intent, &path_idx);
+							SIX_LOCK_intent, 0, &path_idx);
 			if (!_ret) {
 				struct btree_path *path = trans->paths + path_idx;
 
@@ -1132,8 +1160,15 @@ static void btree_update_nodes_written(struct btree_update *as)
 		if (i->b) {
 			lockrestart_do(trans, ({
 				btree_path_idx_t path_idx;
+				/*
+				 * Unarmed take: new nodes are dirty until
+				 * written, hence unreclaimable - the reuse
+				 * race can't reach them, and a spurious skip
+				 * here would leave a node that never gets its
+				 * write kicked.
+				 */
 				int _ret = bch2_btree_node_lock_with_path(trans, &i->b->c,
-							SIX_LOCK_read, &path_idx);
+							SIX_LOCK_read, 0, &path_idx);
 				if (!_ret) {
 					btree_node_write_if_need(trans, i->b, SIX_LOCK_read);
 					bch2_btree_node_unlock_with_path(trans, path_idx,

--- a/fs/btree/iter.c
+++ b/fs/btree/iter.c
@@ -1830,6 +1830,13 @@ void bch2_trans_updates_to_text(struct printbuf *buf, struct btree_trans *trans)
 		bch2_journal_entry_to_text(buf, trans->c, e);
 		prt_newline(buf);
 	}
+
+	for (struct bkey_i *k = btree_trans_subbuf_base(trans, &trans->accounting);
+	     k != btree_trans_subbuf_top(trans, &trans->accounting);
+	     k = bkey_next(k)) {
+		bch2_bkey_val_to_text(buf, trans->c, bkey_i_to_s_c(k));
+		prt_newline(buf);
+	}
 }
 
 noinline __cold

--- a/fs/btree/iter.c
+++ b/fs/btree/iter.c
@@ -4166,11 +4166,19 @@ static void bch2_btree_bkey_cached_common_to_text(struct printbuf *out,
 		   c.n[0], c.n[1], c.n[2], pid);
 }
 
+static char btree_lock_type_char(int lock_type)
+{
+	static const char lock_types[] = { 'r', 'i', 'w' };
+
+	return lock_type >= 0 && lock_type < ARRAY_SIZE(lock_types)
+		? lock_types[lock_type]
+		: '?';
+}
+
 __cold
 void bch2_btree_trans_to_text(struct printbuf *out, struct btree_trans *trans)
 {
 	struct btree_bkey_cached_common *b;
-	static char lock_types[] = { 'r', 'i', 'w' };
 	struct task_struct *task = READ_ONCE(trans->locking_wait.task);
 	unsigned l, idx;
 
@@ -4211,10 +4219,12 @@ void bch2_btree_trans_to_text(struct printbuf *out, struct btree_trans *trans)
 		prt_newline(out);
 
 		for (l = 0; l < BTREE_MAX_DEPTH; l++) {
-			if (btree_node_locked(path, l) &&
+			int lock_type = btree_node_locked_type(path, l);
+
+			if (lock_type != BTREE_NODE_UNLOCKED &&
 			    !IS_ERR_OR_NULL(b = (void *) READ_ONCE(path->l[l].b))) {
 				prt_printf(out, "    %c l=%u ",
-					   lock_types[btree_node_locked_type(path, l)], l);
+					   btree_lock_type_char(lock_type), l);
 				bch2_btree_bkey_cached_common_to_text(out, b);
 				prt_newline(out);
 			}
@@ -4224,7 +4234,8 @@ void bch2_btree_trans_to_text(struct printbuf *out, struct btree_trans *trans)
 	b = READ_ONCE(trans->locking);
 	if (b) {
 		prt_printf(out, "  blocked on:\n");
-		prt_printf(out, "    %c", lock_types[trans->locking_wait.lock_want]);
+		prt_printf(out, "    %c",
+			   btree_lock_type_char(READ_ONCE(trans->locking_wait.lock_want)));
 		bch2_btree_bkey_cached_common_to_text(out, b);
 		prt_newline(out);
 	}

--- a/fs/btree/iter.h
+++ b/fs/btree/iter.h
@@ -1054,6 +1054,22 @@ static inline int btree_trans_too_many_iters(struct btree_trans *trans)
 	_ret2 ?: trans_was_restarted(_trans, _orig_restart_count);	\
 })
 
+/*
+ * -BCH_ERR_fc_continue: a per-key _do may return this to say "skip this key,
+ * keep iterating" (e.g. bch2_snapshots_seen_update() skipping keys that are
+ * doomed duplicates of a key in the snapshot a redundant interior collapses
+ * into). The iteration macros absorb it - advance and continue - and squash
+ * it to 0 at loop exit, so callers never see it.
+ *
+ * In the _commit variants, (_do) ?: commit means fc_continue also skips the
+ * per-key commit: it must be returned before any update is queued, which
+ * holds for bch2_snapshots_seen_update() (called at the top of check fns).
+ */
+static inline bool err_is_continue(int err)
+{
+	return !err || err == -BCH_ERR_fc_continue;
+}
+
 #define for_each_btree_key_max_continue(_trans, _iter,			\
 					 _end, _flags, _k, _do)		\
 ({									\
@@ -1073,9 +1089,10 @@ static inline int btree_trans_too_many_iters(struct btree_trans *trans)
 		if (!_ret3)						\
 			bch2_trans_verify_not_restarted(_trans, _restart_count);\
 	} while (bch2_err_matches(_ret3, BCH_ERR_transaction_restart) ||\
-		 (!_ret3 && bch2_btree_iter_advance_type(&(_iter), (_flags))));\
+		 (err_is_continue(_ret3) &&				\
+		  bch2_btree_iter_advance_type(&(_iter), (_flags))));	\
 									\
-	_ret3;								\
+	_ret3 == -BCH_ERR_fc_continue ? 0 : _ret3;			\
 })
 
 #define for_each_btree_key_continue(_trans, _iter, _flags, _k, _do)	\

--- a/fs/btree/iter.rs
+++ b/fs/btree/iter.rs
@@ -507,6 +507,7 @@ bitflags! {
         const SNAPSHOT_FIELD = c::btree_iter_update_trigger_flags::BTREE_ITER_snapshot_field.0;
         const ALL_SNAPSHOTS = c::btree_iter_update_trigger_flags::BTREE_ITER_all_snapshots.0;
         const FILTER_SNAPSHOTS = c::btree_iter_update_trigger_flags::BTREE_ITER_filter_snapshots.0;
+        const NOFILTER_WHITEOUTS = c::btree_iter_update_trigger_flags::BTREE_ITER_nofilter_whiteouts.0;
         const NOPRESERVE = c::btree_iter_update_trigger_flags::BTREE_ITER_nopreserve.0;
         const CACHED_NOFILL = c::btree_iter_update_trigger_flags::BTREE_ITER_cached_nofill.0;
         const KEY_CACHE_FILL = c::btree_iter_update_trigger_flags::BTREE_ITER_key_cache_fill.0;

--- a/fs/btree/key_cache.c
+++ b/fs/btree/key_cache.c
@@ -548,7 +548,7 @@ int bch2_btree_key_cache_journal_flush(struct journal *j,
 		ret = lockrestart_do(trans, ({
 			btree_path_idx_t path_idx;
 			int _ret = bch2_btree_node_lock_with_path(trans, &ck->c,
-								  SIX_LOCK_intent, &path_idx);
+								  SIX_LOCK_intent, 0, &path_idx);
 			bool do_flush = false;
 
 			if (!_ret) {

--- a/fs/btree/locking.c
+++ b/fs/btree/locking.c
@@ -1249,6 +1249,19 @@ void bch2_trans_unlock(struct btree_trans *trans)
 		bch2_btree_cache_cannibalize_unlock(trans);
 }
 
+/*
+ * Slow devices legitimately hold the srcu lock across submit_bio() for a long
+ * time (e.g. scanning the inodes btree off a slow disk during snapshot
+ * deletion), so scale the "held too long" warning past the worst observed
+ * device latency rather than spamming the log when the real problem is just
+ * slow storage. The lock is held over btree node reads on any online device,
+ * so that's the latency we key off.
+ */
+static unsigned long srcu_hold_warn_thresh(struct bch_fs *c)
+{
+	return max(bch2_dev_latency_max(c, &c->devs_online, READ) * 2, HZ * 10UL);
+}
+
 void bch2_trans_unlock_long(struct btree_trans *trans)
 {
 	bch2_trans_unlock(trans);
@@ -1265,7 +1278,9 @@ void bch2_trans_unlock_long(struct btree_trans *trans)
 
 		if (unlikely(trans->srcu_held &&
 			     !trans->srcu_io_submitted &&
-			     time_after(jiffies, trans->srcu_lock_time + HZ * 10))) {
+			     time_after(jiffies, trans->srcu_lock_time + HZ * 10) &&
+			     time_after(jiffies, trans->srcu_lock_time +
+					srcu_hold_warn_thresh(c)))) {
 			CLASS(bch_log_msg_ratelimited, msg)(c);
 
 			prt_printf(&msg.m, "btree trans held srcu lock (delaying memory reclaim) for %lu seconds\n",

--- a/fs/btree/locking.c
+++ b/fs/btree/locking.c
@@ -757,6 +757,20 @@ int bch2_btree_node_lock_write_contended(struct btree_trans *trans, struct btree
  * temporary unlocked path, take the lock, then record the lock on the path
  * so the cycle detector can find us as the holder.
  *
+ * @hash_val is the node's expected identity — btree_ptr_hash_val() of the key
+ * it was found under, or a snapshot of b->hash_val taken while the pointer
+ * was known valid. It arms the node-reuse check in
+ * bch2_six_check_for_deadlock(): if the identity is gone by the time we'd
+ * sleep, the lock attempt aborts with no_btree_node_reused rather than
+ * parking behind an off-path holder (btree_node_reclaim's trylocks) that may
+ * hold the reused node's lock indefinitely.
+ *
+ * Pass 0 only when reclaim genuinely can't take the node — e.g. the write
+ * completion path, which owns the write_in_flight that blocks reclaim — or
+ * for key cache locks, which the check doesn't cover. Beware flags another
+ * thread can clear: a journal pin doesn't pin (the node can be written and
+ * the pin dropped concurrently), and neither does dirty on its own.
+ *
  * Caller releases via bch2_btree_node_unlock_with_path().
  *
  * May return a transaction_restart; wrap in lockrestart_do().
@@ -765,15 +779,14 @@ int __must_check
 bch2_btree_node_lock_with_path(struct btree_trans *trans,
 			       struct btree_bkey_cached_common *b,
 			       enum six_lock_type type,
+			       u64 hash_val,
 			       btree_path_idx_t *path_idx_out)
 {
 	btree_path_idx_t path_idx = bch2_path_get_unlocked_mut(trans,
 				b->btree_id, b->level, btree_node_pos(b), b->cached);
 
 	struct btree_path *path = trans->paths + path_idx;
-	/* No key context here — caller already has the b. Skip the hash_val
-	 * check; we're acquiring on a node the caller already validated. */
-	trans->locking_hash_val = 0;
+	trans->locking_hash_val = hash_val;
 	trans->locking_root_id	= -1;
 	int ret = btree_node_lock(trans, path, b, b->level, type);
 	if (ret) {

--- a/fs/btree/locking.h
+++ b/fs/btree/locking.h
@@ -415,7 +415,8 @@ static inline void bch2_btree_node_lock_write_nofail(struct btree_trans *trans,
 int __must_check
 bch2_btree_node_lock_with_path(struct btree_trans *,
 			       struct btree_bkey_cached_common *,
-			       enum six_lock_type, btree_path_idx_t *);
+			       enum six_lock_type, u64 hash_val,
+			       btree_path_idx_t *);
 
 /* relock: */
 

--- a/fs/btree/update.c
+++ b/fs/btree/update.c
@@ -125,6 +125,18 @@ int __bch2_insert_snapshot_whiteouts(struct btree_trans *trans,
 				     snapshot_id_list *s)
 {
 	darray_for_each(*s, id) {
+		/*
+		 * In fsck, a repair can fan whiteouts across an unbounded
+		 * number of snapshots: commit and restart before the batch
+		 * hits the trans mem cap. The re-drive converges - committed
+		 * whiteouts fail the KEY_TYPE_deleted check below and are
+		 * skipped. Runtime callers (extent splits) are excluded so
+		 * their whiteouts stay atomic with the extent update:
+		 */
+		if (test_bit(BCH_FS_in_fsck, &trans->c->flags))
+			try(bch2_trans_commit_lazy_if_full(trans, NULL, NULL,
+						BCH_TRANS_COMMIT_no_enospc));
+
 		pos.snapshot = *id;
 
 		CLASS(btree_iter, iter)(trans, btree, pos, BTREE_ITER_not_extents|BTREE_ITER_intent);

--- a/fs/btree/update.h
+++ b/fs/btree/update.h
@@ -356,6 +356,28 @@ static inline int bch2_trans_commit_lazy(struct btree_trans *trans,
 	return __bch2_trans_commit(trans, flags, true);
 }
 
+/*
+ * For repair loops that batch unbounded work - an update per snapshot
+ * version, typically - into one transaction: once substantial work has
+ * accumulated, commit and signal a restart (transaction_restart_commit)
+ * so the caller's restart loop re-drives, instead of the bump allocator
+ * running into BTREE_TRANS_MEM_MAX.
+ *
+ * The re-drive runs with the partial batch committed: callers must
+ * re-check on-disk state and skip already-committed repairs, so the
+ * re-drive shrinks - otherwise it trips this at the same point again
+ * and the restart loop can't make forward progress.
+ */
+static inline int bch2_trans_commit_lazy_if_full(struct btree_trans *trans,
+						 struct disk_reservation *disk_res,
+						 u64 *journal_seq,
+						 unsigned flags)
+{
+	return likely(trans->mem_top < BTREE_TRANS_MEM_MAX / 2)
+		? 0
+		: bch2_trans_commit_lazy(trans, disk_res, journal_seq, flags);
+}
+
 #define commit_do(_trans, _disk_res, _journal_seq, _flags, _do)	\
 	lockrestart_do(_trans, _do ?: bch2_trans_commit(_trans, (_disk_res),\
 					(_journal_seq), (_flags)))

--- a/fs/btree/write.c
+++ b/fs/btree/write.c
@@ -179,7 +179,8 @@ static void btree_node_write_work(struct work_struct *work)
 
 	lockrestart_do(trans, ({
 		btree_path_idx_t path_idx;
-		int ret = bch2_btree_node_lock_with_path(trans, &b->c, SIX_LOCK_read, &path_idx);
+		/* identity pinned: write_in_flight (cleared below) blocks reclaim */
+		int ret = bch2_btree_node_lock_with_path(trans, &b->c, SIX_LOCK_read, 0, &path_idx);
 		if (!ret) {
 			__btree_node_write_done(trans, b);
 			bch2_btree_node_unlock_with_path(trans, path_idx, b->c.level);

--- a/fs/btree/write_buffer.c
+++ b/fs/btree/write_buffer.c
@@ -931,7 +931,7 @@ static int fetch_wb_keys_from_journal(struct bch_fs *c, u64 max_seq)
 	bool blocked;
 	int ret = 0;
 
-	guard(mutex)(&j->buf_lock);
+	guard(mutex_noio)(&j->buf_lock);
 	bch2_journal_keys_to_write_buffer_lock(c, &dst);
 
 	while (!ret && (buf = bch2_next_write_buffer_flush_journal_buf(j, max_seq, &blocked))) {

--- a/fs/btree/write_buffer.c
+++ b/fs/btree/write_buffer.c
@@ -603,16 +603,22 @@ static int bch2_btree_write_buffer_flush_locked(struct btree_trans *trans,
 	bool accounting_replay_done = test_bit(BCH_FS_accounting_replay_done, &c->flags);
 	int ret = 0;
 
+	/*
+	 * The flush allocates under the write buffer locks (flush shards, key
+	 * array resizes), and with swap on bcachefs those locks are on the
+	 * reclaim path - all of flush runs NOIO so allocations can't recurse
+	 * into the IO this flush is needed to complete:
+	 */
+	guard(memalloc_flags)(PF_MEMALLOC_NOIO);
+
 	try(bch2_journal_error(&c->journal));
 
-	scoped_guard(memalloc_flags, PF_MEMALLOC_NOIO) {
-		if (!wb->flushing.keys.nr) {
-			guard(mutex)(&wb->inc.lock);
-			move_keys_from_inc_to_flushing(wb);
-		} else if (mutex_trylock(&wb->inc.lock)) {
-			move_keys_from_inc_to_flushing(wb);
-			mutex_unlock(&wb->inc.lock);
-		}
+	if (!wb->flushing.keys.nr) {
+		guard(mutex)(&wb->inc.lock);
+		move_keys_from_inc_to_flushing(wb);
+	} else if (mutex_trylock(&wb->inc.lock)) {
+		move_keys_from_inc_to_flushing(wb);
+		mutex_unlock(&wb->inc.lock);
 	}
 
 	if (!wb->flushing.keys.nr)
@@ -833,6 +839,14 @@ err:
 static void bch2_journal_keys_to_write_buffer_lock(struct bch_fs *c,
 						   struct journal_keys_to_wb *dst)
 {
+	/*
+	 * Intake allocates under the write buffer locks (key array resizes,
+	 * accounting pushes), which sit on the reclaim path when swap is on
+	 * bcachefs: callers must have established a NOIO scope. Both current
+	 * callers hold j->buf_lock, a mutex_noio, across the whole bracket:
+	 */
+	EBUG_ON(!(current->flags & PF_MEMALLOC_NOIO));
+
 	memset(dst, 0, sizeof(*dst));
 
 	for (enum bch_wb_btree idx = 0; idx < BCH_WB_BTREE_NR; idx++) {
@@ -1354,6 +1368,9 @@ int bch2_journal_keys_to_write_buffer_end(struct bch_fs *c, struct journal_keys_
 
 int bch2_btree_write_buffer_resize(struct bch_fs *c, size_t new_size)
 {
+	/* Reallocates the key arrays under the write buffer locks: */
+	guard(memalloc_flags)(PF_MEMALLOC_NOIO);
+
 	for (unsigned i = 0; i < BCH_WB_BTREE_NR; i++) {
 		struct bch_fs_btree_write_buffer *wb = &c->btree.write_buffer[i];
 		try(wb_keys_resize(&wb->flushing, new_size));

--- a/fs/build.rs
+++ b/fs/build.rs
@@ -13,8 +13,19 @@ include!("codegen.rs");
 fn watch_dir(dir: &str) {
     let Ok(entries) = std::fs::read_dir(dir) else { return };
     for entry in entries.flatten() {
+        // file_type() reads the dirent directly - unlike Path::is_dir() it does
+        // NOT follow symlinks. Following them descends ktest-out/kernel into a
+        // full kernel tree and ktest-out/vm into /tmp; over virtiofs in the test
+        // VM that stat-storm makes the build crawl. We walk "..", so this is
+        // reachable whenever a build has been run in-tree.
+        let Ok(file_type) = entry.file_type() else { continue };
         let path = entry.path();
-        if path.is_dir() {
+        if file_type.is_dir() {
+            // Build output and VCS dirs hold no wrapper-included C/H, only huge
+            // file counts - don't recurse into them.
+            if matches!(entry.file_name().to_str(), Some("target" | "ktest-out" | ".git")) {
+                continue;
+            }
             watch_dir(&path.to_string_lossy());
         } else if path.extension().is_some_and(|e| e == "h" || e == "c") {
             println!("cargo:rerun-if-changed={}", path.display());

--- a/fs/codegen.rs
+++ b/fs/codegen.rs
@@ -890,6 +890,19 @@ fn generate_btree_ids_known(entries: &[Vec<String>]) -> String {
     }
     out.push_str("];\n");
 
+    let mut mask: u64 = 0;
+    for e in entries {
+        let nr: u32 = e[1].trim().parse().expect("BCH_BTREE_IDS: numeric id");
+        if e[2].contains("BTREE_IS_snapshots") {
+            mask |= 1 << nr;
+        }
+    }
+    out.push_str(&format!(
+        "\n/// Btrees whose keys are snapshotted; mirrors the C btree_has_snapshots_mask\n\
+         /// (a static const bindgen can't see).\n\
+         pub const BTREE_HAS_SNAPSHOTS_MASK: u64 = {mask:#x};\n"
+    ));
+
     out
 }
 

--- a/fs/data/ec/create.c
+++ b/fs/data/ec/create.c
@@ -1051,6 +1051,20 @@ static int __new_stripe_alloc_buckets(struct btree_trans *trans,
 	unsigned i, j, nr_have_parity = 0, nr_have_data = 0;
 
 	req->new_stripe_alloc = true;
+	/*
+	 * For erasure coding, distinct failure domains are a hard requirement,
+	 * not a preference: the allocator excludes devices sharing an
+	 * already-placed block's domain (see bch2_dev_domain_keys_update()).
+	 */
+	req->failure_domains_required = true;
+
+	/*
+	 * Rebuilt below from the current stripe blocks. We may be called twice
+	 * on the same req (full-stripe attempt, then stripe reuse), and the
+	 * released first-attempt buckets must not linger here - a stale bit
+	 * would wrongly exclude that device's whole domain, above.
+	 */
+	memset(&req->devs_chosen, 0, sizeof(req->devs_chosen));
 
 	/* * We bypass the sector allocator which normally does this: */
 	bitmap_and(req->devs_may_alloc.d, req->devs_may_alloc.d,
@@ -1063,8 +1077,11 @@ static int __new_stripe_alloc_buckets(struct btree_trans *trans,
 		 * walk backpointers and update all extents that point to that
 		 * block when updating the stripe
 		 */
-		if (v->ptrs[i].dev != BCH_SB_MEMBER_INVALID)
+		if (v->ptrs[i].dev != BCH_SB_MEMBER_INVALID) {
 			__clear_bit(v->ptrs[i].dev, req->devs_may_alloc.d);
+			/* spread new blocks away from existing blocks' domains: */
+			__set_bit(v->ptrs[i].dev, req->devs_chosen.d);
+		}
 
 		if (i < nr_data)
 			nr_have_data++;
@@ -1769,6 +1786,16 @@ static void ec_stripe_head_devs_update(struct bch_fs *c, struct ec_stripe_head *
 	 */
 	h->insufficient_devs = h->nr_active_devs < h->redundancy + 2;
 
+	/*
+	 * One block per failure domain is a hard requirement (see
+	 * __new_stripe_alloc_buckets): too few domains for redundancy to mean
+	 * anything means no stripes at all. With no failure domains configured
+	 * each device is its own domain, so this only tightens the device-count
+	 * check above when devices share domains.
+	 */
+	unsigned nr_domains = bch2_target_nr_domains(c, &h->devs);
+	h->insufficient_devs |= nr_domains < h->redundancy + 2;
+
 	struct bch_devs_mask devs_leaving;
 	bitmap_andnot(devs_leaving.d, old_devs.d, h->devs.d, BCH_SB_MEMBERS_MAX);
 
@@ -1894,6 +1921,17 @@ struct ec_stripe_head *bch2_ec_stripe_head_get(struct btree_trans *trans,
 		unsigned active = min_t(unsigned, h->nr_active_devs, BCH_BKEY_PTRS_MAX);
 		unsigned nr_data = min_t(unsigned, active - h->redundancy,
 					 req->ec_max_data_blocks ?: ~0U);
+
+		/*
+		 * One block per failure domain: the stripe can't be wider than
+		 * the domains available. If a domain becomes unavailable, the
+		 * next stripe is allocated narrower rather than doubling up.
+		 * With no failure domains each device is its own domain, so this
+		 * is the usual device-count cap.
+		 */
+		unsigned nr_domains = bch2_target_nr_domains(c, &h->devs);
+		/* insufficient_devs was checked - at least redundancy + 2 domains: */
+		nr_data = min(nr_data, nr_domains - h->redundancy);
 
 		h->s = ec_new_stripe_alloc(c,
 					   h->devs,

--- a/fs/data/read.c
+++ b/fs/data/read.c
@@ -1724,6 +1724,17 @@ err:
 
 		if (ret && !data_read_err_should_retry(ret))
 			break;
+
+		/*
+		 * A stale BCH_READ_last_fragment on the retry would falsely
+		 * terminate the read: bvec_iter is stable across attempts but
+		 * the extent isn't - if it shrank (a concurrent write
+		 * splitting it), the retried fragment is no longer the last
+		 * and the rest of the buffer would never be read. must_clone
+		 * stays: splits demand cloning for error attribution.
+		 */
+		if (ret)
+			flags &= ~BCH_READ_last_fragment;
 	}
 
 	if (unlikely(ret)) {

--- a/fs/data/read.c
+++ b/fs/data/read.c
@@ -934,7 +934,17 @@ static int __bch2_read_endio_work(struct bch_read_bio *rbio)
 	if (unlikely(rbio->narrow_crcs) && csum_good)
 		bch2_rbio_narrow_crcs(rbio);
 
-	if (likely(!parent->data_update)) {
+	if (unlikely(parent->nodecode)) {
+		/*
+		 * Checksum verified above; skip decompress/decrypt.
+		 * Copy raw on-disk data from bounce buffer if bounced.
+		 */
+		if (rbio->bounce) {
+			struct bvec_iter src_iter = src->bi_iter;
+
+			bio_copy_data_iter(dst, &dst_iter, src, &src_iter);
+		}
+	} else if (likely(!parent->data_update)) {
 		/* Adjust crc to point to subset of data we want: */
 		crc.offset     += rbio->offset_into_extent;
 		crc.live_size	= bvec_iter_sectors(rbio->bvec_iter);

--- a/fs/data/read.h
+++ b/fs/data/read.h
@@ -57,6 +57,7 @@ struct bch_read_bio {
 	struct {
 	u16			data_update:1,
 				data_update_verify_decompress:1,
+			nodecode:1,
 				promote:1,
 				bounce:1,
 				split:1,

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -884,8 +884,10 @@ static int __do_reconcile_extent(struct moving_context *ctxt,
 	if (ret) {
 		WARN_ONCE(!bch2_err_matches(ret, EROFS) &&
 			  !bch2_err_matches(ret, BCH_ERR_snapshot) &&
-			  ret != -BCH_ERR_data_update_fail_no_snapshot &&
-			  ret != -BCH_ERR_data_update_fail_in_flight,
+			  !bch2_err_matches(ret, BCH_ERR_data_update_fail_no_snapshot) &&
+			  !bch2_err_matches(ret, BCH_ERR_data_update_fail_in_flight) &&
+			  !bch2_err_matches(ret, BCH_ERR_freelist_empty) &&
+			  !bch2_err_matches(ret, BCH_ERR_open_buckets_empty),
 			  "unhandled error from move_extent: %s", bch2_err_str(ret));
 		/* skip it and continue */
 	}

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -13,11 +13,14 @@
 #include "btree/update.h"
 #include "btree/write_buffer.h"
 
+#include "data/checksum.h"
 #include "data/compress.h"
 #include "data/copygc.h"
 #include "data/ec/create.h"
 #include "data/ec/trigger.h"
+#include "data/extents.h"
 #include "data/move.h"
+#include "data/read.h"
 #include "data/reconcile/work.h"
 #include "data/write.h"
 
@@ -819,6 +822,184 @@ static int do_retry_stripes(struct moving_context *ctxt,
 	return 0;
 }
 
+/* Completion callback for synchronous reconcile checksum reads */
+static void reconcile_rechecksum_endio(struct bio *bio)
+{
+	complete(bio->bi_private);
+}
+
+/*
+ * Metadata-only checksum reconcile: when the only thing wrong with an
+ * extent is its checksum type, we can read the data, verify the old
+ * checksum, compute the new checksum, and update the btree — without
+ * rewriting the data on disk.
+ *
+ * Returns 0 on success, -errno on failure, 1 if we should fall through
+ * to the full data rewrite path.
+ */
+static int reconcile_rechecksum_extent(struct btree_trans *trans,
+				       struct btree_iter *iter,
+				       struct bkey_s_c k,
+				       unsigned new_csum_type)
+{
+	struct bch_fs *c = trans->c;
+	struct bkey_ptrs_c ptrs = bch2_bkey_ptrs_c(k);
+	const union bch_extent_entry *entry;
+	struct extent_ptr_decoded p;
+	int ret;
+
+	/* Don't handle encrypted extents here */
+	if (bch2_csum_type_is_encryption(new_csum_type))
+		return 1;
+
+	/*
+	 * Find the CRC info for computing the nonce and new checksum.
+	 */
+	struct bch_extent_crc_unpacked first_crc = {};
+	bool found = false;
+
+	bkey_for_each_ptr_decode(k.k, ptrs, p, entry) {
+		if (p.ptr.cached)
+			continue;
+		if (bch2_csum_type_is_encryption(p.crc.csum_type))
+			return 1;
+		if (!found) {
+			first_crc = p.crc;
+			found = true;
+		}
+	}
+
+	if (!found)
+		return 1;
+
+	unsigned sectors = first_crc.compressed_size;
+	unsigned bytes = sectors << 9;
+
+	/* Allocate bio and pages for the read */
+	struct bio *bio = bio_alloc_bioset(NULL, DIV_ROUND_UP(bytes, PAGE_SIZE),
+					   REQ_OP_READ, GFP_KERNEL, &c->bio_read);
+	if (!bio)
+		return -ENOMEM;
+
+	if (bch2_bio_alloc_pages(bio, c->opts.block_size, bytes, GFP_KERNEL)) {
+		bch2_bio_free_pages_pool(c, bio);
+		bio_put(bio);
+		return -ENOMEM;
+	}
+
+	/* Save key state before dropping locks for I/O */
+	struct bkey_buf saved_k __cleanup(bch2_bkey_buf_exit);
+	bch2_bkey_buf_init(&saved_k);
+	bch2_bkey_buf_reassemble(&saved_k, k);
+
+	/*
+	 * Issue synchronous read via the read path with nodecode.
+	 * This gives us: device selection, checksum verification,
+	 * retry on error — but skips decompress/decrypt, keeping
+	 * raw on-disk data (compressed stays compressed).
+	 */
+	DECLARE_COMPLETION_ONSTACK(done);
+	bio->bi_private = &done;
+
+	struct bch_read_bio *rbio = rbio_init(bio, c,
+					      (struct bch_inode_opts) { 0 },
+					      reconcile_rechecksum_endio);
+	rbio->data_pos = bkey_start_pos(k.k);
+	rbio->nodecode = true;
+
+	/* Drop btree locks for blocking I/O */
+	bch2_trans_unlock_long(trans);
+
+	__bch2_read_extent(trans, rbio, bio->bi_iter,
+			   bkey_start_pos(k.k),
+			   iter->btree_id, k, 0, NULL,
+			   BCH_READ_last_fragment, -1);
+
+	wait_for_completion(&done);
+
+	if (rbio->ret) {
+		/*
+		 * Read failed or old checksum bad — the read path
+		 * already handled retries from other replicas.
+		 * Fall through to full rewrite which handles errors.
+		 */
+		ret = 1;
+		goto out_free;
+	}
+
+	/*
+	 * The read path verified the old checksum.
+	 * Now compute the new one against the raw on-disk data.
+	 */
+	struct nonce nonce = extent_nonce(saved_k.k->k.bversion, first_crc);
+	struct bch_csum new_csum = bch2_checksum_bio(c, new_csum_type,
+						     nonce, bio);
+
+	/* Relock and verify the key hasn't changed */
+	ret = bch2_trans_relock(trans);
+	if (ret)
+		goto out_free;
+
+	struct bkey_s_c cur_k = bch2_btree_iter_peek_slot(iter);
+	if (bkey_err(cur_k)) {
+		ret = bkey_err(cur_k);
+		goto out_free;
+	}
+	if (!bkey_and_val_eq(bkey_i_to_s_c(saved_k.k), cur_k)) {
+		ret = 0; /* key changed, skip */
+		goto out_free;
+	}
+
+	/*
+	 * Rebuild the key with updated CRC entries.
+	 * Use ptr_decoded_append to handle any CRC entry size.
+	 */
+	struct bkey_i *new = bch2_trans_kmalloc(trans,
+			bkey_bytes(k.k) + sizeof(struct bch_extent_crc128));
+	if (IS_ERR(new)) {
+		ret = PTR_ERR(new);
+		goto out_free;
+	}
+
+	bkey_init(&new->k);
+	new->k.p = cur_k.k->p;
+	new->k.size = cur_k.k->size;
+	new->k.type = cur_k.k->type;
+	new->k.bversion = cur_k.k->bversion;
+
+	ptrs = bch2_bkey_ptrs_c(cur_k);
+	bkey_for_each_ptr_decode(cur_k.k, ptrs, p, entry) {
+		if (!p.ptr.cached) {
+			p.crc.csum_type = new_csum_type;
+			p.crc.csum = new_csum;
+		}
+		bch2_extent_ptr_decoded_append(c, new, &p);
+	}
+
+	/* Copy over non-ptr/crc entries (reconcile, flags, etc.) */
+	ptrs = bch2_bkey_ptrs_c(cur_k);
+	bkey_extent_entry_for_each(ptrs, entry) {
+		if (!extent_entry_is_crc(entry) &&
+		    !extent_entry_is_ptr(entry) &&
+		    extent_entry_type(entry) != BCH_EXTENT_ENTRY_stripe_ptr)
+			__extent_entry_insert(c, new,
+				bkey_val_end(bkey_i_to_s(new)),
+				(union bch_extent_entry *) entry);
+	}
+
+	ret = bch2_trans_update(trans, iter, new,
+				BTREE_UPDATE_internal_snapshot_node);
+	if (ret)
+		goto out_free;
+
+	ret = bch2_trans_commit(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc);
+
+out_free:
+	bch2_bio_free_pages_pool(c, bio);
+	bio_put(bio);
+	return ret;
+}
+
 static int __do_reconcile_extent(struct moving_context *ctxt,
 				 struct per_snapshot_io_opts *snapshot_io_opts,
 				 struct bch_inode_opts *opts,
@@ -851,6 +1032,26 @@ static int __do_reconcile_extent(struct moving_context *ctxt,
 	int ret = reconcile_set_data_opts(trans, iter, level, k, opts, data_opts);
 	if (ret <= 0)
 		return ret;
+
+	const struct bch_extent_reconcile *r = bch2_bkey_reconcile_opts(c, k);
+
+	/*
+	 * Checksum-only reconcile: if the only thing wrong is the
+	 * checksum type, do a metadata-only update (read + recompute
+	 * checksum + btree update, no data write).
+	 */
+	if (r && r->need_rb == BIT(BCH_RECONCILE_data_checksum)) {
+		unsigned csum_type = bch2_data_checksum_type_rb(c, *r);
+
+		ret = reconcile_rechecksum_extent(trans, iter, k, csum_type);
+		if (ret == 0) {
+			trans->restart_count = restart_count;
+			return 0;
+		}
+		if (ret != 1)
+			return ret;
+		/* ret == 1: fall through to full rewrite */
+	}
 
 	if (work.btree == BTREE_ID_reconcile_pending) {
 		int ret = bch2_can_do_data_update(trans, opts, data_opts, k, NULL);

--- a/fs/data/reflink.c
+++ b/fs/data/reflink.c
@@ -207,7 +207,8 @@ static int bch2_indirect_extent_missing_error(struct btree_trans *trans,
 	prt_printf(&buf, "\nmissing reflink btree range %llu-%llu",
 		   missing_start, missing_end);
 
-	if (ret_fsck_err(trans, reflink_p_to_missing_reflink_v, "%s", buf.buf)) {
+	if (ret_inode_fsck_err(trans, p.k->p,
+			       reflink_p_to_missing_reflink_v, "%s", buf.buf)) {
 		struct bkey_i_reflink_p *new =
 			errptr_try(bch2_bkey_make_mut_noupdate_typed(trans, p.s_c, reflink_p));
 

--- a/fs/data/write.c
+++ b/fs/data/write.c
@@ -377,8 +377,13 @@
  * candidates is chosen; devices with a different bucket size are excluded). The
  * minimum is \texttt{redundancy + 2} devices (3 for RAID-5, 4 for RAID-6). With
  * $n$ eligible devices, a stripe has $n - \mathrm{redundancy}$ data blocks and
- * \texttt{redundancy} parity blocks, maximizing storage efficiency. There is no
- * configuration to limit stripe width to a subset of available devices.
+ * \texttt{redundancy} parity blocks, maximizing storage efficiency. Data blocks
+ * per stripe may be capped with the \texttt{ec\_max\_data\_blocks} option; the
+ * cap excludes parity (a cap of 9 with 2 parity blocks gives stripes 11 blocks
+ * wide). When \hyperref[sec:failure-domains]{failure domains} are configured, a
+ * stripe takes at most one block per domain, so width is also bounded by the
+ * number of available domains. Which devices are used within these bounds is
+ * not configurable.
  *
  * Stripe fragmentation is tracked in the LRU btree. When all data blocks in a
  * stripe become empty (sector count zero), the stripe is automatically deleted.

--- a/fs/data/write.c
+++ b/fs/data/write.c
@@ -1324,6 +1324,14 @@ static void __bch2_write_index(struct bch_write_op *op)
 	struct keylist *keys = &op->insert_keys;
 	int ret = 0;
 
+	/*
+	 * the btree code sets PF_MEMALLOC_NOIO when it has btree locks held,
+	 * but will drop locks and do GFP_KERNEL allocations
+	 *
+	 * But here, our btree updates really are required for memory reclaim:
+	 */
+	guard(memalloc_flags)(PF_MEMALLOC_NOIO);
+
 	if (unlikely(op->io_error)) {
 		ret = bch2_write_drop_io_error_ptrs(op);
 

--- a/fs/debug/debug.c
+++ b/fs/debug/debug.c
@@ -815,7 +815,7 @@ static const struct file_operations btree_node_scan_ops = {
  * The full fsck damaged-paths list, untruncated: the end-of-fsck summary
  * prints only the first FSCK_DAMAGED_PATHS_PRINT entries, which isn't enough
  * when triaging a badly damaged filesystem. Interim surface until the damage
- * btree lands; unlike the summary, pure-reattached entries are listed too.
+ * btree lands.
  */
 static ssize_t bch2_fsck_damaged_paths_read(struct file *file, char __user *buf,
 					    size_t size, loff_t *ppos)

--- a/fs/debug/debug.c
+++ b/fs/debug/debug.c
@@ -811,6 +811,60 @@ static const struct file_operations btree_node_scan_ops = {
 	.read		= bch2_btree_node_scan_read,
 };
 
+/*
+ * The full fsck damaged-paths list, untruncated: the end-of-fsck summary
+ * prints only the first FSCK_DAMAGED_PATHS_PRINT entries, which isn't enough
+ * when triaging a badly damaged filesystem. Interim surface until the damage
+ * btree lands; unlike the summary, pure-reattached entries are listed too.
+ */
+static ssize_t bch2_fsck_damaged_paths_read(struct file *file, char __user *buf,
+					    size_t size, loff_t *ppos)
+{
+	struct dump_iter *i = file->private_data;
+	struct bch_fs *c = i->c;
+
+	i->ubuf = buf;
+	i->size	= size;
+	i->ret	= 0;
+
+	if (!test_bit(BCH_FS_may_go_rw, &c->flags))
+		return 0;
+
+	CLASS(btree_trans, trans)(c);
+
+	while (1) {
+		try(bch2_debugfs_flush_buf(i));
+
+		/*
+		 * Snapshot the entry under the lock, resolve outside it: path
+		 * resolution takes btree locks, and fsck error paths take
+		 * msgs_lock under those.
+		 */
+		struct fsck_damaged_path entry;
+		bool done;
+
+		scoped_guard(mutex, &c->errors.msgs_lock) {
+			done = i->iter >= c->errors.damaged_paths.nr;
+			if (!done)
+				entry = c->errors.damaged_paths.data[i->iter];
+		}
+		if (done)
+			break;
+
+		bch2_fsck_damaged_path_to_text(&i->buf, trans, &entry);
+		i->iter++;
+	}
+
+	return bch2_debugfs_flush_buf(i) ?: i->ret;
+}
+
+static const struct file_operations fsck_damaged_paths_ops = {
+	.owner		= THIS_MODULE,
+	.open		= bch2_dump_open,
+	.release	= bch2_dump_release,
+	.read		= bch2_fsck_damaged_paths_read,
+};
+
 void bch2_fs_debug_exit(struct bch_fs *c)
 {
 	if (!IS_ERR_OR_NULL(c->fs_debug_dir))
@@ -869,6 +923,9 @@ void bch2_fs_debug_init(struct bch_fs *c)
 
 	debugfs_create_file("btree_node_scan", 0400, c->fs_debug_dir,
 			    c->btree_debug, &btree_node_scan_ops);
+
+	debugfs_create_file("fsck_damaged_paths", 0400, c->fs_debug_dir,
+			    c->btree_debug, &fsck_damaged_paths_ops);
 
 	debugfs_create_file("write_points", 0400, c->fs_debug_dir,
 			    c->btree_debug, &write_points_ops);

--- a/fs/debug/sysfs.c
+++ b/fs/debug/sysfs.c
@@ -777,6 +777,14 @@ static ssize_t sysfs_opt_show(struct bch_fs *c,
 	u64 v;
 
 	if (ca) {
+		if (opt->type == BCH_OPT_STR_MEMBER) {
+			/* The value lives in the member, not a u64 - render it here: */
+			guard(mutex_noio)(&c->sb_lock);
+			struct bch_member m = bch2_sb_member_get(c->disk_sb.sb, ca->dev_idx);
+			prt_printf(out, "%.*s\n", (int) opt->member_size,
+				   (char *) &m + opt->member_offset);
+			return 0;
+		}
 		if (!((opt->flags & OPT_DEVICE) && opt->get_member))
 			return bch_err_throw(c, EINVAL_sysfs_opt_not_found);
 		v = bch2_opt_from_sb(c->disk_sb.sb, id, ca->dev_idx);
@@ -814,16 +822,18 @@ static ssize_t sysfs_opt_store(struct bch_fs *c,
 	guard(opt_change_lock)(c);
 	CLASS(opt_change_scope, opt_scope)(c);
 
+	char *val = strim(tmp);
 	u64 v;
-	ret =   bch2_opt_parse(c, opt, strim(tmp), &v, NULL) ?:
+	ret =   bch2_opt_parse(c, opt, val, &v, NULL) ?:
 		bch2_opt_hook_pre_set(c, ca, 0, id, v, true, &opt_scope);
 
 	if (!ret) {
-		bool is_sb = opt->get_sb || opt->get_member || opt->get_ext;
+		bool is_sb = opt->get_sb || opt->get_member || opt->get_ext ||
+			     opt->type == BCH_OPT_STR_MEMBER;
 		bool changed = false;
 
 		if (is_sb) {
-			changed = bch2_opt_set_sb(c, ca, opt, v);
+			changed = bch2_opt_set_sb(c, ca, opt, v, val);
 		} else if (!ca) {
 			changed = bch2_opt_get_by_id(&c->opts, id) != v;
 		} else {

--- a/fs/errcode.h
+++ b/fs/errcode.h
@@ -311,6 +311,7 @@
 	x(EINVAL,			inode_unpack_error)			\
 	x(EINVAL,			inode_not_unlinked)			\
 	x(EINVAL,			inode_has_child_snapshot)		\
+	x(EINVAL,			inode_is_subvolume_root)		\
 	x(EINVAL,			varint_decode_error)			\
 	x(EINVAL,			erasure_coding_found_btree_node)	\
 	x(EINVAL,			erasure_coding_stripe_update_err)	\

--- a/fs/errcode.h
+++ b/fs/errcode.h
@@ -596,7 +596,8 @@
 	x(0,				shutdown_with_errors)			\
 	x(BCH_ERR_shutdown_with_errors,	shutdown_with_errors_fixed)		\
 	x(BCH_ERR_shutdown_with_errors,	shutdown_with_errors_unfixed)		\
-	x(BCH_ERR_shutdown_with_errors,	shutdown_with_emergency_ro)
+	x(BCH_ERR_shutdown_with_errors,	shutdown_with_emergency_ro)		\
+	x(0,				fc_continue)
 
 enum bch_errcode {
 	BCH_ERR_START		= 2048,

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -1890,6 +1890,29 @@ static int check_dirent(struct btree_trans *trans, struct btree_iter *iter,
 				      bch2_bkey_val_to_text(&buf, c, k),
 				      buf.buf))) {
 				darray_for_each(target->inodes, i) {
+					try(bch2_trans_commit_lazy_if_full(trans, NULL, NULL,
+							BCH_TRANS_COMMIT_no_enospc));
+
+					/*
+					 * The inode-side state firing this repair is
+					 * unchanged by the copies, so a re-drive after a
+					 * partially-committed batch fires it again: skip
+					 * the copies already committed, or the
+					 * commit_lazy_if_full() restart can't make
+					 * forward progress:
+					 */
+					CLASS(btree_iter, probe)(trans, BTREE_ID_dirents,
+							SPOS(k.k->p.inode, k.k->p.offset,
+							     i->inode.bi_snapshot), 0);
+					struct bkey_s_c old =
+						bkey_try(bch2_btree_iter_peek_slot(&probe));
+
+					if (old.k->p.snapshot == i->inode.bi_snapshot &&
+					    old.k->type == k.k->type &&
+					    bkey_val_bytes(old.k) == bkey_val_bytes(k.k) &&
+					    !memcmp(old.v, k.v, bkey_val_bytes(k.k)))
+						continue;
+
 					struct bkey_i *n =
 						errptr_try(bch2_bkey_make_mut_noupdate(trans, k));
 
@@ -1931,27 +1954,56 @@ static int check_dirent(struct btree_trans *trans, struct btree_iter *iter,
 			try(bch2_fsck_remove_dirent(trans, d.k->p));
 		}
 
-		darray_for_each(target->inodes, i)
-			try(bch2_check_dirent_target(trans, iter, d, &i->inode, true));
+		darray_for_each(target->inodes, i) {
+			/*
+			 * One repair per snapshot version of the target inode:
+			 * bounded only by snapshot count, so commit-and-restart
+			 * before the batch outgrows the trans bump allocator.
+			 * The re-drive converges: get_visible_inodes() rereads
+			 * the versions and committed repairs no longer fire.
+			 */
+			try(bch2_trans_commit_lazy_if_full(trans, NULL, NULL,
+						BCH_TRANS_COMMIT_no_enospc));
 
-		darray_for_each(target->deletes, i)
-			if (fsck_err_on(!snapshot_list_has_id(&s->ids, *i),
-					trans, dirent_to_overwritten_inode,
-					"dirent points to inode overwritten in snapshot %u:\n%s",
-					*i,
-					(printbuf_reset(&buf),
-					 bch2_bkey_val_to_text(&buf, c, k),
-					 buf.buf))) {
-				CLASS(btree_iter, delete_iter)(trans,
-						     BTREE_ID_dirents,
-						     SPOS(k.k->p.inode, k.k->p.offset, *i),
-						     BTREE_ITER_intent);
-				try(bch2_btree_iter_traverse(&delete_iter));
+			try(bch2_check_dirent_target(trans, iter, d, &i->inode, true));
+		}
+
+		darray_for_each(target->deletes, i) {
+			if (snapshot_list_has_id(&s->ids, *i))
+				continue;
+
+			try(bch2_trans_commit_lazy_if_full(trans, NULL, NULL,
+						BCH_TRANS_COMMIT_no_enospc));
+
+			CLASS(btree_iter, delete_iter)(trans,
+					     BTREE_ID_dirents,
+					     SPOS(k.k->p.inode, k.k->p.offset, *i),
+					     BTREE_ITER_intent);
+			/*
+			 * The deletes list is derived from inode-side state the
+			 * whiteouts don't change: check whether the dirent is
+			 * still visible in this snapshot, both so a re-drive
+			 * after a partially-committed batch skips the committed
+			 * whiteouts (or the commit_lazy_if_full() restart can't
+			 * make forward progress), and so an already-invisible
+			 * dirent isn't reported and "repaired" redundantly:
+			 */
+			struct bkey_s_c visible =
+				bkey_try(bch2_btree_iter_peek_slot(&delete_iter));
+			if (visible.k->type != KEY_TYPE_dirent)
+				continue;
+
+			if (fsck_err(trans, dirent_to_overwritten_inode,
+				     "dirent points to inode overwritten in snapshot %u:\n%s",
+				     *i,
+				     (printbuf_reset(&buf),
+				      bch2_bkey_val_to_text(&buf, c, k),
+				      buf.buf)))
 				try(bch2_hash_delete_at(trans, bch2_dirent_hash_desc,
 							hash_info,
 							&delete_iter,
 							BTREE_UPDATE_internal_snapshot_node));
-			}
+		}
 	}
 
 	/*

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -1202,16 +1202,35 @@ static int check_inode(struct btree_trans *trans,
 		if (ret && !bch2_err_matches(ret, ENOENT))
 			return ret;
 
-		if (ret && (c->sb.btrees_lost_data & BIT_ULL(BTREE_ID_subvolumes))) {
-			ret = 0;
-			try(reconstruct_subvol(trans, k.k->p.snapshot, u.bi_subvol, u.bi_inum));
-			goto do_update;
-		}
-
 		struct bch_snapshot snapshot;
 		int snapshot_ret = bch2_snapshot_lookup(trans, u.bi_snapshot, &snapshot);
 		if (snapshot_ret && !bch2_err_matches(snapshot_ret, ENOENT))
 			return snapshot_ret;
+
+		/*
+		 * A missing subvolume is reconstructed on either provenance -
+		 * the subvolumes btree is known to have lost data - or
+		 * corroboration: this root inode names the subvolume, and the
+		 * live snapshot it lives at names the same subvolume in its
+		 * backref. Two independent witnesses to the edge outweigh the
+		 * missing key. (A will_delete snapshot doesn't corroborate:
+		 * there the missing subvolume is a deletion in flight, and
+		 * reconstructing it live would revert the deletion - the
+		 * sweep owns those keys.) Singly-witnessed damage falls
+		 * through to the conservative arms below, which strip the
+		 * reference.
+		 */
+		bool corroborated = !snapshot_ret &&
+			bch2_snapshot_state_compat(&snapshot) == SNAPSHOT_STATE_live &&
+			le32_to_cpu(snapshot.subvol) == u.bi_subvol;
+
+		if (ret &&
+		    ((c->sb.btrees_lost_data & BIT_ULL(BTREE_ID_subvolumes)) ||
+		     corroborated)) {
+			ret = 0;
+			try(reconstruct_subvol(trans, k.k->p.snapshot, u.bi_subvol, u.bi_inum));
+			goto do_update;
+		}
 
 		printbuf_reset(&buf);
 		bch2_inode_unpacked_to_text(&buf, &u);

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -1724,21 +1724,57 @@ fsck_err:
 	return ret;
 }
 
+/*
+ * Re-scan a directory from the start after a repair moved one of its dirents to
+ * a position we'd already scanned past - a check_key_has_snapshot migration to
+ * a lower snapshot ID, a dirent moved into descendant snapshots, or a hash-table
+ * repair. Any of those leaves the directory's subdir count built from the old
+ * layout, so rebuild it by forcing the inode_walker to reload and re-tally.
+ */
+static void dirents_rescan_reset(struct inode_walker *dir)
+{
+	dir->have_inodes = false;	/* suppress the boundary check_subdir_count */
+	dir->last_pos = POS_MIN;	/* force get_inodes_all_snapshots + count reset */
+}
+
+static int check_dirent_restart_inum(struct btree_trans *trans, struct btree_iter *iter,
+				     struct inode_walker *dir, u64 inum)
+{
+	dirents_rescan_reset(dir);
+	bch2_btree_iter_set_pos(iter, POS(inum, 0));
+	return btree_trans_restart(trans, BCH_ERR_transaction_restart_nested);
+}
+
 static int check_dirent(struct btree_trans *trans, struct btree_iter *iter,
 			struct bkey_s_c k,
 			struct bch_hash_info *hash_info,
 			struct inode_walker *dir,
 			struct inode_walker *target,
-			struct snapshots_seen *s,
-			bool *need_second_pass)
+			struct snapshots_seen *s)
 {
 	struct bch_fs *c = trans->c;
 	CLASS(printbuf, buf)();
+	u64 inum = k.k->p.inode;
 	int ret = 0;
 
+	/*
+	 * We've moved on from a directory that had a repair; re-scan it now so
+	 * its subdir count is rebuilt from the migrated/moved dirents.
+	 * restarted_inum bounds this to one re-scan per directory.
+	 */
+	if (dir->repaired_inum &&
+	    inum > dir->repaired_inum &&
+	    dir->repaired_inum != dir->restarted_inum) {
+		dir->restarted_inum = dir->repaired_inum;
+		return check_dirent_restart_inum(trans, iter, dir, dir->repaired_inum);
+	}
+
 	ret = bch2_check_key_has_snapshot(trans, iter, k);
-	if (ret)
+	if (ret) {
+		if (ret > 0)
+			dir->repaired_inum = inum;
 		return ret < 0 ? ret : 0;
+	}
 
 	ret = bch2_snapshots_seen_update(c, s, iter->btree_id, k.k->p);
 	if (ret)
@@ -1767,14 +1803,19 @@ static int check_dirent(struct btree_trans *trans, struct btree_iter *iter,
 
 	hash_info->cf_encoding = bch2_inode_casefold(c, &i->inode) ? c->cf_encoding : NULL;
 
-	bool invalidated_inodes = false;
+	bool need_second_pass = false, invalidated_inodes = false;
 	ret = bch2_str_hash_check_key(trans, s, &bch2_dirent_hash_desc, hash_info,
-				      k, need_second_pass, &invalidated_inodes);
-	if (invalidated_inodes) {
-		dir->last_pos.inode = 0;
-		dir->inodes.nr = 0;
-		return bch_err_throw(c, transaction_restart_nested);
-	}
+				      k, &need_second_pass, &invalidated_inodes);
+	/*
+	 * A hash-table repair or an inode-cache invalidation moved keys within
+	 * this directory: re-scan it so the subdir count is rebuilt. The cache
+	 * invalidation must reload before we continue, so re-scan immediately;
+	 * the hash repair can wait until we've finished the directory.
+	 */
+	if (invalidated_inodes)
+		return check_dirent_restart_inum(trans, iter, dir, inum);
+	if (need_second_pass)
+		dir->repaired_inum = inum;
 
 	if (ret < 0)
 		return ret;
@@ -1841,7 +1882,13 @@ static int check_dirent(struct btree_trans *trans, struct btree_iter *iter,
 				try(bch2_hash_delete_at(trans, bch2_dirent_hash_desc,
 							hash_info, &del_iter,
 							BTREE_UPDATE_internal_snapshot_node));
-				*need_second_pass = true;
+				/*
+				 * The copies were inserted into descendant
+				 * snapshots (lower IDs, earlier positions):
+				 * re-scan this directory to revisit them for the
+				 * target checks and subdir count.
+				 */
+				dir->repaired_inum = inum;
 				return 0;
 			}
 		}
@@ -1906,19 +1953,46 @@ int bch2_check_dirents(struct bch_fs *c)
 	CLASS(inode_walker, dir)();
 	CLASS(inode_walker, target)();
 	struct progress_indicator progress;
-	bool need_second_pass = false, did_second_pass = false;
-	int ret;
-again:
 	bch2_progress_init(&progress, __func__, c, BIT_ULL(BTREE_ID_dirents), 0);
 
-	ret = for_each_btree_key_commit(trans, iter, BTREE_ID_dirents,
-				POS(BCACHEFS_ROOT_INO, 0),
-				BTREE_ITER_prefetch|BTREE_ITER_all_snapshots, k,
-				NULL, NULL, BCH_TRANS_COMMIT_no_enospc, ({
-			bch2_progress_update_iter(trans, &progress, &iter) ?:
-			check_dirent(trans, &iter, k, &hash_info, &dir, &target, &s,
-				     &need_second_pass);
+	CLASS(btree_iter, iter)(trans, BTREE_ID_dirents, POS(BCACHEFS_ROOT_INO, 0),
+				BTREE_ITER_prefetch|BTREE_ITER_all_snapshots);
+	int ret;
+
+	while (1) {
+		struct bkey_s_c k;
+		/*
+		 * peek, process and commit are one commit_do() so a restart
+		 * anywhere - including check_dirent's in-loop re-scan (a set_pos
+		 * plus forced restart) - re-drives the whole thing atomically.
+		 */
+		ret = commit_do(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc, ({
+			bkey_err(k = bch2_btree_iter_peek(&iter)) ?:
+			(!k.k ? 0
+			      : (bch2_progress_update_iter(trans, &progress, &iter) ?:
+				 check_dirent(trans, &iter, k, &hash_info, &dir, &target, &s)));
 		}));
+		if (ret)
+			break;
+
+		if (!k.k) {
+			/*
+			 * End of the btree: the last directory has no following
+			 * key to trigger check_dirent_restart_inum, so re-scan it
+			 * here if it had a pending repair. restarted_inum bounds
+			 * this to one re-scan, same as the in-loop path.
+			 */
+			if (dir.repaired_inum == dir.restarted_inum)
+				break;
+			dir.restarted_inum = dir.repaired_inum;
+			dirents_rescan_reset(&dir);
+			bch2_btree_iter_set_pos(&iter, POS(dir.repaired_inum, 0));
+			continue;
+		}
+
+		bch2_btree_iter_advance(&iter);
+	}
+
 	if (!ret) {
 		/*
 		 * Final flush of the last directory's subdir count. Exempt the
@@ -1932,17 +2006,6 @@ again:
 		trans->begin_may_drop_updates = true;
 		ret = check_subdir_count_notnested(trans, &dir);
 		trans->begin_may_drop_updates = false;
-	}
-
-	if (!ret && need_second_pass && !did_second_pass) {
-		bch_info(c, "check_dirents requires second pass");
-		swap(did_second_pass, need_second_pass);
-		goto again;
-	}
-
-	if (!ret && need_second_pass) {
-		bch_err(c, "dirents not repairing");
-		ret = -EINVAL;
 	}
 
 	return ret;

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -1924,13 +1924,21 @@ again:
 			bch2_progress_update_iter(trans, &progress, &iter) ?:
 			check_dirent(trans, &iter, k, &hash_info, &dir, &target, &s,
 				     &need_second_pass);
-		})) ?:
+		}));
+	if (!ret) {
 		/*
-		 * Final flush, via the nested check_subdir_dirents_count so the
-		 * inner fsck_write_inode commits are exempt from the trans_begin
-		 * dropped-updates warning (same as check_extents).
+		 * Final flush of the last directory's subdir count. Exempt the
+		 * inner fsck_write_inode commits from the dropped-updates warning
+		 * as check_subdir_dirents_count() does - but call _notnested
+		 * directly, NOT the nested wrapper: that returns
+		 * trans_was_restarted() for an in-loop caller to retry on, and at
+		 * this post-loop flush the restart has no handler and faults
+		 * recovery (it broke every transaction-restart-injection test).
 		 */
-		check_subdir_dirents_count(trans, &dir);
+		trans->begin_may_drop_updates = true;
+		ret = check_subdir_count_notnested(trans, &dir);
+		trans->begin_may_drop_updates = false;
+	}
 
 	if (!ret && need_second_pass && !did_second_pass) {
 		bch_info(c, "check_dirents requires second pass");

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -2140,8 +2140,18 @@ static int check_xattr(struct btree_trans *trans, struct btree_iter *iter,
 		unsigned x_type = bkey_s_c_to_xattr(k).v->x_type;
 		struct inode_walker_entry *i2;
 
+		/*
+		 * One repair per visible snapshot version, bounded only by
+		 * snapshot count: commit-and-restart before the batch
+		 * outgrows the trans bump allocator. The re-drive converges -
+		 * the walker revalidates on commit (commit_count), so
+		 * committed flag repairs no longer fire:
+		 */
 		if (x_type == KEY_TYPE_XATTR_INDEX_POSIX_ACL_ACCESS)
-			for_each_visible_inode(trans, s, inode, k.k->p.snapshot, i2)
+			for_each_visible_inode(trans, s, inode, k.k->p.snapshot, i2) {
+				try(bch2_trans_commit_lazy_if_full(trans, NULL, NULL,
+							BCH_TRANS_COMMIT_no_enospc));
+
 				if (!i2->whiteout &&
 				    fsck_err_on(!(i2->inode.bi_flags & BCH_INODE_has_access_acl),
 						trans, inode_has_access_acl_flag_wrong,
@@ -2151,9 +2161,13 @@ static int check_xattr(struct btree_trans *trans, struct btree_iter *iter,
 					inode_u.bi_flags |= BCH_INODE_has_access_acl;
 					try(__bch2_fsck_write_inode(trans, &inode_u));
 				}
+			}
 
 		if (x_type == KEY_TYPE_XATTR_INDEX_POSIX_ACL_DEFAULT)
-			for_each_visible_inode(trans, s, inode, k.k->p.snapshot, i2)
+			for_each_visible_inode(trans, s, inode, k.k->p.snapshot, i2) {
+				try(bch2_trans_commit_lazy_if_full(trans, NULL, NULL,
+							BCH_TRANS_COMMIT_no_enospc));
+
 				if (!i2->whiteout &&
 				    fsck_err_on(!(i2->inode.bi_flags & BCH_INODE_has_default_acl),
 						trans, inode_has_default_acl_flag_wrong,
@@ -2163,6 +2177,7 @@ static int check_xattr(struct btree_trans *trans, struct btree_iter *iter,
 					inode_u.bi_flags |= BCH_INODE_has_default_acl;
 					try(__bch2_fsck_write_inode(trans, &inode_u));
 				}
+			}
 	}
 
 	bool need_second_pass = false;

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -952,7 +952,7 @@ static int check_inode(struct btree_trans *trans,
 	try(bch2_snapshots_seen_update(c, s, iter->btree_id, k.k->p));
 
 	/* after snapshots_seen: keep the seen list complete even for skipped keys */
-	if (bch2_snapshot_will_delete(c, k.k->p.snapshot))
+	if (bch2_snapshot_will_delete(c, k.k->p.snapshot, &s->ids))
 		return 0;
 
 	if (!bkey_is_inode(k.k))
@@ -1740,7 +1740,7 @@ static int check_dirent(struct btree_trans *trans, struct btree_iter *iter,
 		return ret;
 
 	/* after snapshots_seen: keep the seen list complete even for skipped keys */
-	if (bch2_snapshot_will_delete(c, k.k->p.snapshot))
+	if (bch2_snapshot_will_delete(c, k.k->p.snapshot, &s->ids))
 		return 0;
 
 	if (k.k->type == KEY_TYPE_whiteout)
@@ -1958,7 +1958,7 @@ static int check_xattr(struct btree_trans *trans, struct btree_iter *iter,
 	try(bch2_snapshots_seen_update(c, s, iter->btree_id, k.k->p));
 
 	/* after snapshots_seen: keep the seen list complete even for skipped keys */
-	if (bch2_snapshot_will_delete(c, k.k->p.snapshot))
+	if (bch2_snapshot_will_delete(c, k.k->p.snapshot, &s->ids))
 		return 0;
 
 	struct inode_walker_entry *i = errptr_try(bch2_walk_inode(trans, inode, k));

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -1760,6 +1760,16 @@ static int check_dirent_to_subvol(struct btree_trans *trans, struct btree_iter *
 	if (ret && !bch2_err_matches(ret, ENOENT))
 		return ret;
 
+	/*
+	 * A deleted-state subvolume is a tombstone pending the snapshot
+	 * sweep: bch2_subvolume_get() reports those as ENOENT, but this is a
+	 * raw read (the fs_path_parent repair below needs the key). Treat it
+	 * as missing here too - otherwise the dirent outlives the subvolume,
+	 * and fsck stops converging once the sweep removes the key:
+	 */
+	if (!ret && bch2_subvolume_state_compat(s.v) == SUBVOLUME_STATE_deleted)
+		ret = bch_err_throw(c, ENOENT_subvolume_deleted);
+
 	if (ret) {
 		if (fsck_err(trans, dirent_to_missing_subvol,
 			     "dirent points to missing subvolume\n%s",

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -2304,12 +2304,44 @@ static int check_root_trans(struct btree_trans *trans)
 	if (ret && !bch2_err_matches(ret, ENOENT))
 		return ret;
 
+	/*
+	 * The missing subvolume key is not the only record of root's active
+	 * snapshot: snapshot nodes carry a subvol backref, so root's active
+	 * snapshot is the leaf claiming BCACHEFS_ROOT_SUBVOL. Only when no
+	 * node does (fresh filesystem, or the snapshots btree is gone too)
+	 * is U32_MAX - the initial snapshot id - correct; on a snapshotted
+	 * filesystem U32_MAX is an interior node, and a subvolume pointing
+	 * at it is subvol_snapshot_not_leaf, which has no repair.
+	 *
+	 * _norestart: we're inside the caller's commit_do(), so restarts must
+	 * propagate out to it:
+	 */
+	u32 root_snapshot = 0;
+	if (ret) {
+		struct bkey_s_c k;
+		int ret2 = 0;
+
+		for_each_btree_key_norestart(trans, iter, BTREE_ID_snapshots,
+					     POS_MIN, 0, k, ret2) {
+			if (k.k->type == KEY_TYPE_snapshot) {
+				struct bkey_s_c_snapshot s = bkey_s_c_to_snapshot(k);
+
+				if (le32_to_cpu(s.v->subvol) == BCACHEFS_ROOT_SUBVOL &&
+				    !s.v->children[0]) {
+					root_snapshot = k.k->p.offset;
+					break;
+				}
+			}
+		}
+		try(ret2);
+	}
+
 	if (mustfix_fsck_err_on(ret, trans, root_subvol_missing,
 				"root subvol missing")) {
 		struct bkey_i_subvolume *root_subvol =
 			errptr_try(bch2_trans_kmalloc(trans, sizeof(*root_subvol)));
 
-		snapshot	= U32_MAX;
+		snapshot	= root_snapshot ?: U32_MAX;
 		inum		= BCACHEFS_ROOT_INO;
 
 		bkey_subvolume_init(&root_subvol->k_i);

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -1271,16 +1271,31 @@ static int find_oldest_inode_needs_reattach(struct btree_trans *trans,
 
 static int check_unreachable_inode(struct btree_trans *trans,
 				   struct btree_iter *iter,
-				   struct bkey_s_c k)
+				   struct bkey_s_c k,
+				   struct snapshots_seen *s)
 {
+	struct bch_fs *c = trans->c;
 	CLASS(printbuf, buf)();
 	int ret = 0;
+
+	try(bch2_snapshots_seen_update(c, s, iter->btree_id, k.k->p));
+
+	/*
+	 * Skip inodes in a will_delete snapshot: delete_dead_snapshots(), a
+	 * later pass, sweeps them. This is the interrupted-deletion state - the
+	 * subvolume root has no backpointer, so it looks reattachable, but
+	 * reattaching it would manufacture a dirent to a subvolume that's about
+	 * to go away, wedging the verify pass on a dangling dirent. check_inode()
+	 * leaves the same root alone for the same reason.
+	 */
+	if (bch2_snapshot_will_delete(c, k.k->p.snapshot, &s->ids))
+		return 0;
 
 	if (!bkey_is_inode(k.k))
 		return 0;
 
 	struct bch_inode_unpacked inode;
-	bch2_inode_unpack(trans->c, k, &inode);
+	bch2_inode_unpack(c, k, &inode);
 
 	if (!inode_should_reattach(&inode))
 		return 0;
@@ -1312,12 +1327,13 @@ int bch2_check_unreachable_inodes(struct bch_fs *c)
 	bch2_progress_init(&progress, __func__, c, BIT_ULL(BTREE_ID_inodes), 0);
 
 	CLASS(btree_trans, trans)(c);
+	CLASS(snapshots_seen, s)();
 	return for_each_btree_key_commit(trans, iter, BTREE_ID_inodes,
 				POS_MIN,
 				BTREE_ITER_prefetch|BTREE_ITER_all_snapshots, k,
 				NULL, NULL, BCH_TRANS_COMMIT_no_enospc, ({
 		bch2_progress_update_iter(trans, &progress, &iter) ?:
-		check_unreachable_inode(trans, &iter, k);
+		check_unreachable_inode(trans, &iter, k, &s);
 	}));
 }
 

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -2386,14 +2386,23 @@ static int check_root_trans(struct btree_trans *trans)
 
 	if (mustfix_fsck_err_on(ret,
 				trans, root_dir_missing,
-				"root directory missing") ||
-	    mustfix_fsck_err_on(!S_ISDIR(root_inode.bi_mode),
-				trans, root_inode_not_dir,
-				"root inode not a directory")) {
+				"root directory missing")) {
 		bch2_inode_init(c, &root_inode, 0, 0, S_IFDIR|0755,
 				0, NULL);
 		root_inode.bi_inum = inum;
 		root_inode.bi_snapshot = snapshot;
+
+		ret = __bch2_fsck_write_inode(trans, &root_inode);
+		bch_err_msg(c, ret, "writing root inode");
+	} else if (mustfix_fsck_err_on(!S_ISDIR(root_inode.bi_mode),
+				trans, root_inode_not_dir,
+				"root inode not a directory")) {
+		/*
+		 * The inode exists: fix only the mode. Reinitializing it
+		 * generates a fresh hash_seed - invalidating the hash offset
+		 * of every dirent in the root directory - and wipes bi_subvol:
+		 */
+		root_inode.bi_mode = S_IFDIR|0755;
 
 		ret = __bch2_fsck_write_inode(trans, &root_inode);
 		bch_err_msg(c, ret, "writing root inode");

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -1732,7 +1732,14 @@ static int check_dirent_to_subvol(struct btree_trans *trans, struct btree_iter *
 			return bch_err_throw(c, fsck_repair_unimplemented);
 		}
 
-		struct bkey_i_dirent *new_dirent = errptr_try(bch2_bkey_make_mut_typed(trans, iter, &d.s_c, 0, dirent));
+		/*
+		 * The dirent is rewritten at its own position, which may be an
+		 * interior snapshot node - dirents in old snapshots need this
+		 * repair too:
+		 */
+		struct bkey_i_dirent *new_dirent =
+			errptr_try(bch2_bkey_make_mut_typed(trans, iter, &d.s_c,
+						BTREE_UPDATE_internal_snapshot_node, dirent));
 
 		new_dirent->v.d_parent_subvol = cpu_to_le32(new_parent_subvol);
 	}

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -653,8 +653,20 @@ static int get_inodes_all_snapshots(struct btree_trans *trans,
 
 	for_each_btree_key_max_norestart(trans, iter,
 			BTREE_ID_inodes, POS(0, inum), SPOS(0, inum, U32_MAX),
-			BTREE_ITER_all_snapshots, k, ret)
+			BTREE_ITER_all_snapshots, k, ret) {
+		/*
+		 * The content passes skip keys in dying subtrees (same
+		 * predicate, right after their bch2_check_key_has_snapshot()
+		 * calls), so those keys are never accumulated into i_sectors/
+		 * subdir counts - a dying inode version in the walker would
+		 * always look wrong. Skip them here too; a dying snapshot has
+		 * no live descendants, so live keys can never resolve to one:
+		 */
+		if (bch2_snapshot_will_delete(c, k.k->p.snapshot, NULL))
+			continue;
+
 		try(add_inode(c, w, k));
+	}
 
 	if (ret)
 		return ret;

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -1232,7 +1232,18 @@ static int check_inode(struct btree_trans *trans,
 			do_update = true;
 		}
 
-		if (!deletion_pending &&
+		/*
+		 * A reference to the root subvolume is never the broken side:
+		 * subvol 1's existence is an invariant, and check_root()
+		 * recreates it if lost. Stripping bi_subvol around the
+		 * absence takes a valid backref off the root inode - and
+		 * check_unreachable_inodes() then reattaches the root
+		 * directory into lost+found:
+		 */
+		bool root_subvol_ref = ret && u.bi_subvol == BCACHEFS_ROOT_SUBVOL;
+
+		if (!root_subvol_ref &&
+		    !deletion_pending &&
 		    (fsck_err_on(ret,
 				trans, inode_bi_subvol_missing,
 				"inode bi_subvol points to missing subvolume %u\n%s",
@@ -1708,6 +1719,19 @@ static int check_dirent_to_subvol(struct btree_trans *trans, struct btree_iter *
 	if (ret && !bch2_err_matches(ret, ENOENT))
 		return ret;
 
+	if (ret && parent_subvol == BCACHEFS_ROOT_SUBVOL) {
+		/*
+		 * A reference to the root subvolume is never the broken side:
+		 * subvol 1's existence is an invariant, and check_root()
+		 * recreates it if lost. Rewiring parent_subvol around the
+		 * absence reparents the root directory's subvolume dirents
+		 * onto arbitrary subvolumes; left alone, they're valid the
+		 * moment the root subvolume is back:
+		 */
+		ret = 0;
+		goto check_target;
+	}
+
 	if (ret ||
 	    (!ret && !bch2_snapshot_is_ancestor(trans, parent_snapshot, d.k->p.snapshot))) {
 		ret = find_snapshot_subvol(trans, d.k->p.snapshot, &new_parent_subvol);
@@ -1754,6 +1778,7 @@ static int check_dirent_to_subvol(struct btree_trans *trans, struct btree_iter *
 		new_dirent->v.d_parent_subvol = cpu_to_le32(new_parent_subvol);
 	}
 
+check_target:
 	bch2_trans_iter_init(trans, &subvol_iter, BTREE_ID_subvolumes, POS(0, target_subvol), 0);
 	struct bkey_s_c_subvolume s = bch2_bkey_get_typed(&subvol_iter, subvolume);
 	ret = bkey_err(s.s_c);

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -1007,15 +1007,14 @@ static int check_inode(struct btree_trans *trans,
 
 	if (S_ISDIR(u.bi_mode) && (u.bi_flags & BCH_INODE_unlinked)) {
 		/*
-		 * An unlinked subvolume root legitimately carries the flag -
-		 * and is legitimately non-empty, since the snapshot sweep is
-		 * what deletes the contents. Only strip it when the subvolume
-		 * isn't being deleted: the subvolume key is what links a
-		 * subvolume root, so a live subvolume means this inode is not
-		 * actually unlinked.
+		 * BCH_INODE_unlinked is allowed on a directory only if it's a
+		 * subvolume root and the subvolume is unlinked - the root is
+		 * then legitimately non-empty, since the snapshot sweep is
+		 * what deletes the contents. Anything else: strip the flag so
+		 * check_unreachable_inodes() reattaches it.
 		 */
 		ret = bch2_inode_is_subvolume_root(&u)
-			? bch2_subvolume_deletion_pending(trans, u.bi_subvol, u.bi_snapshot)
+			? bch2_subvolume_is_unlinked(trans, u.bi_subvol)
 			: 0;
 		if (ret < 0)
 			return ret;
@@ -1196,43 +1195,15 @@ static int check_inode(struct btree_trans *trans,
 			prt_str(&buf, "(missing)");
 
 		/*
-		 * A subvolume root whose subvolume is being deleted: the
-		 * subvolume reads as missing here (unlinked subvolumes still
-		 * resolve, but deleted tombstones and swept keys don't) while
-		 * the root inode waits for the snapshot sweep to delete it -
-		 * not corruption, leave bi_subvol be, the whole snapshot is
-		 * going away. Only when the deletion chain corroborates,
-		 * though: subvolume gone but snapshot still live means the
-		 * chain broke, and the repair below must run or
+		 * No exemption for a missing subvolume: an unlinked subvolume
+		 * still resolves, and once it's tombstoned the snapshot is
+		 * will_delete and we never visit these keys - the sweep owns
+		 * them. A root inode pointing at a subvolume that's actually
+		 * gone is damage, and the repair below must run or
 		 * check_unreachable_inodes() meets an orphan whose bi_subvol
 		 * points nowhere and the reattach fail-stops the pass (field
 		 * report, 2026-07-21).
 		 *
-		 * Pending roots carry BCH_INODE_unlinked - no dirent points at
-		 * them, by design, and the sweep rather than the inode reaper
-		 * deletes them (see bch2_inode_is_subvolume_root()).
-		 * Filesystems that deleted subvolumes before the delete path
-		 * set the flag have flag-less pending roots; converge them:
-		 */
-		bool deletion_pending = false;
-		if (ret && !bch2_inode_has_backpointer(&u)) {
-			int ret2 = bch2_subvolume_deletion_pending(trans, u.bi_subvol,
-								   u.bi_snapshot);
-			if (ret2 < 0)
-				return ret2;
-			deletion_pending = ret2;
-		}
-
-		if (deletion_pending &&
-		    fsck_err_on(!(u.bi_flags & BCH_INODE_unlinked),
-				trans, subvol_root_unlinked_flag_missing,
-				"unlinked subvolume root missing BCH_INODE_unlinked\n%s",
-				buf.buf)) {
-			u.bi_flags |= BCH_INODE_unlinked;
-			do_update = true;
-		}
-
-		/*
 		 * A reference to the root subvolume is never the broken side:
 		 * subvol 1's existence is an invariant, and check_root()
 		 * recreates it if lost. Stripping bi_subvol around the
@@ -1243,7 +1214,6 @@ static int check_inode(struct btree_trans *trans,
 		bool root_subvol_ref = ret && u.bi_subvol == BCACHEFS_ROOT_SUBVOL;
 
 		if (!root_subvol_ref &&
-		    !deletion_pending &&
 		    (fsck_err_on(ret,
 				trans, inode_bi_subvol_missing,
 				"inode bi_subvol points to missing subvolume %u\n%s",

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -677,6 +677,27 @@ static int get_inodes_all_snapshots(struct btree_trans *trans,
 	return 0;
 }
 
+/*
+ * Find the inode versions a dirent's target can resolve to.
+ *
+ * Typical operation: creating a file creates the dirent and the inode
+ * together, and then the inode sees many updates with no corresponding
+ * dirent update - so the inode's versions live in snapshots equal to or
+ * newer than the dirent's, and the reverse walk down from the dirent's
+ * snapshot finds them, whiteouts shadowing older versions.
+ *
+ * It's also possible for the dirent to be newer than the inode: the version
+ * resolving the dirent's own view is in an ancestor snapshot. (The inode's
+ * backpointer then dangles in the inode's snapshot.) fsck has to cope: if
+ * there's no key at the dirent's own snapshot - versions in descendants don't
+ * resolve its view, and a whiteout at it means the view is definitively empty -
+ * fetch at most one ancestor version with a snapshot-filtered peek_slot(),
+ * which resolves to whatever the dirent's view actually sees: an inode resolves
+ * the dirent, a whiteout means the inode really is deleted in this view.
+ *
+ * A dirent newer than the inode isn't constructible by userspace - but does
+ * happen during snapshot deletion.
+ */
 static int get_visible_inodes(struct btree_trans *trans,
 			      struct inode_walker *w,
 			      struct snapshots_seen *s,
@@ -689,10 +710,14 @@ static int get_visible_inodes(struct btree_trans *trans,
 	w->inodes.nr = 0;
 	w->deletes.nr = 0;
 
+	bool have_key_at_pos = false;
+
 	for_each_btree_key_reverse_norestart(trans, iter, BTREE_ID_inodes, SPOS(0, inum, s->pos.snapshot),
 			   BTREE_ITER_all_snapshots, k, ret) {
 		if (k.k->p.offset != inum)
 			break;
+
+		have_key_at_pos |= k.k->p.snapshot == s->pos.snapshot;
 
 		if (!bch2_ref_visible(trans, s, s->pos.snapshot, k.k->p.snapshot))
 			continue;
@@ -700,11 +725,17 @@ static int get_visible_inodes(struct btree_trans *trans,
 		if (snapshot_list_has_ancestor(trans, &w->deletes, k.k->p.snapshot))
 			continue;
 
-		ret = bkey_is_inode(k.k)
-			? add_inode(c, w, k)
-			: snapshot_list_add(c, &w->deletes, k.k->p.snapshot);
-		if (ret)
-			break;
+		try(bkey_is_inode(k.k)
+		    ? add_inode(c, w, k)
+		    : snapshot_list_add(c, &w->deletes, k.k->p.snapshot));
+	}
+
+	if (!ret && !have_key_at_pos) {
+		CLASS(btree_iter, ancestor_iter)(trans, BTREE_ID_inodes,
+						 SPOS(0, inum, s->pos.snapshot), 0);
+		k = bkey_try(bch2_btree_iter_peek_slot(&ancestor_iter));
+		if (bkey_is_inode(k.k))
+			try(add_inode(c, w, k));
 	}
 
 	return ret;

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -1181,8 +1181,26 @@ static int check_inode(struct btree_trans *trans,
 		 * reads as missing, but that's the expected not-live state, not
 		 * corruption - leave bi_subvol be; the whole snapshot is going
 		 * away.
+		 *
+		 * Only when the deletion chain corroborates, though: an
+		 * orderly deletion tombstones the subvolume (which reports
+		 * ENOENT here) and marks the snapshot will_delete together.
+		 * Subvolume gone but snapshot still live means the chain
+		 * broke - damage, not pending deletion - and the repair
+		 * below must run, or check_unreachable_inodes() meets an
+		 * orphan whose bi_subvol points nowhere and the reattach
+		 * fail-stops the pass (field report, 2026-07-21).
+		 *
+		 * The unlinked flag also corroborates: the delete path is
+		 * gaining "set the unlinked flag on the root inode", but
+		 * every filesystem deleted-on before that has flag-less
+		 * pending roots, so the flag alone can't be required:
 		 */
-		bool subvol_unlinked = ret && !bch2_inode_has_backpointer(&u);
+		bool subvol_unlinked = ret &&
+			!bch2_inode_has_backpointer(&u) &&
+			((u.bi_flags & BCH_INODE_unlinked) ||
+			 (!snapshot_ret &&
+			  bch2_snapshot_state_compat(&snapshot) != SNAPSHOT_STATE_live));
 
 		if (!subvol_unlinked &&
 		    (fsck_err_on(ret,

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -376,6 +376,9 @@ int bch2_reattach_inode(struct btree_trans *trans, struct bch_inode_unpacked *in
 		bch_info(c, "reattached at %s", buf.buf);
 	}
 
+	bch2_fsck_damaged(trans, SPOS(inode->bi_inum, 0, inode->bi_snapshot),
+			  FSCK_DAMAGE_reattached);
+
 	/*
 	 * Fix up inodes in child snapshots: if they should also be reattached
 	 * update the backpointer field, if they should not be we need to emit
@@ -1667,8 +1670,10 @@ static int check_dirent_to_subvol(struct btree_trans *trans, struct btree_iter *
 	if (ret) {
 		if (fsck_err(trans, dirent_to_missing_subvol,
 			     "dirent points to missing subvolume\n%s",
-			     (bch2_bkey_val_to_text(&buf, c, d.s_c), buf.buf)))
+			     (bch2_bkey_val_to_text(&buf, c, d.s_c), buf.buf))) {
+			bch2_fsck_damaged(trans, d.k->p, FSCK_DAMAGE_dir_entries_removed);
 			return bch2_fsck_remove_dirent(trans, d.k->p);
+		}
 		return 0;
 	}
 
@@ -1846,8 +1851,10 @@ static int check_dirent(struct btree_trans *trans, struct btree_iter *iter,
 				"dirent points to missing inode:\n%s",
 				(printbuf_reset(&buf),
 				 bch2_bkey_val_to_text(&buf, c, k),
-				 buf.buf)))
+				 buf.buf))) {
+			bch2_fsck_damaged(trans, d.k->p, FSCK_DAMAGE_dir_entries_removed);
 			try(bch2_fsck_remove_dirent(trans, d.k->p));
+		}
 
 		darray_for_each(target->inodes, i)
 			try(bch2_check_dirent_target(trans, iter, d, &i->inode, true));

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -326,8 +326,7 @@ int bch2_reattach_inode(struct btree_trans *trans, struct bch_inode_unpacked *in
 
 		subvol->v.fs_path_parent = BCACHEFS_ROOT_SUBVOL;
 
-		u64 root_inum;
-		try(subvol_lookup(trans, inode->bi_parent_subvol, &dirent_snapshot, &root_inum));
+		try(bch2_subvolume_get_snapshot(trans, inode->bi_parent_subvol, &dirent_snapshot));
 
 		snprintf(name_buf, sizeof(name_buf), "subvol-%u", inode->bi_subvol);
 	} else {
@@ -701,8 +700,10 @@ lookup_inode_for_snapshot(struct btree_trans *trans, struct inode_walker *w, str
 {
 	struct bch_fs *c = trans->c;
 
+	u32 k_snapshot = bch2_snapshot_redundant_interior(c, k.k->p.snapshot) ?: k.k->p.snapshot;
+
 	struct inode_walker_entry *i = darray_find_p(w->inodes, i,
-		    bch2_snapshot_is_ancestor(trans, k.k->p.snapshot, i->inode.bi_snapshot));
+		    bch2_snapshot_is_ancestor(trans, k_snapshot, i->inode.bi_snapshot));
 
 	if (!i)
 		return NULL;
@@ -710,7 +711,9 @@ lookup_inode_for_snapshot(struct btree_trans *trans, struct inode_walker *w, str
 	CLASS(printbuf, buf)();
 	int ret = 0;
 
-	if (fsck_err_on(k.k->p.snapshot != i->inode.bi_snapshot,
+	u32 inode_snapshot = bch2_snapshot_redundant_interior(c, i->inode.bi_snapshot) ?: i->inode.bi_snapshot;
+
+	if (fsck_err_on(k_snapshot != inode_snapshot,
 			trans, snapshot_key_missing_inode_snapshot,
 			 "have key for inode %llu:%u but have inode in ancestor snapshot %u\n"
 			 "unexpected because we should always update the inode when we update a key in that inode\n"
@@ -808,7 +811,7 @@ int bch2_fsck_update_backpointers(struct btree_trans *trans,
 		/*
 		 * A subvolume dirent's backpointer lives on the child
 		 * subvolume's root inode (bi_dir_offset), same as a regular
-		 * inode - see inode_get_dirent(). Resolve child_subvol -> root
+		 * inode - see bch2_inode_get_dirent(). Resolve child_subvol -> root
 		 * inode and update it. A dangling subvol dirent (subvol or root
 		 * inode gone) is check_subvols/check_dirents' problem, not ours.
 		 */
@@ -843,21 +846,6 @@ int bch2_fsck_update_backpointers(struct btree_trans *trans,
 	}
 }
 
-static struct bkey_s_c_dirent inode_get_dirent(struct btree_trans *trans,
-					       struct btree_iter *iter,
-					       struct bch_inode_unpacked *inode,
-					       u32 *snapshot)
-{
-	if (inode->bi_subvol) {
-		u64 inum;
-		int ret = subvol_lookup(trans, inode->bi_parent_subvol, snapshot, &inum);
-		if (ret)
-			return ((struct bkey_s_c_dirent) { .k = ERR_PTR(ret) });
-	}
-
-	return dirent_get_by_pos(trans, iter, SPOS(inode->bi_dir, inode->bi_dir_offset, *snapshot));
-}
-
 static int check_inode_deleted_list(struct btree_trans *trans, struct bpos p)
 {
 	CLASS(btree_iter, iter)(trans, BTREE_ID_deleted_inodes, p, 0);
@@ -874,7 +862,7 @@ static int check_inode_dirent_inode(struct btree_trans *trans,
 
 	u32 inode_snapshot = inode->bi_snapshot;
 	CLASS(btree_iter_uninit, dirent_iter)(trans);
-	struct bkey_s_c_dirent d = inode_get_dirent(trans, &dirent_iter, inode, &inode_snapshot);
+	struct bkey_s_c_dirent d = bch2_inode_get_dirent(trans, &dirent_iter, inode, &inode_snapshot);
 	int ret = bkey_err(d);
 	if (ret && !bch2_err_matches(ret, ENOENT))
 		return ret;
@@ -1624,11 +1612,10 @@ static int check_dirent_to_subvol(struct btree_trans *trans, struct btree_iter *
 	u32 target_subvol = le32_to_cpu(d.v->d_child_subvol);
 	u32 parent_snapshot;
 	u32 new_parent_subvol = 0;
-	u64 parent_inum;
 	CLASS(printbuf, buf)();
 	int ret = 0;
 
-	ret = subvol_lookup(trans, parent_subvol, &parent_snapshot, &parent_inum);
+	ret = bch2_subvolume_get_snapshot(trans, parent_subvol, &parent_snapshot);
 	if (ret && !bch2_err_matches(ret, ENOENT))
 		return ret;
 

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -902,7 +902,7 @@ static int check_inode_dirent_inode(struct btree_trans *trans,
 	struct bch_fs *c = trans->c;
 	CLASS(printbuf, buf)();
 
-	u32 inode_snapshot = inode->bi_snapshot;
+	u32 inode_snapshot = bch2_snapshot_redundant_interior(c, inode->bi_snapshot);
 	CLASS(btree_iter_uninit, dirent_iter)(trans);
 	struct bkey_s_c_dirent d = bch2_inode_get_dirent(trans, &dirent_iter, inode, &inode_snapshot);
 	int ret = bkey_err(d);

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -1006,19 +1006,35 @@ static int check_inode(struct btree_trans *trans,
 	}
 
 	if (S_ISDIR(u.bi_mode) && (u.bi_flags & BCH_INODE_unlinked)) {
-		/* Check for this early so that check_unreachable_inode() will reattach it */
-
-		ret = bch2_empty_dir_snapshot(trans, k.k->p.offset, 0, k.k->p.snapshot);
-		if (ret && ret != -BCH_ERR_ENOTEMPTY_dir_not_empty)
+		/*
+		 * An unlinked subvolume root legitimately carries the flag -
+		 * and is legitimately non-empty, since the snapshot sweep is
+		 * what deletes the contents. Only strip it when the subvolume
+		 * isn't being deleted: the subvolume key is what links a
+		 * subvolume root, so a live subvolume means this inode is not
+		 * actually unlinked.
+		 */
+		ret = bch2_inode_is_subvolume_root(&u)
+			? bch2_subvolume_deletion_pending(trans, u.bi_subvol, u.bi_snapshot)
+			: 0;
+		if (ret < 0)
 			return ret;
 
-		fsck_err_on(ret, trans, inode_dir_unlinked_but_not_empty,
-			    "dir unlinked but not empty\n%s",
-			    (printbuf_reset(&buf),
-			     bch2_inode_unpacked_to_text(&buf, &u),
-			     buf.buf));
-		u.bi_flags &= ~BCH_INODE_unlinked;
-		do_update = true;
+		if (!ret) {
+			/* Check for this early so that check_unreachable_inode() will reattach it */
+
+			ret = bch2_empty_dir_snapshot(trans, k.k->p.offset, 0, k.k->p.snapshot);
+			if (ret && ret != -BCH_ERR_ENOTEMPTY_dir_not_empty)
+				return ret;
+
+			fsck_err_on(ret, trans, inode_dir_unlinked_but_not_empty,
+				    "dir unlinked but not empty\n%s",
+				    (printbuf_reset(&buf),
+				     bch2_inode_unpacked_to_text(&buf, &u),
+				     buf.buf));
+			u.bi_flags &= ~BCH_INODE_unlinked;
+			do_update = true;
+		}
 		ret = 0;
 	}
 
@@ -1049,7 +1065,13 @@ static int check_inode(struct btree_trans *trans,
 	}
 	ret = 0;
 
+	/*
+	 * Unlinked subvolume roots are skipped here: their deletion belongs
+	 * to the subvolume path (check_subvols() resumes it after a crash),
+	 * not the inode reaper or the deleted_inodes btree:
+	 */
 	if ((u.bi_flags & BCH_INODE_unlinked) &&
+	    !bch2_inode_is_subvolume_root(&u) &&
 	    !(u.bi_flags & BCH_INODE_has_child_snapshot)) {
 		if (!test_bit(BCH_FS_started, &c->flags)) {
 			/*
@@ -1174,35 +1196,43 @@ static int check_inode(struct btree_trans *trans,
 			prt_str(&buf, "(missing)");
 
 		/*
-		 * bi_dir/bi_dir_offset zeroed on a subvolume root means the
-		 * subvolume was unlinked: deletion tombstones the subvolume and
-		 * marks its snapshot will_delete together, leaving this root
-		 * inode pending sweep by delete_dead_snapshots(). The subvolume
-		 * reads as missing, but that's the expected not-live state, not
-		 * corruption - leave bi_subvol be; the whole snapshot is going
-		 * away.
+		 * A subvolume root whose subvolume is being deleted: the
+		 * subvolume reads as missing here (unlinked subvolumes still
+		 * resolve, but deleted tombstones and swept keys don't) while
+		 * the root inode waits for the snapshot sweep to delete it -
+		 * not corruption, leave bi_subvol be, the whole snapshot is
+		 * going away. Only when the deletion chain corroborates,
+		 * though: subvolume gone but snapshot still live means the
+		 * chain broke, and the repair below must run or
+		 * check_unreachable_inodes() meets an orphan whose bi_subvol
+		 * points nowhere and the reattach fail-stops the pass (field
+		 * report, 2026-07-21).
 		 *
-		 * Only when the deletion chain corroborates, though: an
-		 * orderly deletion tombstones the subvolume (which reports
-		 * ENOENT here) and marks the snapshot will_delete together.
-		 * Subvolume gone but snapshot still live means the chain
-		 * broke - damage, not pending deletion - and the repair
-		 * below must run, or check_unreachable_inodes() meets an
-		 * orphan whose bi_subvol points nowhere and the reattach
-		 * fail-stops the pass (field report, 2026-07-21).
-		 *
-		 * The unlinked flag also corroborates: the delete path is
-		 * gaining "set the unlinked flag on the root inode", but
-		 * every filesystem deleted-on before that has flag-less
-		 * pending roots, so the flag alone can't be required:
+		 * Pending roots carry BCH_INODE_unlinked - no dirent points at
+		 * them, by design, and the sweep rather than the inode reaper
+		 * deletes them (see bch2_inode_is_subvolume_root()).
+		 * Filesystems that deleted subvolumes before the delete path
+		 * set the flag have flag-less pending roots; converge them:
 		 */
-		bool subvol_unlinked = ret &&
-			!bch2_inode_has_backpointer(&u) &&
-			((u.bi_flags & BCH_INODE_unlinked) ||
-			 (!snapshot_ret &&
-			  bch2_snapshot_state_compat(&snapshot) != SNAPSHOT_STATE_live));
+		bool deletion_pending = false;
+		if (ret && !bch2_inode_has_backpointer(&u)) {
+			int ret2 = bch2_subvolume_deletion_pending(trans, u.bi_subvol,
+								   u.bi_snapshot);
+			if (ret2 < 0)
+				return ret2;
+			deletion_pending = ret2;
+		}
 
-		if (!subvol_unlinked &&
+		if (deletion_pending &&
+		    fsck_err_on(!(u.bi_flags & BCH_INODE_unlinked),
+				trans, subvol_root_unlinked_flag_missing,
+				"unlinked subvolume root missing BCH_INODE_unlinked\n%s",
+				buf.buf)) {
+			u.bi_flags |= BCH_INODE_unlinked;
+			do_update = true;
+		}
+
+		if (!deletion_pending &&
 		    (fsck_err_on(ret,
 				trans, inode_bi_subvol_missing,
 				"inode bi_subvol points to missing subvolume %u\n%s",

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -1925,7 +1925,12 @@ again:
 			check_dirent(trans, &iter, k, &hash_info, &dir, &target, &s,
 				     &need_second_pass);
 		})) ?:
-		check_subdir_count_notnested(trans, &dir);
+		/*
+		 * Final flush, via the nested check_subdir_dirents_count so the
+		 * inner fsck_write_inode commits are exempt from the trans_begin
+		 * dropped-updates warning (same as check_extents).
+		 */
+		check_subdir_dirents_count(trans, &dir);
 
 	if (!ret && need_second_pass && !did_second_pass) {
 		bch_info(c, "check_dirents requires second pass");

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -1524,7 +1524,16 @@ int bch2_check_key_has_inode(struct btree_trans *trans,
 				u32 snapshot = i->inode.bi_snapshot;
 				i->inode = good_ancestor->inode;
 				i->inode.bi_snapshot = snapshot;
-				try(bch2_fsck_write_inode(trans, &i->inode));
+				/*
+				 * __ (non-committing) version: we're inside the
+				 * caller's commit_do(). The self-committing one
+				 * eats restarts, and when the following lazy
+				 * commit then has nothing to do it returns 0 -
+				 * leaking the advanced restart_count to the
+				 * caller's verify (panic, restart_count N
+				 * should be M):
+				 */
+				try(__bch2_fsck_write_inode(trans, &i->inode));
 				try(bch2_trans_commit_lazy(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc));
 			}
 		}
@@ -1552,7 +1561,8 @@ int bch2_check_key_has_inode(struct btree_trans *trans,
 			else
 				i->inode.bi_mode |= S_IFREG;
 
-			try(bch2_fsck_write_inode(trans, &i->inode));
+			/* __: see above - don't eat restarts under the caller's commit_do() */
+			try(__bch2_fsck_write_inode(trans, &i->inode));
 			try(bch2_trans_commit_lazy(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc));
 		}
 	}

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -963,6 +963,10 @@ static int check_inode(struct btree_trans *trans,
 
 	try(bch2_snapshots_seen_update(c, s, iter->btree_id, k.k->p));
 
+	/* after snapshots_seen: keep the seen list complete even for skipped keys */
+	if (bch2_snapshot_will_delete(c, k.k->p.snapshot))
+		return 0;
+
 	if (!bkey_is_inode(k.k))
 		return 0;
 
@@ -1748,6 +1752,10 @@ static int check_dirent(struct btree_trans *trans, struct btree_iter *iter,
 	if (ret)
 		return ret;
 
+	/* after snapshots_seen: keep the seen list complete even for skipped keys */
+	if (bch2_snapshot_will_delete(c, k.k->p.snapshot))
+		return 0;
+
 	if (k.k->type == KEY_TYPE_whiteout)
 		return 0;
 
@@ -1948,6 +1956,10 @@ static int check_xattr(struct btree_trans *trans, struct btree_iter *iter,
 		return 0;
 
 	try(bch2_snapshots_seen_update(c, s, iter->btree_id, k.k->p));
+
+	/* after snapshots_seen: keep the seen list complete even for skipped keys */
+	if (bch2_snapshot_will_delete(c, k.k->p.snapshot))
+		return 0;
 
 	struct inode_walker_entry *i = errptr_try(bch2_walk_inode(trans, inode, k));
 

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -613,10 +613,6 @@ int bch2_ref_visible2(struct btree_trans *trans,
 	return bch2_key_visible_in_snapshot(trans, src_seen, dst, src);
 }
 
-#define for_each_visible_inode(_trans, _s, _w, _snapshot, _i)				\
-	for (_i = (_w)->inodes.data; _i < (_w)->inodes.data + (_w)->inodes.nr &&	\
-	     (_i)->inode.bi_snapshot <= (_snapshot); _i++)				\
-		if (bch2_key_visible_in_snapshot(_trans, _s, _i->inode.bi_snapshot, _snapshot))
 
 static int add_inode(struct bch_fs *c, struct inode_walker *w,
 		     struct bkey_s_c inode)

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -337,7 +337,53 @@ int bch2_reattach_inode(struct btree_trans *trans, struct bch_inode_unpacked *in
 
 	bch_verbose(c, "got lostfound inum %llu", lostfound.bi_inum);
 
-	lostfound.bi_nlink += S_ISDIR(inode->bi_mode);
+	struct qstr name = QSTR(name_buf);
+
+	/*
+	 * Adopt instead of create: the child fixup loop below commits in
+	 * chunks (bch2_trans_commit_lazy_if_full()), so a re-drive can find
+	 * the reattach dirent already committed - at our snapshot or an
+	 * ancestor, when the committed fixups moved the oldest-needing-
+	 * reattach point down. The name is deterministic, so look it up:
+	 * adopting avoids the STR_HASH_must_create collision and re-bumping
+	 * lost+found's nlink.
+	 */
+	struct bch_hash_info lostfound_hash;
+	try(bch2_hash_info_init(c, &lostfound, &lostfound_hash));
+
+	bool adopted = false;
+	{
+		CLASS(btree_iter_uninit, d_iter)(trans);
+		struct bkey_s_c k = bch2_hash_lookup_in_snapshot(trans, &d_iter,
+				bch2_dirent_hash_desc, &lostfound_hash,
+				(subvol_inum) { inode->bi_parent_subvol, lostfound.bi_inum },
+				&name, 0, dirent_snapshot);
+		ret = bkey_err(k);
+		if (ret && !bch2_err_matches(ret, ENOENT))
+			return ret;
+
+		if (!ret) {
+			struct bkey_s_c_dirent d = bkey_s_c_to_dirent(k);
+			u64 target = d.v->d_type == DT_SUBVOL
+				? le32_to_cpu(d.v->d_child_subvol)
+				: le64_to_cpu(d.v->d_inum);
+
+			if (target != (inode->bi_subvol ?: inode->bi_inum)) {
+				CLASS(printbuf, buf)();
+				bch2_bkey_val_to_text(&buf, c, k);
+				bch_err(c, "reattaching inode %llu:%u: lost+found entry %s exists but points elsewhere:\n%s",
+					inode->bi_inum, inode->bi_snapshot, name_buf, buf.buf);
+				return bch_err_throw(c, fsck_repair_unimplemented);
+			}
+
+			inode->bi_dir		= lostfound.bi_inum;
+			inode->bi_dir_offset	= d.k->p.offset;
+			adopted = true;
+		}
+	}
+
+	if (!adopted)
+		lostfound.bi_nlink += S_ISDIR(inode->bi_mode);
 
 	/* ensure lost+found inode is also present in inode snapshot */
 	if (!inode->bi_subvol) {
@@ -347,23 +393,23 @@ int bch2_reattach_inode(struct btree_trans *trans, struct bch_inode_unpacked *in
 
 	try(__bch2_fsck_write_inode(trans, &lostfound));
 
-	struct qstr name = QSTR(name_buf);
+	if (!adopted) {
+		inode->bi_dir = lostfound.bi_inum;
 
-	inode->bi_dir = lostfound.bi_inum;
-
-	ret = bch2_dirent_create_snapshot(trans,
-				inode->bi_parent_subvol,
-				dirent_snapshot,
-				&lostfound,
-				inode_d_type(inode),
-				&name,
-				inode->bi_subvol ?: inode->bi_inum,
-				&inode->bi_dir_offset,
-				BTREE_UPDATE_internal_snapshot_node|
-				STR_HASH_must_create);
-	if (ret) {
-		bch_err_msg(c, ret, "error creating dirent");
-		return ret;
+		ret = bch2_dirent_create_snapshot(trans,
+					inode->bi_parent_subvol,
+					dirent_snapshot,
+					&lostfound,
+					inode_d_type(inode),
+					&name,
+					inode->bi_subvol ?: inode->bi_inum,
+					&inode->bi_dir_offset,
+					BTREE_UPDATE_internal_snapshot_node|
+					STR_HASH_must_create);
+		if (ret) {
+			bch_err_msg(c, ret, "error creating dirent");
+			return ret;
+		}
 	}
 
 	try(__bch2_fsck_write_inode(trans, inode));
@@ -373,7 +419,10 @@ int bch2_reattach_inode(struct btree_trans *trans, struct bch_inode_unpacked *in
 		try(bch2_inum_snapshot_to_path(trans, inode->bi_inum,
 					       inode->bi_snapshot, NULL, &buf));
 
-		bch_info(c, "reattached at %s", buf.buf);
+		if (adopted)
+			bch_verbose(c, "resuming reattach at %s", buf.buf);
+		else
+			bch_info(c, "reattached at %s", buf.buf);
 	}
 
 	/*
@@ -393,6 +442,18 @@ int bch2_reattach_inode(struct btree_trans *trans, struct bch_inode_unpacked *in
 			if (k.k->p.offset != inode->bi_inum)
 				break;
 
+			/*
+			 * This loop batches an update per descendant snapshot
+			 * version into one transaction; a fat chain overflows
+			 * the bump allocator. Commit once substantial work has
+			 * accumulated - the restart re-drives us, the adopt
+			 * path above resumes without duplicating the reattach
+			 * dirent, and already-fixed children are skipped
+			 * below:
+			 */
+			try(bch2_trans_commit_lazy_if_full(trans, NULL, NULL,
+					BCH_TRANS_COMMIT_no_enospc));
+
 			if (!bkey_is_inode(k.k) ||
 			    !bch2_snapshot_is_ancestor(trans, k.k->p.snapshot, inode->bi_snapshot) ||
 			    snapshot_list_has_ancestor(trans, &whiteouts_done, k.k->p.snapshot))
@@ -400,6 +461,18 @@ int bch2_reattach_inode(struct btree_trans *trans, struct bch_inode_unpacked *in
 
 			struct bch_inode_unpacked child_inode;
 			bch2_inode_unpack(c, k, &child_inode);
+
+			/*
+			 * Fixed by a previous partial commit: its backpointer
+			 * already names our reattach dirent. Must be checked
+			 * before inode_should_reattach() - having a
+			 * backpointer, it would fall into the whiteout arm
+			 * and turn the committed fixup into a dangling
+			 * backpointer:
+			 */
+			if (child_inode.bi_dir == inode->bi_dir &&
+			    child_inode.bi_dir_offset == inode->bi_dir_offset)
+				continue;
 
 			if (!inode_should_reattach(&child_inode)) {
 				try(maybe_delete_dirent(trans,

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -545,6 +545,7 @@ int bch2_snapshots_seen_update(struct bch_fs *c, struct snapshots_seen *s,
 	s->pos = pos;
 
 	u32 equiv = bch2_snapshot_redundant_interior(c, pos.snapshot);
+	s->pos_equiv = equiv;
 
 	if (snapshot_list_has_id(&s->ids, equiv))
 		return -BCH_ERR_fc_continue;
@@ -623,19 +624,41 @@ int bch2_ref_visible2(struct btree_trans *trans,
 
 
 static int add_inode(struct bch_fs *c, struct inode_walker *w,
-		     struct bkey_s_c inode)
+		     struct bkey_s_c inode, bool reverse)
 {
-	try(darray_push(&w->inodes, ((struct inode_walker_entry) {
-		.whiteout	= !bkey_is_inode(inode.k),
-	})));
+	/*
+	 * One entry per collapse equivalence class, at the class terminal:
+	 * repairs that write an entry back write to the correct destination
+	 * snapshot, pre-doing a bit of delete_dead_snapshots' cleanup.
+	 *
+	 * Of a class's versions keep the one nearest the terminal (lowest
+	 * snapshot id) - the version delete_dead_snapshots' migration keeps.
+	 * Iteration order tells us which that is: walking forwards it's the
+	 * first of a class, so bail on a match; in reverse it's the last, so
+	 * overwrite.
+	 */
+	u32 equiv = bch2_snapshot_redundant_interior(c, inode.k->p.snapshot);
 
-	struct inode_walker_entry *n = &darray_last(w->inodes);
+	struct inode_walker_entry *n = darray_find_p(w->inodes, i,
+					i->inode.bi_snapshot == equiv);
+	if (n && !reverse)
+		return 0;
+
+	if (!n) {
+		try(darray_push(&w->inodes, ((struct inode_walker_entry) {})));
+		n = &darray_last(w->inodes);
+	}
+
+	*n = (struct inode_walker_entry) {
+		.whiteout	= !bkey_is_inode(inode.k),
+	};
+
 	if (!n->whiteout) {
 		bch2_inode_unpack(c, inode, &n->inode);
 	} else {
 		n->inode.bi_inum	= inode.k->p.offset;
-		n->inode.bi_snapshot	= inode.k->p.snapshot;
 	}
+	n->inode.bi_snapshot = equiv;
 	return 0;
 }
 
@@ -669,7 +692,7 @@ static int get_inodes_all_snapshots(struct btree_trans *trans,
 		if (bch2_snapshot_will_delete(c, k.k->p.snapshot, NULL))
 			continue;
 
-		try(add_inode(c, w, k));
+		try(add_inode(c, w, k, false));
 	}
 
 	if (ret)
@@ -730,7 +753,7 @@ static int get_visible_inodes(struct btree_trans *trans,
 			continue;
 
 		try(bkey_is_inode(k.k)
-		    ? add_inode(c, w, k)
+		    ? add_inode(c, w, k, true)
 		    : snapshot_list_add(c, &w->deletes, k.k->p.snapshot));
 	}
 
@@ -738,8 +761,13 @@ static int get_visible_inodes(struct btree_trans *trans,
 		CLASS(btree_iter, ancestor_iter)(trans, BTREE_ID_inodes,
 						 SPOS(0, inum, s->pos.snapshot), 0);
 		k = bkey_try(bch2_btree_iter_peek_slot(&ancestor_iter));
+		/*
+		 * Not part of the reverse walk: an ancestor whose collapse
+		 * chain terminates at a collected descendant's class must not
+		 * displace it:
+		 */
 		if (bkey_is_inode(k.k))
-			try(add_inode(c, w, k));
+			try(add_inode(c, w, k, false));
 	}
 
 	return ret;
@@ -761,7 +789,8 @@ lookup_inode_for_snapshot(struct btree_trans *trans, struct inode_walker *w, str
 	CLASS(printbuf, buf)();
 	int ret = 0;
 
-	u32 inode_snapshot = bch2_snapshot_redundant_interior(c, i->inode.bi_snapshot);
+	/* walker entries are pre-mapped to the collapse terminal by add_inode() */
+	u32 inode_snapshot = i->inode.bi_snapshot;
 
 	if (fsck_err_on(k_snapshot != inode_snapshot,
 			trans, snapshot_key_missing_inode_snapshot,
@@ -1514,10 +1543,13 @@ int bch2_check_key_has_inode(struct btree_trans *trans,
 	else
 		prt_str(&buf, "key in missing inode");
 
+	/* entries are collapse-frame; compare the key in the same frame */
+	u32 k_equiv = bch2_snapshot_redundant_interior(c, k.k->p.snapshot);
+
 	struct inode_walker_entry *good_ancestor = NULL;
 	darray_for_each(inode->inodes, i2)
 		if (!i2->whiteout &&
-		    bch2_snapshot_is_ancestor(trans, k.k->p.snapshot, i2->inode.bi_snapshot) &&
+		    bch2_snapshot_is_ancestor(trans, k_equiv, i2->inode.bi_snapshot) &&
 		    btree_matches_i_mode(iter->btree_id, i2->inode.bi_mode)) {
 			prt_printf(&buf, ", but found good inode in older snapshot");
 			bch2_inode_unpacked_to_text(&buf, &i2->inode);

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -910,13 +910,36 @@ int bch2_fsck_update_backpointers(struct btree_trans *trans,
 		if (ret)
 			return ret;
 
-		root_inode.bi_dir_offset = d->k.p.offset;
+		if (root_inode.bi_dir == d->k.p.inode &&
+		    root_inode.bi_dir_offset == d->k.p.offset)
+			return 0;
+
+		root_inode.bi_dir		= d->k.p.inode;
+		root_inode.bi_dir_offset	= d->k.p.offset;
 		return __bch2_fsck_write_inode(trans, &root_inode);
 	} else {
 		try(get_visible_inodes(trans, &target, s, le64_to_cpu(d->v.d_inum)));
 
+		/*
+		 * A backpointer is the (bi_dir, bi_dir_offset) pair - compare
+		 * and set both, or an offset match into the wrong directory
+		 * skips a broken backpointer, and an offset-only write
+		 * manufactures one.
+		 *
+		 * Skip before the write: __bch2_fsck_write_inode allocates a
+		 * bkey_inode_buf of trans mem per call, and this loop runs once
+		 * per visible snapshot version in one transaction - an
+		 * already-correct backpointer must cost nothing, both to bound
+		 * trans mem and so a re-run over partially-repaired state
+		 * shrinks instead of repeating the whole batch.
+		 */
 		darray_for_each(target.inodes, i) {
-			i->inode.bi_dir_offset = d->k.p.offset;
+			if (i->inode.bi_dir == d->k.p.inode &&
+			    i->inode.bi_dir_offset == d->k.p.offset)
+				continue;
+
+			i->inode.bi_dir		= d->k.p.inode;
+			i->inode.bi_dir_offset	= d->k.p.offset;
 			try(__bch2_fsck_write_inode(trans, &i->inode));
 		}
 

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -1428,6 +1428,184 @@ static int find_oldest_inode_needs_reattach(struct btree_trans *trans,
 	return ret;
 }
 
+/*
+ * An unreachable inode version may still be attached in a descendant
+ * snapshot: incomplete snapshot deletion can move a dirent further down the
+ * snapshot tree than the inode that points to it (an interrupted pass
+ * resumes against new topology, so the two stop at different termini),
+ * leaving ancestor views orphaned while the descendant view is intact.
+ *
+ * check_inodes zeroed this version's backpointer, but the attached
+ * descendant version still carries its verified one - find that dirent, so
+ * we can propagate a copy up to this version's snapshot instead of
+ * reattaching in lost+found.
+ *
+ * Requirements checked here: the dirent names this inode from a strict
+ * descendant, the parent directory is visible (and not unlinked) in this
+ * version's view, the dirent's name hashes to its offset under that
+ * directory's hash info (a mismatched seed - e.g. a reconstructed directory
+ * inode - would get the propagated dirent rehashed by the next
+ * check_dirents, dangling every backpointer to it), and the destination
+ * slot is empty - a whiteout there means the entry was deliberately deleted
+ * in this view, and must not be resurrected.
+ *
+ * Returns a copy in transaction memory: the caller uses it across
+ * fsck_err(), which can cycle transaction locks, so a reference into a
+ * btree node buffer would be a use after unlock.
+ */
+static struct bkey_i *find_attached_dirent_in_descendant(struct btree_trans *trans,
+					struct bch_inode_unpacked *inode)
+{
+	struct bch_fs *c = trans->c;
+	struct bch_inode_unpacked child;
+	bool found = false;
+	struct bkey_s_c k;
+	int ret = 0;
+
+	/*
+	 * Dirents pointing to subvolume roots live in the parent subvolume -
+	 * a different snapshot space; those take the reattach path:
+	 */
+	if (inode->bi_subvol)
+		return NULL;
+
+	for_each_btree_key_norestart(trans, iter, BTREE_ID_inodes,
+				     SPOS(0, inode->bi_inum, 0),
+				     BTREE_ITER_all_snapshots, k, ret) {
+		if (k.k->p.offset != inode->bi_inum ||
+		    k.k->p.snapshot >= inode->bi_snapshot)
+			break;
+
+		if (!bkey_is_inode(k.k) ||
+		    !bch2_snapshot_is_ancestor(trans, k.k->p.snapshot, inode->bi_snapshot))
+			continue;
+
+		bch2_inode_unpack(c, k, &child);
+		if (bch2_inode_has_backpointer(&child) && !child.bi_parent_subvol) {
+			found = true;
+			break;
+		}
+	}
+	if (ret)
+		return ERR_PTR(ret);
+	if (!found)
+		return NULL;
+
+	u32 snapshot = child.bi_snapshot;
+	CLASS(btree_iter_uninit, dirent_iter)(trans);
+	struct bkey_s_c_dirent d = bch2_inode_get_dirent(trans, &dirent_iter, &child, &snapshot);
+	ret = bkey_err(d);
+	if (bch2_err_matches(ret, ENOENT))
+		return NULL;
+	if (ret)
+		return ERR_PTR(ret);
+
+	if (dirent_points_to_inode_nowarn(c, d, inode))
+		return NULL;
+
+	/*
+	 * Classify our snapshot's view of that position. (d is visible at
+	 * the descendant, so it lies on the descendant's rootward path and
+	 * is always comparable with our snapshot - no separate ancestry
+	 * check is needed.)
+	 *
+	 * - matching dirent already visible (a propagation done at an older
+	 *   version of this inode earlier in the pass): only the
+	 *   backpointer needs fixing. No further requirements - there's no
+	 *   insert, and falling back to lost+found would create a duplicate
+	 *   link to a reachable file
+	 * - nothing visible and the slot is empty: propagate a copy, which
+	 *   also requires the parent directory to be visible and not
+	 *   unlinked. (No hash check needed: check_dirents verified the
+	 *   dirent at the descendant's view, and hash info is invariant
+	 *   across an inode's snapshot versions - enforced by check_inodes -
+	 *   so it hashes identically under the directory here.)
+	 * - a different inode's dirent visible: the name belongs to someone
+	 *   else in this view, and inserting over it would hide that file
+	 *   from every view below; a whiteout in the slot: the entry was
+	 *   deliberately deleted here. Both fall back to lost+found.
+	 */
+	CLASS(btree_iter, vis_iter)(trans, BTREE_ID_dirents,
+				    SPOS(d.k->p.inode, d.k->p.offset, inode->bi_snapshot), 0);
+	struct bkey_s_c vis = bch2_btree_iter_peek_slot(&vis_iter);
+	ret = bkey_err(vis);
+	if (ret)
+		return ERR_PTR(ret);
+
+	if (vis.k->type == KEY_TYPE_dirent) {
+		if (dirent_points_to_inode_nowarn(c, bkey_s_c_to_dirent(vis), inode))
+			return NULL;
+	} else {
+		struct bch_inode_unpacked dir;
+		ret = bch2_inode_find_by_inum_snapshot(trans, d.k->p.inode,
+						       inode->bi_snapshot, &dir, 0);
+		if (bch2_err_matches(ret, ENOENT))
+			return NULL;
+		if (ret)
+			return ERR_PTR(ret);
+
+		if (dir.bi_flags & BCH_INODE_unlinked)
+			return NULL;
+
+		CLASS(btree_iter, dst_iter)(trans, BTREE_ID_dirents,
+					    SPOS(d.k->p.inode, d.k->p.offset, inode->bi_snapshot),
+					    BTREE_ITER_all_snapshots);
+		struct bkey_s_c dst = bch2_btree_iter_peek_slot(&dst_iter);
+		ret = bkey_err(dst);
+		if (ret)
+			return ERR_PTR(ret);
+		if (!bkey_deleted(dst.k))
+			return NULL;
+	}
+
+	return bch2_bkey_make_mut_noupdate(trans, d.s_c);
+}
+
+static int reattach_via_descendant_dirent(struct btree_trans *trans,
+					  struct bch_inode_unpacked *inode,
+					  struct bkey_i *new)
+{
+	struct bch_fs *c = trans->c;
+
+	new->k.p.snapshot = inode->bi_snapshot;
+
+	/*
+	 * Re-classify under the intent lock: the probe ran before fsck_err(),
+	 * which can cycle transaction locks, and this pass can run online. A
+	 * matching dirent that's become visible only needs the backpointer
+	 * set; anything else now occupying the position must not be
+	 * clobbered.
+	 */
+	CLASS(btree_iter, vis_iter)(trans, BTREE_ID_dirents, new->k.p,
+				    BTREE_ITER_intent);
+	struct bkey_s_c vis = bkey_try(bch2_btree_iter_peek_slot(&vis_iter));
+
+	bool have_dirent = vis.k->type == KEY_TYPE_dirent &&
+		!dirent_points_to_inode_nowarn(c, bkey_s_c_to_dirent(vis), inode);
+
+	if (!have_dirent) {
+		if (vis.k->type == KEY_TYPE_dirent)
+			goto bail;
+
+		CLASS(btree_iter, dst_iter)(trans, BTREE_ID_dirents, new->k.p,
+					    BTREE_ITER_all_snapshots|BTREE_ITER_intent);
+		struct bkey_s_c dst = bkey_try(bch2_btree_iter_peek_slot(&dst_iter));
+		if (!bkey_deleted(dst.k))
+			goto bail;
+
+		try(bch2_trans_update(trans, &dst_iter, new, BTREE_UPDATE_internal_snapshot_node));
+	}
+
+	inode->bi_dir		= new->k.p.inode;
+	inode->bi_dir_offset	= new->k.p.offset;
+	return __bch2_fsck_write_inode(trans, inode);
+bail:
+	bch_err(c, "not propagating dirent for inode %llu:%u: destination %llu:%llu:%u now occupied",
+		inode->bi_inum, inode->bi_snapshot,
+		new->k.p.inode, new->k.p.offset, new->k.p.snapshot);
+	return 0;
+}
+
 static int check_unreachable_inode(struct btree_trans *trans,
 				   struct btree_iter *iter,
 				   struct bkey_s_c k,
@@ -1460,6 +1638,24 @@ static int check_unreachable_inode(struct btree_trans *trans,
 		return 0;
 
 	try(find_oldest_inode_needs_reattach(trans, &inode));
+
+	/*
+	 * Attached in a descendant snapshot? Then this version has a proper
+	 * home; propagate the dirent up to our snapshot rather than
+	 * manufacturing a lost+found entry visible in every view below:
+	 */
+	struct bkey_i *d = errptr_try(find_attached_dirent_in_descendant(trans, &inode));
+
+	if (d) {
+		if (inode_fsck_err(trans, SPOS(0, inode.bi_inum, inode.bi_snapshot),
+				   inode_unreachable_dirent_in_descendant,
+			     "unreachable inode with dirent in descendant snapshot %u, propagating:\n%s",
+			     d->k.p.snapshot,
+			     (bch2_inode_unpacked_to_text(&buf, &inode),
+			      buf.buf)))
+			try(reattach_via_descendant_dirent(trans, &inode, d));
+		return ret;
+	}
 
 	if (inode_fsck_err(trans, SPOS(0, inode.bi_inum, inode.bi_snapshot),
 			   inode_unreachable,

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -960,12 +960,14 @@ static int check_inode_dirent_inode(struct btree_trans *trans,
 		return 0;
 	}
 
-	if (fsck_err_on(ret,
-			trans, inode_points_to_missing_dirent,
+	if (inode_fsck_err_on(ret,
+			trans, SPOS(0, inode->bi_inum, inode->bi_snapshot),
+			inode_points_to_missing_dirent,
 			"inode points to missing dirent\n%s",
 			(bch2_inode_unpacked_to_text(&buf, inode), buf.buf)) ||
-	    fsck_err_on(!ret && dirent_points_to_inode_nowarn(c, d, inode),
-			trans, inode_points_to_wrong_dirent,
+	    inode_fsck_err_on(!ret && dirent_points_to_inode_nowarn(c, d, inode),
+			trans, SPOS(0, inode->bi_inum, inode->bi_snapshot),
+			inode_points_to_wrong_dirent,
 			"%s",
 			(printbuf_reset(&buf),
 			 bch2_dirent_inode_mismatch_msg(&buf, c, d, inode),
@@ -1097,7 +1099,8 @@ static int check_inode(struct btree_trans *trans,
 			if (ret && ret != -BCH_ERR_ENOTEMPTY_dir_not_empty)
 				return ret;
 
-			fsck_err_on(ret, trans, inode_dir_unlinked_but_not_empty,
+			inode_fsck_err_on(ret, trans, k.k->p,
+				    inode_dir_unlinked_but_not_empty,
 				    "dir unlinked but not empty\n%s",
 				    (printbuf_reset(&buf),
 				     bch2_inode_unpacked_to_text(&buf, &u),
@@ -1433,7 +1436,7 @@ static int check_unreachable_inode(struct btree_trans *trans,
 
 	try(find_oldest_inode_needs_reattach(trans, &inode));
 
-	if (inode_fsck_err(trans, inode.bi_inum, inode.bi_snapshot,
+	if (inode_fsck_err(trans, SPOS(0, inode.bi_inum, inode.bi_snapshot),
 			   inode_unreachable,
 		     "unreachable inode:\n%s",
 		     (bch2_inode_unpacked_to_text(&buf, &inode),
@@ -1585,7 +1588,8 @@ int bch2_check_key_has_inode(struct btree_trans *trans,
 		if (inode_looks_deleted)
 			prt_str(&buf, "inode was deleted, will delete key\n");
 
-		if (ret_fsck_err(trans, key_in_missing_inode, "%s", buf.buf)) {
+		if (ret_inode_fsck_err(trans, k.k->p,
+				       key_in_missing_inode, "%s", buf.buf)) {
 			if (inode_looks_deleted)
 				return bch2_btree_delete_at(trans, iter, BTREE_UPDATE_internal_snapshot_node);
 
@@ -1613,7 +1617,8 @@ int bch2_check_key_has_inode(struct btree_trans *trans,
 			}
 		}
 	} else {
-		if (ret_fsck_err(trans, key_in_wrong_inode_type, "%s", buf.buf)) {
+		if (ret_inode_fsck_err(trans, k.k->p,
+				       key_in_wrong_inode_type, "%s", buf.buf)) {
 			int nr_extents = iter->btree_id == BTREE_ID_extents
 				? nr_keys : count_inode_keys(trans, inode_pos, BTREE_ID_extents, NULL);
 			if (nr_extents < 0)
@@ -1663,7 +1668,8 @@ static int maybe_reconstruct_inum_btree(struct btree_trans *trans,
 	if (ret <= 0)
 		return ret;
 
-	if (fsck_err(trans, missing_inode_with_contents,
+	if (inode_fsck_err(trans, SPOS(0, inum, snapshot),
+		     missing_inode_with_contents,
 		     "inode %llu:%u type %s missing, but contents found: reconstruct?",
 		     inum, snapshot,
 		     btree == BTREE_ID_extents ? "reg" : "dir"))
@@ -1860,7 +1866,7 @@ check_target:
 		ret = bch_err_throw(c, ENOENT_subvolume_deleted);
 
 	if (ret) {
-		if (inode_fsck_err(trans, d.k->p.inode, d.k->p.snapshot,
+		if (inode_fsck_err(trans, d.k->p,
 				   dirent_to_missing_subvol,
 			     "dirent points to missing subvolume\n%s",
 			     (bch2_bkey_val_to_text(&buf, c, d.s_c), buf.buf)))
@@ -2047,7 +2053,8 @@ static int check_dirent(struct btree_trans *trans, struct btree_iter *iter,
 			 * exists. The second pass revisits the copies for the
 			 * target checks and directory counts:
 			 */
-			if (fsck_err(trans, dirent_to_inode_in_descendant_snapshot,
+			if (inode_fsck_err(trans, d.k->p,
+				     dirent_to_inode_in_descendant_snapshot,
 				     "dirent with inode(s) only in descendant snapshots:\n%s",
 				     (printbuf_reset(&buf),
 				      bch2_bkey_val_to_text(&buf, c, k),
@@ -2108,7 +2115,7 @@ static int check_dirent(struct btree_trans *trans, struct btree_iter *iter,
 		}
 
 		if (inode_fsck_err_on(!target->inodes.nr,
-				trans, d.k->p.inode, d.k->p.snapshot,
+				trans, d.k->p,
 				dirent_to_missing_inode,
 				"dirent points to missing inode:\n%s",
 				(printbuf_reset(&buf),
@@ -2155,7 +2162,8 @@ static int check_dirent(struct btree_trans *trans, struct btree_iter *iter,
 			if (visible.k->type != KEY_TYPE_dirent)
 				continue;
 
-			if (fsck_err(trans, dirent_to_overwritten_inode,
+			if (inode_fsck_err(trans, visible.k->p,
+				     dirent_to_overwritten_inode,
 				     "dirent points to inode overwritten in snapshot %u:\n%s",
 				     *i,
 				     (printbuf_reset(&buf),

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -742,7 +742,7 @@ lookup_inode_for_snapshot(struct btree_trans *trans, struct inode_walker *w, str
 {
 	struct bch_fs *c = trans->c;
 
-	u32 k_snapshot = bch2_snapshot_redundant_interior(c, k.k->p.snapshot) ?: k.k->p.snapshot;
+	u32 k_snapshot = bch2_snapshot_redundant_interior(c, k.k->p.snapshot);
 
 	struct inode_walker_entry *i = darray_find_p(w->inodes, i,
 		    bch2_snapshot_is_ancestor(trans, k_snapshot, i->inode.bi_snapshot));
@@ -753,7 +753,7 @@ lookup_inode_for_snapshot(struct btree_trans *trans, struct inode_walker *w, str
 	CLASS(printbuf, buf)();
 	int ret = 0;
 
-	u32 inode_snapshot = bch2_snapshot_redundant_interior(c, i->inode.bi_snapshot) ?: i->inode.bi_snapshot;
+	u32 inode_snapshot = bch2_snapshot_redundant_interior(c, i->inode.bi_snapshot);
 
 	if (fsck_err_on(k_snapshot != inode_snapshot,
 			trans, snapshot_key_missing_inode_snapshot,

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -376,9 +376,6 @@ int bch2_reattach_inode(struct btree_trans *trans, struct bch_inode_unpacked *in
 		bch_info(c, "reattached at %s", buf.buf);
 	}
 
-	bch2_fsck_damaged(trans, SPOS(inode->bi_inum, 0, inode->bi_snapshot),
-			  FSCK_DAMAGE_reattached);
-
 	/*
 	 * Fix up inodes in child snapshots: if they should also be reattached
 	 * update the backpointer field, if they should not be we need to emit
@@ -1436,7 +1433,8 @@ static int check_unreachable_inode(struct btree_trans *trans,
 
 	try(find_oldest_inode_needs_reattach(trans, &inode));
 
-	if (fsck_err(trans, inode_unreachable,
+	if (inode_fsck_err(trans, inode.bi_inum, inode.bi_snapshot,
+			   inode_unreachable,
 		     "unreachable inode:\n%s",
 		     (bch2_inode_unpacked_to_text(&buf, &inode),
 		      buf.buf)))
@@ -1862,12 +1860,11 @@ check_target:
 		ret = bch_err_throw(c, ENOENT_subvolume_deleted);
 
 	if (ret) {
-		if (fsck_err(trans, dirent_to_missing_subvol,
+		if (inode_fsck_err(trans, d.k->p.inode, d.k->p.snapshot,
+				   dirent_to_missing_subvol,
 			     "dirent points to missing subvolume\n%s",
-			     (bch2_bkey_val_to_text(&buf, c, d.s_c), buf.buf))) {
-			bch2_fsck_damaged(trans, d.k->p, FSCK_DAMAGE_dir_entries_removed);
+			     (bch2_bkey_val_to_text(&buf, c, d.s_c), buf.buf)))
 			return bch2_fsck_remove_dirent(trans, d.k->p);
-		}
 		return 0;
 	}
 
@@ -2110,15 +2107,14 @@ static int check_dirent(struct btree_trans *trans, struct btree_iter *iter,
 			}
 		}
 
-		if (fsck_err_on(!target->inodes.nr,
-				trans, dirent_to_missing_inode,
+		if (inode_fsck_err_on(!target->inodes.nr,
+				trans, d.k->p.inode, d.k->p.snapshot,
+				dirent_to_missing_inode,
 				"dirent points to missing inode:\n%s",
 				(printbuf_reset(&buf),
 				 bch2_bkey_val_to_text(&buf, c, k),
-				 buf.buf))) {
-			bch2_fsck_damaged(trans, d.k->p, FSCK_DAMAGE_dir_entries_removed);
+				 buf.buf)))
 			try(bch2_fsck_remove_dirent(trans, d.k->p));
-		}
 
 		darray_for_each(target->inodes, i) {
 			/*

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -537,11 +537,19 @@ static int reconstruct_inode(struct btree_trans *trans, enum btree_id btree, u32
 int bch2_snapshots_seen_update(struct bch_fs *c, struct snapshots_seen *s,
 			       enum btree_id btree_id, struct bpos pos)
 {
+	if (bpos_eq(s->pos, pos))
+		return 0;
+
 	if (!bkey_eq(s->pos, pos))
 		s->ids.nr = 0;
 	s->pos = pos;
 
-	return snapshot_list_add_nodup(c, &s->ids, pos.snapshot);
+	u32 equiv = bch2_snapshot_redundant_interior(c, pos.snapshot);
+
+	if (snapshot_list_has_id(&s->ids, equiv))
+		return -BCH_ERR_fc_continue;
+
+	return snapshot_list_add_nodup(c, &s->ids, equiv);
 }
 
 /**
@@ -2178,7 +2186,7 @@ int bch2_check_dirents(struct bch_fs *c)
 			      : (bch2_progress_update_iter(trans, &progress, &iter) ?:
 				 check_dirent(trans, &iter, k, &hash_info, &dir, &target, &s)));
 		}));
-		if (ret)
+		if (!err_is_continue(ret))
 			break;
 
 		if (!k.k) {

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -500,7 +500,9 @@ static int reconstruct_inode(struct btree_trans *trans, enum btree_id btree, u32
 		CLASS(btree_iter, iter)(trans, BTREE_ID_extents, SPOS(inum, U64_MAX, snapshot), 0);
 		struct bkey_s_c k = bkey_try(bch2_btree_iter_peek_prev_min(&iter, POS(inum, 0)));
 
-		i_size = k.k->p.offset << 9;
+		/* may race with repair deleting the extents that triggered us: */
+		if (k.k)
+			i_size = k.k->p.offset << 9;
 		break;
 	}
 	case BTREE_ID_dirents:

--- a/fs/fs/check.c
+++ b/fs/fs/check.c
@@ -947,6 +947,27 @@ static int check_inode_dirent_inode(struct btree_trans *trans,
 		*write_inode = true;
 	}
 
+	if (!ret &&
+	    !dirent_points_to_inode_nowarn(c, d, inode) &&
+	    fsck_err_on(inode->bi_flags & BCH_INODE_unlinked,
+			trans, inode_unlinked_but_has_dirent,
+			"inode unlinked but has dirent\n%s",
+			(printbuf_reset(&buf),
+			 bch2_inode_unpacked_to_text(&buf, inode),
+			 prt_newline(&buf),
+			 bch2_bkey_val_to_text(&buf, c, d.s_c),
+			 buf.buf))) {
+		/*
+		 * The dirent was just verified to point at this inode, so the
+		 * unlinked flag is wrong - and the flag clear is the complete
+		 * repair: bi_nlink counts links beyond the first, so this
+		 * yields nlink 1 (check_nlinks recounts hardlinks), and the
+		 * inode trigger removes the deleted_inodes entry.
+		 */
+		inode->bi_flags &= ~BCH_INODE_unlinked;
+		*write_inode = true;
+	}
+
 	ret = 0;
 fsck_err:
 	bch_err_fn(c, ret);
@@ -1020,17 +1041,6 @@ static int check_inode(struct btree_trans *trans,
 
 	if (bch2_inode_has_backpointer(&u))
 		try(check_inode_dirent_inode(trans, &u, &do_update));
-
-	if (fsck_err_on(bch2_inode_has_backpointer(&u) &&
-			(u.bi_flags & BCH_INODE_unlinked),
-			trans, inode_unlinked_but_has_dirent,
-			"inode unlinked but has dirent\n%s",
-			(printbuf_reset(&buf),
-			 bch2_inode_unpacked_to_text(&buf, &u),
-			 buf.buf))) {
-		u.bi_flags &= ~BCH_INODE_unlinked;
-		do_update = true;
-	}
 
 	if (S_ISDIR(u.bi_mode) && (u.bi_flags & BCH_INODE_unlinked)) {
 		/*

--- a/fs/fs/check.h
+++ b/fs/fs/check.h
@@ -81,6 +81,36 @@ struct inode_walker_entry *bch2_walk_inode(struct btree_trans *,
 					   struct inode_walker *,
 					   struct bkey_s_c);
 
+static inline struct inode_walker_entry *
+bch2_visible_inode_next(struct btree_trans *trans, struct snapshots_seen *s,
+			struct inode_walker *w, u32 snapshot,
+			struct inode_walker_entry *prev)
+{
+	/*
+	 * A version at @snapshot or the first visible ancestor resolves the
+	 * ref - possibly a whiteout - and shadows everything past it:
+	 */
+	if (prev && prev->inode.bi_snapshot >= snapshot)
+		return NULL;
+
+	for (struct inode_walker_entry *i = prev ? prev + 1 : w->inodes.data;
+	     i < w->inodes.data + w->inodes.nr;
+	     i++)
+		if (bch2_ref_visible(trans, s, snapshot, i->inode.bi_snapshot))
+			return i;
+	return NULL;
+}
+
+/*
+ * Iterate the inode versions whose view includes a key at @_snapshot: every
+ * newer version that sees it via the overwrite check, then the one version the
+ * key resolves to.
+ */
+#define for_each_visible_inode(_trans, _s, _w, _snapshot, _i)			\
+	for (_i = bch2_visible_inode_next(_trans, _s, _w, _snapshot, NULL);	\
+	     _i;								\
+	     _i = bch2_visible_inode_next(_trans, _s, _w, _snapshot, _i))
+
 void bch2_dirent_inode_mismatch_msg(struct printbuf *, struct bch_fs *,
 				    struct bkey_s_c_dirent,
 				    struct bch_inode_unpacked *);

--- a/fs/fs/check.h
+++ b/fs/fs/check.h
@@ -48,6 +48,16 @@ struct inode_walker {
 	/* cached inodes are valid while trans->commit_count is unchanged: */
 	u32				commit_count;
 
+	/*
+	 * check_key_has_snapshot may migrate a key to a lower snapshot ID -
+	 * a position we've already scanned past - so once we've finished the
+	 * inode we re-scan it to rebuild the per-inode accumulations. repaired_inum
+	 * is the inode that was repaired; restarted_inum bounds this to one
+	 * re-scan per inode so it can't loop.
+	 */
+	u64				repaired_inum;
+	u64				restarted_inum;
+
 	DARRAY(struct inode_walker_entry) inodes;
 	snapshot_id_list		deletes;
 };

--- a/fs/fs/check.h
+++ b/fs/fs/check.h
@@ -7,6 +7,8 @@
 /* recoverds snapshot IDs of overwrites at @pos */
 struct snapshots_seen {
 	struct bpos			pos;
+	/* pos.snapshot's collapse terminal, computed by seen_update: */
+	u32				pos_equiv;
 	snapshot_id_list		ids;
 };
 
@@ -35,6 +37,10 @@ int bch2_ref_visible2(struct btree_trans *,
 		      u32, struct snapshots_seen *);
 
 struct inode_walker_entry {
+	/*
+	 * One entry per collapse equivalence class; bi_snapshot is the
+	 * bch2_snapshot_redundant_interior() terminal (see add_inode()).
+	 */
 	struct bch_inode_unpacked inode;
 	bool			whiteout;
 	u64			count;
@@ -86,6 +92,15 @@ bch2_visible_inode_next(struct btree_trans *trans, struct snapshots_seen *s,
 			struct inode_walker *w, u32 snapshot,
 			struct inode_walker_entry *prev)
 {
+	/*
+	 * Walker entries are per collapse equivalence class - compare in the
+	 * same frame, or the shadow-stop below misfires when the resolving
+	 * version's class terminal sits below @snapshot. @snapshot is the key
+	 * seen_update just processed, so its terminal is already computed:
+	 */
+	EBUG_ON(snapshot != s->pos.snapshot);
+	snapshot = s->pos_equiv;
+
 	/*
 	 * A version at @snapshot or the first visible ancestor resolves the
 	 * ref - possibly a whiteout - and shadows everything past it:

--- a/fs/fs/check_dir_structure.c
+++ b/fs/fs/check_dir_structure.c
@@ -27,13 +27,10 @@ static int remove_backpointer(struct btree_trans *trans,
 
 	u32 snapshot = inode->bi_snapshot;
 
-	if (inode->bi_parent_subvol)
-		try(bch2_subvolume_get_snapshot(trans, inode->bi_parent_subvol, &snapshot));
-
 	struct bch_fs *c = trans->c;
+
 	CLASS(btree_iter_uninit, iter)(trans);
-	struct bkey_s_c_dirent d = bkey_try(dirent_get_by_pos(trans, &iter,
-				     SPOS(inode->bi_dir, inode->bi_dir_offset, snapshot)));
+	struct bkey_s_c_dirent d = bch2_inode_get_dirent(trans, &iter, inode, &snapshot);
 
 	try(dirent_points_to_inode(c, d, inode));
 	try(bch2_fsck_remove_dirent(trans, d.k->p));
@@ -187,6 +184,19 @@ static int check_path_loop(struct btree_trans *trans, struct bkey_s_c inode_k)
 
 	struct bch_inode_unpacked inode;
 	bch2_inode_unpack(c, inode_k, &inode);
+
+	/*
+	 * If this inode sits at a redundant interior snapshot node that
+	 * delete_dead_snapshots will collapse into a live descendant, do the whole
+	 * path traversal in the descendant's view: an interrupted collapse migrated
+	 * the naming dirents and parent inodes down there, and that's the state the
+	 * subtree is converging on - otherwise a half-migrated dirent reads as a
+	 * spurious unreachable-inode. Computed once (the walk stays in one
+	 * snapshot); no-op on a healthy fs.
+	 */
+	u32 collapse_terminal = bch2_snapshot_redundant_interior(c, snapshot);
+	if (collapse_terminal)
+		snapshot = collapse_terminal;
 
 	CLASS(btree_iter, inode_iter)(trans, BTREE_ID_inodes, POS_MIN, 0);
 

--- a/fs/fs/check_dir_structure.c
+++ b/fs/fs/check_dir_structure.c
@@ -67,6 +67,16 @@ static int check_subvol_path(struct btree_trans *trans, struct btree_iter *iter,
 	if (k.k->type != KEY_TYPE_subvolume)
 		return 0;
 
+	/*
+	 * A tombstoned subvolume is mid-deletion: delete_dead_snapshots (a
+	 * later pass) reaps it. Its unreachability is the expected not-live
+	 * state, not corruption - reattaching it here manufactures a dirent to
+	 * a subvolume that's about to go away, wedging the verify pass. Same
+	 * reasoning as check_unreachable_inode()'s will_delete skip.
+	 */
+	if (bch2_subvolume_state_compat(bkey_s_c_to_subvolume(k).v) != SUBVOLUME_STATE_live)
+		return 0;
+
 	CLASS(btree_iter, parent_iter)(trans, BTREE_ID_subvolumes, POS_MIN, 0);
 
 	subvol_inum start = {

--- a/fs/fs/check_dir_structure.c
+++ b/fs/fs/check_dir_structure.c
@@ -205,10 +205,19 @@ static int check_path_loop(struct btree_trans *trans, struct bkey_s_c inode_k)
 			return ret;
 
 		if (bch2_err_matches(ret, ENOENT)) {
+			/*
+			 * The naming dirent is gone, so we can't recover the
+			 * filename - but bi_dir still tells us which directory
+			 * the inode was in. Print that path so the user can see
+			 * what was lost. A restart from the path walk just
+			 * propagates to the enclosing for_each_..._commit loop.
+			 */
 			printbuf_reset(&buf);
-			bch2_bkey_val_to_text(&buf, c, inode_k);
-			bch_err(c, "unreachable inode in check_directory_structure: %s\n%s",
-				bch2_err_str(ret), buf.buf);
+			prt_str(&buf, "unreachable inode, naming dirent missing; was in directory ");
+			try(bch2_inum_snapshot_to_path(trans, inode.bi_dir, snapshot, NULL, &buf));
+			prt_newline(&buf);
+			bch2_inode_unpacked_to_text(&buf, &inode);
+			bch_err(c, "%s", buf.buf);
 			return ret;
 		}
 

--- a/fs/fs/check_dir_structure.c
+++ b/fs/fs/check_dir_structure.c
@@ -104,7 +104,9 @@ static int check_subvol_path(struct btree_trans *trans, struct btree_iter *iter,
 
 			try(bch2_inum_to_path(trans, start, &buf));
 
-			if (fsck_err(trans, subvol_loop, "%s", buf.buf))
+			if (inode_fsck_err(trans, le64_to_cpu(s.v->inode),
+					   le32_to_cpu(s.v->snapshot),
+					   subvol_loop, "%s", buf.buf))
 				ret = reattach_subvol(trans, s);
 			break;
 		}
@@ -112,8 +114,10 @@ static int check_subvol_path(struct btree_trans *trans, struct btree_iter *iter,
 		bch2_btree_iter_set_pos(&parent_iter, POS(0, parent));
 		k = bkey_try(bch2_btree_iter_peek_slot(&parent_iter));
 
-		if (fsck_err_on(k.k->type != KEY_TYPE_subvolume,
-				trans, subvol_unreachable,
+		if (inode_fsck_err_on(k.k->type != KEY_TYPE_subvolume,
+				trans, le64_to_cpu(s.v->inode),
+				le32_to_cpu(s.v->snapshot),
+				subvol_unreachable,
 				"unreachable subvolume %s",
 				(printbuf_reset(&buf),
 				 bch2_bkey_val_to_text(&buf, c, s.s_c),
@@ -278,7 +282,8 @@ static int check_path_loop(struct btree_trans *trans, struct bkey_s_c inode_k)
 					prt_printf(&buf, "%llu ", *i);
 			}
 
-			if (fsck_err(trans, dir_loop, "%s", buf.buf)) {
+			if (inode_fsck_err(trans, inode.bi_inum, inode.bi_snapshot,
+					   dir_loop, "%s", buf.buf)) {
 				ret = remove_backpointer(trans, &inode);
 				bch_err_msg(c, ret, "removing dirent");
 				if (ret)

--- a/fs/fs/check_dir_structure.c
+++ b/fs/fs/check_dir_structure.c
@@ -104,8 +104,8 @@ static int check_subvol_path(struct btree_trans *trans, struct btree_iter *iter,
 
 			try(bch2_inum_to_path(trans, start, &buf));
 
-			if (inode_fsck_err(trans, le64_to_cpu(s.v->inode),
-					   le32_to_cpu(s.v->snapshot),
+			if (inode_fsck_err(trans, SPOS(0, le64_to_cpu(s.v->inode),
+						       le32_to_cpu(s.v->snapshot)),
 					   subvol_loop, "%s", buf.buf))
 				ret = reattach_subvol(trans, s);
 			break;
@@ -115,8 +115,8 @@ static int check_subvol_path(struct btree_trans *trans, struct btree_iter *iter,
 		k = bkey_try(bch2_btree_iter_peek_slot(&parent_iter));
 
 		if (inode_fsck_err_on(k.k->type != KEY_TYPE_subvolume,
-				trans, le64_to_cpu(s.v->inode),
-				le32_to_cpu(s.v->snapshot),
+				trans, SPOS(0, le64_to_cpu(s.v->inode),
+					    le32_to_cpu(s.v->snapshot)),
 				subvol_unreachable,
 				"unreachable subvolume %s",
 				(printbuf_reset(&buf),
@@ -282,7 +282,7 @@ static int check_path_loop(struct btree_trans *trans, struct bkey_s_c inode_k)
 					prt_printf(&buf, "%llu ", *i);
 			}
 
-			if (inode_fsck_err(trans, inode.bi_inum, inode.bi_snapshot,
+			if (inode_fsck_err(trans, SPOS(0, inode.bi_inum, inode.bi_snapshot),
 					   dir_loop, "%s", buf.buf)) {
 				ret = remove_backpointer(trans, &inode);
 				bch_err_msg(c, ret, "removing dirent");

--- a/fs/fs/check_extents.c
+++ b/fs/fs/check_extents.c
@@ -366,7 +366,7 @@ static int check_extent(struct btree_trans *trans, struct btree_iter *iter,
 	/* Skip repair after updating snapshots_seen: the seen list must stay
 	 * complete even for keys we skip, since will_delete can change during
 	 * fsck and a later visibility check mustn't miss this key's snapshot */
-	if (bch2_snapshot_will_delete(c, k.k->p.snapshot))
+	if (bch2_snapshot_will_delete(c, k.k->p.snapshot, &s->ids))
 		return 0;
 
 	struct inode_walker_entry *extent_i = errptr_try(bch2_walk_inode(trans, inode, k));

--- a/fs/fs/check_extents.c
+++ b/fs/fs/check_extents.c
@@ -474,16 +474,10 @@ static int check_extent(struct btree_trans *trans, struct btree_iter *iter,
 	try(bch2_trans_commit(trans, res, NULL, BCH_TRANS_COMMIT_no_enospc));
 
 	if (bkey_extent_is_allocation(k.k)) {
-		for (struct inode_walker_entry *i = extent_i ?: &darray_last(inode->inodes);
-		     inode->inodes.data && i >= inode->inodes.data;
-		     --i) {
-			if (i->whiteout ||
-			    i->inode.bi_snapshot > k.k->p.snapshot ||
-			    !bch2_key_visible_in_snapshot(trans, s, i->inode.bi_snapshot, k.k->p.snapshot))
-				continue;
-
-			i->count += k.k->size;
-		}
+		struct inode_walker_entry *i;
+		for_each_visible_inode(trans, s, inode, k.k->p.snapshot, i)
+			if (!i->whiteout)
+				i->count += k.k->size;
 	}
 
 	if (k.k->type != KEY_TYPE_whiteout)

--- a/fs/fs/check_extents.c
+++ b/fs/fs/check_extents.c
@@ -453,20 +453,29 @@ int bch2_check_extents(struct bch_fs *c)
 	struct progress_indicator progress;
 	bch2_progress_init(&progress, __func__, c, BIT_ULL(BTREE_ID_extents), 0);
 
-	return for_each_btree_key(trans, iter, BTREE_ID_extents,
+	int ret = for_each_btree_key(trans, iter, BTREE_ID_extents,
 				POS(BCACHEFS_ROOT_INO, 0),
 				BTREE_ITER_prefetch|BTREE_ITER_all_snapshots, k, ({
 		bch2_disk_reservation_put(c, &res.r);
 		bch2_progress_update_iter(trans, &progress, &iter) ?:
 		check_extent(trans, &iter, k, &w, &s, &extent_ends, &res.r);
-	})) ?:
-	/*
-	 * Final flush of the last inode's i_sectors, via the nested
-	 * check_i_sectors so the inner fsck_write_inode commits are exempt from
-	 * the trans_begin dropped-updates warning (calling _notnested directly
-	 * would trip it).
-	 */
-	check_i_sectors(trans, &w);
+	}));
+	if (!ret) {
+		/*
+		 * Final flush of the last inode's i_sectors. The inner
+		 * fsck_write_inode() commits must be exempt from the trans_begin
+		 * dropped-updates warning, so set begin_may_drop_updates as
+		 * check_i_sectors() does - but call _notnested directly, NOT the
+		 * nested check_i_sectors(): that returns trans_was_restarted()
+		 * for an in-loop caller to retry on, and at this post-loop flush
+		 * the restart has no handler and faults recovery (it broke every
+		 * transaction-restart-injection test).
+		 */
+		trans->begin_may_drop_updates = true;
+		ret = check_i_sectors_notnested(trans, &w);
+		trans->begin_may_drop_updates = false;
+	}
+	return ret;
 }
 
 int bch2_check_indirect_extents(struct bch_fs *c)

--- a/fs/fs/check_extents.c
+++ b/fs/fs/check_extents.c
@@ -340,6 +340,37 @@ static int check_extent_overbig(struct btree_trans *trans, struct btree_iter *it
 	return 0;
 }
 
+/*
+ * After a check_key_has_snapshot repair moved one of an inode's keys to a lower
+ * (live descendant) snapshot ID - an earlier position we'd already scanned past
+ * - the per-inode accumulations (i_sectors tally, extent_ends overlap state) no
+ * longer match the keys on disk, so we re-scan the inode from the start to
+ * rebuild them. Deferred to the inode boundary so each inode is re-scanned at
+ * most once. Overlap repair only ever trims genuinely-overlapping data (a
+ * migration changes key placement, never snapshot ancestry), so the stale state
+ * could never have destroyed anything - but the i_sectors tally would be
+ * repaired wrong, and a new overlap the migration created at the destination
+ * missed.
+ */
+static void extents_rescan_reset(struct inode_walker *inode,
+				 struct extent_ends *extent_ends)
+{
+	extent_ends_reset(extent_ends);
+	inode->have_inodes = false;	/* suppress the boundary check_i_sectors */
+	inode->last_pos = POS_MIN;	/* force get_inodes_all_snapshots + count reset */
+}
+
+static int check_extent_restart_inum(struct btree_trans *trans,
+				     struct btree_iter *iter,
+				     struct inode_walker *inode,
+				     struct extent_ends *extent_ends,
+				     u64 inum)
+{
+	extents_rescan_reset(inode, extent_ends);
+	bch2_btree_iter_set_pos(iter, POS(inum, 0));
+	return btree_trans_restart(trans, BCH_ERR_transaction_restart_nested);
+}
+
 noinline_for_stack
 static int check_extent(struct btree_trans *trans, struct btree_iter *iter,
 			struct bkey_s_c k,
@@ -350,17 +381,36 @@ static int check_extent(struct btree_trans *trans, struct btree_iter *iter,
 {
 	struct bch_fs *c = trans->c;
 	CLASS(printbuf, buf)();
+	u64 inum = k.k->p.inode;
 	int ret = 0;
+
+	/*
+	 * We've moved on from an inode that had a check_key_has_snapshot repair:
+	 * re-scan it now so its finalizing checks see the migrated keys. The
+	 * restarted_inum guard makes this at most one re-scan per inode - a hard
+	 * bound against looping.
+	 */
+	if (inode->repaired_inum &&
+	    inum > inode->repaired_inum &&
+	    inode->repaired_inum != inode->restarted_inum) {
+		inode->restarted_inum = inode->repaired_inum;
+		return check_extent_restart_inum(trans, iter, inode, extent_ends,
+						 inode->repaired_inum);
+	}
 
 	ret = bch2_check_key_has_snapshot(trans, iter, k);
 	if (ret < 0)
 		return ret;
-	/*
-	 * We can't use for_each_btree_key_commit() here because we have work to
-	 * do after the commit that can't handle a transaction restart
-	 */
-	if (ret)
-		return bch2_trans_commit(trans, res, NULL, BCH_TRANS_COMMIT_no_enospc);
+	if (ret) {
+		/*
+		 * Repaired a dead-snapshot key (typically migrated it to a lower
+		 * snapshot ID): note the inode so we re-scan it once we've moved
+		 * past it - see check_extent_restart_inum. The loop's commit_do
+		 * flushes the repair.
+		 */
+		inode->repaired_inum = inum;
+		return 0;
+	}
 
 	if (inode->last_pos.inode != k.k->p.inode && inode->have_inodes)
 		try(check_i_sectors(trans, inode));
@@ -457,13 +507,45 @@ int bch2_check_extents(struct bch_fs *c)
 	struct progress_indicator progress;
 	bch2_progress_init(&progress, __func__, c, BIT_ULL(BTREE_ID_extents), 0);
 
-	int ret = for_each_btree_key(trans, iter, BTREE_ID_extents,
-				POS(BCACHEFS_ROOT_INO, 0),
-				BTREE_ITER_prefetch|BTREE_ITER_all_snapshots, k, ({
-		bch2_disk_reservation_put(c, &res.r);
-		bch2_progress_update_iter(trans, &progress, &iter) ?:
-		check_extent(trans, &iter, k, &w, &s, &extent_ends, &res.r);
-	}));
+	CLASS(btree_iter, iter)(trans, BTREE_ID_extents, POS(BCACHEFS_ROOT_INO, 0),
+				BTREE_ITER_prefetch|BTREE_ITER_all_snapshots);
+	int ret;
+
+	while (1) {
+		struct bkey_s_c k;
+		/*
+		 * peek, process and commit are one commit_do() so a restart
+		 * anywhere - including check_extent's in-loop re-scan (a set_pos
+		 * plus forced restart) - re-drives the whole thing atomically.
+		 */
+		ret = commit_do(trans, &res.r, NULL, BCH_TRANS_COMMIT_no_enospc, ({
+			bch2_disk_reservation_put(c, &res.r);
+			bkey_err(k = bch2_btree_iter_peek(&iter)) ?:
+			(!k.k ? 0
+			      : (bch2_progress_update_iter(trans, &progress, &iter) ?:
+				 check_extent(trans, &iter, k, &w, &s, &extent_ends, &res.r)));
+		}));
+		if (ret)
+			break;
+
+		if (!k.k) {
+			/*
+			 * End of the btree: the last inode has no following key to
+			 * trigger check_extent_restart_inum, so if it had a repair
+			 * we haven't re-scanned yet, re-scan it now. restarted_inum
+			 * bounds this to one re-scan, same as the in-loop path.
+			 */
+			if (w.repaired_inum == w.restarted_inum)
+				break;
+			w.restarted_inum = w.repaired_inum;
+			extents_rescan_reset(&w, &extent_ends);
+			bch2_btree_iter_set_pos(&iter, POS(w.repaired_inum, 0));
+			continue;
+		}
+
+		bch2_btree_iter_advance(&iter);
+	}
+
 	if (!ret) {
 		/*
 		 * Final flush of the last inode's i_sectors. The inner

--- a/fs/fs/check_extents.c
+++ b/fs/fs/check_extents.c
@@ -363,6 +363,12 @@ static int check_extent(struct btree_trans *trans, struct btree_iter *iter,
 
 	try(bch2_snapshots_seen_update(c, s, iter->btree_id, k.k->p));
 
+	/* Skip repair after updating snapshots_seen: the seen list must stay
+	 * complete even for keys we skip, since will_delete can change during
+	 * fsck and a later visibility check mustn't miss this key's snapshot */
+	if (bch2_snapshot_will_delete(c, k.k->p.snapshot))
+		return 0;
+
 	struct inode_walker_entry *extent_i = errptr_try(bch2_walk_inode(trans, inode, k));
 
 	try(bch2_check_key_has_inode(trans, iter, inode, extent_i, k));

--- a/fs/fs/check_extents.c
+++ b/fs/fs/check_extents.c
@@ -64,7 +64,8 @@ static int check_i_sectors_notnested(struct btree_trans *trans, struct inode_wal
 						   i->inode.bi_inum,
 						   i->inode.bi_snapshot, NULL, &buf));
 
-		count2 = bch2_count_inode_sectors(trans, w->last_pos.inode, i->inode.bi_snapshot);
+		count2 = bch2_count_inode_sectors(trans, w->last_pos.inode,
+					bch2_snapshot_redundant_interior(c, i->inode.bi_snapshot));
 
 		if (w->recalculate_sums)
 			i->count = count2;

--- a/fs/fs/check_extents.c
+++ b/fs/fs/check_extents.c
@@ -233,6 +233,10 @@ static int overlapping_extents_found(struct btree_trans *trans,
 	prt_printf(&buf, "\noverwriting %s extent", first ? "first" : "second");
 
 	if (ret_fsck_err(trans, extent_overlapping, "%s", buf.buf)) {
+		bch2_fsck_damaged(trans, SPOS(pos1.inode, 0,
+					      min(pos1.snapshot, pos2.p.snapshot)),
+				  FSCK_DAMAGE_data_overwritten);
+
 		struct btree_iter *old_iter = &iter1;
 
 		if (!first) {

--- a/fs/fs/check_extents.c
+++ b/fs/fs/check_extents.c
@@ -460,7 +460,13 @@ int bch2_check_extents(struct bch_fs *c)
 		bch2_progress_update_iter(trans, &progress, &iter) ?:
 		check_extent(trans, &iter, k, &w, &s, &extent_ends, &res.r);
 	})) ?:
-	check_i_sectors_notnested(trans, &w);
+	/*
+	 * Final flush of the last inode's i_sectors, via the nested
+	 * check_i_sectors so the inner fsck_write_inode commits are exempt from
+	 * the trans_begin dropped-updates warning (calling _notnested directly
+	 * would trip it).
+	 */
+	check_i_sectors(trans, &w);
 }
 
 int bch2_check_indirect_extents(struct bch_fs *c)

--- a/fs/fs/check_extents.c
+++ b/fs/fs/check_extents.c
@@ -65,7 +65,7 @@ static int check_i_sectors_notnested(struct btree_trans *trans, struct inode_wal
 						   i->inode.bi_snapshot, NULL, &buf));
 
 		count2 = bch2_count_inode_sectors(trans, w->last_pos.inode,
-					bch2_snapshot_redundant_interior(c, i->inode.bi_snapshot));
+					i->inode.bi_snapshot);
 
 		if (w->recalculate_sums)
 			i->count = count2;

--- a/fs/fs/check_extents.c
+++ b/fs/fs/check_extents.c
@@ -520,7 +520,7 @@ int bch2_check_extents(struct bch_fs *c)
 			      : (bch2_progress_update_iter(trans, &progress, &iter) ?:
 				 check_extent(trans, &iter, k, &w, &s, &extent_ends, &res.r)));
 		}));
-		if (ret)
+		if (!err_is_continue(ret))
 			break;
 
 		if (!k.k) {

--- a/fs/fs/check_extents.c
+++ b/fs/fs/check_extents.c
@@ -233,8 +233,7 @@ static int overlapping_extents_found(struct btree_trans *trans,
 
 	prt_printf(&buf, "\noverwriting %s extent", first ? "first" : "second");
 
-	if (ret_inode_fsck_err(trans, pos1.inode,
-			       min(pos1.snapshot, pos2.p.snapshot),
+	if (ret_inode_fsck_err(trans, k1.k->p,
 			       extent_overlapping, "%s", buf.buf)) {
 		struct btree_iter *old_iter = &iter1;
 

--- a/fs/fs/check_extents.c
+++ b/fs/fs/check_extents.c
@@ -233,11 +233,9 @@ static int overlapping_extents_found(struct btree_trans *trans,
 
 	prt_printf(&buf, "\noverwriting %s extent", first ? "first" : "second");
 
-	if (ret_fsck_err(trans, extent_overlapping, "%s", buf.buf)) {
-		bch2_fsck_damaged(trans, SPOS(pos1.inode, 0,
-					      min(pos1.snapshot, pos2.p.snapshot)),
-				  FSCK_DAMAGE_data_overwritten);
-
+	if (ret_inode_fsck_err(trans, pos1.inode,
+			       min(pos1.snapshot, pos2.p.snapshot),
+			       extent_overlapping, "%s", buf.buf)) {
 		struct btree_iter *old_iter = &iter1;
 
 		if (!first) {

--- a/fs/fs/check_nlinks.c
+++ b/fs/fs/check_nlinks.c
@@ -136,11 +136,16 @@ static int check_nlinks_walk_dirents(struct bch_fs *c, struct nlink_table *links
 				   BTREE_ITER_intent|
 				   BTREE_ITER_prefetch|
 				   BTREE_ITER_all_snapshots, k, ({
-		ret = bch2_snapshots_seen_update(c, &s, iter.btree_id, k.k->p);
-		if (ret)
-			break;
+		/*
+		 * No break on error: break mid-_do leaves the macro's return
+		 * value 0, silently truncating the scan - and fc_continue must
+		 * reach the macro so it skips the key and keeps going (the
+		 * skipped key is a doomed duplicate; counting it would double
+		 * the link count).
+		 */
+		int ret2 = bch2_snapshots_seen_update(c, &s, iter.btree_id, k.k->p);
 
-		if (k.k->type == KEY_TYPE_dirent) {
+		if (!ret2 && k.k->type == KEY_TYPE_dirent) {
 			struct bkey_s_c_dirent d = bkey_s_c_to_dirent(k);
 
 			if (d.v->d_type != DT_DIR &&
@@ -148,7 +153,7 @@ static int check_nlinks_walk_dirents(struct bch_fs *c, struct nlink_table *links
 				inc_link(trans, &s, links, range_start, range_end,
 					 le64_to_cpu(d.v->d_inum), d.k->p.snapshot);
 		}
-		0;
+		ret2;
 	}));
 
 	bch_err_fn(c, ret);

--- a/fs/fs/inode.c
+++ b/fs/fs/inode.c
@@ -1483,6 +1483,21 @@ static int may_delete_deleted_inode(struct btree_trans *trans, struct bpos pos,
 
 	bch2_inode_unpack(trans->c, k, inode);
 
+	/*
+	 * Subvolume roots are deleted by the subvolume deletion path, never
+	 * the inode reaper (see bch2_inode_is_subvolume_root()). A
+	 * deleted_inodes entry for one is expected, not damage - the trigger
+	 * enrolls any inode transitioning to unlinked - but consuming it here
+	 * would race the snapshot sweep; crash recovery for subvolume deletion
+	 * is check_subvols(), keyed off SUBVOLUME_STATE_unlinked. Just drop
+	 * the entry:
+	 */
+	if (bch2_inode_is_subvolume_root(inode)) {
+		if (from_deleted_inodes)
+			goto delete;
+		return bch_err_throw(c, inode_is_subvolume_root);
+	}
+
 	if (S_ISDIR(inode->bi_mode)) {
 		ret = bch2_empty_dir_snapshot(trans, pos.offset, 0, pos.snapshot);
 		if (fsck_err_on(from_deleted_inodes &&

--- a/fs/fs/inode.c
+++ b/fs/fs/inode.c
@@ -1411,22 +1411,46 @@ int bch2_inode_set_casefold(struct btree_trans *trans, subvol_inum inum,
 
 static noinline int __bch2_inode_rm_snapshot(struct btree_trans *trans, u64 inum, u32 snapshot)
 {
-	bch2_btree_delete_range_trans(trans, BTREE_ID_extents,
-				      SPOS(inum, 0, snapshot),
-				      SPOS(inum, U64_MAX, snapshot),
-				      BTREE_UPDATE_internal_snapshot_node);
-	bch2_btree_delete_range_trans(trans, BTREE_ID_dirents,
-				      SPOS(inum, 0, snapshot),
-				      SPOS(inum, U64_MAX, snapshot),
-				      BTREE_UPDATE_internal_snapshot_node);
-	bch2_btree_delete_range_trans(trans, BTREE_ID_xattrs,
-				      SPOS(inum, 0, snapshot),
-				      SPOS(inum, U64_MAX, snapshot),
-				      BTREE_UPDATE_internal_snapshot_node);
-	try(commit_do(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc,
-		      bch2_btree_delete(trans, BTREE_ID_inodes, SPOS(0, inum, snapshot),
-					BTREE_UPDATE_internal_snapshot_node)));
-	return 0;
+	static const enum btree_id content_btrees[] = {
+		BTREE_ID_extents,
+		BTREE_ID_dirents,
+		BTREE_ID_xattrs,
+	};
+	int ret = 0;
+
+	for (unsigned i = 0; i < ARRAY_SIZE(content_btrees); i++) {
+		int ret2 = bch2_btree_delete_range_trans(trans, content_btrees[i],
+					SPOS(inum, 0, snapshot),
+					SPOS(inum, U64_MAX, snapshot),
+					BTREE_UPDATE_internal_snapshot_node);
+		/* handled restarts are an FYI - the range was fully deleted: */
+		if (bch2_err_matches(ret2, BCH_ERR_transaction_restart))
+			ret2 = 0;
+		ret = ret ?: ret2;
+	}
+
+	if (!ret)
+		return commit_do(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc,
+				 bch2_btree_delete(trans, BTREE_ID_inodes,
+						   SPOS(0, inum, snapshot),
+						   BTREE_UPDATE_internal_snapshot_node));
+
+	/*
+	 * Content left behind: whiteout the inode key instead of deleting it,
+	 * so the ancestor's version doesn't resurface here and the deletion
+	 * scan/fsck can still find this position:
+	 */
+	bch_err_msg(trans->c, ret, "deleting content of inode %llu:%u, leaving whiteout",
+		    inum, snapshot);
+
+	struct bkey_i whiteout;
+	bkey_init(&whiteout.k);
+	whiteout.k.type	= KEY_TYPE_whiteout;
+	whiteout.k.p	= SPOS(0, inum, snapshot);
+
+	return commit_do(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc,
+			 bch2_btree_insert_trans(trans, BTREE_ID_inodes, &whiteout,
+						 BTREE_UPDATE_internal_snapshot_node)) ?: ret;
 }
 
 /*

--- a/fs/fs/inode.h
+++ b/fs/fs/inode.h
@@ -277,6 +277,19 @@ static inline bool bch2_inode_has_backpointer(const struct bch_inode_unpacked *b
 	return bi->bi_dir || bi->bi_dir_offset;
 }
 
+/*
+ * Subvolume root inodes are deleted by the subvolume deletion path -
+ * subvolume state set to unlinked, VFS eviction, then the snapshot sweep
+ * deletes the keys - never by the inode reaper (VFS eviction ->
+ * bch2_inode_rm(), or the deleted_inodes btree): BCH_INODE_unlinked on a
+ * subvolume root only records that no dirent points at it, not that the
+ * inode reaper may delete it.
+ */
+static inline bool bch2_inode_is_subvolume_root(const struct bch_inode_unpacked *bi)
+{
+	return bi->bi_subvol != 0;
+}
+
 /* i_nlink: */
 
 static inline unsigned nlink_bias(umode_t mode)

--- a/fs/fs/inode_format.h
+++ b/fs/fs/inode_format.h
@@ -131,6 +131,21 @@ enum inode_opt_id {
 };
 
 /*
+ * BCH_INODE_unlinked means we definitively know that there isn't, and
+ * shouldn't be, a dirent pointing to this inode: it is (or is about to
+ * be) deleted. check_unreachable_inodes() keys off it to distinguish
+ * "unreachable by design" from damage needing reattach, and setting it
+ * enrolls the inode in the deleted_inodes btree (bch2_trigger_inode())
+ * so a crash can't leak the inode.
+ *
+ * Ordinary inodes carrying it are deleted by the inode reaper - VFS
+ * eviction -> bch2_inode_rm(), or bch2_delete_dead_inodes() after a
+ * crash. Subvolume root inodes carry it too once their subvolume has
+ * been unlinked, but their deletion belongs to the subvolume deletion
+ * path (subvolume state unlinked -> VFS eviction -> snapshot sweep) and
+ * the inode reaper must leave them alone - see
+ * bch2_inode_is_subvolume_root().
+ *
  * BCH_INODE_has_case_insensitive is set if any descendent is case insensitive -
  * for overlayfs
  *

--- a/fs/fs/namei.c
+++ b/fs/fs/namei.c
@@ -276,6 +276,13 @@ int bch2_unlink_trans(struct btree_trans *trans,
 	if (deleting_subvol || inode_u->bi_subvol) {
 		try(bch2_subvolume_unlink(trans, inode_u->bi_subvol));
 
+		/*
+		 * No dirent will ever point at this inode again - deletion
+		 * belongs to the subvolume path, though: the inode reaper keys
+		 * off bch2_inode_is_subvolume_root() to leave it alone.
+		 */
+		inode_u->bi_flags |= BCH_INODE_unlinked;
+
 		struct bkey_s_c k = bkey_try(bch2_btree_iter_peek_slot(&dirent_iter));
 
 		/*

--- a/fs/fs/namei.c
+++ b/fs/fs/namei.c
@@ -472,8 +472,22 @@ int bch2_rename_trans(struct btree_trans *trans,
 		src_dir_u->bi_nlink += mode == BCH_RENAME_EXCHANGE;
 	}
 
-	if (mode == BCH_RENAME_OVERWRITE)
-		bch2_inode_nlink_dec(trans, dst_inode_u);
+	if (mode == BCH_RENAME_OVERWRITE) {
+		/*
+		 * Overwriting a subvolume root deletes the subvolume, same as
+		 * unlink (the victim was empty or a bare file, per the checks
+		 * above): hand it to the subvolume deletion path, don't treat
+		 * it as an ordinary inode losing its last link - see
+		 * bch2_unlink_trans():
+		 */
+		if (dst_inode_u->bi_subvol) {
+			try(bch2_subvol_has_children(trans, dst_inode_u->bi_subvol));
+			try(bch2_subvolume_unlink(trans, dst_inode_u->bi_subvol));
+			dst_inode_u->bi_flags |= BCH_INODE_unlinked;
+		} else {
+			bch2_inode_nlink_dec(trans, dst_inode_u);
+		}
+	}
 
 	src_dir_u->bi_mtime		= now;
 	src_dir_u->bi_ctime		= now;

--- a/fs/fs/namei.c
+++ b/fs/fs/namei.c
@@ -536,7 +536,7 @@ struct bkey_s_c_dirent bch2_inode_get_dirent(struct btree_trans *trans,
 	 * interior node snapshots) but not the inode - do the lookup in the
 	 * child snapshot we'll be moving to:
 	 */
-	*snapshot = bch2_snapshot_redundant_interior(trans->c, *snapshot) ?: *snapshot;
+	*snapshot = bch2_snapshot_redundant_interior(trans->c, *snapshot);
 
 	return dirent_get_by_pos(trans, iter, SPOS(inode->bi_dir, inode->bi_dir_offset, *snapshot));
 }

--- a/fs/fs/namei.c
+++ b/fs/fs/namei.c
@@ -498,6 +498,28 @@ int bch2_rename_trans(struct btree_trans *trans,
 	return 0;
 }
 
+struct bkey_s_c_dirent bch2_inode_get_dirent(struct btree_trans *trans,
+					     struct btree_iter *iter,
+					     struct bch_inode_unpacked *inode,
+					     u32 *snapshot)
+{
+	if (inode->bi_parent_subvol) {
+		int ret = bch2_subvolume_get_snapshot(trans, inode->bi_parent_subvol, snapshot);;
+		if (ret)
+			return ((struct bkey_s_c_dirent) { .k = ERR_PTR(ret) });
+	}
+
+	/*
+	 * If we're running after an interrupted snapshot deletion, the dirent
+	 * may have been moved to a child snapshot (when cleaning up redundant
+	 * interior node snapshots) but not the inode - do the lookup in the
+	 * child snapshot we'll be moving to:
+	 */
+	*snapshot = bch2_snapshot_redundant_interior(trans->c, *snapshot) ?: *snapshot;
+
+	return dirent_get_by_pos(trans, iter, SPOS(inode->bi_dir, inode->bi_dir_offset, *snapshot));
+}
+
 /* inum_to_path */
 
 static inline void reverse_bytes(void *b, size_t n)
@@ -606,16 +628,8 @@ static int bch2_inum_to_path_reversed(struct btree_trans *trans,
 			break;
 		}
 
-		if (inode.bi_parent_subvol) {
-			subvol = inode.bi_parent_subvol;
-			ret = bch2_subvolume_get_snapshot(trans, inode.bi_parent_subvol, &snapshot);
-			if (ret)
-				break;
-		}
-
-		CLASS(btree_iter, d_iter)(trans, BTREE_ID_dirents,
-					  SPOS(inode.bi_dir, inode.bi_dir_offset, snapshot), 0);
-		struct bkey_s_c_dirent d = bch2_bkey_get_typed(&d_iter, dirent);
+		CLASS(btree_iter_uninit, d_iter)(trans);
+		struct bkey_s_c_dirent d = bch2_inode_get_dirent(trans, &d_iter, &inode, &snapshot);
 		ret = bkey_err(d.s_c);
 		if (ret)
 			break;
@@ -624,6 +638,15 @@ static int bch2_inum_to_path_reversed(struct btree_trans *trans,
 
 		prt_bytes_reversed(path, dirent_name.name, dirent_name.len);
 		prt_char(path, '/');
+
+		/*
+		 * Track the subvol as we cross boundaries: the loop-detection key
+		 * above is (subvol ?: snapshot, inum), and inode numbers repeat
+		 * across subvolumes (a snapshot shares its source's root inum), so
+		 * without this the key collides and a valid path reads as a loop.
+		 */
+		if (inode.bi_parent_subvol)
+			subvol = inode.bi_parent_subvol;
 
 		inum = inode.bi_dir;
 	}

--- a/fs/fs/namei.h
+++ b/fs/fs/namei.h
@@ -43,6 +43,9 @@ int bch2_rename_trans(struct btree_trans *,
 bool bch2_reinherit_attrs(struct bch_inode_unpacked *,
 			  struct bch_inode_unpacked *);
 
+struct bkey_s_c_dirent bch2_inode_get_dirent(struct btree_trans *, struct btree_iter *,
+					     struct bch_inode_unpacked *, u32 *);
+
 int bch2_inum_to_path(struct btree_trans *, subvol_inum, struct printbuf *);
 
 #define INUM_TO_PATH_FAIL_ON_ERR	(1 << 0)

--- a/fs/fs/str_hash.c
+++ b/fs/fs/str_hash.c
@@ -272,10 +272,13 @@ static int str_hash_dup_entries(struct btree_trans *trans,
 	if (!ret_fsck_err(trans, hash_table_key_duplicate, "%s", buf.buf))
 		return 0;
 
-	if (ret == 2) {
+	bool renamed = ret == 2;
+	if (renamed) {
 		try(bch2_fsck_rename_dirent(trans, s, *desc, hash_info,
 					    bkey_s_c_to_dirent(k),
 					    updated_before_k_pos));
+		bch2_fsck_damaged(trans, SPOS(k.k->p.inode, 0, k.k->p.snapshot),
+				  FSCK_DAMAGE_dir_entries_renamed);
 		/* delete @k */
 		ret = 1;
 	}
@@ -298,6 +301,11 @@ static int str_hash_dup_entries(struct btree_trans *trans,
 				    BTREE_ITER_slots);
 	try(bch2_btree_iter_traverse(&del_iter));
 	try(bch2_hash_delete_at(trans, *desc, hash_info, &del_iter, 0));
+
+	/* renames already recorded above; no damage type for xattrs yet: */
+	if (!renamed && desc->btree_id == BTREE_ID_dirents)
+		bch2_fsck_damaged(trans, SPOS(k.k->p.inode, 0, del_snapshot),
+				  FSCK_DAMAGE_dir_entries_removed);
 
 	return bch2_trans_commit_lazy(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc);
 }

--- a/fs/fs/str_hash.c
+++ b/fs/fs/str_hash.c
@@ -269,7 +269,7 @@ static int str_hash_dup_entries(struct btree_trans *trans,
 	prt_newline(&buf);
 	bch2_bkey_val_to_text(&buf, c, dup_k);
 
-	if (!ret_inode_fsck_err(trans, k.k->p.inode, k.k->p.snapshot,
+	if (!ret_inode_fsck_err(trans, k.k->p,
 				hash_table_key_duplicate, "%s", buf.buf))
 		return 0;
 

--- a/fs/fs/str_hash.c
+++ b/fs/fs/str_hash.c
@@ -269,7 +269,8 @@ static int str_hash_dup_entries(struct btree_trans *trans,
 	prt_newline(&buf);
 	bch2_bkey_val_to_text(&buf, c, dup_k);
 
-	if (!ret_fsck_err(trans, hash_table_key_duplicate, "%s", buf.buf))
+	if (!ret_inode_fsck_err(trans, k.k->p.inode, k.k->p.snapshot,
+				hash_table_key_duplicate, "%s", buf.buf))
 		return 0;
 
 	bool renamed = ret == 2;
@@ -277,8 +278,6 @@ static int str_hash_dup_entries(struct btree_trans *trans,
 		try(bch2_fsck_rename_dirent(trans, s, *desc, hash_info,
 					    bkey_s_c_to_dirent(k),
 					    updated_before_k_pos));
-		bch2_fsck_damaged(trans, SPOS(k.k->p.inode, 0, k.k->p.snapshot),
-				  FSCK_DAMAGE_dir_entries_renamed);
 		/* delete @k */
 		ret = 1;
 	}
@@ -301,11 +300,6 @@ static int str_hash_dup_entries(struct btree_trans *trans,
 				    BTREE_ITER_slots);
 	try(bch2_btree_iter_traverse(&del_iter));
 	try(bch2_hash_delete_at(trans, *desc, hash_info, &del_iter, 0));
-
-	/* renames already recorded above; no damage type for xattrs yet: */
-	if (!renamed && desc->btree_id == BTREE_ID_dirents)
-		bch2_fsck_damaged(trans, SPOS(k.k->p.inode, 0, del_snapshot),
-				  FSCK_DAMAGE_dir_entries_removed);
 
 	return bch2_trans_commit_lazy(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc);
 }

--- a/fs/fs/str_hash.h
+++ b/fs/fs/str_hash.h
@@ -414,7 +414,7 @@ static inline int bch2_str_hash_check_key(struct btree_trans *trans,
 	 * image - the names are meaningless.
 	 */
 	if (desc->btree_id == BTREE_ID_dirents &&
-	    BCH_SB_DIRENTS_SANITIZED(trans->c->disk_sb.sb))
+	    trans->c->sb.dirents_sanitized)
 		return 0;
 
 	return str_hash_key_needs_check(desc, hash_info, hash_k)

--- a/fs/init/chardev.c
+++ b/fs/init/chardev.c
@@ -718,6 +718,7 @@ static const unsigned query_btree_keys_flags_to_iter_flags[] = {
 	[ilog2(BCH_IOCTL_QUERY_BTREE_KEYS_slots)]		= BTREE_ITER_slots,
 	[ilog2(BCH_IOCTL_QUERY_BTREE_KEYS_prev)]		= BTREE_ITER_prev,
 	[ilog2(BCH_IOCTL_QUERY_BTREE_KEYS_all_snapshots)]	= BTREE_ITER_all_snapshots,
+	[ilog2(BCH_IOCTL_QUERY_BTREE_KEYS_nofilter_whiteouts)]	= BTREE_ITER_nofilter_whiteouts,
 };
 
 static long bch2_ioctl_query_btree_keys(struct bch_fs *c,

--- a/fs/init/dev.c
+++ b/fs/init/dev.c
@@ -1260,6 +1260,12 @@ int bch2_dev_add(struct bch_fs *c, const char *path, struct printbuf *err)
 				}
 			}
 
+			/*
+			 * The failure domain string carried over with the
+			 * member copy above; re-intern so the new device gets
+			 * its failure_domain id.
+			 */
+			bch2_sb_members_to_cpu(c);
 
 			bool write_sb = false;
 			bch2_dev_mi_field_upgrades_locked(c, ca, &identity, &write_sb);

--- a/fs/init/error.c
+++ b/fs/init/error.c
@@ -830,6 +830,38 @@ void bch2_fsck_damaged(struct btree_trans *trans, struct bpos pos,
 		c->errors.damaged_paths_alloc_err = true;
 }
 
+/*
+ * A damage entry's snapshot may itself be dead by report time - that's
+ * exactly how keys_deleted entries arise - so a failed resolution retries
+ * through the inode's surviving snapshot versions: the path in a live view
+ * still names the file for the user.
+ */
+static int damaged_path_resolve(struct btree_trans *trans, u64 inum,
+				u32 snapshot, struct printbuf *path)
+{
+	printbuf_reset(path);
+	int ret = bch2_inum_snapshot_to_path(trans, inum, snapshot, NULL, path);
+	if (!ret || bch2_err_matches(ret, BCH_ERR_transaction_restart))
+		return ret;
+
+	struct bkey_s_c k;
+	for_each_btree_key_norestart(trans, iter, BTREE_ID_inodes, POS(0, inum),
+				     BTREE_ITER_all_snapshots, k, ret) {
+		if (k.k->p.offset != inum)
+			break;
+		if (k.k->p.snapshot == snapshot || !bkey_is_inode(k.k))
+			continue;
+
+		printbuf_reset(path);
+		ret = bch2_inum_snapshot_to_path(trans, inum, k.k->p.snapshot,
+						 NULL, path);
+		if (!ret || bch2_err_matches(ret, BCH_ERR_transaction_restart))
+			return ret;
+	}
+
+	return ret ?: bch_err_throw(trans->c, ENOENT_inode);
+}
+
 void bch2_fsck_damaged_paths_to_text(struct printbuf *out, struct bch_fs *c)
 {
 	if (!c->errors.damaged_paths.nr)
@@ -867,8 +899,8 @@ void bch2_fsck_damaged_paths_to_text(struct printbuf *out, struct bch_fs *c)
 		}
 
 		/* Resolve into a temp buffer so a restart doesn't duplicate output: */
-		int ret = lockrestart_do(trans, (printbuf_reset(&path),
-			bch2_inum_snapshot_to_path(trans, i->inum, i->snapshot, NULL, &path)));
+		int ret = lockrestart_do(trans,
+			damaged_path_resolve(trans, i->inum, i->snapshot, &path));
 		if (!ret)
 			prt_str(out, path.buf);
 		else

--- a/fs/init/error.c
+++ b/fs/init/error.c
@@ -789,6 +789,108 @@ void bch2_free_fsck_errs(struct bch_fs *c)
 	__bch2_flush_fsck_errs(c, false);
 }
 
+/*
+ * Paths damaged during fsck, remembered for the end-of-fsck summary - see
+ * struct fsck_damaged_path. Recorded at the repair sites (reattach, dirent to
+ * missing inode, overlapping extents), deduped by (inum, snapshot) with reasons
+ * OR'd together. Dedup is what makes this restart-safe: a repair that runs
+ * again after a transaction restart just re-ORs the same bit.
+ */
+
+#define FSCK_DAMAGED_PATHS_MAX	4096
+#define FSCK_DAMAGED_PATHS_PRINT 200
+
+void bch2_fsck_damaged(struct btree_trans *trans, struct bpos pos,
+		       enum bch_fsck_damage_type reason)
+{
+	struct bch_fs *c = trans->c;
+	guard(mutex)(&c->errors.msgs_lock);
+
+	/* Damage on one inode arrives in runs - check the last entry first: */
+	if (c->errors.damaged_paths.nr) {
+		struct fsck_damaged_path *last = &darray_last(c->errors.damaged_paths);
+		if (last->inum == pos.inode && last->snapshot == pos.snapshot) {
+			last->reasons |= reason;
+			return;
+		}
+	}
+
+	darray_for_each(c->errors.damaged_paths, i)
+		if (i->inum == pos.inode && i->snapshot == pos.snapshot) {
+			i->reasons |= reason;
+			return;
+		}
+
+	if (c->errors.damaged_paths.nr >= FSCK_DAMAGED_PATHS_MAX ||
+	    darray_push(&c->errors.damaged_paths, ((struct fsck_damaged_path) {
+			.inum		= pos.inode,
+			.snapshot	= pos.snapshot,
+			.reasons	= reason,
+		})))
+		c->errors.damaged_paths_alloc_err = true;
+}
+
+void bch2_fsck_damaged_paths_to_text(struct printbuf *out, struct bch_fs *c)
+{
+	if (!c->errors.damaged_paths.nr)
+		return;
+
+	u32 nr_reattached = 0, nr_listed = 0;
+	darray_for_each(c->errors.damaged_paths, i) {
+		nr_reattached	+= !!(i->reasons & FSCK_DAMAGE_reattached);
+		nr_listed	+= !!(i->reasons & ~FSCK_DAMAGE_reattached);
+	}
+
+	if (nr_reattached)
+		prt_printf(out, "%u inodes reattached in lost+found\n", nr_reattached);
+
+	if (!nr_listed)
+		return;
+
+	prt_printf(out, "%u paths damaged by fsck", nr_listed);
+	if (c->errors.damaged_paths_alloc_err)
+		prt_str(out, " (list incomplete)");
+	prt_str(out, ":\n");
+	bch2_printbuf_indent_add(out, 2);
+
+	CLASS(btree_trans, trans)(c);
+	CLASS(printbuf, path)();
+	u32 nr_printed = 0;
+
+	darray_for_each(c->errors.damaged_paths, i) {
+		if (!(i->reasons & ~FSCK_DAMAGE_reattached))
+			continue;
+
+		if (nr_printed++ >= FSCK_DAMAGED_PATHS_PRINT) {
+			prt_printf(out, "... and %u more\n", nr_listed - FSCK_DAMAGED_PATHS_PRINT);
+			break;
+		}
+
+		/* Resolve into a temp buffer so a restart doesn't duplicate output: */
+		int ret = lockrestart_do(trans, (printbuf_reset(&path),
+			bch2_inum_snapshot_to_path(trans, i->inum, i->snapshot, NULL, &path)));
+		if (!ret)
+			prt_str(out, path.buf);
+		else
+			prt_printf(out, "inum %llu:%u", i->inum, i->snapshot);
+
+		prt_str(out, ": ");
+
+		bool first = true;
+#define x(t, n, s)							\
+		if (i->reasons & FSCK_DAMAGE_##t) {			\
+			prt_str(out, first ? "" : ", ");			\
+			prt_str(out, s);				\
+			first = false;					\
+		}
+		BCH_FSCK_DAMAGE_TYPES()
+#undef x
+		prt_newline(out);
+	}
+
+	bch2_printbuf_indent_sub(out, 2);
+}
+
 int bch2_inum_offset_err_msg_trans_norestart(struct btree_trans *trans, struct printbuf *out,
 					     u32 subvol, struct bpos pos)
 {
@@ -817,12 +919,14 @@ void bch2_inum_offset_err_msg_trans(struct btree_trans *trans, struct printbuf *
 
 void bch2_fs_errors_exit(struct bch_fs *c)
 {
+	darray_exit(&c->errors.damaged_paths);
 	darray_exit(&c->errors.counts);
 }
 
 void bch2_fs_errors_init_early(struct bch_fs *c)
 {
 	darray_init(&c->errors.msgs);
+	darray_init(&c->errors.damaged_paths);
 	mutex_init(&c->errors.msgs_lock);
 
 	mutex_init(&c->errors.counts_lock);

--- a/fs/init/error.c
+++ b/fs/init/error.c
@@ -342,7 +342,7 @@ void bch2_fsck_err_counts_to_text(struct printbuf *out, struct bch_fs *c)
 
 	darray_for_each(c->errors.msgs, i) {
 		bch2_sb_error_id_to_text(out, (*i)->id);
-		prt_printf(out, ": %llu\n", (*i)->nr);
+		prt_printf(out, "\t%llu\n", (*i)->nr);
 	}
 }
 

--- a/fs/init/error.c
+++ b/fs/init/error.c
@@ -862,6 +862,33 @@ static int damaged_path_resolve(struct btree_trans *trans, u64 inum,
 	return ret ?: bch_err_throw(trans->c, ENOENT_inode);
 }
 
+void bch2_fsck_damaged_path_to_text(struct printbuf *out, struct btree_trans *trans,
+				    const struct fsck_damaged_path *i)
+{
+	CLASS(printbuf, path)();
+
+	/* Resolve into a temp buffer so a restart doesn't duplicate output: */
+	int ret = lockrestart_do(trans,
+		damaged_path_resolve(trans, i->inum, i->snapshot, &path));
+	if (!ret)
+		prt_str(out, path.buf);
+	else
+		prt_printf(out, "inum %llu:%u", i->inum, i->snapshot);
+
+	prt_str(out, ": ");
+
+	bool first = true;
+#define x(t, n, s)							\
+	if (i->reasons & FSCK_DAMAGE_##t) {				\
+		prt_str(out, first ? "" : ", ");			\
+		prt_str(out, s);					\
+		first = false;						\
+	}
+	BCH_FSCK_DAMAGE_TYPES()
+#undef x
+	prt_newline(out);
+}
+
 void bch2_fsck_damaged_paths_to_text(struct printbuf *out, struct bch_fs *c)
 {
 	if (!c->errors.damaged_paths.nr)
@@ -886,7 +913,6 @@ void bch2_fsck_damaged_paths_to_text(struct printbuf *out, struct bch_fs *c)
 	bch2_printbuf_indent_add(out, 2);
 
 	CLASS(btree_trans, trans)(c);
-	CLASS(printbuf, path)();
 	u32 nr_printed = 0;
 
 	darray_for_each(c->errors.damaged_paths, i) {
@@ -894,30 +920,12 @@ void bch2_fsck_damaged_paths_to_text(struct printbuf *out, struct bch_fs *c)
 			continue;
 
 		if (nr_printed++ >= FSCK_DAMAGED_PATHS_PRINT) {
-			prt_printf(out, "... and %u more\n", nr_listed - FSCK_DAMAGED_PATHS_PRINT);
+			prt_printf(out, "... and %u more (untruncated list in debugfs: fsck_damaged_paths)\n",
+				   nr_listed - FSCK_DAMAGED_PATHS_PRINT);
 			break;
 		}
 
-		/* Resolve into a temp buffer so a restart doesn't duplicate output: */
-		int ret = lockrestart_do(trans,
-			damaged_path_resolve(trans, i->inum, i->snapshot, &path));
-		if (!ret)
-			prt_str(out, path.buf);
-		else
-			prt_printf(out, "inum %llu:%u", i->inum, i->snapshot);
-
-		prt_str(out, ": ");
-
-		bool first = true;
-#define x(t, n, s)							\
-		if (i->reasons & FSCK_DAMAGE_##t) {			\
-			prt_str(out, first ? "" : ", ");			\
-			prt_str(out, s);				\
-			first = false;					\
-		}
-		BCH_FSCK_DAMAGE_TYPES()
-#undef x
-		prt_newline(out);
+		bch2_fsck_damaged_path_to_text(out, trans, i);
 	}
 
 	bch2_printbuf_indent_sub(out, 2);

--- a/fs/init/error.c
+++ b/fs/init/error.c
@@ -487,6 +487,7 @@ int bch2_fsck_err_opt(struct bch_fs *c,
 
 int __bch2_fsck_err(struct bch_fs *c,
 		  struct btree_trans *trans,
+		  struct bpos pos,
 		  enum bch_fsck_flags flags,
 		  enum bch_sb_error_id err,
 		  const char *fmt, ...)
@@ -504,6 +505,15 @@ int __bch2_fsck_err(struct bch_fs *c,
 
 	if (!c)
 		c = trans->c;
+
+	/*
+	 * An inode-scoped error (pos != POS_MIN) records damage against the
+	 * inode before the outcome below is decided: the error is the damage,
+	 * whether or not we fix it - and silent/ratelimited instances still
+	 * record (recording is idempotent).
+	 */
+	if (!bpos_eq(pos, POS_MIN) && !WARN_ON(!trans))
+		try(bch2_damage_record(trans, pos, err));
 
 	/*
 	 * Ugly: if there's a transaction in the current task it has to be
@@ -758,7 +768,7 @@ int __bch2_bkey_fsck_err(struct bch_fs *c,
 	prt_vprintf(&buf, fmt, args);
 	va_end(args);
 
-	int ret = __bch2_fsck_err(c, NULL, fsck_flags, err, "%s, delete?", buf.buf);
+	int ret = __bch2_fsck_err(c, NULL, POS_MIN, fsck_flags, err, "%s, delete?", buf.buf);
 	return ret;
 }
 
@@ -791,17 +801,28 @@ void bch2_free_fsck_errs(struct bch_fs *c)
 
 /*
  * Paths damaged during fsck, remembered for the end-of-fsck summary - see
- * struct fsck_damaged_path. Recorded at the repair sites (reattach, dirent to
- * missing inode, overlapping extents), deduped by (inum, snapshot) with reasons
- * OR'd together. Dedup is what makes this restart-safe: a repair that runs
- * again after a transaction restart just re-ORs the same bit.
+ * struct fsck_damaged_path. Recorded when an inode-scoped error is reported
+ * (__bch2_fsck_err() with a pos), deduped by (inum, snapshot) with error ids
+ * merged. Dedup is what makes this restart-safe: an error re-reported after a
+ * transaction restart just re-merges the same id.
  */
 
 #define FSCK_DAMAGED_PATHS_MAX	4096
 #define FSCK_DAMAGED_PATHS_PRINT 200
 
-void bch2_fsck_damaged(struct btree_trans *trans, struct bpos pos,
-		       enum bch_fsck_damage_type reason)
+static void fsck_damaged_path_add_err(struct fsck_damaged_path *i,
+				      enum bch_sb_error_id err)
+{
+	for (unsigned j = 0; j < i->nr_errors; j++)
+		if (i->errors[j] == err)
+			return;
+
+	if (i->nr_errors < ARRAY_SIZE(i->errors))
+		i->errors[i->nr_errors++] = err;
+}
+
+static void bch2_fsck_damaged(struct btree_trans *trans, struct bpos pos,
+			      enum bch_sb_error_id err)
 {
 	struct bch_fs *c = trans->c;
 	guard(mutex)(&c->errors.msgs_lock);
@@ -810,14 +831,14 @@ void bch2_fsck_damaged(struct btree_trans *trans, struct bpos pos,
 	if (c->errors.damaged_paths.nr) {
 		struct fsck_damaged_path *last = &darray_last(c->errors.damaged_paths);
 		if (last->inum == pos.inode && last->snapshot == pos.snapshot) {
-			last->reasons |= reason;
+			fsck_damaged_path_add_err(last, err);
 			return;
 		}
 	}
 
 	darray_for_each(c->errors.damaged_paths, i)
 		if (i->inum == pos.inode && i->snapshot == pos.snapshot) {
-			i->reasons |= reason;
+			fsck_damaged_path_add_err(i, err);
 			return;
 		}
 
@@ -825,9 +846,23 @@ void bch2_fsck_damaged(struct btree_trans *trans, struct bpos pos,
 	    darray_push(&c->errors.damaged_paths, ((struct fsck_damaged_path) {
 			.inum		= pos.inode,
 			.snapshot	= pos.snapshot,
-			.reasons	= reason,
+			.nr_errors	= 1,
+			.errors		= { err },
 		})))
 		c->errors.damaged_paths_alloc_err = true;
+}
+
+/*
+ * In-memory backing: the damage series replaces this with the damage
+ * btree (one key per inode, written in the repair's transaction), same
+ * identifiers - the macros and their call sites don't change when it
+ * lands.
+ */
+int bch2_damage_record(struct btree_trans *trans, struct bpos pos,
+		       enum bch_sb_error_id err)
+{
+	bch2_fsck_damaged(trans, pos, err);
+	return 0;
 }
 
 /*
@@ -877,15 +912,11 @@ void bch2_fsck_damaged_path_to_text(struct printbuf *out, struct btree_trans *tr
 
 	prt_str(out, ": ");
 
-	bool first = true;
-#define x(t, n, s)							\
-	if (i->reasons & FSCK_DAMAGE_##t) {				\
-		prt_str(out, first ? "" : ", ");			\
-		prt_str(out, s);					\
-		first = false;						\
+	for (unsigned j = 0; j < i->nr_errors; j++) {
+		if (j)
+			prt_str(out, ", ");
+		prt_str(out, bch2_sb_error_strs[i->errors[j]]);
 	}
-	BCH_FSCK_DAMAGE_TYPES()
-#undef x
 	prt_newline(out);
 }
 
@@ -894,19 +925,7 @@ void bch2_fsck_damaged_paths_to_text(struct printbuf *out, struct bch_fs *c)
 	if (!c->errors.damaged_paths.nr)
 		return;
 
-	u32 nr_reattached = 0, nr_listed = 0;
-	darray_for_each(c->errors.damaged_paths, i) {
-		nr_reattached	+= !!(i->reasons & FSCK_DAMAGE_reattached);
-		nr_listed	+= !!(i->reasons & ~FSCK_DAMAGE_reattached);
-	}
-
-	if (nr_reattached)
-		prt_printf(out, "%u inodes reattached in lost+found\n", nr_reattached);
-
-	if (!nr_listed)
-		return;
-
-	prt_printf(out, "%u paths damaged by fsck", nr_listed);
+	prt_printf(out, "%zu paths damaged by fsck", c->errors.damaged_paths.nr);
 	if (c->errors.damaged_paths_alloc_err)
 		prt_str(out, " (list incomplete)");
 	prt_str(out, ":\n");
@@ -916,12 +935,9 @@ void bch2_fsck_damaged_paths_to_text(struct printbuf *out, struct bch_fs *c)
 	u32 nr_printed = 0;
 
 	darray_for_each(c->errors.damaged_paths, i) {
-		if (!(i->reasons & ~FSCK_DAMAGE_reattached))
-			continue;
-
 		if (nr_printed++ >= FSCK_DAMAGED_PATHS_PRINT) {
-			prt_printf(out, "... and %u more (untruncated list in debugfs: fsck_damaged_paths)\n",
-				   nr_listed - FSCK_DAMAGED_PATHS_PRINT);
+			prt_printf(out, "... and %zu more (untruncated list in debugfs: fsck_damaged_paths)\n",
+				   c->errors.damaged_paths.nr - FSCK_DAMAGED_PATHS_PRINT);
 			break;
 		}
 

--- a/fs/init/error.c
+++ b/fs/init/error.c
@@ -825,26 +825,34 @@ static void bch2_fsck_damaged(struct btree_trans *trans, struct bpos pos,
 			      enum bch_sb_error_id err)
 {
 	struct bch_fs *c = trans->c;
+
+	/*
+	 * Both key-position conventions land here: extent-style keys carry
+	 * the inum in pos.inode; inode keys live at (0, inum, snapshot), so
+	 * a zero inode field means the inum is in the offset field:
+	 */
+	u64 inum = pos.inode ?: pos.offset;
+
 	guard(mutex)(&c->errors.msgs_lock);
 
 	/* Damage on one inode arrives in runs - check the last entry first: */
 	if (c->errors.damaged_paths.nr) {
 		struct fsck_damaged_path *last = &darray_last(c->errors.damaged_paths);
-		if (last->inum == pos.inode && last->snapshot == pos.snapshot) {
+		if (last->inum == inum && last->snapshot == pos.snapshot) {
 			fsck_damaged_path_add_err(last, err);
 			return;
 		}
 	}
 
 	darray_for_each(c->errors.damaged_paths, i)
-		if (i->inum == pos.inode && i->snapshot == pos.snapshot) {
+		if (i->inum == inum && i->snapshot == pos.snapshot) {
 			fsck_damaged_path_add_err(i, err);
 			return;
 		}
 
 	if (c->errors.damaged_paths.nr >= FSCK_DAMAGED_PATHS_MAX ||
 	    darray_push(&c->errors.damaged_paths, ((struct fsck_damaged_path) {
-			.inum		= pos.inode,
+			.inum		= inum,
 			.snapshot	= pos.snapshot,
 			.nr_errors	= 1,
 			.errors		= { err },

--- a/fs/init/error.h
+++ b/fs/init/error.h
@@ -93,6 +93,27 @@ int __bch2_fsck_err(struct bch_fs *, struct btree_trans *,
 			type_is(c, struct btree_trans *) ? (struct btree_trans *) c : NULL,\
 			_flags, BCH_FSCK_ERR_##_err_type, __VA_ARGS__)
 
+/*
+ * Damage that fsck did to a specific path, remembered for the end-of-fsck
+ * summary. Bitmask: a single path may collect more than one. "reattached" is
+ * counted for a one-line summary, not listed; the rest are listed with their
+ * path.
+ */
+#define BCH_FSCK_DAMAGE_TYPES()						\
+	x(reattached,		0,	"reattached in lost+found")	\
+	x(dir_entries_removed,	1,	"had dangling entries removed") \
+	x(data_overwritten,	2,	"had data overwritten (overlapping extents)") \
+	x(keys_deleted,		3,	"had keys removed (snapshot no longer exists)")
+
+enum bch_fsck_damage_type {
+#define x(t, n, s)	FSCK_DAMAGE_##t = BIT(n),
+	BCH_FSCK_DAMAGE_TYPES()
+#undef x
+};
+
+void bch2_fsck_damaged(struct btree_trans *, struct bpos, enum bch_fsck_damage_type);
+void bch2_fsck_damaged_paths_to_text(struct printbuf *, struct bch_fs *);
+
 void bch2_flush_fsck_errs(struct bch_fs *);
 void bch2_free_fsck_errs(struct bch_fs *);
 

--- a/fs/init/error.h
+++ b/fs/init/error.h
@@ -103,7 +103,8 @@ int __bch2_fsck_err(struct bch_fs *, struct btree_trans *,
 	x(reattached,		0,	"reattached in lost+found")	\
 	x(dir_entries_removed,	1,	"had dangling entries removed") \
 	x(data_overwritten,	2,	"had data overwritten (overlapping extents)") \
-	x(keys_deleted,		3,	"had keys removed (snapshot no longer exists)")
+	x(keys_deleted,		3,	"had keys removed (snapshot no longer exists)") \
+	x(dir_entries_renamed,	4,	"had entries renamed (duplicate hash table keys)")
 
 enum bch_fsck_damage_type {
 #define x(t, n, s)	FSCK_DAMAGE_##t = BIT(n),

--- a/fs/init/error.h
+++ b/fs/init/error.h
@@ -113,6 +113,8 @@ enum bch_fsck_damage_type {
 };
 
 void bch2_fsck_damaged(struct btree_trans *, struct bpos, enum bch_fsck_damage_type);
+void bch2_fsck_damaged_path_to_text(struct printbuf *, struct btree_trans *,
+				    const struct fsck_damaged_path *);
 void bch2_fsck_damaged_paths_to_text(struct printbuf *, struct bch_fs *);
 
 void bch2_flush_fsck_errs(struct bch_fs *);

--- a/fs/init/error.h
+++ b/fs/init/error.h
@@ -83,36 +83,25 @@ int bch2_fsck_err_opt(struct bch_fs *,
 		      enum bch_fsck_flags,
 		      enum bch_sb_error_id);
 
-__printf(5, 6) __cold
+__printf(6, 7) __cold
 int __bch2_fsck_err(struct bch_fs *, struct btree_trans *,
+		  struct bpos,
 		  enum bch_fsck_flags,
 		  enum bch_sb_error_id,
 		  const char *, ...);
 #define bch2_fsck_err(c, _flags, _err_type, ...)				\
 	__bch2_fsck_err(type_is(c, struct bch_fs *) ? (struct bch_fs *) c : NULL,\
 			type_is(c, struct btree_trans *) ? (struct btree_trans *) c : NULL,\
-			_flags, BCH_FSCK_ERR_##_err_type, __VA_ARGS__)
+			POS_MIN, _flags, BCH_FSCK_ERR_##_err_type, __VA_ARGS__)
 
 /*
- * Damage that fsck did to a specific path, remembered for the end-of-fsck
- * summary. Bitmask: a single path may collect more than one. "reattached" is
- * counted for a one-line summary, not listed; the rest are listed with their
- * path.
+ * Record damage to an inode: which errors happened to it, as
+ * bch_sb_error_id - the same identifiers the superblock error counters
+ * and fsck use. Currently the in-memory list behind the end-of-fsck
+ * summary and the fsck_damaged_paths debugfs file; the damage series
+ * replaces the backing with the damage btree, same identifiers.
  */
-#define BCH_FSCK_DAMAGE_TYPES()						\
-	x(reattached,		0,	"reattached in lost+found")	\
-	x(dir_entries_removed,	1,	"had dangling entries removed") \
-	x(data_overwritten,	2,	"had data overwritten (overlapping extents)") \
-	x(keys_deleted,		3,	"had keys removed (snapshot no longer exists)") \
-	x(dir_entries_renamed,	4,	"had entries renamed (duplicate hash table keys)")
-
-enum bch_fsck_damage_type {
-#define x(t, n, s)	FSCK_DAMAGE_##t = BIT(n),
-	BCH_FSCK_DAMAGE_TYPES()
-#undef x
-};
-
-void bch2_fsck_damaged(struct btree_trans *, struct bpos, enum bch_fsck_damage_type);
+int bch2_damage_record(struct btree_trans *, struct bpos, enum bch_sb_error_id);
 void bch2_fsck_damaged_path_to_text(struct printbuf *, struct btree_trans *,
 				    const struct fsck_damaged_path *);
 void bch2_fsck_damaged_paths_to_text(struct printbuf *, struct bch_fs *);
@@ -171,6 +160,38 @@ void bch2_free_fsck_errs(struct bch_fs *);
 	_ret;								\
 })
 
+/*
+ * The fsck_err() variants for errors that are about a specific inode: the
+ * error is recorded as damage against the inode - unconditionally, before
+ * the fix/ignore outcome is decided (see __bch2_fsck_err()): the error
+ * is the damage, whether or not we decide to fix it. Recording
+ * completeness comes from these being the only way an inode-scoped error
+ * is reported - not from remembering to call a helper at each repair
+ * site.
+ */
+
+#define __inode_fsck_err(_trans, _inum, _snapshot, _flags, _err_type, ...)\
+	fsck_err_wrap(__bch2_fsck_err(NULL, _trans,			\
+			SPOS(_inum, 0, _snapshot), _flags,		\
+			BCH_FSCK_ERR_##_err_type, __VA_ARGS__))
+
+#define __inode_fsck_err_on(cond, _trans, _inum, _snapshot, _flags, _err_type, ...)\
+({									\
+	might_sleep();							\
+	unlikely(cond)							\
+		? __inode_fsck_err(_trans, _inum, _snapshot, _flags,	\
+				   _err_type, __VA_ARGS__)		\
+		: false;						\
+})
+
+#define inode_fsck_err(_trans, _inum, _snapshot, _err_type, ...)	\
+	__inode_fsck_err(_trans, _inum, _snapshot,			\
+			 FSCK_CAN_FIX|FSCK_CAN_IGNORE, _err_type, __VA_ARGS__)
+
+#define inode_fsck_err_on(cond, _trans, _inum, _snapshot, _err_type, ...)\
+	__inode_fsck_err_on(cond, _trans, _inum, _snapshot,		\
+			    FSCK_CAN_FIX|FSCK_CAN_IGNORE, _err_type, __VA_ARGS__)
+
 #define ret_fsck_err_wrap(_do)						\
 ({									\
 	int _ret = _do;							\
@@ -198,6 +219,12 @@ void bch2_free_fsck_errs(struct bch_fs *);
 
 #define ret_fsck_err_on(cond, c, _err_type, ...)			\
 	__ret_fsck_err_on(cond, c, FSCK_CAN_FIX|FSCK_CAN_IGNORE, _err_type, __VA_ARGS__)
+
+#define ret_inode_fsck_err(_trans, _inum, _snapshot, _err_type, ...)	\
+	ret_fsck_err_wrap(__bch2_fsck_err(NULL, _trans,			\
+			SPOS(_inum, 0, _snapshot),			\
+			FSCK_CAN_FIX|FSCK_CAN_IGNORE,			\
+			BCH_FSCK_ERR_##_err_type, __VA_ARGS__))
 
 #define ret_log_fsck_err(c, _err_type, ...)				\
 	__ret_fsck_err(c, FSCK_CAN_IGNORE, _err_type, __VA_ARGS__)

--- a/fs/init/error.h
+++ b/fs/init/error.h
@@ -170,26 +170,25 @@ void bch2_free_fsck_errs(struct bch_fs *);
  * site.
  */
 
-#define __inode_fsck_err(_trans, _inum, _snapshot, _flags, _err_type, ...)\
-	fsck_err_wrap(__bch2_fsck_err(NULL, _trans,			\
-			SPOS(_inum, 0, _snapshot), _flags,		\
+#define __inode_fsck_err(_trans, _pos, _flags, _err_type, ...)		\
+	fsck_err_wrap(__bch2_fsck_err(NULL, _trans, _pos, _flags,	\
 			BCH_FSCK_ERR_##_err_type, __VA_ARGS__))
 
-#define __inode_fsck_err_on(cond, _trans, _inum, _snapshot, _flags, _err_type, ...)\
+#define __inode_fsck_err_on(cond, _trans, _pos, _flags, _err_type, ...)	\
 ({									\
 	might_sleep();							\
 	unlikely(cond)							\
-		? __inode_fsck_err(_trans, _inum, _snapshot, _flags,	\
-				   _err_type, __VA_ARGS__)		\
+		? __inode_fsck_err(_trans, _pos, _flags, _err_type,	\
+				   __VA_ARGS__)				\
 		: false;						\
 })
 
-#define inode_fsck_err(_trans, _inum, _snapshot, _err_type, ...)	\
-	__inode_fsck_err(_trans, _inum, _snapshot,			\
+#define inode_fsck_err(_trans, _pos, _err_type, ...)			\
+	__inode_fsck_err(_trans, _pos,					\
 			 FSCK_CAN_FIX|FSCK_CAN_IGNORE, _err_type, __VA_ARGS__)
 
-#define inode_fsck_err_on(cond, _trans, _inum, _snapshot, _err_type, ...)\
-	__inode_fsck_err_on(cond, _trans, _inum, _snapshot,		\
+#define inode_fsck_err_on(cond, _trans, _pos, _err_type, ...)		\
+	__inode_fsck_err_on(cond, _trans, _pos,				\
 			    FSCK_CAN_FIX|FSCK_CAN_IGNORE, _err_type, __VA_ARGS__)
 
 #define ret_fsck_err_wrap(_do)						\
@@ -220,9 +219,8 @@ void bch2_free_fsck_errs(struct bch_fs *);
 #define ret_fsck_err_on(cond, c, _err_type, ...)			\
 	__ret_fsck_err_on(cond, c, FSCK_CAN_FIX|FSCK_CAN_IGNORE, _err_type, __VA_ARGS__)
 
-#define ret_inode_fsck_err(_trans, _inum, _snapshot, _err_type, ...)	\
-	ret_fsck_err_wrap(__bch2_fsck_err(NULL, _trans,			\
-			SPOS(_inum, 0, _snapshot),			\
+#define ret_inode_fsck_err(_trans, _pos, _err_type, ...)		\
+	ret_fsck_err_wrap(__bch2_fsck_err(NULL, _trans, _pos,		\
 			FSCK_CAN_FIX|FSCK_CAN_IGNORE,			\
 			BCH_FSCK_ERR_##_err_type, __VA_ARGS__))
 

--- a/fs/init/error_types.h
+++ b/fs/init/error_types.h
@@ -6,10 +6,27 @@
 
 struct fsck_err_state;
 
+/*
+ * A path that fsck damaged or couldn't fully recover, remembered so we can
+ * print a short per-path summary at the end instead of burying it in the error
+ * firehose. Keyed by (inum, snapshot); reasons is a bitmask of enum
+ * bch_fsck_damage_type - deduped and OR'd on insert, so one line per path lists
+ * everything that happened to it, and re-recording on transaction restart is a
+ * no-op.
+ */
+struct fsck_damaged_path {
+	u64			inum;
+	u32			snapshot;
+	u32			reasons;
+};
+
 struct bch_fs_errors {
 	DARRAY(struct fsck_err_state *)	msgs;
 	struct mutex		msgs_lock;
 	bool			msgs_alloc_err;
+
+	DARRAY(struct fsck_damaged_path) damaged_paths;
+	bool			damaged_paths_alloc_err;
 
 	bch_sb_errors_cpu	counts;
 	struct mutex		counts_lock;

--- a/fs/init/error_types.h
+++ b/fs/init/error_types.h
@@ -17,7 +17,9 @@ struct fsck_err_state;
 struct fsck_damaged_path {
 	u64			inum;
 	u32			snapshot;
-	u32			reasons;
+	/* bch_sb_error_id, deduped; 0 terminated (error 0 is fs-level) */
+	u16			nr_errors;
+	u16			errors[7];
 };
 
 struct bch_fs_errors {

--- a/fs/init/passes.c
+++ b/fs/init/passes.c
@@ -435,9 +435,19 @@ int __bch2_run_explicit_recovery_pass(struct bch_fs *c,
 		r->current_passes |= BIT_ULL(pass);
 
 		if (rewind) {
-			r->rewound_to = r->rewound_to
+			unsigned rewound_to = r->rewound_to
 				? min(r->rewound_to, pass)
 				: pass;
+			/*
+			 * Only log when the rewind target actually changes - the
+			 * same rewind gets re-requested on every call that finds the
+			 * same damage, and we don't want to spam for those.
+			 */
+			if (rewound_to != r->rewound_to)
+				bch_info(c, "recovery: rewinding to %s (%u), currently running %s (%u)",
+					 bch2_recovery_passes[pass], pass,
+					 bch2_recovery_passes[r->current_pass], r->current_pass);
+			r->rewound_to = rewound_to;
 			return bch_err_throw(c, restart_recovery);
 		}
 	} else {

--- a/fs/init/passes.c
+++ b/fs/init/passes.c
@@ -387,6 +387,9 @@ int __bch2_run_explicit_recovery_pass(struct bch_fs *c,
 	if (!(flags & RUN_RECOVERY_PASS_ephemeral))
 		lockdep_assert_held(&c->sb_lock.lock);
 
+	if (c->opts.recovery_passes_exclude & BIT_ULL(pass))
+		return 0;
+
 	bch2_printbuf_make_room(out, 1024);
 	guard(printbuf_atomic)(out);
 	guard(spinlock_irq)(&r->lock);

--- a/fs/init/passes.c
+++ b/fs/init/passes.c
@@ -387,7 +387,8 @@ int __bch2_run_explicit_recovery_pass(struct bch_fs *c,
 	if (!(flags & RUN_RECOVERY_PASS_ephemeral))
 		lockdep_assert_held(&c->sb_lock.lock);
 
-	if (c->opts.recovery_passes_exclude & BIT_ULL(pass))
+	if (c->opts.norecovery ||
+	    (c->opts.recovery_passes_exclude & BIT_ULL(pass)))
 		return 0;
 
 	bch2_printbuf_make_room(out, 1024);

--- a/fs/init/passes.c
+++ b/fs/init/passes.c
@@ -340,6 +340,10 @@ static bool recovery_pass_needs_set(struct bch_fs *c,
 	if (pass == BCH_RECOVERY_PASS_scan_for_btree_nodes)
 		*flags |= RUN_RECOVERY_PASS_nopersistent;
 
+	if ((*flags & RUN_RECOVERY_PASS_skip_if_complete) &&
+	    (r->passes_complete & BIT_ULL(pass)))
+		return false;
+
 	if ((*flags & RUN_RECOVERY_PASS_ratelimit) &&
 	    !bch2_recovery_pass_want_ratelimit_locked(c, pass, 100))
 		*flags &= ~RUN_RECOVERY_PASS_ratelimit;

--- a/fs/init/passes.c
+++ b/fs/init/passes.c
@@ -418,14 +418,28 @@ int __bch2_run_explicit_recovery_pass(struct bch_fs *c,
 	bool rewind = recovery_pass_needs_rewind(c, pass);
 
 	/*
+	 * A pass that already completed this run must never be re-run in the
+	 * same loop - that's the rewind invariant, which recovery_pass_needs_rewind
+	 * enforces by gating on passes_complete. The "run it now because it can't
+	 * be deferred to the background" arm has to honor the same invariant:
+	 * otherwise a pass that reschedules an earlier, already-completed pass
+	 * (check_key_has_snapshot scheduling check_inodes/check_extents while
+	 * running check_xattrs, once the dead-snapshot keys those passes would
+	 * clean are still present) injects it back into current_passes and we
+	 * re-run the whole content-check range out of order, looping.
+	 */
+	bool run_now = rewind ||
+		(!recovery_pass_should_defer(pass, r->current_passes) &&
+		 !(r->passes_complete & BIT_ULL(pass)));
+
+	/*
 	 * Ephemeral scheduling is best-effort and must never rewind: the caller
 	 * may be a BTREE_TRIGGER_atomic trigger committed to its commit, which
 	 * can't restart recovery (and ignores our return). If the pass already
 	 * ran, the scheduled_passes_ephemeral backstop reruns it via the async
 	 * runner instead.
 	 */
-	if (running && !ratelimit &&
-	    (rewind || !recovery_pass_should_defer(pass, r->current_passes)) &&
+	if (running && !ratelimit && run_now &&
 	    !(rewind && (flags & RUN_RECOVERY_PASS_ephemeral))) {
 		prt_printf(out, "running recovery pass %s (%u), currently at %s (%u)%s\n",
 			   bch2_recovery_passes[pass], pass,

--- a/fs/init/passes.c
+++ b/fs/init/passes.c
@@ -324,7 +324,7 @@ static bool recovery_pass_needs_rewind(struct bch_fs *c,
 	struct bch_fs_recovery *r = &c->recovery;
 	return  test_bit(BCH_FS_running_recovery_passes, &c->flags) &&
 		r->current_pass > pass &&
-		!(r->passes_complete & BIT_ULL(pass));
+		!(r->passes_attempted & BIT_ULL(pass));
 }
 
 static bool recovery_pass_needs_set(struct bch_fs *c,
@@ -418,19 +418,22 @@ int __bch2_run_explicit_recovery_pass(struct bch_fs *c,
 	bool rewind = recovery_pass_needs_rewind(c, pass);
 
 	/*
-	 * A pass that already completed this run must never be re-run in the
-	 * same loop - that's the rewind invariant, which recovery_pass_needs_rewind
-	 * enforces by gating on passes_complete. The "run it now because it can't
-	 * be deferred to the background" arm has to honor the same invariant:
-	 * otherwise a pass that reschedules an earlier, already-completed pass
-	 * (check_key_has_snapshot scheduling check_inodes/check_extents while
-	 * running check_xattrs, once the dead-snapshot keys those passes would
-	 * clean are still present) injects it back into current_passes and we
-	 * re-run the whole content-check range out of order, looping.
+	 * A pass that already ran this run - completed OR failed - must never
+	 * be re-run in the same loop: that's the rewind invariant, which
+	 * recovery_pass_needs_rewind enforces by gating on passes_attempted.
+	 * (Gating on passes_complete looped: a failing pass never completes,
+	 * so under errors=continue a later pass re-requesting it rewound
+	 * forever.) The "run it now because it can't be deferred to the
+	 * background" arm has to honor the same invariant: otherwise a pass
+	 * that reschedules an earlier, already-run pass (check_key_has_snapshot
+	 * scheduling check_inodes/check_extents while running check_xattrs,
+	 * once the dead-snapshot keys those passes would clean are still
+	 * present) injects it back into current_passes and we re-run the whole
+	 * content-check range out of order, looping.
 	 */
 	bool run_now = rewind ||
 		(!recovery_pass_should_defer(pass, r->current_passes) &&
-		 !(r->passes_complete & BIT_ULL(pass)));
+		 !(r->passes_attempted & BIT_ULL(pass)));
 
 	/*
 	 * Ephemeral scheduling is best-effort and must never rewind: the caller
@@ -638,6 +641,12 @@ int bch2_run_recovery_passes(struct bch_fs *c, u64 orig_passes_to_run, bool fail
 	}
 
 	r->current_passes = orig_passes_to_run;
+	/*
+	 * Fresh attempt-epoch per run: a pass attempted in a previous
+	 * (online) run is fair game again; within one run, attempted passes
+	 * are never rewound to or re-queued behind current_pass.
+	 */
+	r->passes_attempted = 0;
 
 	/*
 	 * Passes scheduled ephemerally mid-run (e.g. delete_dead_snapshots via a
@@ -657,6 +666,7 @@ int bch2_run_recovery_passes(struct bch_fs *c, u64 orig_passes_to_run, bool fail
 		r->current_pass			= pass;
 		r->current_passes		&= ~BIT_ULL(pass);
 		r->scheduled_passes_ephemeral	&= ~BIT_ULL(pass);
+		r->passes_attempted		|= BIT_ULL(pass);
 
 		spin_unlock_irq(&r->lock);
 

--- a/fs/init/passes.h
+++ b/fs/init/passes.h
@@ -24,6 +24,14 @@ enum bch_run_recovery_pass_flags {
 	 * superblock. The need is re-derivable, so persistence isn't required.
 	 */
 	RUN_RECOVERY_PASS_ephemeral	= BIT(2),
+	/*
+	 * Don't schedule if the pass already completed successfully this
+	 * instance: for callers that schedule cleanup passes on encountering
+	 * damage those passes might not fix. If the pass ran and the damage is
+	 * still here, rescheduling can't help - it just re-arms the pass in the
+	 * superblock on every encounter, forcing fsck on every subsequent mount.
+	 */
+	RUN_RECOVERY_PASS_skip_if_complete = BIT(3),
 };
 
 static inline bool go_rw_in_recovery(struct bch_fs *c)

--- a/fs/init/passes_format.h
+++ b/fs/init/passes_format.h
@@ -142,23 +142,16 @@
 	  "Walk subvolume_children btree and remove entries "					\
 	  "not matching a real subvolume with correct "						\
 	  "fs_path_parent")									\
-	x(delete_dead_snapshots,		21, PASS_ONLINE|PASS_FSCK,			\
-	  BIT_ULL(BCH_RECOVERY_PASS_check_snapshots),						\
-	  "Delete snapshot data keys across all "						\
-	  "snapshot-bearing btrees, then remove snapshot "					\
-	  "nodes and mark empty interior nodes")						\
 	x(fs_upgrade_for_subvolumes,		22, 0,					0,	\
 	  "One-time migration: set bi_subvol on root inode "					\
 	  "for pre-subvolumes filesystems")							\
 	x(check_inodes,				24, PASS_FSCK,					\
-	  BIT_ULL(BCH_RECOVERY_PASS_check_snapshots)|						\
-	  BIT_ULL(BCH_RECOVERY_PASS_delete_dead_snapshots),					\
+	  BIT_ULL(BCH_RECOVERY_PASS_check_snapshots),						\
 	  "Validate inode fields (mode, flags, i_size, "					\
 	  "bi_subvol), delete orphaned unlinked inodes, "					\
 	  "repair invalid backpointers")							\
 	x(check_extents,			25, PASS_FSCK,					\
-	  BIT_ULL(BCH_RECOVERY_PASS_check_inodes)|						\
-	  BIT_ULL(BCH_RECOVERY_PASS_delete_dead_snapshots),					\
+	  BIT_ULL(BCH_RECOVERY_PASS_check_inodes),						\
 	  "Validate extent keys: owning inode exists, "						\
 	  "snapshot valid, no overlaps, i_size and "						\
 	  "i_sectors consistent")								\
@@ -168,14 +161,12 @@
 	  "device pointers whose generation no longer "						\
 	  "matches")										\
 	x(check_dirents,			27, PASS_FSCK,					\
-	  BIT_ULL(BCH_RECOVERY_PASS_check_inodes)|						\
-	  BIT_ULL(BCH_RECOVERY_PASS_delete_dead_snapshots),					\
+	  BIT_ULL(BCH_RECOVERY_PASS_check_inodes),						\
 	  "Validate directory entries: target inode exists "					\
 	  "in correct snapshot, d_type matches inode mode, "					\
 	  "hash values correct")								\
 	x(check_xattrs,				28, PASS_FSCK,					\
-	  BIT_ULL(BCH_RECOVERY_PASS_check_inodes)|						\
-	  BIT_ULL(BCH_RECOVERY_PASS_delete_dead_snapshots),					\
+	  BIT_ULL(BCH_RECOVERY_PASS_check_inodes),						\
 	  "Validate xattr entries: owning inode exists "					\
 	  "in valid snapshot, hash correct; delete orphans")					\
 	x(check_root,				29, PASS_ONLINE|PASS_FSCK,			\
@@ -209,6 +200,11 @@
 	  "Validate reconcile work/hipri/pending/scan "						\
 	  "btrees against actual extent data; remove "						\
 	  "stale entries")									\
+	x(delete_dead_snapshots,		21, PASS_ONLINE|PASS_FSCK,			\
+	  BIT_ULL(BCH_RECOVERY_PASS_check_snapshots),						\
+	  "Delete snapshot data keys across all "						\
+	  "snapshot-bearing btrees, then remove snapshot "					\
+	  "nodes and mark empty interior nodes")						\
 	x(resume_logged_ops,			23, PASS_ALWAYS,			0,	\
 	  "Resume incomplete logged operations "						\
 	  "(fallocate, stripe creation) from logged_ops "					\

--- a/fs/init/passes_format.h
+++ b/fs/init/passes_format.h
@@ -201,7 +201,11 @@
 	  "btrees against actual extent data; remove "						\
 	  "stale entries")									\
 	x(delete_dead_snapshots,		21, PASS_ONLINE|PASS_FSCK,			\
-	  BIT_ULL(BCH_RECOVERY_PASS_check_snapshots),						\
+	  BIT_ULL(BCH_RECOVERY_PASS_check_snapshots)|						\
+	  BIT_ULL(BCH_RECOVERY_PASS_check_inodes)|						\
+	  BIT_ULL(BCH_RECOVERY_PASS_check_extents)|						\
+	  BIT_ULL(BCH_RECOVERY_PASS_check_dirents)|						\
+	  BIT_ULL(BCH_RECOVERY_PASS_check_xattrs),						\
 	  "Delete snapshot data keys across all "						\
 	  "snapshot-bearing btrees, then remove snapshot "					\
 	  "nodes and mark empty interior nodes")						\

--- a/fs/init/passes_types.h
+++ b/fs/init/passes_types.h
@@ -18,6 +18,16 @@ struct bch_fs_recovery {
 
 	/* bitmask of recovery passes that we actually ran */
 	u64			passes_complete;
+	/*
+	 * Every pass this run dispatched, successful or not - the rewind
+	 * gate: we never rewind to (or re-queue behind us) a pass that
+	 * already ran this run. Gating on passes_complete alone looped: a
+	 * pass that runs and fails never completes, so under
+	 * errors=continue a later pass re-requesting it rewound forever
+	 * (delete_dead_snapshots <-> check_subvols on an unrepairable
+	 * snapshot/subvol edge).
+	 */
+	u64			passes_attempted;
 	u64			passes_failing;
 	u64			passes_ratelimiting;
 

--- a/fs/init/recovery.c
+++ b/fs/init/recovery.c
@@ -989,6 +989,12 @@ use_clean:
 		bch_info(c, "errors this recovery:\n%s", buf.buf);
 	}
 
+	if (c->errors.damaged_paths.nr) {
+		CLASS(printbuf, buf)();
+		bch2_fsck_damaged_paths_to_text(&buf, c);
+		bch_info(c, "%s", buf.buf);
+	}
+
 	/* If we fixed errors, verify that fs is actually clean now: */
 	if (IS_ENABLED(CONFIG_BCACHEFS_DEBUG) &&
 	    errors_fixed &&

--- a/fs/init/recovery.c
+++ b/fs/init/recovery.c
@@ -984,15 +984,10 @@ use_clean:
 	}
 
 	if (c->errors.msgs.nr) {
-		CLASS(printbuf, buf)();
-		bch2_fsck_err_counts_to_text(&buf, c);
-		bch_info(c, "errors this recovery:\n%s", buf.buf);
-	}
-
-	if (c->errors.damaged_paths.nr) {
-		CLASS(printbuf, buf)();
-		bch2_fsck_damaged_paths_to_text(&buf, c);
-		bch_info(c, "%s", buf.buf);
+		CLASS(bch_log_msg, msg)(c);
+		prt_printf(&msg.m, "errors this recovery:\n");
+		bch2_fsck_err_counts_to_text(&msg.m, c);
+		bch2_fsck_damaged_paths_to_text(&msg.m, c);
 	}
 
 	/* If we fixed errors, verify that fs is actually clean now: */

--- a/fs/journal/init.c
+++ b/fs/journal/init.c
@@ -735,7 +735,7 @@ void bch2_fs_journal_init_early(struct journal *j)
 {
 	static struct lock_class_key res_key;
 
-	mutex_init(&j->buf_lock);
+	mutex_noio_init(&j->buf_lock);
 	spin_lock_init(&j->lock);
 	spin_lock_init(&j->err_lock);
 	INIT_DELAYED_WORK(&j->write_work, bch2_journal_write_work);

--- a/fs/journal/journal.c
+++ b/fs/journal/journal.c
@@ -934,17 +934,6 @@ out:
 	return ret;
 }
 
-static unsigned max_dev_latency(struct bch_fs *c)
-{
-	u64 nsecs = 0;
-
-	guard(rcu)();
-	for_each_member_device_rcu(c, ca, &c->allocator.rw_devs[BCH_DATA_journal])
-		nsecs = max(nsecs, ca->io_latency[WRITE].stats.max_duration);
-
-	return nsecs_to_jiffies(nsecs);
-}
-
 /*
  * Essentially the entry function to the journaling code. When bcachefs is doing
  * a btree insert, it calls this function to get the current journal write.
@@ -963,7 +952,7 @@ int bch2_journal_res_get_slowpath(struct journal *j, struct journal_res *res,
 		return __journal_res_get(j, res, flags);
 
 	struct bch_fs *c = container_of(j, struct bch_fs, journal);
-	long total_wait = max(max_dev_latency(c) * 2, HZ * 10);
+	long total_wait = max(bch2_dev_latency_max(c, &c->allocator.rw_devs[BCH_DATA_journal], WRITE) * 2, HZ * 10);
 	int ret;
 
 	if (trans_wait_event_timeout(trans, &j->async_wait,
@@ -1211,7 +1200,7 @@ int bch2_journal_flush_seq(struct journal *j, u64 seq, unsigned task_state)
 	 * legitimately take: twice the longest write latency we've seen, or 10s,
 	 * whichever is greater (matches bch2_journal_res_get_slowpath()).
 	 */
-	long total_wait = max(max_dev_latency(c) * 2, HZ * 10);
+	long total_wait = max(bch2_dev_latency_max(c, &c->allocator.rw_devs[BCH_DATA_journal], WRITE) * 2, HZ * 10);
 
 	if (closure_sync_timeout(&cl, total_wait)) {
 		CLASS(printbuf, buf)();

--- a/fs/journal/reclaim.c
+++ b/fs/journal/reclaim.c
@@ -654,8 +654,16 @@ void bch2_journal_pin_copy(struct journal *j,
 			spin_lock_nested(&dst_l->lock, 1);
 		}
 
+		/*
+		 * Keep-oldest, like bch2_journal_pin_add(): a dst already
+		 * pinning an older seq must not be moved forward, or we
+		 * release an obligation - the callers (interior update pin
+		 * transfers: reparent, will_free_node) copy several pins into
+		 * one and need the min. A pin at an older seq covers src_seq.
+		 */
+		bool keep = dst_seq && dst_seq <= src_seq;
 		bool reclaim = false, race = src_seq != src->seq || dst_seq != dst->seq;
-		if (!race)
+		if (!race && !keep)
 			reclaim = bch2_journal_pin_set_locked(j, dst_l, src_l, dst, src_seq, flush_fn);
 
 		if (dst_l && dst_l != src_l)
@@ -667,7 +675,7 @@ void bch2_journal_pin_copy(struct journal *j,
 			 * If the journal is currently full,  we might want to call flush_fn
 			 * immediately:
 			 */
-			if (src_seq == j->last_seq)
+			if (!keep && src_seq == j->last_seq)
 				journal_wake(j);
 			if (reclaim)
 				bch2_journal_maybe_update_last_seq(j);

--- a/fs/journal/reclaim.c
+++ b/fs/journal/reclaim.c
@@ -3,6 +3,7 @@
 #include "bcachefs.h"
 
 #include "alloc/buckets.h"
+#include "alloc/foreground.h"
 #include "alloc/replicas.h"
 
 #include "btree/key_cache.h"
@@ -77,18 +78,31 @@ void bch2_journal_set_watermark(struct journal *j)
 		j->space[journal_space_total].total;
 	bool low_on_pin = fifo_free(&j->pin) < j->pin.size / 4;
 	bool low_on_wb = bch2_btree_write_buffer_must_wait(c);
+	/*
+	 * Open buckets are a fixed pool that btree nodes hold until their update's
+	 * journal commit lands; the reclaim path (write-buffer flush -> journal ->
+	 * writeback) both frees them and, to make progress, allocates them. If new
+	 * journal-reserving work (fsck repair) drains the pool, that reclaim path
+	 * can't get the buckets it needs to advance the journal and everything
+	 * wedges. Throttle new work early, keeping headroom above the reclaim
+	 * reserve - the reclaim path itself is exempt (no_journal_res).
+	 */
+	bool low_on_open_buckets =
+		c->allocator.open_buckets_nr_free < bch2_open_buckets_journal_reserved();
 
-	unsigned watermark = low_on_space || low_on_pin || low_on_wb
+	unsigned watermark = low_on_space || low_on_pin || low_on_wb || low_on_open_buckets
 		? BCH_WATERMARK_reclaim
 		: BCH_WATERMARK_stripe;
 
 	if (track_event_change(&c->times[BCH_TIME_blocked_journal_low_on_space], low_on_space) |
 	    track_event_change(&c->times[BCH_TIME_blocked_journal_low_on_pin], low_on_pin) |
+	    track_event_change(&c->times[BCH_TIME_blocked_journal_low_on_open_buckets], low_on_open_buckets) |
 	    track_event_change(&c->times[BCH_TIME_blocked_write_buffer_full], low_on_wb))
 		event_inc_trace(c, journal_full, buf, ({
 			guard(printbuf_atomic)(&buf);
 			prt_printf(&buf, "low_on_space %u\n",	low_on_space);
 			prt_printf(&buf, "low_on_pin %u\n",	low_on_pin);
+			prt_printf(&buf, "low_on_open_buckets %u\n", low_on_open_buckets);
 			prt_printf(&buf, "low_on_wb %u\n",	low_on_wb);
 			if (low_on_wb)
 				bch2_btree_write_buffer_to_text(&buf, c);
@@ -99,6 +113,7 @@ void bch2_journal_set_watermark(struct journal *j)
 	mod_bit(JOURNAL_low_on_space,	&j->flags, low_on_space);
 	mod_bit(JOURNAL_low_on_pin,	&j->flags, low_on_pin);
 	mod_bit(JOURNAL_low_on_wb,	&j->flags, low_on_wb);
+	mod_bit(JOURNAL_low_on_open_buckets, &j->flags, low_on_open_buckets);
 
 	swap(watermark, j->watermark);
 	if (watermark > j->watermark)
@@ -1402,6 +1417,7 @@ __cold void bch2_journal_reclaim_to_text(struct printbuf *out, struct journal *j
 	prt_printf(out, "Blocked time stats:\tcount\tavg\tmax\n");
 	bch2_time_stats_summary_to_text(out, "  low_on_space",		&c->times[BCH_TIME_blocked_journal_low_on_space]);
 	bch2_time_stats_summary_to_text(out, "  low_on_pin",		&c->times[BCH_TIME_blocked_journal_low_on_pin]);
+	bch2_time_stats_summary_to_text(out, "  low_on_open_buckets",	&c->times[BCH_TIME_blocked_journal_low_on_open_buckets]);
 	bch2_time_stats_summary_to_text(out, "  max_in_flight",		&c->times[BCH_TIME_blocked_journal_max_in_flight]);
 	bch2_time_stats_summary_to_text(out, "  max_open",		&c->times[BCH_TIME_blocked_journal_max_open]);
 	bch2_time_stats_summary_to_text(out, "  write_buffer_full",	&c->times[BCH_TIME_blocked_write_buffer_full]);

--- a/fs/journal/types.h
+++ b/fs/journal/types.h
@@ -285,7 +285,7 @@ struct journal {
 	 * reservation: for synchronization between the btree write buffer code
 	 * and the journal write path:
 	 */
-	struct mutex		buf_lock;
+	struct mutex_noio	buf_lock;
 	/*
 	 * Ring of slots indexed by seq & JOURNAL_STATE_BUF_MASK; only used by
 	 * the reservation fastpath. Updated in journal_entry_open() when a new

--- a/fs/journal/types.h
+++ b/fs/journal/types.h
@@ -221,7 +221,8 @@ enum journal_space_from {
 	x(med_on_space)			\
 	x(low_on_space)			\
 	x(low_on_pin)			\
-	x(low_on_wb)
+	x(low_on_wb)			\
+	x(low_on_open_buckets)
 
 enum journal_flags {
 #define x(n)	JOURNAL_##n,

--- a/fs/journal/types.h
+++ b/fs/journal/types.h
@@ -381,6 +381,11 @@ struct journal {
 	u64			replay_journal_seq_end;
 
 	struct write_point	wp;
+	/*
+	 * Failure domain keys scratch for journal_write_alloc() - like
+	 * wp.stripe, protected by journal writes being allocated in order:
+	 */
+	u64			wp_domain_keys[BCH_SB_MEMBERS_MAX];
 	spinlock_t		err_lock;
 
 	struct mutex		reclaim_lock;

--- a/fs/journal/write.c
+++ b/fs/journal/write.c
@@ -274,78 +274,77 @@ static CLOSURE_CALLBACK(journal_write_done)
 	 * Lock ordering: buf_lock, pin_resize_lock, then j->lock - same as the
 	 * flusher and the journal write path.
 	 */
-	mutex_lock(&j->buf_lock);
-
-	/*
-	 * pin_resize_lock held across the journal pin FIFO updates below; it
-	 * keeps the pin_list stable while we rebuild temp replicas entries from
-	 * the compact device list for refcount updates.
-	 */
-	percpu_down_read(&j->pin_resize_lock);
-	struct journal_entry_pin_list *pin = journal_seq_pin(j, seq_wrote);
-
-	if (unlikely(w->failed.nr)) {
-		union bch_replicas_padded r;
-		journal_pin_devs_to_replicas(&r, pin);
-		bch2_replicas_entry_put(c, &r.e);
-		pin->devs.nr = 0;
-	}
-
-	if (!pin->devs.nr && !w->empty) {
-		union bch_replicas_padded r;
-		bch2_devlist_to_replicas(&r.e, BCH_DATA_journal, w->devs_written);
-		err = bch2_replicas_entry_get(c, &r.e);
-		if (!err)
-			journal_pin_set_devs(pin, &w->devs_written);
-	}
-
-	if (unlikely(w->failed.nr || err)) {
-		CLASS(bch_log_msg, msg)(c);
-
-		/* Separate ratelimit_states for hard and soft errors */
-		msg.m.suppress = !err
-			? bch2_ratelimit(c)
-			: bch2_ratelimit(c);
-
-		prt_printf(&msg.m, "error writing journal entry %llu\n", seq_wrote);
-		bch2_io_failures_to_text(&msg.m, c, &w->failed);
-
-		if (!w->devs_written.nr)
-			err = bch_err_throw(c, journal_write_err);
-
-		if (!err) {
-			prt_printf(&msg.m, "wrote degraded to ");
-			bch2_devs_list_to_text(&msg.m, c, &w->devs_written);
-			prt_newline(&msg.m);
-		} else {
-			prt_printf(&msg.m, "error %s\n", bch2_err_str(err));
-			percpu_up_read(&j->pin_resize_lock);
-			bch2_fs_emergency_read_only(c, &msg.m);
-			percpu_down_read(&j->pin_resize_lock);
-		}
-	}
-
-	closure_debug_destroy(cl);
 
 	CLASS(darray_replicas_entry_refs, replicas_refs)();
+	scoped_guard(mutex_noio, &j->buf_lock) {
+		/*
+		 * pin_resize_lock held across the journal pin FIFO updates below; it
+		 * keeps the pin_list stable while we rebuild temp replicas entries from
+		 * the compact device list for refcount updates.
+		 */
+		percpu_down_read(&j->pin_resize_lock);
+		struct journal_entry_pin_list *pin = journal_seq_pin(j, seq_wrote);
 
-	spin_lock(&j->lock);
-	BUG_ON(seq_wrote < j->pin.front);
-	if (err && (!j->err_seq || seq_wrote < j->err_seq))
-		j->err_seq = seq_wrote;
+		if (unlikely(w->failed.nr)) {
+			union bch_replicas_padded r;
+			journal_pin_devs_to_replicas(&r, pin);
+			bch2_replicas_entry_put(c, &r.e);
+			pin->devs.nr = 0;
+		}
 
-	j->flushes_outstanding -= w->flush;
+		if (!pin->devs.nr && !w->empty) {
+			union bch_replicas_padded r;
+			bch2_devlist_to_replicas(&r.e, BCH_DATA_journal, w->devs_written);
+			err = bch2_replicas_entry_get(c, &r.e);
+			if (!err)
+				journal_pin_set_devs(pin, &w->devs_written);
+		}
 
-	if (!j->free_buf || j->free_buf_size < w->buf_size) {
-		swap(j->free_buf,	w->data);
-		swap(j->free_buf_size,	w->buf_size);
+		if (unlikely(w->failed.nr || err)) {
+			CLASS(bch_log_msg, msg)(c);
+
+			/* Separate ratelimit_states for hard and soft errors */
+			msg.m.suppress = !err
+				? bch2_ratelimit(c)
+				: bch2_ratelimit(c);
+
+			prt_printf(&msg.m, "error writing journal entry %llu\n", seq_wrote);
+			bch2_io_failures_to_text(&msg.m, c, &w->failed);
+
+			if (!w->devs_written.nr)
+				err = bch_err_throw(c, journal_write_err);
+
+			if (!err) {
+				prt_printf(&msg.m, "wrote degraded to ");
+				bch2_devs_list_to_text(&msg.m, c, &w->devs_written);
+				prt_newline(&msg.m);
+			} else {
+				prt_printf(&msg.m, "error %s\n", bch2_err_str(err));
+				percpu_up_read(&j->pin_resize_lock);
+				bch2_fs_emergency_read_only(c, &msg.m);
+				percpu_down_read(&j->pin_resize_lock);
+			}
+		}
+
+		closure_debug_destroy(cl);
+
+		spin_lock(&j->lock);
+		BUG_ON(seq_wrote < j->pin.front);
+		if (err && (!j->err_seq || seq_wrote < j->err_seq))
+			j->err_seq = seq_wrote;
+
+		j->flushes_outstanding -= w->flush;
+
+		if (!j->free_buf || j->free_buf_size < w->buf_size) {
+			swap(j->free_buf,	w->data);
+			swap(j->free_buf_size,	w->buf_size);
+		}
+
+		/* kvfree can allocate memory, and can't be called under j->lock */
+		void *buf_to_free __free(kvfree) = w->data;
+		w->data = NULL;
+		w->buf_size = 0;
 	}
-
-	/* kvfree can allocate memory, and can't be called under j->lock */
-	void *buf_to_free __free(kvfree) = w->data;
-	w->data = NULL;
-	w->buf_size = 0;
-	mutex_unlock(&j->buf_lock);
 
 	bool completed = false;
 	bool last_seq_ondisk_updated = false;
@@ -814,7 +813,7 @@ CLOSURE_CALLBACK(bch2_journal_write)
 
 	j->write_start_time = local_clock();
 
-	scoped_guard(mutex, &j->buf_lock) {
+	scoped_guard(mutex_noio, &j->buf_lock) {
 		journal_buf_realloc(j, w);
 
 		ret = bch2_journal_write_prep(j, w);

--- a/fs/journal/write.c
+++ b/fs/journal/write.c
@@ -27,14 +27,15 @@
 #include <linux/ioprio.h>
 
 static void journal_advance_devs_to_next_bucket(struct journal *j,
-						struct dev_alloc_list *devs,
+						struct bch_devs_mask *devs,
 						unsigned sectors, __le64 seq)
 {
 	struct bch_fs *c = container_of(j, struct bch_fs, journal);
+	unsigned i;
 
 	guard(rcu)();
-	darray_for_each(*devs, i) {
-		struct bch_dev *ca = rcu_dereference(c->devs[*i]);
+	for_each_set_bit(i, devs->d, BCH_SB_MEMBERS_MAX) {
+		struct bch_dev *ca = rcu_dereference(c->devs[i]);
 		if (!ca)
 			continue;
 
@@ -58,31 +59,56 @@ static void journal_advance_devs_to_next_bucket(struct journal *j,
 
 static void __journal_write_alloc(struct journal *j,
 				  struct journal_buf *w,
-				  struct dev_alloc_list *devs,
+				  struct bch_devs_mask *devs,
 				  unsigned sectors,
 				  unsigned *replicas,
 				  unsigned replicas_want)
 {
 	struct bch_fs *c = container_of(j, struct bch_fs, journal);
 
-	darray_for_each(*devs, i) {
-		struct bch_dev *ca = bch2_dev_get_ioref(c, *i, WRITE,
-					BCH_DEV_WRITE_REF_journal_write);
+	while (*replicas < replicas_want) {
+		/*
+		 * Journal replicas spread across failure domains, like data:
+		 * one pick per sort, since each pick changes the occupancy
+		 * the next should avoid:
+		 */
+		struct bch_devs_mask chosen = {};
+		bkey_for_each_ptr(bch2_bkey_ptrs_c(bkey_i_to_s_c(&w->key)), ptr)
+			__set_bit(ptr->dev, chosen.d);
+
+		struct dev_alloc_list devs_sorted;
+		bch2_dev_alloc_list_devs(c, &j->wp.stripe, devs,
+					 &chosen, j->wp_domain_keys, &devs_sorted);
+
+		struct bch_dev *ca = NULL;
+		darray_for_each(devs_sorted, i) {
+			ca = bch2_dev_get_ioref(c, *i, WRITE,
+						BCH_DEV_WRITE_REF_journal_write);
+			if (!ca)
+				continue;
+
+			struct journal_device *ja = &ca->journal;
+
+			/*
+			 * Check that we can use this device, and aren't
+			 * already using it:
+			 */
+			if (!ja->nr ||
+			    bch2_bkey_has_device_c(c, bkey_i_to_s_c(&w->key), ca->dev_idx) ||
+			    sectors > ja->sectors_free) {
+				enumerated_ref_put(&ca->io_ref[WRITE],
+						   BCH_DEV_WRITE_REF_journal_write);
+				ca = NULL;
+				continue;
+			}
+
+			break;
+		}
+
 		if (!ca)
-			continue;
+			return;
 
 		struct journal_device *ja = &ca->journal;
-
-		/*
-		 * Check that we can use this device, and aren't already using
-		 * it:
-		 */
-		if (!ja->nr ||
-		    bch2_bkey_has_device_c(c, bkey_i_to_s_c(&w->key), ca->dev_idx) ||
-		    sectors > ja->sectors_free) {
-			enumerated_ref_put(&ca->io_ref[WRITE], BCH_DEV_WRITE_REF_journal_write);
-			continue;
-		}
 
 		bch2_dev_stripe_increment(ca, &j->wp.stripe);
 
@@ -103,9 +129,6 @@ static void __journal_write_alloc(struct journal *j,
 		ja->bucket_seq[ja->cur_idx] = le64_to_cpu(w->data->seq);
 
 		*replicas += ca->mi.durability;
-
-		if (*replicas >= replicas_want)
-			break;
 	}
 }
 
@@ -114,9 +137,6 @@ static int journal_write_alloc(struct journal *j, struct journal_buf *w,
 {
 	struct bch_fs *c = container_of(j, struct bch_fs, journal);
 	struct bch_devs_mask devs;
-	struct bch_devs_mask devs_chosen = {};
-	u64 domain_keys[BCH_SB_MEMBERS_MAX];
-	struct dev_alloc_list devs_sorted;
 	unsigned sectors = vstruct_sectors(w->data, c->block_bits);
 	unsigned target = c->opts.metadata_target ?:
 		c->opts.foreground_target;
@@ -125,16 +145,14 @@ static int journal_write_alloc(struct journal *j, struct journal_buf *w,
 
 retry_target:
 	devs = target_rw_devs(c, BCH_DATA_journal, target);
-	bch2_dev_alloc_list_devs(c, &j->wp.stripe, &devs,
-				 &devs_chosen, domain_keys, &devs_sorted);
 retry_alloc:
-	__journal_write_alloc(j, w, &devs_sorted, sectors, replicas, replicas_want);
+	__journal_write_alloc(j, w, &devs, sectors, replicas, replicas_want);
 
 	if (likely(*replicas >= replicas_want))
 		goto done;
 
 	if (!advance_done) {
-		journal_advance_devs_to_next_bucket(j, &devs_sorted, sectors, w->data->seq);
+		journal_advance_devs_to_next_bucket(j, &devs, sectors, w->data->seq);
 		advance_done = true;
 		goto retry_alloc;
 	}

--- a/fs/journal/write.c
+++ b/fs/journal/write.c
@@ -275,6 +275,15 @@ static CLOSURE_CALLBACK(journal_write_done)
 	 * flusher and the journal write path.
 	 */
 
+	/*
+	 * kvfree can sleep, so it can't run under j->lock (or any lock here):
+	 * function scope defers the cleanup until return, after every lock is
+	 * dropped. Declared inside the scoped_guard below, it would run at the
+	 * block's closing brace - where j->lock, taken inside the block, is
+	 * still held for the completion loop that follows:
+	 */
+	void *buf_to_free __free(kvfree) = NULL;
+
 	CLASS(darray_replicas_entry_refs, replicas_refs)();
 	scoped_guard(mutex_noio, &j->buf_lock) {
 		/*
@@ -340,8 +349,7 @@ static CLOSURE_CALLBACK(journal_write_done)
 			swap(j->free_buf_size,	w->buf_size);
 		}
 
-		/* kvfree can allocate memory, and can't be called under j->lock */
-		void *buf_to_free __free(kvfree) = w->data;
+		buf_to_free = w->data;
 		w->data = NULL;
 		w->buf_size = 0;
 	}

--- a/fs/journal/write.c
+++ b/fs/journal/write.c
@@ -114,6 +114,8 @@ static int journal_write_alloc(struct journal *j, struct journal_buf *w,
 {
 	struct bch_fs *c = container_of(j, struct bch_fs, journal);
 	struct bch_devs_mask devs;
+	struct bch_devs_mask devs_chosen = {};
+	u64 domain_keys[BCH_SB_MEMBERS_MAX];
 	struct dev_alloc_list devs_sorted;
 	unsigned sectors = vstruct_sectors(w->data, c->block_bits);
 	unsigned target = c->opts.metadata_target ?:
@@ -123,7 +125,8 @@ static int journal_write_alloc(struct journal *j, struct journal_buf *w,
 
 retry_target:
 	devs = target_rw_devs(c, BCH_DATA_journal, target);
-	bch2_dev_alloc_list(c, &j->wp.stripe, &devs, &devs_sorted);
+	bch2_dev_alloc_list_devs(c, &j->wp.stripe, &devs,
+				 &devs_chosen, domain_keys, &devs_sorted);
 retry_alloc:
 	__journal_write_alloc(j, w, &devs_sorted, sectors, replicas, replicas_want);
 

--- a/fs/mod.rs
+++ b/fs/mod.rs
@@ -302,3 +302,61 @@ impl From<c::bch_reconcile_accounting_type> for u32 {
         t.0
     }
 }
+
+// ── ARM32 Kernel EABI Division Helpers ──────────────────────────
+//
+// On 32-bit ARM, raw 64-bit integer division lowers to compiler-rt calls.
+// Since the Linux kernel does not export these symbols to out-of-tree modules,
+// we declare them globally using assembly stubs that call the kernel's real
+// exported math functions. We restrict this to non-std (kernel) ARM32 builds.
+
+#[cfg(all(target_arch = "arm", not(feature = "std")))]
+core::arch::global_asm!(
+    ".global __aeabi_uldivmod",
+    ".type __aeabi_uldivmod, %function",
+    "__aeabi_uldivmod:",
+    "    .fnstart",
+    // Push r8 specifically to push exactly 6 registers (24 bytes) total,
+    // maintaining the AAPCS required 8-byte stack alignment for the C call.
+    "    push {{r4, r5, r6, r7, r8, lr}}",
+    "    .save {{r4, r5, r6, r7, r8, lr}}",
+    "    mov r4, r0",
+    "    mov r5, r1",
+    "    mov r6, r2",
+    "    mov r7, r3",
+    "    bl div64_u64",
+    "    umull r2, r3, r0, r6",
+    "    mla r3, r0, r7, r3",
+    "    mla r3, r1, r6, r3",
+    "    subs r2, r4, r2",
+    "    sbc r3, r5, r3",
+    "    pop {{r4, r5, r6, r7, r8, pc}}",
+    "    .fnend",
+    ".size __aeabi_uldivmod, . - __aeabi_uldivmod"
+);
+
+
+#[cfg(all(target_arch = "arm", not(feature = "std")))]
+core::arch::global_asm!(
+    ".global __aeabi_ldivmod",
+    ".type __aeabi_ldivmod, %function",
+    "__aeabi_ldivmod:",
+    "    .fnstart",
+    // Push r8 specifically to push exactly 6 registers (24 bytes) total,
+    // maintaining the AAPCS required 8-byte stack alignment for the C call.
+    "    push {{r4, r5, r6, r7, r8, lr}}",
+    "    .save {{r4, r5, r6, r7, r8, lr}}",
+    "    mov r4, r0",
+    "    mov r5, r1",
+    "    mov r6, r2",
+    "    mov r7, r3",
+    "    bl div64_s64",
+    "    umull r2, r3, r0, r6",
+    "    mla r3, r0, r7, r3",
+    "    mla r3, r1, r6, r3",
+    "    subs r2, r4, r2",
+    "    sbc r3, r5, r3",
+    "    pop {{r4, r5, r6, r7, r8, pc}}",
+    "    .fnend",
+    ".size __aeabi_ldivmod, . - __aeabi_ldivmod"
+);

--- a/fs/opts.c
+++ b/fs/opts.c
@@ -648,6 +648,7 @@ static int opt_hook_io(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum bch_
 			(struct reconcile_scan) { .type = RECONCILE_SCAN_stripes }, post, scope));
 		break;
 	case Opt_label:
+	case Opt_failure_domain:
 		/*
 		 * Refresh the cpu label tree before the scan wakes: reconcile
 		 * reads the group devs masks. Errors here (ENOMEM) just leave
@@ -658,8 +659,13 @@ static int opt_hook_io(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum bch_
 				bch_err_fn(c, bch2_sb_disk_groups_to_cpu(c));
 		}
 
-		try(reconcile_scan_bracket(c,
-			(struct reconcile_scan) { .type = RECONCILE_SCAN_pending }, post, scope));
+		/*
+		 * Only the label affects targeting - a failure domain change
+		 * only affects the spreading of future allocations, no rescan:
+		 */
+		if (id == Opt_label)
+			try(reconcile_scan_bracket(c,
+				(struct reconcile_scan) { .type = RECONCILE_SCAN_pending }, post, scope));
 		break;
 	default:
 		break;

--- a/fs/opts.c
+++ b/fs/opts.c
@@ -295,6 +295,9 @@ const struct bch_option bch2_opt_table[] = {
 				.choices = _choices,			\
 				.choices_allowed_mask = _choices_allowed_mask
 #define OPT_FN(_fn)		.type = BCH_OPT_FN, .fn	= _fn
+#define OPT_STR_MEMBER(_field)	.type = BCH_OPT_STR_MEMBER,		\
+				.member_offset = offsetof(struct bch_member, _field),\
+				.member_size = sizeof(((struct bch_member *) NULL)->_field)
 
 #define x(_name, _bits, _flags, _type, _sb_opt, _default, _hint, _help)	\
 	[Opt_##_name] = {						\
@@ -481,6 +484,20 @@ int bch2_opt_parse(struct bch_fs *c,
 		*res = v;
 		break;
 	}
+	case BCH_OPT_STR_MEMBER:
+		if (!val) {
+			prt_printf(err, "%s: required value", opt->attr.name);
+			return -BCH_ERR_EINVAL_opt_parse_str_required;
+		}
+		if (strlen(val) > opt->member_size) {
+			if (err)
+				prt_printf(err, "%s: too long (max %u bytes)",
+					   opt->attr.name, opt->member_size);
+			return -ENAMETOOLONG;
+		}
+		/* Applied to the member directly in __bch2_opt_set_sb(): */
+		*res = 0;
+		break;
 	case BCH_OPT_FN:
 		ret = opt->fn.parse(c, val, res, err);
 
@@ -535,6 +552,9 @@ __cold void bch2_opt_to_text(struct printbuf *out,
 		break;
 	case BCH_OPT_FN:
 		opt->fn.to_text(out, c, sb, v);
+		break;
+	case BCH_OPT_STR_MEMBER:
+		/* Rendered per-device from the member (see bch2_member_to_text) */
 		break;
 	default:
 		BUG();
@@ -918,7 +938,7 @@ int bch2_opts_from_sb(struct bch_opts *opts, struct bch_sb *sb)
 }
 
 bool __bch2_opt_set_sb(struct bch_sb *sb, int dev_idx,
-		       const struct bch_option *opt, u64 v)
+		       const struct bch_option *opt, u64 v, const char *val)
 {
 	bool changed = false;
 
@@ -953,14 +973,33 @@ bool __bch2_opt_set_sb(struct bch_sb *sb, int dev_idx,
 		opt->set_member(m, v);
 	}
 
+	if (opt->type == BCH_OPT_STR_MEMBER &&
+	    (opt->flags & OPT_DEVICE) && dev_idx >= 0) {
+		if (WARN(!bch2_member_exists(sb, dev_idx),
+			 "tried to set device option %s on nonexistent device %i",
+			 opt->attr.name, dev_idx))
+			return false;
+
+		struct bch_member *m = bch2_members_v2_get_mut(sb, dev_idx);
+		char *field = (char *) m + opt->member_offset;
+		size_t len = val ? strlen(val) : 0;
+
+		/* zero-padded, so equal strings compare equal in the interning: */
+		for (unsigned i = 0; i < opt->member_size; i++) {
+			char want = i < len ? val[i] : 0;
+			changed |= field[i] != want;
+			field[i] = want;
+		}
+	}
+
 	return changed;
 }
 
 bool bch2_opt_set_sb(struct bch_fs *c, struct bch_dev *ca,
-		     const struct bch_option *opt, u64 v)
+		     const struct bch_option *opt, u64 v, const char *val)
 {
 	guard(mutex_noio)(&c->sb_lock);
-	bool changed = __bch2_opt_set_sb(c->disk_sb.sb, ca ? ca->dev_idx : -1, opt, v);
+	bool changed = __bch2_opt_set_sb(c->disk_sb.sb, ca ? ca->dev_idx : -1, opt, v, val);
 	if (changed)
 		bch2_write_super(c);
 	return changed;

--- a/fs/opts.h
+++ b/fs/opts.h
@@ -81,6 +81,8 @@ enum opt_type {
 	BCH_OPT_STR,
 	BCH_OPT_BITFIELD,
 	BCH_OPT_FN,
+	/* A free-form string stored directly in a bch_member char[] field: */
+	BCH_OPT_STR_MEMBER,
 };
 
 struct bch_opt_fn {
@@ -694,6 +696,9 @@ struct bch_option {
 	u64			(*get_ext)(const struct bch_sb_field_ext *);
 	void			(*set_ext)(struct bch_sb_field_ext *, u64);
 
+	/* BCH_OPT_STR_MEMBER: the bch_member char[] field the string lives in */
+	unsigned		member_offset;
+	unsigned		member_size;
 };
 
 extern const struct bch_option bch2_opt_table[];
@@ -704,10 +709,10 @@ void bch2_opt_set_by_id(struct bch_opts *, enum bch_opt_id, u64);
 
 u64 bch2_opt_from_sb(struct bch_sb *, enum bch_opt_id, int);
 int bch2_opts_from_sb(struct bch_opts *, struct bch_sb *);
-bool __bch2_opt_set_sb(struct bch_sb *, int, const struct bch_option *, u64);
+bool __bch2_opt_set_sb(struct bch_sb *, int, const struct bch_option *, u64, const char *);
 
 struct bch_dev;
-bool bch2_opt_set_sb(struct bch_fs *, struct bch_dev *, const struct bch_option *, u64);
+bool bch2_opt_set_sb(struct bch_fs *, struct bch_dev *, const struct bch_option *, u64, const char *);
 
 int bch2_opt_lookup(const char *);
 int bch2_opt_validate(const struct bch_option *, u64, struct printbuf *);

--- a/fs/opts.h
+++ b/fs/opts.h
@@ -567,6 +567,14 @@ enum fsck_err_opts {
 	  OPT_FN(bch2_opt_disk_label),					\
 	  BCH_MEMBER_GROUP,		0,				\
 	  "(label)",	"Device label: position in the label tree")	\
+	x(failure_domain,		u8,				\
+	  OPT_DEVICE|OPT_FORMAT|OPT_RUNTIME,				\
+	  OPT_STR_MEMBER(failure_domain),				\
+	  BCH2_NO_SB_OPT,		0,				\
+	  "(domain)",	"Failure domain: devices sharing a name are in the\n"\
+			"same failure domain; allocation spreads replicas\n"\
+			"across domains (a hard requirement for erasure\n"\
+			"coded stripe blocks)")				\
 	x(bucket_size,			u32,				\
 	  OPT_DEVICE|OPT_HUMAN_READABLE|OPT_SB_FIELD_SECTORS,		\
 	  OPT_UINT(0, S64_MAX),						\

--- a/fs/opts.h
+++ b/fs/opts.h
@@ -386,7 +386,7 @@ enum fsck_err_opts {
 	  BCH2_NO_SB_OPT,		FSCK_FIX_exit,			\
 	  NULL,		"Fix errors during fsck without asking")	\
 	x(ratelimit_errors,		u8,				\
-	  OPT_FS|OPT_MOUNT,						\
+	  OPT_FS|OPT_MOUNT|OPT_RUNTIME,					\
 	  OPT_BOOL(),							\
 	  BCH2_NO_SB_OPT,		RATELIMIT_ERRORS_DEFAULT,	\
 	  NULL,		"Ratelimit error messages during fsck")		\

--- a/fs/opts.rs
+++ b/fs/opts.rs
@@ -86,7 +86,8 @@ pub fn opts_default() -> &'static c::bch_opts {
 
 /// Set a superblock option from the opt table.
 pub fn opt_set_sb(sb: &mut c::bch_sb, dev_idx: i32, opt: &c::bch_option, v: u64) {
-    unsafe { c::__bch2_opt_set_sb(sb, dev_idx, opt, v); }
+    // val is only used by BCH_OPT_STR_MEMBER options, not set through this path:
+    unsafe { c::__bch2_opt_set_sb(sb, dev_idx, opt, v, core::ptr::null()); }
 }
 
 /// Set an option value in a bch_opts struct by id.

--- a/fs/sb/errors_format.h
+++ b/fs/sb/errors_format.h
@@ -299,7 +299,7 @@ enum bch_fsck_flags {
 	x(dirent_name_dot_or_dotdot,				223,	0)		\
 	x(dirent_name_has_slash,				224,	0)		\
 	x(dirent_d_type_wrong,					225,	FSCK_AUTOFIX)	\
-	x(inode_bi_parent_wrong,				226,	0)		\
+	x(inode_bi_parent_wrong,				226,	FSCK_AUTOFIX)	\
 	x(dirent_in_missing_dir_inode,				227,	0)		\
 	x(dirent_in_non_dir_inode,				228,	0)		\
 	x(dirent_to_missing_inode,				229,	FSCK_AUTOFIX)	\
@@ -329,7 +329,7 @@ enum bch_fsck_flags {
 	x(missing_inode_with_contents,				321,	FSCK_AUTOFIX)	\
 	x(dirent_to_missing_parent_subvol,			252,	0)		\
 	x(dirent_not_visible_in_parent_subvol,			253,	0)		\
-	x(subvol_fs_path_parent_wrong,				254,	0)		\
+	x(subvol_fs_path_parent_wrong,				254,	FSCK_AUTOFIX)	\
 	x(subvol_root_fs_path_parent_nonzero,			255,	0)		\
 	x(subvol_children_not_set,				256,	0)		\
 	x(subvol_children_bad,					257,	0)		\

--- a/fs/sb/errors_format.h
+++ b/fs/sb/errors_format.h
@@ -228,7 +228,7 @@ enum bch_fsck_flags {
 	x(snapshot_state_bad,					373,	FSCK_AUTOFIX)	\
 	x(snapshot_state_bitflip,				379,	FSCK_AUTOFIX)	\
 	x(snapshot_state_stale_tombstone,			382,	FSCK_AUTOFIX)	\
-	x(snapshot_will_delete_but_subvol_live,			376,	FSCK_AUTOFIX)		\
+	x(snapshot_deleted_but_subvol_live,			376,	FSCK_AUTOFIX)	\
 	x(snapshot_deleted_has_live_children,			381,	FSCK_AUTOFIX)	\
 	x(snapshot_subvol_backref_wrong,			377,	0)		\
 	x(snapshot_no_keys_childless,				378,	FSCK_AUTOFIX)	\

--- a/fs/sb/errors_format.h
+++ b/fs/sb/errors_format.h
@@ -314,9 +314,9 @@ enum bch_fsck_flags {
 	x(xattr_invalid_type,					235,	0)		\
 	x(xattr_name_invalid_chars,				236,	0)		\
 	x(xattr_in_missing_inode,				237,	0)		\
-	x(root_subvol_missing,					238,	0)		\
-	x(root_dir_missing,					239,	0)		\
-	x(root_inode_not_dir,					240,	0)		\
+	x(root_subvol_missing,					238,	FSCK_AUTOFIX)	\
+	x(root_dir_missing,					239,	FSCK_AUTOFIX)	\
+	x(root_inode_not_dir,					240,	FSCK_AUTOFIX)	\
 	x(dir_loop,						241,	FSCK_AUTOFIX)	\
 	x(hash_table_key_duplicate,				242,	FSCK_AUTOFIX)	\
 	x(hash_table_key_wrong_offset,				243,	FSCK_AUTOFIX)	\

--- a/fs/sb/errors_format.h
+++ b/fs/sb/errors_format.h
@@ -227,6 +227,7 @@ enum bch_fsck_flags {
 	x(snapshot_edge_bad,					371,	0)		\
 	x(snapshot_state_bad,					373,	FSCK_AUTOFIX)	\
 	x(snapshot_state_bitflip,				379,	FSCK_AUTOFIX)	\
+	x(snapshot_state_stale_tombstone,			382,	FSCK_AUTOFIX)	\
 	x(snapshot_will_delete_but_subvol_live,			376,	FSCK_AUTOFIX)		\
 	x(snapshot_deleted_has_live_children,			381,	FSCK_AUTOFIX)	\
 	x(snapshot_subvol_backref_wrong,			377,	0)		\
@@ -393,7 +394,7 @@ enum bch_fsck_flags {
 	x(inode_has_access_acl_flag_wrong,			366,	FSCK_AUTOFIX)	\
 	x(inode_has_default_acl_flag_wrong,			367,	FSCK_AUTOFIX)	\
 	x(dirent_to_inode_in_descendant_snapshot,		368,	FSCK_AUTOFIX)	\
-	x(MAX,							382,	0)
+	x(MAX,							383,	0)
 
 enum bch_sb_error_id {
 #define x(t, n, ...) BCH_FSCK_ERR_##t = n,

--- a/fs/sb/errors_format.h
+++ b/fs/sb/errors_format.h
@@ -228,6 +228,7 @@ enum bch_fsck_flags {
 	x(snapshot_state_bad,					373,	FSCK_AUTOFIX)	\
 	x(snapshot_state_bitflip,				379,	FSCK_AUTOFIX)	\
 	x(snapshot_state_stale_tombstone,			382,	FSCK_AUTOFIX)	\
+	x(snapshot_subvol_state_mismatch,			386,	FSCK_AUTOFIX)	\
 	x(snapshot_deleted_but_subvol_live,			376,	FSCK_AUTOFIX)	\
 	x(snapshot_deleted_has_live_children,			381,	FSCK_AUTOFIX)	\
 	x(snapshot_deleted_but_linked,				384,	FSCK_AUTOFIX)	\
@@ -397,7 +398,7 @@ enum bch_fsck_flags {
 	x(inode_has_access_acl_flag_wrong,			366,	FSCK_AUTOFIX)	\
 	x(inode_has_default_acl_flag_wrong,			367,	FSCK_AUTOFIX)	\
 	x(dirent_to_inode_in_descendant_snapshot,		368,	FSCK_AUTOFIX)	\
-	x(MAX,							386,	0)
+	x(MAX,							387,	0)
 
 enum bch_sb_error_id {
 #define x(t, n, ...) BCH_FSCK_ERR_##t = n,

--- a/fs/sb/errors_format.h
+++ b/fs/sb/errors_format.h
@@ -305,7 +305,7 @@ enum bch_fsck_flags {
 	x(dirent_in_non_dir_inode,				228,	0)		\
 	x(dirent_to_missing_inode,				229,	FSCK_AUTOFIX)	\
 	x(dirent_to_overwritten_inode,				302,	FSCK_AUTOFIX)	\
-	x(dirent_to_missing_subvol,				230,	0)		\
+	x(dirent_to_missing_subvol,				230,	FSCK_AUTOFIX)	\
 	x(dirent_to_itself,					231,	0)		\
 	x(dirent_casefold_mismatch,				318,	FSCK_AUTOFIX)	\
 	x(quota_type_invalid,					232,	0)		\

--- a/fs/sb/errors_format.h
+++ b/fs/sb/errors_format.h
@@ -245,6 +245,7 @@ enum bch_fsck_flags {
 	x(subvol_not_master_and_not_snapshot,			187,	FSCK_AUTOFIX)	\
 	x(subvol_to_missing_root,				188,	FSCK_AUTOFIX)	\
 	x(subvol_root_wrong_bi_subvol,				189,	FSCK_AUTOFIX)	\
+	x(subvol_root_unlinked_flag_missing,			383,	FSCK_AUTOFIX)	\
 	x(bkey_in_missing_snapshot,				190,	0)		\
 	x(bkey_in_deleted_snapshot,				315,	FSCK_AUTOFIX)	\
 	x(inode_pos_inode_nonzero,				191,	0)		\
@@ -394,7 +395,7 @@ enum bch_fsck_flags {
 	x(inode_has_access_acl_flag_wrong,			366,	FSCK_AUTOFIX)	\
 	x(inode_has_default_acl_flag_wrong,			367,	FSCK_AUTOFIX)	\
 	x(dirent_to_inode_in_descendant_snapshot,		368,	FSCK_AUTOFIX)	\
-	x(MAX,							383,	0)
+	x(MAX,							384,	0)
 
 enum bch_sb_error_id {
 #define x(t, n, ...) BCH_FSCK_ERR_##t = n,

--- a/fs/sb/errors_format.h
+++ b/fs/sb/errors_format.h
@@ -230,6 +230,8 @@ enum bch_fsck_flags {
 	x(snapshot_state_stale_tombstone,			382,	FSCK_AUTOFIX)	\
 	x(snapshot_deleted_but_subvol_live,			376,	FSCK_AUTOFIX)	\
 	x(snapshot_deleted_has_live_children,			381,	FSCK_AUTOFIX)	\
+	x(snapshot_deleted_but_linked,				384,	FSCK_AUTOFIX)	\
+	x(snapshot_deleted_but_has_data,			385,	FSCK_AUTOFIX)	\
 	x(snapshot_subvol_backref_wrong,			377,	0)		\
 	x(snapshot_no_keys_childless,				378,	FSCK_AUTOFIX)	\
 	x(snapshot_should_not_have_subvol,			182,	0)		\
@@ -395,7 +397,7 @@ enum bch_fsck_flags {
 	x(inode_has_access_acl_flag_wrong,			366,	FSCK_AUTOFIX)	\
 	x(inode_has_default_acl_flag_wrong,			367,	FSCK_AUTOFIX)	\
 	x(dirent_to_inode_in_descendant_snapshot,		368,	FSCK_AUTOFIX)	\
-	x(MAX,							384,	0)
+	x(MAX,							386,	0)
 
 enum bch_sb_error_id {
 #define x(t, n, ...) BCH_FSCK_ERR_##t = n,

--- a/fs/sb/errors_format.h
+++ b/fs/sb/errors_format.h
@@ -262,7 +262,7 @@ enum bch_fsck_flags {
 	x(inode_unlinked_but_clean,				197,	0)		\
 	x(inode_unlinked_but_nlink_nonzero,			198,	0)		\
 	x(inode_unlinked_and_not_open,				281,	0)		\
-	x(inode_unlinked_but_has_dirent,			285,	0)		\
+	x(inode_unlinked_but_has_dirent,			285,	FSCK_AUTOFIX)	\
 	x(unlinked_inode_not_on_deleted_list,			244,	FSCK_AUTOFIX)	\
 	x(inode_checksum_type_invalid,				199,	0)		\
 	x(inode_compression_type_invalid,			200,	0)		\

--- a/fs/sb/errors_format.h
+++ b/fs/sb/errors_format.h
@@ -280,6 +280,7 @@ enum bch_fsck_flags {
 	x(inode_wrong_nlink,					209,	FSCK_AUTOFIX)	\
 	x(inode_has_child_snapshots_wrong,			287,	FSCK_AUTOFIX)	\
 	x(inode_unreachable,					210,	FSCK_AUTOFIX)	\
+	x(inode_unreachable_dirent_in_descendant,		387,	FSCK_AUTOFIX)	\
 	x(inode_journal_seq_in_future,				299,	FSCK_AUTOFIX)	\
 	x(inode_i_sectors_underflow,				312,	FSCK_AUTOFIX)	\
 	x(inode_has_case_insensitive_not_set,			316,	FSCK_AUTOFIX)	\
@@ -398,7 +399,7 @@ enum bch_fsck_flags {
 	x(inode_has_access_acl_flag_wrong,			366,	FSCK_AUTOFIX)	\
 	x(inode_has_default_acl_flag_wrong,			367,	FSCK_AUTOFIX)	\
 	x(dirent_to_inode_in_descendant_snapshot,		368,	FSCK_AUTOFIX)	\
-	x(MAX,							387,	0)
+	x(MAX,							388,	0)
 
 enum bch_sb_error_id {
 #define x(t, n, ...) BCH_FSCK_ERR_##t = n,

--- a/fs/sb/io.c
+++ b/fs/sb/io.c
@@ -719,6 +719,7 @@ static void bch2_sb_update(struct bch_fs *c)
 	c->sb.features		= le64_to_cpu(src->features[0]);
 	c->sb.compat		= le64_to_cpu(src->compat[0]);
 	c->sb.multi_device	= BCH_SB_MULTI_DEVICE(src);
+	c->sb.dirents_sanitized	= BCH_SB_DIRENTS_SANITIZED(src);
 
 	struct bch_sb_field_ext *ext = bch2_sb_field_get(src, ext);
 	if (ext) {
@@ -1737,6 +1738,10 @@ __cold void bch2_sb_to_text(struct printbuf *out,
 	prt_newline(out);
 
 	prt_printf(out, "Clean:\t%llu\n", BCH_SB_CLEAN(sb));
+
+	if (BCH_SB_DIRENTS_SANITIZED(sb))
+		prt_printf(out, "Dirents sanitized:\t1\n");
+
 	prt_printf(out, "Devices:\t%u\n", bch2_sb_nr_devices(sb));
 
 	prt_printf(out, "Sections:\t");

--- a/fs/sb/io_types.h
+++ b/fs/sb/io_types.h
@@ -16,6 +16,7 @@ struct bch_sb_cpu {
 	u8		nr_devices;
 	u8		clean;
 	bool		multi_device; /* true if we've ever had more than one device */
+	bool		dirents_sanitized;
 
 	u8		encryption_type;
 

--- a/fs/sb/members.c
+++ b/fs/sb/members.c
@@ -788,6 +788,21 @@ unsigned bch2_sb_nr_devices(const struct bch_sb *sb)
 	return nr;
 }
 
+/*
+ * Worst observed IO latency (@rw) across @devs, in jiffies - used to scale
+ * timeouts and "held too long" warnings so slow storage doesn't trip them.
+ */
+unsigned long bch2_dev_latency_max(struct bch_fs *c, struct bch_devs_mask *devs, int rw)
+{
+	u64 nsecs = 0;
+
+	guard(rcu)();
+	for_each_member_device_rcu(c, ca, devs)
+		nsecs = max(nsecs, ca->io_latency[rw].stats.max_duration);
+
+	return nsecs_to_jiffies(nsecs);
+}
+
 static int bch2_sb_member_find_slot(struct bch_fs *c)
 {
 	int best = -1;

--- a/fs/sb/members.c
+++ b/fs/sb/members.c
@@ -236,6 +236,10 @@ __cold void bch2_member_to_text(struct printbuf *out,
 		prt_printf(out, "(none)");
 	prt_newline(out);
 
+	if (m->failure_domain[0])
+		prt_printf(out, "Failure domain:\t%.*s\n",
+			   (int) sizeof(m->failure_domain), m->failure_domain);
+
 	prt_printf(out, "UUID:\t");
 	pr_uuid(out, m->uuid.b);
 	prt_newline(out);
@@ -328,6 +332,10 @@ static void bch2_member_to_text_short_sb(struct printbuf *out,
 				BCH_MEMBER_GROUP(m) - 1);
 		prt_newline(out);
 	}
+
+	if (m->failure_domain[0])
+		prt_printf(out, "Failure domain:\t%.*s\n",
+			   (int) sizeof(m->failure_domain), m->failure_domain);
 
 	prt_printf(out, "Device:\t%.*s\n", (int) sizeof(m->device_name), m->device_name);
 	prt_printf(out, "Model:\t%.*s\n", (int) sizeof(m->device_model), m->device_model);
@@ -497,14 +505,52 @@ void bch2_sb_members_from_cpu(struct bch_fs *c)
 	}
 }
 
+struct failure_domain {
+	u8	name[32];
+};
+
 void bch2_sb_members_to_cpu(struct bch_fs *c)
 {
+	BUILD_BUG_ON(sizeof(((struct failure_domain *) NULL)->name) !=
+		     sizeof(((struct bch_member *) NULL)->failure_domain));
+
 	for_each_member_device(c, ca) {
 		struct bch_member m = bch2_sb_member_get(c->disk_sb.sb, ca->dev_idx);
 		ca->mi = bch2_mi_to_cpu(&m);
 
 		mod_bit(ca->dev_idx, c->devs_rotational.d, ca->mi.rotational);
 	}
+
+	/*
+	 * Intern failure domain strings to small ids: two devices are in the
+	 * same failure domain iff their (non-empty) strings match. The id is the
+	 * 1-based index into the set of distinct strings, 0 = unset. The table is
+	 * transient - the ids stored on ca->mi are what we keep.
+	 */
+	DARRAY(struct failure_domain) domains = {};
+	for_each_member_device(c, ca) {
+		struct bch_member m = bch2_sb_member_get(c->disk_sb.sb, ca->dev_idx);
+		if (!m.failure_domain[0])
+			continue;
+
+		u16 id = 0;
+		darray_for_each(domains, d)
+			if (!memcmp(d->name, m.failure_domain, sizeof(d->name))) {
+				id = (d - domains.data) + 1;
+				break;
+			}
+
+		if (!id) {
+			struct failure_domain d;
+			memcpy(d.name, m.failure_domain, sizeof(d.name));
+			if (darray_push(&domains, d))
+				continue;	/* -ENOMEM: leave unset, safe */
+			id = domains.nr;
+		}
+
+		ca->mi.failure_domain = id;
+	}
+	darray_exit(&domains);
 
 	struct bch_sb_field_members_v2 *mi2 = bch2_sb_field_get(c->disk_sb.sb, members_v2);
 	if (mi2)

--- a/fs/sb/members.h
+++ b/fs/sb/members.h
@@ -422,6 +422,7 @@ static inline struct bch_member_cpu bch2_mi_to_cpu(struct bch_member *mi)
 		.first_bucket	= le16_to_cpu(mi->first_bucket),
 		.bucket_size	= le16_to_cpu(mi->bucket_size),
 		.group		= BCH_MEMBER_GROUP(mi),
+		/* .failure_domain is interned in bch2_sb_members_to_cpu() */
 		.state		= BCH_MEMBER_STATE(mi),
 		.discard	= BCH_MEMBER_DISCARD(mi),
 		.data_allowed	= BCH_MEMBER_DATA_ALLOWED(mi),

--- a/fs/sb/members.h
+++ b/fs/sb/members.h
@@ -50,6 +50,8 @@ void bch2_member_to_text_short_locked(struct printbuf *, struct bch_fs *, struct
 void bch2_member_to_text_short(struct printbuf *, struct bch_fs *, struct bch_dev *);
 void bch2_devs_mask_to_text_locked(struct printbuf *, struct bch_fs *, struct bch_devs_mask *);
 
+unsigned long bch2_dev_latency_max(struct bch_fs *, struct bch_devs_mask *, int);
+
 /* Device online state: */
 
 static inline bool bch2_dev_is_online(struct bch_dev *ca)

--- a/fs/sb/members_format.h
+++ b/fs/sb/members_format.h
@@ -76,6 +76,15 @@ struct bch_member {
 	__u8			device_model[64] __nonstring;
 	__le64			flush_errors;
 	__u8			device_serial[64] __nonstring;
+	/*
+	 * Failure domain: devices sharing a (non-empty) string are in the same
+	 * failure domain, and allocation spreads replicas - and, for erasure
+	 * coding, requires stripe blocks - across domains. A flat, intrinsic
+	 * device property with no relationship to the disk_groups label tree.
+	 * Interned to a small id in memory (bch_member_cpu.failure_domain) for
+	 * the allocation path.
+	 */
+	__u8			failure_domain[32] __nonstring;
 };
 
 /*
@@ -105,6 +114,7 @@ LE64_BITMASK(BCH_MEMBER_RESIZE_ON_MOUNT,struct bch_member, flags, 31, 32)
 LE64_BITMASK(BCH_MEMBER_ROTATIONAL,	struct bch_member, flags, 32, 33)
 LE64_BITMASK(BCH_MEMBER_ROTATIONAL_SET,	struct bch_member, flags, 33, 34)
 LE64_BITMASK(BCH_MEMBER_INITIALIZED,	struct bch_member, flags, 34, 38)
+/* 38-46 free, was FAILURE_DOMAIN (now a string, member.failure_domain) */
 
 #if 0
 LE64_BITMASK(BCH_MEMBER_NR_READ_ERRORS,	struct bch_member, flags[1], 0,  20);

--- a/fs/sb/members_types.h
+++ b/fs/sb/members_types.h
@@ -8,6 +8,7 @@ struct bch_member_cpu {
 	u16			first_bucket;   /* index of first bucket used */
 	u16			bucket_size;	/* sectors */
 	u16			group;
+	u16			failure_domain;
 	u8			state;
 	u8			discard;
 	u8			data_allowed;

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -1078,14 +1078,9 @@ static int check_snapshot_exists(struct btree_trans *trans, u32 id)
 	snapshot->v.tree	= cpu_to_le32(tree_id);
 	snapshot->v.btime.lo	= cpu_to_le64(bch2_current_time(c));
 
-	for_each_btree_key_norestart(trans, iter, BTREE_ID_subvolumes, POS_MIN,
-				     0, k, ret) {
-		if (k.k->type == KEY_TYPE_subvolume &&
-		    le32_to_cpu(bkey_s_c_to_subvolume(k).v->snapshot) == id) {
-			snapshot->v.subvol = cpu_to_le32(k.k->p.offset);
-			break;
-		}
-	}
+	u32 subvol_id = 0;
+	try(subvol_claiming_snapshot(trans, id, &subvol_id));
+	snapshot->v.subvol = cpu_to_le32(subvol_id);
 
 	bch2_snapshot_state_set(&snapshot->v, SNAPSHOT_STATE_live);
 

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -336,15 +336,32 @@ static int check_snapshot_to_subvol(struct btree_trans *trans,
 		/* dangling snapshot will be handled later */
 		u32 id = le32_to_cpu(s->subvol);
 
-		struct bch_subvolume subvol;
-		int ret = bch2_subvolume_get(trans, id, false, &subvol);
-		if (bch2_err_matches(ret, ENOENT)) {
-			bch_err(c, "snapshot points to nonexistent subvolume:\n  %s",
-				(bch2_bkey_val_to_text(&buf, c, k), buf.buf));
+		/*
+		 * Raw read: bch2_subvolume_get() reports deleted subvolumes
+		 * as ENOENT, and the message should show what's actually
+		 * there:
+		 */
+		CLASS(btree_iter, subvol_iter)(trans, BTREE_ID_subvolumes, POS(0, id), 0);
+		struct bkey_s_c_subvolume subvol_k = bch2_bkey_get_typed(&subvol_iter, subvolume);
+		int ret = bkey_err(subvol_k);
+		if (ret && !bch2_err_matches(ret, ENOENT))
+			return ret;
+
+		struct bch_subvolume subvol = {};
+		if (!ret)
+			bkey_val_copy_pad(&subvol, subvol_k);
+
+		if (ret || bch2_subvolume_state_compat(&subvol) == SUBVOLUME_STATE_deleted) {
+			printbuf_reset(&buf);
+			prt_str(&buf, "snapshot points to missing or deleted subvolume:\n  ");
+			bch2_bkey_val_to_text(&buf, c, k);
+			if (!ret) {
+				prt_str(&buf, "\n  ");
+				bch2_bkey_val_to_text(&buf, c, subvol_k.s_c);
+			}
+			bch_err(c, "%s", buf.buf);
 			return 0;
 		}
-		if (ret)
-			return ret;
 
 		/*
 		 * A live subvolume that doesn't point back isn't this
@@ -356,9 +373,10 @@ static int check_snapshot_to_subvol(struct btree_trans *trans,
 		    le32_to_cpu(subvol.snapshot) != k.k->p.offset) {
 			CLASS(bch_log_msg, msg)(c);
 
-			prt_printf(&msg.m, "snapshot points to live subvolume %u, which points to snapshot %u:\n",
-				   id, le32_to_cpu(subvol.snapshot));
+			prt_printf(&msg.m, "snapshot points to live subvolume, which points elsewhere:\n");
 			bch2_bkey_val_to_text(&msg.m, c, k);
+			prt_newline(&msg.m);
+			bch2_bkey_val_to_text(&msg.m, c, subvol_k.s_c);
 			msg.m.suppress = !bch2_count_fsck_err(c, snapshot_subvol_backref_wrong, &msg.m);
 
 			return bch_err_throw(c, fsck_repair_unimplemented);

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -1171,6 +1171,7 @@ int __bch2_check_key_has_snapshot(struct btree_trans *trans,
 		return 1;
 
 	if (state != SNAPSHOT_ID_deleted &&
+	    state != SNAPSHOT_ID_no_keys &&
 	    state != SNAPSHOT_ID_empty)
 		return 0;
 
@@ -1219,7 +1220,8 @@ int __bch2_check_key_has_snapshot(struct btree_trans *trans,
 
 	unsigned repair_flags = FSCK_CAN_IGNORE | (!ret ? FSCK_CAN_FIX : 0);
 
-	if (state == SNAPSHOT_ID_deleted) {
+	if (state == SNAPSHOT_ID_deleted ||
+	    state == SNAPSHOT_ID_no_keys) {
 		/*
 		 * If there's no live descendant (a leaf, or an interior node whose
 		 * subtree is entirely deleted) the key is genuinely orphaned -

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -333,7 +333,6 @@ static int check_snapshot_to_subvol(struct btree_trans *trans,
 		 bch2_snapshot_state(s) == SNAPSHOT_STATE_will_delete);
 
 	if (s->subvol) {
-		/* dangling snapshot will be handled later */
 		u32 id = le32_to_cpu(s->subvol);
 
 		/*
@@ -351,35 +350,61 @@ static int check_snapshot_to_subvol(struct btree_trans *trans,
 		if (!ret)
 			bkey_val_copy_pad(&subvol, subvol_k);
 
-		if (ret || bch2_subvolume_state_compat(&subvol) == SUBVOLUME_STATE_deleted) {
-			printbuf_reset(&buf);
-			prt_str(&buf, "snapshot points to missing or deleted subvolume:\n  ");
-			bch2_bkey_val_to_text(&buf, c, k);
+		bool snap_deleting	= bch2_snapshot_state(s) == SNAPSHOT_STATE_will_delete;
+		bool subvol_deleted	= !ret &&
+			bch2_subvolume_state_compat(&subvol) == SUBVOLUME_STATE_deleted;
+		bool points_back	= !ret &&
+			le32_to_cpu(subvol.snapshot) == k.k->p.offset;
+
+		if (ret || !points_back) {
+			/*
+			 * Missing subvolume or wrong backref: repair needs
+			 * the subvolume side validated first - it belongs to
+			 * the dedicated pass after check_subvols. Report
+			 * only; an error return here would regress mounts of
+			 * filesystems mid-deletion:
+			 */
+			CLASS(bch_log_msg, msg)(c);
+
+			if (ret)
+				prt_printf(&msg.m, "snapshot points to missing subvolume %u:\n", id);
+			else
+				prt_printf(&msg.m, "snapshot's subvolume doesn't point back at it:\n");
+			bch2_bkey_val_to_text(&msg.m, c, k);
 			if (!ret) {
-				prt_str(&buf, "\n  ");
-				bch2_bkey_val_to_text(&buf, c, subvol_k.s_c);
+				prt_newline(&msg.m);
+				bch2_bkey_val_to_text(&msg.m, c, subvol_k.s_c);
 			}
-			bch_err(c, "%s", buf.buf);
+			msg.m.suppress = !bch2_count_fsck_err(c, snapshot_subvol_backref_wrong, &msg.m);
 			return 0;
 		}
 
 		/*
-		 * A live subvolume that doesn't point back isn't this
-		 * leaf's owner - the leaf needs its own subvolume
-		 * created, which we can't do yet. (One that does point
-		 * back was handled by check_snapshot()'s corroboration.)
+		 * The deletion machinery couples exactly one bit on each
+		 * side: a snapshot is will_delete iff its subvolume is
+		 * tombstoned (live vs unlinked is the subvolume's own
+		 * user-visibility business, invisible to the snapshot).
+		 * With the edge intact, a state mismatch repairs in one
+		 * direction only: the subvolume implies the snapshot state
+		 * exactly, while the reverse would have to guess between
+		 * live and unlinked.
 		 */
-		if (bch2_subvolume_state_compat(&subvol) == SUBVOLUME_STATE_live &&
-		    le32_to_cpu(subvol.snapshot) != k.k->p.offset) {
-			CLASS(bch_log_msg, msg)(c);
-
-			prt_printf(&msg.m, "snapshot points to live subvolume, which points elsewhere:\n");
-			bch2_bkey_val_to_text(&msg.m, c, k);
-			prt_newline(&msg.m);
-			bch2_bkey_val_to_text(&msg.m, c, subvol_k.s_c);
-			msg.m.suppress = !bch2_count_fsck_err(c, snapshot_subvol_backref_wrong, &msg.m);
-
-			return bch_err_throw(c, fsck_repair_unimplemented);
+		if (ret_fsck_err_on(snap_deleting != subvol_deleted,
+				    trans, snapshot_subvol_state_mismatch,
+				    "snapshot %s but its subvolume is %s:\n%s",
+				    snap_deleting ? "will_delete" : "live",
+				    subvol_deleted ? "deleted" : "not deleted",
+				    (printbuf_reset(&buf),
+				     bch2_bkey_val_to_text(&buf, c, k),
+				     prt_newline(&buf),
+				     bch2_bkey_val_to_text(&buf, c, subvol_k.s_c),
+				     buf.buf))) {
+			u = u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
+			bch2_snapshot_state_set(&u->v,
+						subvol_deleted
+						? SNAPSHOT_STATE_will_delete
+						: SNAPSHOT_STATE_live);
+			*s = u->v;
 		}
 	} else if (should_have_subvol &&
 		   bch2_snapshot_state(s) == SNAPSHOT_STATE_live) {

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -1218,6 +1218,8 @@ int __bch2_check_key_has_snapshot(struct btree_trans *trans,
 
 	try(ret);
 
+	/* inodes btree keys the inum in the offset field, everything else in inode */
+	u64 inum = iter->btree_id == BTREE_ID_inodes ? k.k->p.offset : k.k->p.inode;
 	unsigned repair_flags = FSCK_CAN_IGNORE | (!ret ? FSCK_CAN_FIX : 0);
 
 	if (state == SNAPSHOT_ID_deleted ||
@@ -1249,9 +1251,12 @@ int __bch2_check_key_has_snapshot(struct btree_trans *trans,
 				"key in deleted snapshot %s, delete?",
 				(bch2_btree_id_to_text(&buf, iter->btree_id),
 				 prt_char(&buf, ' '),
-				 bch2_bkey_val_to_text(&buf, c, k), buf.buf)))
+				 bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
+			bch2_fsck_damaged(trans, SPOS(inum, 0, k.k->p.snapshot),
+					  FSCK_DAMAGE_keys_deleted);
 			ret = bch2_btree_delete_at(trans, iter,
 						   BTREE_UPDATE_internal_snapshot_node) ?: 1;
+		}
 
 		if (__fsck_err_on(live_child,
 				trans, repair_flags, bkey_in_deleted_interior_snapshot,
@@ -1268,9 +1273,12 @@ int __bch2_check_key_has_snapshot(struct btree_trans *trans,
 			     "key in missing snapshot %s, delete?",
 			     (bch2_btree_id_to_text(&buf, iter->btree_id),
 			      prt_char(&buf, ' '),
-			      bch2_bkey_val_to_text(&buf, c, k), buf.buf)))
+			      bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
+			bch2_fsck_damaged(trans, SPOS(inum, 0, k.k->p.snapshot),
+					  FSCK_DAMAGE_keys_deleted);
 			ret = bch2_btree_delete_at(trans, iter,
 						   BTREE_UPDATE_internal_snapshot_node) ?: 1;
+		}
 	}
 fsck_err:
 	return ret;

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -273,6 +273,24 @@ static int snapshot_tree_ptr_repair(struct btree_trans *trans,
 	return 0;
 }
 
+/* Find a subvolume claiming snapshot @id, to restore a wiped backref: */
+static int subvol_claiming_snapshot(struct btree_trans *trans, u32 id,
+				    u32 *subvol_id)
+{
+	struct bkey_s_c k;
+	int ret;
+
+	for_each_btree_key_norestart(trans, iter, BTREE_ID_subvolumes, POS_MIN,
+				     0, k, ret)
+		if (k.k->type == KEY_TYPE_subvolume &&
+		    le32_to_cpu(bkey_s_c_to_subvolume(k).v->snapshot) == id) {
+			*subvol_id = k.k->p.offset;
+			break;
+		}
+
+	return ret;
+}
+
 static int check_snapshot_to_subvol(struct btree_trans *trans,
 			  struct btree_iter *iter,
 			  struct bkey_s_c k,
@@ -316,6 +334,29 @@ static int check_snapshot_to_subvol(struct btree_trans *trans,
 			msg.m.suppress = !bch2_count_fsck_err(c, snapshot_subvol_backref_wrong, &msg.m);
 
 			return bch_err_throw(c, fsck_repair_unimplemented);
+		}
+	} else if (should_have_subvol &&
+		   bch2_snapshot_state(s) == SNAPSHOT_STATE_live) {
+		/*
+		 * A live leaf with no backref: a subvolume still pointing at
+		 * it means the backref was wiped - restore it. (A second
+		 * claimant, if damage minted one, still hits check_subvols'
+		 * doesn't-point-back fail-stop.) No claimant is an orphan
+		 * leaf, whose repair (creating a subvolume) is
+		 * unimplemented, as above.
+		 */
+		u32 subvol_id = 0;
+		try(subvol_claiming_snapshot(trans, k.k->p.offset, &subvol_id));
+
+		if (subvol_id &&
+		    ret_fsck_err(trans, snapshot_subvol_backref_wrong,
+				 "snapshot leaf missing subvol backref, subvolume %u points at it - restoring:\n%s",
+				 subvol_id,
+				 (bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
+			u = u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
+			u->v.subvol = cpu_to_le32(subvol_id);
+			SET_BCH_SNAPSHOT_SUBVOL_OBSOLETE(&u->v, true);
+			*s = u->v;
 		}
 	}
 

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -1,4 +1,27 @@
 // SPDX-License-Identifier: GPL-2.0
+/*
+ * Snapshot fsck: the passes over the snapshots and snapshot_trees btrees.
+ *
+ * check_snapshot_trees: every tree key names a live root and master subvol.
+ *
+ * check_snapshots: per-node, in three stages - check_snapshot_state()
+ * recovers the state field itself; check_snapshot_deleted() holds a
+ * non-live state up against its witnesses; then the topology checks
+ * (edges, tree pointer, depth, skiplists, subvol backref).
+ *
+ * reconstruct_snapshots: rebuild missing snapshot nodes from the keys
+ * that reference them.
+ *
+ * __bch2_check_key_has_snapshot: per-key repair for keys whose snapshot
+ * node is missing or dead; also called from runtime paths.
+ *
+ * Repair philosophy: enumerate which writers can produce a state before
+ * repairing it. Unconstructible combinations are rejected at commit
+ * (bch2_snapshot_validate()); real damage is repaired toward the side
+ * the witnesses corroborate - child snapshots, the subvolume (deletion
+ * tombstones it in the same transaction that condemns its snapshot).
+ * Ambiguity fail-stops rather than guessing.
+ */
 #include "bcachefs.h"
 
 #include "alloc/accounting.h"
@@ -96,6 +119,8 @@ static int bch2_snapshot_tree_master_subvol(struct btree_trans *trans,
 	SET_BCH_SUBVOLUME_SNAP(&u->v, false);
 	return 0;
 }
+
+/* check_snapshot_trees: */
 
 static int check_snapshot_tree(struct btree_trans *trans,
 			       struct btree_iter *iter,
@@ -200,6 +225,8 @@ int bch2_check_snapshot_trees(struct bch_fs *c)
  * Look up snapshot tree for @tree_id and find root,
  * make sure @snap_id is a descendent:
  */
+/* check_snapshots: */
+
 static int snapshot_tree_ptr_good(struct btree_trans *trans,
 				  u32 snap_id, u32 tree_id)
 {
@@ -416,6 +443,8 @@ static int check_snapshot_to_subvol(struct btree_trans *trans,
  */
 
 enum { EDGE_PARENT, EDGE_CHILD };
+
+/* snapshot edge repair: */
 
 static bool snapshot_node_points_back(const struct bch_snapshot *s, unsigned side, u32 other)
 {
@@ -714,20 +743,19 @@ static int snapshot_referenced(struct btree_trans *trans,
 	return 0;
 }
 
-static int check_snapshot(struct btree_trans *trans,
-			  struct btree_iter *iter,
-			  struct bkey_s_c k)
+/*
+ * Recover the state field itself: stamp it from the legacy flags when
+ * unset, decode a corrupted value back to the nearest codeword, and
+ * correct a state left stale by a legacy flags-only tombstone.
+ */
+static int check_snapshot_state(struct btree_trans *trans,
+				struct btree_iter *iter,
+				struct bkey_s_c k,
+				struct bch_snapshot *s,
+				struct bkey_i_snapshot **u)
 {
 	struct bch_fs *c = trans->c;
 	CLASS(printbuf, buf)();
-	struct bkey_i_snapshot *u = NULL;
-	int ret = 0;
-
-	if (k.k->type != KEY_TYPE_snapshot)
-		return 0;
-
-	struct bch_snapshot s;
-	bkey_val_copy_pad(&s, bkey_s_c_to_snapshot(k));
 
 	/*
 	 * A zero state field means the key predates the state field, or was
@@ -738,16 +766,16 @@ static int check_snapshot(struct btree_trans *trans,
 	 * ran) heals too. Mid-upgrade this is the expected migration and silent;
 	 * post-upgrade an unset state is unexpected, so surface it (autofix).
 	 */
-	if (!bch2_snapshot_state(&s)) {
+	if (!bch2_snapshot_state(s)) {
 		bool upgrading = c->sb.version_upgrade_complete <
 			bcachefs_metadata_version_per_dev_fragmentation_lru;
 		if (upgrading ||
 		    ret_fsck_err(trans, snapshot_state_bad,
 				 "snapshot state unset, recovering from legacy flags:\n%s",
 				 (bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
-			u = u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
-			u->v.state = cpu_to_le32(bch2_snapshot_state_from_flags(&s));
-			s = u->v;
+			*u = *u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
+			(*u)->v.state = cpu_to_le32(bch2_snapshot_state_from_flags(s));
+			*s = (*u)->v;
 		}
 	}
 
@@ -757,10 +785,10 @@ static int check_snapshot(struct btree_trans *trans,
 	 * is corruption. No repair yet, and state-keyed repairs must not run
 	 * on a state we can't read:
 	 */
-	if (!bch2_snapshot_state_valid(bch2_snapshot_state(&s))) {
+	if (!bch2_snapshot_state_valid(bch2_snapshot_state(s))) {
 		unsigned dist;
 		enum bch_snapshot_state nearest =
-			bch2_snapshot_state_nearest(le32_to_cpu(s.state), &dist);
+			bch2_snapshot_state_nearest(le32_to_cpu(s->state), &dist);
 
 		/*
 		 * Codewords are >= 14 apart, so anything <= 6 bits out is
@@ -772,22 +800,22 @@ static int check_snapshot(struct btree_trans *trans,
 		if (dist <= 2) {
 			if (ret_fsck_err(trans, snapshot_state_bitflip,
 					 "snapshot state 0x%x is a %u-bit flip of %s - correcting:\n%s",
-					 le32_to_cpu(s.state), dist,
+					 le32_to_cpu(s->state), dist,
 					 bch2_snapshot_state_str(nearest),
 					 (bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
-				u = u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
-				bch2_snapshot_state_set(&u->v, nearest);
-				s = u->v;
+				*u = *u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
+				bch2_snapshot_state_set(&(*u)->v, nearest);
+				*s = (*u)->v;
 			}
 		} else if (dist <= 6) {
 			if (ret_fsck_err(trans, snapshot_state_bad,
 					 "snapshot state 0x%x is %u bits from %s - correcting:\n%s",
-					 le32_to_cpu(s.state), dist,
+					 le32_to_cpu(s->state), dist,
 					 bch2_snapshot_state_str(nearest),
 					 (bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
-				u = u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
-				bch2_snapshot_state_set(&u->v, nearest);
-				s = u->v;
+				*u = *u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
+				bch2_snapshot_state_set(&(*u)->v, nearest);
+				*s = (*u)->v;
 			}
 		} else {
 			/*
@@ -797,24 +825,24 @@ static int check_snapshot(struct btree_trans *trans,
 			 * unreferenced garbage node we can't place: fail-stop.
 			 */
 			bool ref;
-			int ret2 = snapshot_referenced(trans, &s, k.k->p.offset, &ref);
+			int ret2 = snapshot_referenced(trans, s, k.k->p.offset, &ref);
 			if (ret2)
 				return ret2;
 
 			if (ref) {
 				if (ret_fsck_err(trans, snapshot_state_bad,
 						 "snapshot state 0x%x is garbage, but the node is referenced - marking live:\n%s",
-						 le32_to_cpu(s.state),
+						 le32_to_cpu(s->state),
 						 (bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
-					u = u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
-					bch2_snapshot_state_set(&u->v, SNAPSHOT_STATE_live);
-					s = u->v;
+					*u = *u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
+					bch2_snapshot_state_set(&(*u)->v, SNAPSHOT_STATE_live);
+					*s = (*u)->v;
 				}
 			} else {
 				CLASS(bch_log_msg, msg)(c);
 
 				prt_printf(&msg.m, "snapshot has invalid state 0x%x (nearest codeword %s is %u bits away, node unreferenced):\n",
-					   le32_to_cpu(s.state), bch2_snapshot_state_str(nearest), dist);
+					   le32_to_cpu(s->state), bch2_snapshot_state_str(nearest), dist);
 				bch2_bkey_val_to_text(&msg.m, c, k);
 				msg.m.suppress = !bch2_count_fsck_err(c, snapshot_state_bad, &msg.m);
 
@@ -838,18 +866,35 @@ static int check_snapshot(struct btree_trans *trans,
 	 * fail-stops the edge checks - wedging every mount (the 2026-07-20
 	 * field report; snapshot-inject/stale_state_tombstone).
 	 */
-	if (bch2_snapshot_state(&s) != SNAPSHOT_STATE_deleted &&
-	    BCH_SNAPSHOT_DELETED_OBSOLETE(&s) &&
-	    !s.tree &&
+	if (bch2_snapshot_state(s) != SNAPSHOT_STATE_deleted &&
+	    BCH_SNAPSHOT_DELETED_OBSOLETE(s) &&
+	    !s->tree &&
 	    ret_fsck_err(trans, snapshot_state_stale_tombstone,
 			 "snapshot spliced out by a legacy kernel (tombstone shape, legacy deleted flag)\n"
 			 "but the state field is stale at %s - correcting to deleted:\n%s",
-			 bch2_snapshot_state_str(bch2_snapshot_state(&s)),
+			 bch2_snapshot_state_str(bch2_snapshot_state(s)),
 			 (bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
-		u = u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
-		bch2_snapshot_state_set(&u->v, SNAPSHOT_STATE_deleted);
-		s = u->v;
+		*u = *u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
+		bch2_snapshot_state_set(&(*u)->v, SNAPSHOT_STATE_deleted);
+		*s = (*u)->v;
 	}
+
+	return 0;
+}
+
+/*
+ * A non-live state, checked against its witnesses - child snapshots,
+ * the subvolume. Returns 1 when the node is a settled tombstone: no
+ * further checking.
+ */
+static int check_snapshot_deleted(struct btree_trans *trans,
+				  struct btree_iter *iter,
+				  struct bkey_s_c k,
+				  struct bch_snapshot *s,
+				  struct bkey_i_snapshot **u)
+{
+	struct bch_fs *c = trans->c;
+	CLASS(printbuf, buf)();
 
 	/*
 	 * A non-live node with two live children that both point back at it is a
@@ -869,15 +914,15 @@ static int check_snapshot(struct btree_trans *trans,
 	 * Do this before the deleted early-out, then fall through so the
 	 * edge/depth/tree checks validate the now-live node.
 	 */
-	if (bch2_snapshot_state(&s) != SNAPSHOT_STATE_live) {
+	if (bch2_snapshot_state(s) != SNAPSHOT_STATE_live) {
 		unsigned nr_live_children = 0;
 
 		for (unsigned i = 0; i < 2; i++) {
-			if (!s.children[i])
+			if (!s->children[i])
 				continue;
 
 			struct bch_snapshot child;
-			int ret2 = bch2_snapshot_lookup(trans, le32_to_cpu(s.children[i]), &child);
+			int ret2 = bch2_snapshot_lookup(trans, le32_to_cpu(s->children[i]), &child);
 			if (ret2 && !bch2_err_matches(ret2, ENOENT))
 				return ret2;
 
@@ -889,11 +934,11 @@ static int check_snapshot(struct btree_trans *trans,
 		if (ret_fsck_err_on(nr_live_children == 2,
 				trans, snapshot_deleted_has_live_children,
 				"snapshot marked %s but has two live children - reviving:\n%s",
-				bch2_snapshot_state_str(bch2_snapshot_state(&s)),
+				bch2_snapshot_state_str(bch2_snapshot_state(s)),
 				(bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
-			u = u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
-			bch2_snapshot_state_set(&u->v, SNAPSHOT_STATE_live);
-			s = u->v;
+			*u = *u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
+			bch2_snapshot_state_set(&(*u)->v, SNAPSHOT_STATE_live);
+			*s = (*u)->v;
 		}
 
 		/*
@@ -905,9 +950,9 @@ static int check_snapshot(struct btree_trans *trans,
 		 * corrupt legacy flag. (A tombstoned subvolume reads as
 		 * ENOENT here: that's normal mid-deletion, not evidence.)
 		 */
-		if (!s.children[0] && s.subvol) {
+		if (!s->children[0] && s->subvol) {
 			struct bch_subvolume subvol;
-			int ret2 = bch2_subvolume_get(trans, le32_to_cpu(s.subvol),
+			int ret2 = bch2_subvolume_get(trans, le32_to_cpu(s->subvol),
 						      false, &subvol);
 			if (ret2 && !bch2_err_matches(ret2, ENOENT))
 				return ret2;
@@ -917,17 +962,37 @@ static int check_snapshot(struct btree_trans *trans,
 			    le32_to_cpu(subvol.snapshot) == k.k->p.offset &&
 			    ret_fsck_err(trans, snapshot_deleted_but_subvol_live,
 					 "snapshot marked %s but its subvolume is live - reviving:\n%s",
-					 bch2_snapshot_state_str(bch2_snapshot_state(&s)),
+					 bch2_snapshot_state_str(bch2_snapshot_state(s)),
 					 (bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
-				u = u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
-				bch2_snapshot_state_set(&u->v, SNAPSHOT_STATE_live);
-				s = u->v;
+				*u = *u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
+				bch2_snapshot_state_set(&(*u)->v, SNAPSHOT_STATE_live);
+				*s = (*u)->v;
 			}
 		}
 	}
 
-	if (bch2_snapshot_state(&s) == SNAPSHOT_STATE_deleted)
+	return bch2_snapshot_state(s) == SNAPSHOT_STATE_deleted;
+}
+
+static int check_snapshot(struct btree_trans *trans,
+			  struct btree_iter *iter,
+			  struct bkey_s_c k)
+{
+	struct bch_fs *c = trans->c;
+	CLASS(printbuf, buf)();
+	struct bkey_i_snapshot *u = NULL;
+	int ret = 0;
+
+	if (k.k->type != KEY_TYPE_snapshot)
 		return 0;
+
+	struct bch_snapshot s;
+	bkey_val_copy_pad(&s, bkey_s_c_to_snapshot(k));
+	try(check_snapshot_state(trans, iter, k, &s, &u));
+
+	ret = check_snapshot_deleted(trans, iter, k, &s, &u);
+	if (ret)
+		return ret < 0 ? ret : 0;
 
 	if (s.parent)
 		try(check_snapshot_edge(trans, &s, k.k->p.offset,
@@ -1043,6 +1108,8 @@ int bch2_check_snapshots(struct bch_fs *c)
 		bch2_set_btree_clean(c, BTREE_ID_snapshots);
 	return ret;
 }
+
+/* reconstruct_snapshots: */
 
 static int check_snapshot_exists(struct btree_trans *trans, u32 id)
 {
@@ -1210,6 +1277,8 @@ int bch2_reconstruct_snapshots(struct bch_fs *c)
  * of the descendant, copy it down. A genuinely missing inode is left for a
  * full fsck to reconstruct; we don't do that or schedule passes here.
  */
+/* check_key_has_snapshot - per-key repair, also called at runtime: */
+
 static int check_key_has_inode_in_snapshot(struct btree_trans *trans,
 					   enum btree_id btree, u64 inum, u32 snapshot)
 {

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -799,6 +799,34 @@ static int check_snapshot(struct btree_trans *trans,
 	}
 
 	/*
+	 * A valid state that contradicts the legacy flags: current writers
+	 * dual-write both via bch2_snapshot_state_set(), so only a legacy
+	 * flags-only writer leaves them disagreeing - the flags are the fresher
+	 * write. But the flags are single unprotected bits, so corroborate
+	 * structurally before trusting them over a codeword: a node tombstoned
+	 * by a legacy bch2_snapshot_node_delete() carries the tombstone wipe,
+	 * and no live, will_delete or no_keys node ever has tree == 0. A bare
+	 * DELETED bit on a live-shaped node stays with the state field.
+	 *
+	 * Left as-is, the interior-deletion collector reads the stale no_keys
+	 * state, queues the tombstone, and the breadcrumb child pointer
+	 * fail-stops the edge checks - wedging every mount (the 2026-07-20
+	 * field report; snapshot-inject/stale_state_tombstone).
+	 */
+	if (bch2_snapshot_state(&s) != SNAPSHOT_STATE_deleted &&
+	    BCH_SNAPSHOT_DELETED_OBSOLETE(&s) &&
+	    !s.tree &&
+	    ret_fsck_err(trans, snapshot_state_stale_tombstone,
+			 "snapshot spliced out by a legacy kernel (tombstone shape, legacy deleted flag)\n"
+			 "but the state field is stale at %s - correcting to deleted:\n%s",
+			 bch2_snapshot_state_str(bch2_snapshot_state(&s)),
+			 (bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
+		u = u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
+		bch2_snapshot_state_set(&u->v, SNAPSHOT_STATE_deleted);
+		s = u->v;
+	}
+
+	/*
 	 * A non-live node with two live children that both point back at it is a
 	 * lie: it's a branching interior that two subtrees still depend on as
 	 * their common ancestor, so it can't be gone. Reviving it is the simplest

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -1429,11 +1429,20 @@ int __bch2_check_key_has_snapshot(struct btree_trans *trans,
 	 * only returns the unwind error (deferring this key's own repair) when
 	 * it actually needs to rewind to an earlier pass; scheduling a
 	 * later-or-current pass just marks it to run.
+	 *
+	 * skip_if_complete: at most one sweep per instance. These passes don't
+	 * repair every stranded-key state - if they already ran and this key is
+	 * still here, rescheduling can't fix it, but it would re-arm the passes
+	 * in the superblock on every encounter, forcing fsck on every mount.
 	 */
-	ret = bch2_run_explicit_recovery_pass(c, &buf, BCH_RECOVERY_PASS_check_inodes, 0) ?: ret;
-	ret = bch2_run_explicit_recovery_pass(c, &buf, BCH_RECOVERY_PASS_check_extents, 0) ?: ret;
-	ret = bch2_run_explicit_recovery_pass(c, &buf, BCH_RECOVERY_PASS_check_dirents, 0) ?: ret;
-	ret = bch2_run_explicit_recovery_pass(c, &buf, BCH_RECOVERY_PASS_check_xattrs, 0) ?: ret;
+	ret = bch2_run_explicit_recovery_pass(c, &buf, BCH_RECOVERY_PASS_check_inodes,
+					      RUN_RECOVERY_PASS_skip_if_complete) ?: ret;
+	ret = bch2_run_explicit_recovery_pass(c, &buf, BCH_RECOVERY_PASS_check_extents,
+					      RUN_RECOVERY_PASS_skip_if_complete) ?: ret;
+	ret = bch2_run_explicit_recovery_pass(c, &buf, BCH_RECOVERY_PASS_check_dirents,
+					      RUN_RECOVERY_PASS_skip_if_complete) ?: ret;
+	ret = bch2_run_explicit_recovery_pass(c, &buf, BCH_RECOVERY_PASS_check_xattrs,
+					      RUN_RECOVERY_PASS_skip_if_complete) ?: ret;
 
 	/*
 	 * Snapshot missing entirely: we should have caught this with

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -300,38 +300,22 @@ static int check_snapshot_to_subvol(struct btree_trans *trans,
 		if (ret)
 			return ret;
 
-		if (bch2_subvolume_state_compat(&subvol) == SUBVOLUME_STATE_live) {
-			/*
-			 * A live subvolume that doesn't point back isn't this
-			 * leaf's owner - the leaf needs its own subvolume
-			 * created, which we can't do yet:
-			 */
-			if (le32_to_cpu(subvol.snapshot) != k.k->p.offset) {
-				CLASS(bch_log_msg, msg)(c);
+		/*
+		 * A live subvolume that doesn't point back isn't this
+		 * leaf's owner - the leaf needs its own subvolume
+		 * created, which we can't do yet. (One that does point
+		 * back was handled by check_snapshot()'s corroboration.)
+		 */
+		if (bch2_subvolume_state_compat(&subvol) == SUBVOLUME_STATE_live &&
+		    le32_to_cpu(subvol.snapshot) != k.k->p.offset) {
+			CLASS(bch_log_msg, msg)(c);
 
-				prt_printf(&msg.m, "snapshot points to live subvolume %u, which points to snapshot %u:\n",
-					   id, le32_to_cpu(subvol.snapshot));
-				bch2_bkey_val_to_text(&msg.m, c, k);
-				msg.m.suppress = !bch2_count_fsck_err(c, snapshot_subvol_backref_wrong, &msg.m);
+			prt_printf(&msg.m, "snapshot points to live subvolume %u, which points to snapshot %u:\n",
+				   id, le32_to_cpu(subvol.snapshot));
+			bch2_bkey_val_to_text(&msg.m, c, k);
+			msg.m.suppress = !bch2_count_fsck_err(c, snapshot_subvol_backref_wrong, &msg.m);
 
-				return bch_err_throw(c, fsck_repair_unimplemented);
-			}
-
-			/*
-			 * Deletion tombstones the subvolume in the same
-			 * transaction that marks the leaf will_delete, so
-			 * will_delete with a live owner pointing back means
-			 * the node's state is what's wrong:
-			 */
-			if (ret_fsck_err_on(bch2_snapshot_state(s) == SNAPSHOT_STATE_will_delete,
-					trans, snapshot_will_delete_but_subvol_live,
-					"snapshot marked will_delete but its subvolume is live - resurrecting:\n%s",
-					(bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
-				u = u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
-
-				bch2_snapshot_state_set(&u->v, SNAPSHOT_STATE_live);
-				*s = u->v;
-			}
+			return bch_err_throw(c, fsck_repair_unimplemented);
 		}
 	}
 
@@ -869,6 +853,35 @@ static int check_snapshot(struct btree_trans *trans,
 			u = u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
 			bch2_snapshot_state_set(&u->v, SNAPSHOT_STATE_live);
 			s = u->v;
+		}
+
+		/*
+		 * Same check via the subvolume: deletion tombstones the
+		 * subvolume in the same transaction that marks its snapshot,
+		 * so a non-live leaf whose subvolume is live and points back
+		 * has a bad state field. This also fixes, in the same pass, a
+		 * bad state stamped by the zero-state migration above from a
+		 * corrupt legacy flag. (A tombstoned subvolume reads as
+		 * ENOENT here: that's normal mid-deletion, not evidence.)
+		 */
+		if (!s.children[0] && s.subvol) {
+			struct bch_subvolume subvol;
+			int ret2 = bch2_subvolume_get(trans, le32_to_cpu(s.subvol),
+						      false, &subvol);
+			if (ret2 && !bch2_err_matches(ret2, ENOENT))
+				return ret2;
+
+			if (!ret2 &&
+			    bch2_subvolume_state_compat(&subvol) == SUBVOLUME_STATE_live &&
+			    le32_to_cpu(subvol.snapshot) == k.k->p.offset &&
+			    ret_fsck_err(trans, snapshot_deleted_but_subvol_live,
+					 "snapshot marked %s but its subvolume is live - reviving:\n%s",
+					 bch2_snapshot_state_str(bch2_snapshot_state(&s)),
+					 (bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
+				u = u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
+				bch2_snapshot_state_set(&u->v, SNAPSHOT_STATE_live);
+				s = u->v;
+			}
 		}
 	}
 

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -975,14 +975,10 @@ static int check_snapshot_deleted(struct btree_trans *trans,
 	/*
 	 * Every deleted node gets held up against the accounting: nothing we
 	 * write deletes a node with data still accounted to it, so data means
-	 * the state field is the lie, whatever the node's shape - undelete,
-	 * falling through so the edge checks validate the now-live node.
-	 *
-	 * No data, but the tree pointer was never wiped: the tombstone wipe
-	 * clears it in the same transaction that marks deleted, so this node
-	 * was never spliced out - complete the deletion. (A surviving parent
-	 * pointer is not evidence of anything: legacy tombstones retain it.)
-	 * No data and no tree: settled tombstone, nothing to do.
+	 * the state field is the lie, whatever the rest of the node says -
+	 * undelete, splicing the node back into the tree (the tombstone
+	 * retained its pointers), and fall through so the edge checks
+	 * validate the result. No data: settled tombstone, nothing to do.
 	 */
 	if (bch2_snapshot_state(s) == SNAPSHOT_STATE_deleted) {
 		u64 keys, sectors;
@@ -995,7 +991,7 @@ static int check_snapshot_deleted(struct btree_trans *trans,
 				(printbuf_reset(&buf),
 				 bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
 			*u = *u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
-			bch2_snapshot_state_set(&(*u)->v, SNAPSHOT_STATE_live);
+			try(bch2_snapshot_node_undelete(trans, *u));
 			*s = (*u)->v;
 		}
 	}

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -19,8 +19,9 @@
  * repairing it. Unconstructible combinations are rejected at commit
  * (bch2_snapshot_validate()); real damage is repaired toward the side
  * the witnesses corroborate - child snapshots, the subvolume (deletion
- * tombstones it in the same transaction that condemns its snapshot).
- * Ambiguity fail-stops rather than guessing.
+ * tombstones it in the same transaction that condemns its snapshot),
+ * the per-snapshot accounting (nothing we write deletes a node with
+ * data). Ambiguity fail-stops rather than guessing.
  */
 #include "bcachefs.h"
 
@@ -884,8 +885,8 @@ static int check_snapshot_state(struct btree_trans *trans,
 
 /*
  * A non-live state, checked against its witnesses - child snapshots,
- * the subvolume. Returns 1 when the node is a settled tombstone: no
- * further checking.
+ * the subvolume, the accounting. Returns 1 if the node was deleted or
+ * is a settled tombstone: no further checking.
  */
 static int check_snapshot_deleted(struct btree_trans *trans,
 				  struct btree_iter *iter,
@@ -971,6 +972,47 @@ static int check_snapshot_deleted(struct btree_trans *trans,
 		}
 	}
 
+	/*
+	 * Every deleted node gets held up against the accounting: nothing we
+	 * write deletes a node with data still accounted to it, so data means
+	 * the state field is the lie, whatever the node's shape - undelete,
+	 * falling through so the edge checks validate the now-live node.
+	 *
+	 * No data, but the tree pointer was never wiped: the tombstone wipe
+	 * clears it in the same transaction that marks deleted, so this node
+	 * was never spliced out - complete the deletion. (A surviving parent
+	 * pointer is not evidence of anything: legacy tombstones retain it.)
+	 * No data and no tree: settled tombstone, nothing to do.
+	 */
+	if (bch2_snapshot_state(s) == SNAPSHOT_STATE_deleted) {
+		u64 keys, sectors;
+		bch2_snapshot_accounting_totals(c, k.k->p.offset, &keys, &sectors, NULL);
+
+		if (ret_fsck_err_on(keys || sectors,
+				trans, snapshot_deleted_but_has_data,
+				"deleted snapshot node has %llu keys / %llu sectors accounted - undeleting:\n%s",
+				keys, sectors,
+				(printbuf_reset(&buf),
+				 bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
+			*u = *u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
+			bch2_snapshot_state_set(&(*u)->v, SNAPSHOT_STATE_live);
+			*s = (*u)->v;
+		} else if (ret_fsck_err_on(!keys && !sectors && s->tree,
+				trans, snapshot_deleted_but_linked,
+				"deleted snapshot node was never spliced out, no data accounted - completing deletion:\n%s",
+				(printbuf_reset(&buf),
+				 bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
+			*u = *u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
+			/* pass node_delete's already-deleted guard: */
+			bch2_snapshot_state_set(&(*u)->v, SNAPSHOT_STATE_will_delete);
+			*s = (*u)->v;
+
+			try(bch2_snapshot_node_delete(trans, k.k->p.offset,
+						      !!s->children[0]));
+			return 1;
+		}
+	}
+
 	return bch2_snapshot_state(s) == SNAPSHOT_STATE_deleted;
 }
 
@@ -993,6 +1035,7 @@ static int check_snapshot(struct btree_trans *trans,
 	ret = check_snapshot_deleted(trans, iter, k, &s, &u);
 	if (ret)
 		return ret < 0 ? ret : 0;
+
 
 	if (s.parent)
 		try(check_snapshot_edge(trans, &s, k.k->p.offset,

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -603,6 +603,52 @@ static int check_snapshot_edge(struct btree_trans *trans,
 		return other_ret;
 	bool other_exists = !other_ret;
 
+	/*
+	 * Connectivity: the live tree must be closed over not-deleted nodes.
+	 * A deleted target is history - an interrupted deletion left our edge
+	 * pointing into it - so rewrite our own edge past it: parent edges
+	 * walk up the tombstone's retained parent chain, child edges walk
+	 * down retained children, to the nearest not-deleted node (or
+	 * nothing, if that direction is all dead). The tombstone itself is
+	 * untouched; depth/skiplist fallout is repaired by the checks
+	 * downstream. (A tombstone with two live children was revived by
+	 * check_snapshot_deleted() before we got here, so walking
+	 * children[0] doesn't skip a live sibling.)
+	 */
+	if (other_exists &&
+	    bch2_snapshot_state_compat(&other) == SNAPSHOT_STATE_deleted) {
+		u32 repl = other_id;
+		struct bch_snapshot t = other;
+
+		for (unsigned iters = 0; ; iters++) {
+			if (iters > BTREE_MAX_DEPTH * 64) /* damaged chain, cycle? don't guess */
+				return 0;
+
+			repl = le32_to_cpu(side == EDGE_CHILD ? t.parent : t.children[0]);
+			if (!repl)
+				break;
+
+			int ret2 = bch2_snapshot_lookup(trans, repl, &t);
+			if (bch2_err_matches(ret2, ENOENT)) {
+				repl = 0;
+				break;
+			}
+			if (ret2)
+				return ret2;
+
+			if (bch2_snapshot_state_compat(&t) != SNAPSHOT_STATE_deleted)
+				break;
+		}
+
+		if (ret_fsck_err(trans, snapshot_deleted_but_linked,
+				 "snapshot %u %s pointer %u is a deleted node - %s %u",
+				 id, side == EDGE_CHILD ? "parent" : "child", other_id,
+				 repl ? "re-linking past it to" : "clearing, dead in that direction:",
+				 repl))
+			return snapshot_edge_set_ptr(trans, id, side, other_id, repl);
+		return 0;
+	}
+
 	if (other_exists && snapshot_node_points_back(&other, !side, id))
 		return 0;
 

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -997,19 +997,6 @@ static int check_snapshot_deleted(struct btree_trans *trans,
 			*u = *u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
 			bch2_snapshot_state_set(&(*u)->v, SNAPSHOT_STATE_live);
 			*s = (*u)->v;
-		} else if (ret_fsck_err_on(!keys && !sectors && s->tree,
-				trans, snapshot_deleted_but_linked,
-				"deleted snapshot node was never spliced out, no data accounted - completing deletion:\n%s",
-				(printbuf_reset(&buf),
-				 bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
-			*u = *u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
-			/* pass node_delete's already-deleted guard: */
-			bch2_snapshot_state_set(&(*u)->v, SNAPSHOT_STATE_will_delete);
-			*s = (*u)->v;
-
-			try(bch2_snapshot_node_delete(trans, k.k->p.offset,
-						      !!s->children[0]));
-			return 1;
 		}
 	}
 

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -1037,7 +1037,16 @@ static int check_snapshot_deleted(struct btree_trans *trans,
 				(printbuf_reset(&buf),
 				 bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
 			*u = *u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
-			try(bch2_snapshot_node_undelete(trans, *u));
+
+			/*
+			 * Relinking rewrites pointers on nodes this pass may
+			 * already have verified - require another run:
+			 */
+			bool relinked = false;
+			try(bch2_snapshot_node_undelete(trans, *u, &relinked));
+			if (relinked)
+				try(bch2_require_recovery_pass(c, &buf,
+						BCH_RECOVERY_PASS_check_snapshots));
 			*s = (*u)->v;
 		}
 	}

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -447,7 +447,15 @@ static int check_snapshot_to_subvol(struct btree_trans *trans,
 		*s = u->v;
 	}
 
-	if (BCH_SNAPSHOT_SUBVOL_OBSOLETE(s) != (s->subvol != 0)) {
+	/*
+	 * Live nodes only: the _OBSOLETE flags are old-format compat bits,
+	 * and bch2_snapshot_state_set() clears SUBVOL_OBSOLETE for every
+	 * non-live state even when the subvol backref is retained
+	 * (will_delete keeps it as tombstone testimony) - old kernels must
+	 * not read a dying snapshot as a live subvolume leaf:
+	 */
+	if (bch2_snapshot_state(s) == SNAPSHOT_STATE_live &&
+	    BCH_SNAPSHOT_SUBVOL_OBSOLETE(s) != (s->subvol != 0)) {
 		printbuf_reset(&buf);
 		prt_printf(&buf, "snapshot node %llu has wrong subvol flag:\n",
 			   k.k->p.offset);

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -29,6 +29,7 @@
 
 #include "btree/cache.h"
 #include "btree/update.h"
+#include "btree/write_buffer.h"
 
 #include "fs/inode.h"
 
@@ -534,7 +535,7 @@ static u32 snapshot_table_find_edge(struct bch_fs *c, const struct bch_snapshot 
 	return found;
 }
 
-static u64 snapshot_data_sectors(struct bch_fs *c, u32 id)
+static int snapshot_data_sectors(struct btree_trans *trans, u32 id, u64 *sectors)
 {
 	struct disk_accounting_pos acc;
 	memset(&acc, 0, sizeof(acc));
@@ -543,8 +544,9 @@ static u64 snapshot_data_sectors(struct bch_fs *c, u32 id)
 
 	/* btree 0 (extents, the default) is the only one with external_sectors (counter 2) */
 	u64 v[3] = {};
-	bch2_accounting_mem_read(c, disk_accounting_pos_to_bpos(&acc), v, ARRAY_SIZE(v));
-	return v[2];
+	try(bch2_accounting_btree_read(trans, disk_accounting_pos_to_bpos(&acc), v, ARRAY_SIZE(v)));
+	*sectors = v[2];
+	return 0;
 }
 
 static bool snapshot_parent_child_consistent(const struct bch_snapshot *s, u32 id, unsigned side,
@@ -738,7 +740,8 @@ static int check_snapshot_edge(struct btree_trans *trans,
 		u32 sibling = le32_to_cpu(s->children[0]) == other_id
 			? le32_to_cpu(s->children[1])
 			: le32_to_cpu(s->children[0]);
-		u64 sectors = snapshot_data_sectors(c, other_id);
+		u64 sectors;
+		try(snapshot_data_sectors(trans, other_id, &sectors));
 
 		if (!sectors && sibling &&
 		    ret_fsck_err(trans, snapshot_edge_bad,
@@ -1071,7 +1074,7 @@ static int check_snapshot_deleted(struct btree_trans *trans,
 	 */
 	if (bch2_snapshot_state(s) == SNAPSHOT_STATE_deleted) {
 		u64 keys, sectors;
-		bch2_snapshot_accounting_totals(c, k.k->p.offset, &keys, &sectors, NULL);
+		try(bch2_snapshot_accounting_totals(trans, k.k->p.offset, &keys, &sectors, NULL));
 
 		if (ret_fsck_err_on(keys || sectors,
 				trans, snapshot_deleted_but_has_data,
@@ -1196,6 +1199,15 @@ static int check_snapshot(struct btree_trans *trans,
 
 int bch2_check_snapshots_trans(struct btree_trans *trans)
 {
+	/*
+	 * The accounting-gated repairs below (deleted-but-has-data undelete,
+	 * dangling-child-pointer clear) read snapshot accounting from the
+	 * accounting btree; flush buffered deltas once, up front. check_snapshot
+	 * doesn't delete keys, so the values can't go stale mid-pass in the
+	 * direction that matters:
+	 */
+	try(bch2_btree_write_buffer_flush_sync(trans));
+
 	/*
 	 * We iterate backwards as checking/fixing the depth field requires that
 	 * the parent's depth already be correct:

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -1410,33 +1410,46 @@ int bch2_reconstruct_snapshots(struct bch_fs *c)
  * snapshot-deletion scan's premise - "a key in snapshot X implies an inode in
  * snapshot X" - has to hold at the destination too, or the key gets stranded
  * again on the next deletion. If the inode is only inherited from an ancestor
- * of the descendant, copy it down. A genuinely missing inode is left for a
- * full fsck to reconstruct; we don't do that or schedule passes here.
+ * of the descendant, copy it down; if there's no inode visible at all, insert
+ * a whiteout at the destination snapshot - the deletion scan doesn't care
+ * about key type, only that a key at (inum, snapshot) exists to index the
+ * sweep, and a whiteout provides that without fabricating a live inode.
  */
 /* check_key_has_snapshot - per-key repair, also called at runtime: */
 
 static int check_key_has_inode_in_snapshot(struct btree_trans *trans,
 					   enum btree_id btree, u64 inum, u32 snapshot)
 {
-	switch (btree) {
-	case BTREE_ID_extents:
-	case BTREE_ID_dirents:
-	case BTREE_ID_xattrs:
-		break;
-	default:
+	if (btree == BTREE_ID_inodes)
+		return 0;
+
+	CLASS(btree_iter, iter)(trans, BTREE_ID_inodes, SPOS(0, inum, snapshot), 0);
+	struct bkey_s_c k = bkey_try(bch2_btree_iter_peek_slot(&iter));
+
+	if (bkey_deleted(k.k)) {
+		/*
+		 * No key visible in this view (peek_slot synthesizes a deleted
+		 * key at the search pos for an empty slot, and filters real
+		 * whiteouts): insert a whiteout at the exact snapshot to index
+		 * the position.
+		 */
+		struct bkey_i *whiteout =
+			errptr_try(bch2_trans_kmalloc(trans, sizeof(*whiteout)));
+		bkey_init(&whiteout->k);
+		whiteout->k.type = KEY_TYPE_whiteout;
+		whiteout->k.p = SPOS(0, inum, snapshot);
+
+		return bch2_btree_insert_trans(trans, BTREE_ID_inodes, whiteout,
+					       BTREE_UPDATE_internal_snapshot_node);
+	} else if (k.k->p.snapshot != snapshot) {
+		/* Inherited from an ancestor: copy it down. */
+		struct bkey_i *n = errptr_try(bch2_bkey_make_mut_noupdate(trans, k));
+		n->k.p.snapshot = snapshot;
+		return bch2_btree_insert_trans(trans, BTREE_ID_inodes, n,
+					       BTREE_UPDATE_internal_snapshot_node);
+	} else {
 		return 0;
 	}
-
-	struct bch_inode_unpacked inode;
-	int ret = bch2_inode_find_by_inum_snapshot(trans, inum, snapshot, &inode, 0);
-	if (ret)
-		return bch2_err_matches(ret, ENOENT) ? 0 : ret;
-
-	if (inode.bi_snapshot == snapshot)
-		return 0;
-
-	inode.bi_snapshot = snapshot;
-	return __bch2_fsck_write_inode(trans, &inode);
 }
 
 int __bch2_check_key_has_snapshot(struct btree_trans *trans,
@@ -1555,10 +1568,10 @@ int __bch2_check_key_has_snapshot(struct btree_trans *trans,
 				(bch2_btree_id_to_text(&buf, iter->btree_id),
 				 prt_char(&buf, ' '),
 				 bch2_bkey_val_to_text(&buf, c, k), buf.buf), live_child))
-			ret = bch2_delete_dead_snapshot_key(trans, iter, k, live_child) ?:
-			      check_key_has_inode_in_snapshot(trans, iter->btree_id,
-							      k.k->p.inode, live_child) ?:
-			      1;
+			ret =   check_key_has_inode_in_snapshot(trans, iter->btree_id,
+								k.k->p.inode, live_child) ?:
+				bch2_delete_dead_snapshot_key(trans, iter, k, live_child) ?:
+				1;
 	} else {
 		if (__fsck_err(trans, repair_flags, bkey_in_missing_snapshot,
 			     "key in missing snapshot %s, delete?",

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -1551,7 +1551,7 @@ int __bch2_check_key_has_snapshot(struct btree_trans *trans,
 		}
 
 		if (__inode_fsck_err_on(!live_child,
-				trans, inum, k.k->p.snapshot,
+				trans, k.k->p,
 				repair_flags, bkey_in_deleted_snapshot,
 				"key in deleted snapshot %s, delete?",
 				(bch2_btree_id_to_text(&buf, iter->btree_id),
@@ -1571,7 +1571,7 @@ int __bch2_check_key_has_snapshot(struct btree_trans *trans,
 				bch2_delete_dead_snapshot_key(trans, iter, k, live_child) ?:
 				1;
 	} else {
-		if (__inode_fsck_err(trans, inum, k.k->p.snapshot,
+		if (__inode_fsck_err(trans, k.k->p,
 			     repair_flags, bkey_in_missing_snapshot,
 			     "key in missing snapshot %s, delete?",
 			     (bch2_btree_id_to_text(&buf, iter->btree_id),

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -1074,12 +1074,14 @@ static int check_snapshot_deleted(struct btree_trans *trans,
 	 */
 	if (bch2_snapshot_state(s) == SNAPSHOT_STATE_deleted) {
 		u64 keys, sectors;
-		try(bch2_snapshot_accounting_totals(trans, k.k->p.offset, &keys, &sectors, NULL));
+		CLASS(printbuf, breakdown)();
+		try(bch2_snapshot_accounting_totals(trans, k.k->p.offset, &keys, &sectors,
+						    NULL, &breakdown));
 
 		if (ret_fsck_err_on(keys || sectors,
 				trans, snapshot_deleted_but_has_data,
-				"deleted snapshot node has %llu keys / %llu sectors accounted - undeleting:\n%s",
-				keys, sectors,
+				"deleted snapshot node has data accounted - undeleting:%s\n%s",
+				breakdown.buf,
 				(printbuf_reset(&buf),
 				 bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
 			*u = *u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -1086,15 +1086,7 @@ static int check_snapshot_deleted(struct btree_trans *trans,
 				 bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
 			*u = *u ?: errptr_try(bch2_bkey_make_mut_typed(trans, iter, &k, 0, snapshot));
 
-			/*
-			 * Relinking rewrites pointers on nodes this pass may
-			 * already have verified - require another run:
-			 */
-			bool relinked = false;
-			try(bch2_snapshot_node_undelete(trans, *u, &relinked));
-			if (relinked)
-				try(bch2_require_recovery_pass(c, &buf,
-						BCH_RECOVERY_PASS_check_snapshots));
+			try(bch2_snapshot_node_undelete(trans, *u));
 			*s = (*u)->v;
 		}
 	}

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -1088,6 +1088,13 @@ static int check_snapshot_deleted(struct btree_trans *trans,
 
 			try(bch2_snapshot_node_undelete(trans, *u));
 			*s = (*u)->v;
+			/*
+			 * Short circuit the rest of the checks for this node:
+			 * the in-mem snapshot table won't be updated until we
+			 * commit, we'll rely on the checks already having been
+			 * done on the child.
+			 */
+			return 1;
 		}
 	}
 
@@ -1113,7 +1120,6 @@ static int check_snapshot(struct btree_trans *trans,
 	ret = check_snapshot_deleted(trans, iter, k, &s, &u);
 	if (ret)
 		return ret < 0 ? ret : 0;
-
 
 	if (s.parent)
 		try(check_snapshot_edge(trans, &s, k.k->p.offset,

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -1550,17 +1550,15 @@ int __bch2_check_key_has_snapshot(struct btree_trans *trans,
 			goto fsck_err;
 		}
 
-		if (__fsck_err_on(!live_child,
-				trans, repair_flags, bkey_in_deleted_snapshot,
+		if (__inode_fsck_err_on(!live_child,
+				trans, inum, k.k->p.snapshot,
+				repair_flags, bkey_in_deleted_snapshot,
 				"key in deleted snapshot %s, delete?",
 				(bch2_btree_id_to_text(&buf, iter->btree_id),
 				 prt_char(&buf, ' '),
-				 bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
-			bch2_fsck_damaged(trans, SPOS(inum, 0, k.k->p.snapshot),
-					  FSCK_DAMAGE_keys_deleted);
+				 bch2_bkey_val_to_text(&buf, c, k), buf.buf)))
 			ret = bch2_btree_delete_at(trans, iter,
 						   BTREE_UPDATE_internal_snapshot_node) ?: 1;
-		}
 
 		if (__fsck_err_on(live_child,
 				trans, repair_flags, bkey_in_deleted_interior_snapshot,
@@ -1573,16 +1571,14 @@ int __bch2_check_key_has_snapshot(struct btree_trans *trans,
 				bch2_delete_dead_snapshot_key(trans, iter, k, live_child) ?:
 				1;
 	} else {
-		if (__fsck_err(trans, repair_flags, bkey_in_missing_snapshot,
+		if (__inode_fsck_err(trans, inum, k.k->p.snapshot,
+			     repair_flags, bkey_in_missing_snapshot,
 			     "key in missing snapshot %s, delete?",
 			     (bch2_btree_id_to_text(&buf, iter->btree_id),
 			      prt_char(&buf, ' '),
-			      bch2_bkey_val_to_text(&buf, c, k), buf.buf))) {
-			bch2_fsck_damaged(trans, SPOS(inum, 0, k.k->p.snapshot),
-					  FSCK_DAMAGE_keys_deleted);
+			      bch2_bkey_val_to_text(&buf, c, k), buf.buf)))
 			ret = bch2_btree_delete_at(trans, iter,
 						   BTREE_UPDATE_internal_snapshot_node) ?: 1;
-		}
 	}
 fsck_err:
 	return ret;

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -64,6 +64,26 @@
  *   safety.
  */
 
+/*
+ * Recovery ordering: on a filesystem that may be damaged, delete_dead_snapshots()
+ * must run AFTER the content-check passes - check_inodes, check_extents,
+ * check_dirents, check_xattrs.
+ *
+ * Deleting a dead snapshot migrates its still-live keys down to a live
+ * descendant, and that migration trusts the tree it's handed: it assumes every
+ * key's inode exists at the key's snapshot ID and that the
+ * inode<->dirent<->extent relationships are already consistent. When that
+ * doesn't hold, migrating against the broken structure compounds the damage -
+ * a dirent gets moved to a descendant whose inode is gone, or one half of an
+ * inode<->dirent pair is deleted while the other is left stranded in a snapshot
+ * the worklist won't revisit.
+ *
+ * The content-check passes repair exactly those properties, so running them
+ * first hands us a consistent tree. The fingerprint of getting it wrong is
+ * bidirectional, snapshot-local inode<->dirent breakage: dirents pointing to
+ * missing inodes in one snapshot, inodes with no dirent in another.
+ */
+
 static __cold void bch2_snapshot_delete_nodes_to_text(struct printbuf *out, struct snapshot_delete *d, bool full)
 {
 	size_t limit = !full ? 10 : SIZE_MAX;

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -391,18 +391,11 @@ int bch2_snapshot_node_delete(struct btree_trans *trans, u32 id, bool delete_int
 	}
 
 	if (!bch2_request_incompat_feature(c, bcachefs_metadata_version_snapshot_deletion_v2)) {
-		s->v.parent		= 0;
 		/*
-		 * Retain the pointer to our live descendant: the node is spliced
-		 * out of the live tree, but a stray key later found in this
-		 * deleted snapshot must still be migrated to where it's visible,
-		 * and bch2_snapshot_live_descendent() walks children[0] to find
-		 * it. (child_id is 0 for a leaf - nothing to retain.)
+		 * Retain parent/child pointers; don't destroy information if we
+		 * have to repair:
 		 */
-		s->v.children[0]	= cpu_to_le32(child_id);
-		s->v.children[1]	= 0;
 		s->v.subvol		= 0;
-		s->v.tree		= 0;
 		s->v.depth		= 0;
 		s->v.skip[0]		= 0;
 		s->v.skip[1]		= 0;

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -1038,6 +1038,9 @@ static int bch2_get_dead_interior_snapshots(struct btree_trans *trans, struct bk
 
 int bch2_delete_dead_interior_snapshots(struct bch_fs *c)
 {
+	if (!c->opts.auto_snapshot_deletion)
+		return 0;
+
 	CLASS(btree_trans, trans)(c);
 	CLASS(interior_delete_list, delete)();
 

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -557,6 +557,30 @@ static bool skip_unrelated_snapshot_tree(struct btree_trans *trans, struct btree
 	return ret;
 }
 
+static int delete_dead_snapshot_keys_v1_btree(struct btree_trans *trans, enum btree_id btree)
+{
+	struct bch_fs *c = trans->c;
+	struct snapshot_delete *d = &c->snapshots.delete;
+
+	CLASS(disk_reservation, res)(c);
+	u64 prev_inum = 0;
+
+	try(for_each_btree_key_commit(trans, iter,
+			btree, POS_MIN,
+			BTREE_ITER_prefetch|BTREE_ITER_all_snapshots, k,
+			&res.r, NULL, BCH_TRANS_COMMIT_no_enospc, ({
+		bch2_progress_update_iter(trans, &d->progress, &iter);
+
+		if (skip_unrelated_snapshot_tree(trans, &iter, &prev_inum))
+			continue;
+
+		bch2_disk_reservation_put(c, &res.r);
+		delete_dead_snapshots_process_key(trans, &iter, k);
+	})));
+
+	return 0;
+}
+
 static int delete_dead_snapshot_keys_v1(struct btree_trans *trans)
 {
 	struct bch_fs *c = trans->c;
@@ -566,26 +590,14 @@ static int delete_dead_snapshot_keys_v1(struct btree_trans *trans)
 	d->progress.silent	= true;
 	d->version		= 1;
 
-	for (unsigned btree = 0; btree < BTREE_ID_NR; btree++) {
-		CLASS(disk_reservation, res)(c);
-		u64 prev_inum = 0;
+	for (unsigned btree = 0; btree < BTREE_ID_NR; btree++)
+		if (btree_type_has_snapshots(btree) && btree != BTREE_ID_inodes)
+			try(delete_dead_snapshot_keys_v1_btree(trans, btree));
 
-		if (!btree_type_has_snapshots(btree))
-			continue;
-
-		try(for_each_btree_key_commit(trans, iter,
-				btree, POS_MIN,
-				BTREE_ITER_prefetch|BTREE_ITER_all_snapshots, k,
-				&res.r, NULL, BCH_TRANS_COMMIT_no_enospc, ({
-			bch2_progress_update_iter(trans, &d->progress, &iter);
-
-			if (skip_unrelated_snapshot_tree(trans, &iter, &prev_inum))
-				continue;
-
-			bch2_disk_reservation_put(c, &res.r);
-			delete_dead_snapshots_process_key(trans, &iter, k);
-		})));
-	}
+	/*
+	 * fsck assumes that we'll process the inodes btree last:
+	 */
+	try(delete_dead_snapshot_keys_v1_btree(trans, BTREE_ID_inodes));
 
 	return 0;
 }

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -438,8 +438,13 @@ int bch2_snapshot_node_delete(struct btree_trans *trans, u32 id, bool delete_int
  * already, the deletion never got that far and there's nothing to relink. If
  * the topology has moved on, or an old wiped tombstone retained nothing, the
  * node revives unlinked and the tree pointer checks handle it downstream.
+ *
+ * @relinked is set if we relinked: we've rewritten pointers on nodes
+ * check_snapshots may already have visited and verified, so the caller
+ * must require another run of the pass.
  */
-int bch2_snapshot_node_undelete(struct btree_trans *trans, struct bkey_i_snapshot *u)
+int bch2_snapshot_node_undelete(struct btree_trans *trans, struct bkey_i_snapshot *u,
+				bool *relinked)
 {
 	struct bch_fs *c = trans->c;
 	u32 id = u->k.p.offset;
@@ -511,6 +516,7 @@ int bch2_snapshot_node_undelete(struct btree_trans *trans, struct bkey_i_snapsho
 		child->v.depth	= cpu_to_le32(le32_to_cpu(u->v.depth) + 1);
 	}
 
+	*relinked = true;
 	return 0;
 }
 

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -181,15 +181,19 @@ int bch2_snapshot_node_set_deleted(struct btree_trans *trans, u32 id)
  * way it's an in-memory read per snapshot btree, and the per-btree breakdown
  * points at where any stranded keys live.
  */
-static int bch2_snapshot_node_check_no_data(struct btree_trans *trans, u32 id)
+/*
+ * Total keys/sectors accounted to snapshot @id across the snapshotted
+ * btrees, with a per-btree breakdown appended to @breakdown if non-NULL.
+ * (nr_keys counters exist only post-upgrade and read as zero before.)
+ */
+void bch2_snapshot_accounting_totals(struct bch_fs *c, u32 id,
+				     u64 *total_keys, u64 *total_sectors,
+				     struct printbuf *breakdown)
 {
-	struct bch_fs *c = trans->c;
-
 	bool trust_keys = c->sb.version_upgrade_complete >=
 		bcachefs_metadata_version_per_dev_fragmentation_lru;
 
-	CLASS(printbuf, buf)();
-	u64 total_keys = 0, total_sectors = 0;
+	*total_keys = *total_sectors = 0;
 
 	for (unsigned btree = 0; btree < BTREE_ID_NR; btree++) {
 		if (!btree_type_has_snapshots(btree))
@@ -211,14 +215,26 @@ static int bch2_snapshot_node_check_no_data(struct btree_trans *trans, u32 id)
 		if (!nr_keys && !sectors)
 			continue;
 
-		total_keys	+= nr_keys;
-		total_sectors	+= sectors;
+		*total_keys	+= nr_keys;
+		*total_sectors	+= sectors;
 
-		prt_str(&buf, "\n  ");
-		bch2_btree_id_to_text(&buf, btree);
-		prt_printf(&buf, ": %llu keys (%llu bytes), %llu sectors",
-			   nr_keys, key_bytes, sectors);
+		if (breakdown) {
+			prt_str(breakdown, "\n  ");
+			bch2_btree_id_to_text(breakdown, btree);
+			prt_printf(breakdown, ": %llu keys (%llu bytes), %llu sectors",
+				   nr_keys, key_bytes, sectors);
+		}
 	}
+}
+
+static int bch2_snapshot_node_check_no_data(struct btree_trans *trans, u32 id)
+{
+	struct bch_fs *c = trans->c;
+
+	CLASS(printbuf, buf)();
+	u64 total_keys, total_sectors;
+
+	bch2_snapshot_accounting_totals(c, id, &total_keys, &total_sectors, &buf);
 
 	if (likely(!total_keys && !total_sectors))
 		return 0;
@@ -256,7 +272,7 @@ static inline void normalize_snapshot_child_pointers(struct bch_snapshot *s)
 		swap(s->children[0], s->children[1]);
 }
 
-static int bch2_snapshot_node_delete(struct btree_trans *trans, u32 id, bool delete_interior)
+int bch2_snapshot_node_delete(struct btree_trans *trans, u32 id, bool delete_interior)
 {
 	struct bch_fs *c = trans->c;
 

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -770,14 +770,12 @@ static int check_should_delete_snapshot(struct btree_trans *trans, struct bkey_s
 	}
 
 	/*
-	 * The leaf check above is this body's last restart point: everything
-	 * below is in-memory table lookups and list pushes, so a transaction
-	 * restart replays the body having collected nothing. The lists aren't
-	 * transactional - keep restartable work above this line, or
-	 * collection double-adds on replay. (Repairs invalidate collected
-	 * state differently: the deletion path resets the lists wholesale
-	 * and rescans.)
-	 *
+	 * The loop's per-key commit can restart after the pushes below and
+	 * replay this body - the lists aren't transactional, so every push
+	 * must be idempotent: nodup adds and has_id guards, or collection
+	 * double-adds on replay. (Repairs invalidate collected state
+	 * differently: the deletion path resets the lists wholesale and
+	 * rescans.)
 	 */
 	struct snapshot_delete *d = &c->snapshots.delete;
 	u32 live_child = 0, nr_live_children = 0;
@@ -827,7 +825,7 @@ static int check_should_delete_snapshot(struct btree_trans *trans, struct bkey_s
 						    bch2_snapshot_tree(c, s.k->p.offset)));
 
 		if (!nr_live_children) {
-			try(snapshot_list_add(c, &d->delete_leaves, s.k->p.offset));
+			try(snapshot_list_add_nodup(c, &d->delete_leaves, s.k->p.offset));
 		} else {
 			struct snapshot_interior_delete n = {
 				.id		= s.k->p.offset,
@@ -839,10 +837,13 @@ static int check_should_delete_snapshot(struct btree_trans *trans, struct bkey_s
 			 * nodes, but we still track them so that we can find
 			 * the correct live_child when deleting parents, above:
 			 */
-			if (bch2_snapshot_state(s.v) != SNAPSHOT_STATE_no_keys)
-				try(darray_push(&d->delete_interior, n));
-			else
-				try(darray_push(&d->no_keys, n));
+			if (bch2_snapshot_state(s.v) != SNAPSHOT_STATE_no_keys) {
+				if (!interior_delete_has_id(&d->delete_interior, n.id))
+					try(darray_push(&d->delete_interior, n));
+			} else {
+				if (!interior_delete_has_id(&d->no_keys, n.id))
+					try(darray_push(&d->no_keys, n));
+			}
 		}
 	}
 
@@ -926,9 +927,16 @@ static int delete_dead_snapshots_locked(struct bch_fs *c)
 
 	/*
 	 * For every snapshot node: If we have no live children and it's not
-	 * pointed to by a subvolume, delete it:
+	 * pointed to by a subvolume, delete it.
+	 *
+	 * The per-key commit is for the childless-no_keys fsck_err: its fix
+	 * is out-of-band (the node is only collected here, deleted later),
+	 * but the fsck_err queues its repair log entry on this trans - which
+	 * would otherwise never commit, only be dropped at the next
+	 * trans_begin (the iter.c dropped-updates WARN):
 	 */
-	try(for_each_btree_key(trans, iter, BTREE_ID_snapshots, POS_MIN, 0, k,
+	try(for_each_btree_key_commit(trans, iter, BTREE_ID_snapshots, POS_MIN, 0, k,
+		NULL, NULL, 0,
 		check_should_delete_snapshot(trans, k)));
 
 	struct snapshot_delete *d = &c->snapshots.delete;

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -430,6 +430,91 @@ int bch2_snapshot_node_delete(struct btree_trans *trans, u32 id, bool delete_int
 }
 
 /*
+ * Reinsert an undeleted node into the live tree: the inverse of the splice in
+ * bch2_snapshot_node_delete(). The tombstone retained its pointers as history:
+ * if the parent's child slot (or the snapshot_tree root, for a deleted root)
+ * currently holds one of our retained children, that's where the splice took
+ * us out - take the slot back and take the child back. If the slot holds us
+ * already, the deletion never got that far and there's nothing to relink. If
+ * the topology has moved on, or an old wiped tombstone retained nothing, the
+ * node revives unlinked and the tree pointer checks handle it downstream.
+ */
+int bch2_snapshot_node_undelete(struct btree_trans *trans, struct bkey_i_snapshot *u)
+{
+	struct bch_fs *c = trans->c;
+	u32 id = u->k.p.offset;
+	u32 parent_id = le32_to_cpu(u->v.parent);
+	u32 child_id = 0;
+
+	bch2_snapshot_state_set(&u->v, SNAPSHOT_STATE_live);
+
+	if (parent_id) {
+		struct bkey_i_snapshot *parent =
+			bch2_bkey_get_mut_typed(trans, BTREE_ID_snapshots,
+						POS(0, parent_id), 0, snapshot);
+		int ret = PTR_ERR_OR_ZERO(parent);
+		if (bch2_err_matches(ret, ENOENT))
+			return 0;
+		if (ret)
+			return ret;
+
+		if (bch2_snapshot_state(&parent->v) != SNAPSHOT_STATE_live)
+			return 0;
+
+		for (unsigned i = 0; i < 2; i++) {
+			u32 p_child = le32_to_cpu(parent->v.children[i]);
+
+			if (p_child &&
+			    (p_child == le32_to_cpu(u->v.children[0]) ||
+			     p_child == le32_to_cpu(u->v.children[1]))) {
+				child_id = p_child;
+				parent->v.children[i] = cpu_to_le32(id);
+				normalize_snapshot_child_pointers(&parent->v);
+				break;
+			}
+		}
+		if (!child_id)
+			return 0;
+	} else if (u->v.tree) {
+		struct bkey_i_snapshot_tree *s_t =
+			bch2_bkey_get_mut_typed(trans, BTREE_ID_snapshot_trees,
+						POS(0, le32_to_cpu(u->v.tree)),
+						0, snapshot_tree);
+		int ret = PTR_ERR_OR_ZERO(s_t);
+		if (bch2_err_matches(ret, ENOENT))
+			return 0;
+		if (ret)
+			return ret;
+
+		u32 root_id = le32_to_cpu(s_t->v.root_snapshot);
+		if (root_id != le32_to_cpu(u->v.children[0]) &&
+		    root_id != le32_to_cpu(u->v.children[1]))
+			return 0;
+
+		child_id = root_id;
+		s_t->v.root_snapshot = cpu_to_le32(id);
+	} else {
+		return 0;
+	}
+
+	u->v.depth = cpu_to_le32(bch2_snapshot_depth(c, parent_id));
+	for (unsigned j = 0; j < ARRAY_SIZE(u->v.skip); j++)
+		u->v.skip[j] = cpu_to_le32(bch2_snapshot_skiplist_get(c, parent_id));
+	bubble_sort(u->v.skip, ARRAY_SIZE(u->v.skip), cmp_le32);
+
+	struct bkey_i_snapshot *child =
+		errptr_try(bch2_bkey_get_mut_typed(trans, BTREE_ID_snapshots,
+					POS(0, child_id), 0, snapshot));
+
+	if (le32_to_cpu(child->v.parent) == parent_id) {
+		child->v.parent	= cpu_to_le32(id);
+		child->v.depth	= cpu_to_le32(le32_to_cpu(u->v.depth) + 1);
+	}
+
+	return 0;
+}
+
+/*
  * If we have an unlinked inode in an internal snapshot node, and the inode
  * really has been deleted in all child snapshots, how does this get cleaned up?
  *

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -1059,6 +1059,18 @@ int bch2_delete_dead_interior_snapshots(struct bch_fs *c)
 		try(bch2_check_snapshots_trans(trans));
 
 		/*
+		 * check_snapshots is licensed to change node states (e.g.
+		 * repairing a stale-state legacy tombstone to deleted), so the
+		 * pre-check collection is only good for deciding whether to run
+		 * it - re-collect for the authoritative delete list:
+		 */
+		delete.nr = 0;
+		try(for_each_btree_key(trans, iter, BTREE_ID_snapshots, POS_MIN, 0, k,
+				       bch2_get_dead_interior_snapshots(trans, k, &delete)));
+	}
+
+	if (delete.nr) {
+		/*
 		 * Fixing children of deleted snapshots can't be done completely
 		 * atomically, if we crash between here and when we delete the interior
 		 * nodes some depth fields will be off:

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -493,6 +493,51 @@ int bch2_snapshot_node_undelete(struct btree_trans *trans, struct bkey_i_snapsho
 
 	bch2_snapshot_state_set(&u->v, SNAPSHOT_STATE_live);
 
+	/*
+	 * A wiped tombstone (parent and tree both zeroed) retains only a child
+	 * pointer, but that's enough to recover the splice point without
+	 * corroboration: the child names the branch, and ids ascend strictly
+	 * child -> parent (validate enforces it on every key), so our own id
+	 * identifies the unique position on that branch. Walk up from the
+	 * child to the first ancestor whose id exceeds ours - we splice in
+	 * below it, or become the branch's new root if the walk runs out.
+	 * Recover parent/tree from the walk and fall through to the normal
+	 * relink branches, which do the splice and validate the attachment.
+	 *
+	 * Depths below the splice point are left off by one: renumbering is
+	 * deferred - it should share code with the deletion-side fixup
+	 * (bch2_fix_child_of_deleted_snapshot()) - and the depth checks
+	 * repair nodes against their parents in the meantime.
+	 */
+	if (!parent_id && !u->v.tree &&
+	    u->v.children[0] && !u->v.children[1]) {
+		u32 cur_id = le32_to_cpu(u->v.children[0]);
+		struct bch_snapshot cur;
+
+		int ret = bch2_snapshot_lookup(trans, cur_id, &cur);
+		if (bch2_err_matches(ret, ENOENT))
+			return 0;	/* nothing to go on: revive unlinked */
+		if (ret)
+			return ret;
+
+		for (unsigned iters = 0;
+		     le32_to_cpu(cur.parent) && le32_to_cpu(cur.parent) < id;
+		     iters++) {
+			if (iters > BTREE_MAX_DEPTH * 64) /* damaged chain, cycle? don't guess */
+				return 0;
+
+			cur_id = le32_to_cpu(cur.parent);
+			try(bch2_snapshot_lookup(trans, cur_id, &cur));
+		}
+
+		/* Splice above the node the walk landed on: */
+		u->v.children[0] = cpu_to_le32(cur_id);
+		u->v.tree = cur.tree;
+		if (cur.parent) {
+			parent_id = le32_to_cpu(cur.parent);
+			u->v.parent = cpu_to_le32(parent_id);
+		}
+	}
 
 	if (parent_id) {
 		struct bkey_i_snapshot *parent =

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -264,7 +264,7 @@ static int bch2_snapshot_node_check_no_data(struct btree_trans *trans, u32 id)
 	 * check_inodes alone can't repair a stranded dirent; scheduling only
 	 * it left the refusal firing forever:
 	 */
-	int ret = bch2_require_recovery_pass(c, &msg, BCH_RECOVERY_PASS_check_allocations);
+	int ret = bch2_run_explicit_recovery_pass(c, &msg, BCH_RECOVERY_PASS_check_allocations, 0);
 
 	for (unsigned btree = 0; btree < BTREE_ID_NR; btree++) {
 		if (!(btrees_with_keys & BIT_ULL(btree)))
@@ -279,7 +279,7 @@ static int bch2_snapshot_node_check_no_data(struct btree_trans *trans, u32 id)
 		default:		continue;
 		}
 
-		ret = bch2_require_recovery_pass(c, &msg, pass) ?: ret;
+		ret = bch2_run_explicit_recovery_pass(c, &msg, pass, 0) ?: ret;
 	}
 
 	bch_err(c, "%s", msg.buf);

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -483,13 +483,8 @@ int bch2_snapshot_node_delete(struct btree_trans *trans, u32 id, bool delete_int
  * already, the deletion never got that far and there's nothing to relink. If
  * the topology has moved on, or an old wiped tombstone retained nothing, the
  * node revives unlinked and the tree pointer checks handle it downstream.
- *
- * @relinked is set if we relinked: we've rewritten pointers on nodes
- * check_snapshots may already have visited and verified, so the caller
- * must require another run of the pass.
  */
-int bch2_snapshot_node_undelete(struct btree_trans *trans, struct bkey_i_snapshot *u,
-				bool *relinked)
+int bch2_snapshot_node_undelete(struct btree_trans *trans, struct bkey_i_snapshot *u)
 {
 	struct bch_fs *c = trans->c;
 	u32 id = u->k.p.offset;
@@ -497,6 +492,7 @@ int bch2_snapshot_node_undelete(struct btree_trans *trans, struct bkey_i_snapsho
 	u32 child_id = 0;
 
 	bch2_snapshot_state_set(&u->v, SNAPSHOT_STATE_live);
+
 
 	if (parent_id) {
 		struct bkey_i_snapshot *parent =
@@ -561,7 +557,6 @@ int bch2_snapshot_node_undelete(struct btree_trans *trans, struct bkey_i_snapsho
 		child->v.depth	= cpu_to_le32(le32_to_cpu(u->v.depth) + 1);
 	}
 
-	*relinked = true;
 	return 0;
 }
 

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -488,119 +488,109 @@ int bch2_snapshot_node_undelete(struct btree_trans *trans, struct bkey_i_snapsho
 {
 	struct bch_fs *c = trans->c;
 	u32 id = u->k.p.offset;
-	u32 parent_id = le32_to_cpu(u->v.parent);
-	u32 child_id = 0;
+	u32 child_id = le32_to_cpu(u->v.children[0]);
 
-	bch2_snapshot_state_set(&u->v, SNAPSHOT_STATE_live);
+	CLASS(bch_log_msg, msg)(c);
 
-	/*
-	 * A wiped tombstone (parent and tree both zeroed) retains only a child
-	 * pointer, but that's enough to recover the splice point without
-	 * corroboration: the child names the branch, and ids ascend strictly
-	 * child -> parent (validate enforces it on every key), so our own id
-	 * identifies the unique position on that branch. Walk up from the
-	 * child to the first ancestor whose id exceeds ours - we splice in
-	 * below it, or become the branch's new root if the walk runs out.
-	 * Recover parent/tree from the walk and fall through to the normal
-	 * relink branches, which do the splice and validate the attachment.
-	 *
-	 * Depths below the splice point are left off by one: renumbering is
-	 * deferred - it should share code with the deletion-side fixup
-	 * (bch2_fix_child_of_deleted_snapshot()) - and the depth checks
-	 * repair nodes against their parents in the meantime.
-	 */
-	if (!parent_id && !u->v.tree &&
-	    u->v.children[0] && !u->v.children[1]) {
-		u32 cur_id = le32_to_cpu(u->v.children[0]);
-		struct bch_snapshot cur;
+	bch2_bkey_val_to_text(&msg.m, c, bkey_i_to_s_c(&u->k_i));
+	prt_newline(&msg.m);
 
-		int ret = bch2_snapshot_lookup(trans, cur_id, &cur);
-		if (bch2_err_matches(ret, ENOENT))
-			return 0;	/* nothing to go on: revive unlinked */
-		if (ret)
-			return ret;
-
-		for (unsigned iters = 0;
-		     le32_to_cpu(cur.parent) && le32_to_cpu(cur.parent) < id;
-		     iters++) {
-			if (iters > BTREE_MAX_DEPTH * 64) /* damaged chain, cycle? don't guess */
-				return 0;
-
-			cur_id = le32_to_cpu(cur.parent);
-			try(bch2_snapshot_lookup(trans, cur_id, &cur));
-		}
-
-		/* Splice above the node the walk landed on: */
-		u->v.children[0] = cpu_to_le32(cur_id);
-		u->v.tree = cur.tree;
-		if (cur.parent) {
-			parent_id = le32_to_cpu(cur.parent);
-			u->v.parent = cpu_to_le32(parent_id);
-		}
+	if (u->v.children[1]) {
+		bch_err(c, "cannot undelete a node with two children");
+		return bch_err_throw(c, fsck_repair_unimplemented);
 	}
+
+	if (!u->v.children[0]) {
+		bch_err(c, "cannot undelete a node with no children");
+		return bch_err_throw(c, fsck_repair_unimplemented);
+	}
+
+	struct bkey_i_snapshot *child =
+		bch2_bkey_get_mut_typed(trans, BTREE_ID_snapshots, POS(0, child_id), 0, snapshot);
+	int ret = PTR_ERR_OR_ZERO(child);
+	if (bch2_err_matches(ret, ENOENT)) {
+		bch_err(c, "cannot undelete: child no longer exists");
+		return bch_err_throw(c, fsck_repair_unimplemented);
+	}
+	if (ret)
+		return ret;
+
+	prt_printf(&msg.m, "attaching to child  ");
+	bch2_bkey_val_to_text(&msg.m, c, bkey_i_to_s_c(&child->k_i));
+	prt_newline(&msg.m);
+
+	if (bch2_snapshot_state_compat(&child->v) != SNAPSHOT_STATE_live &&
+	    bch2_snapshot_state_compat(&child->v) != SNAPSHOT_STATE_will_delete) {
+		prt_printf(&msg.m, "cannot undelete: child not live");
+		return bch_err_throw(c, fsck_repair_unimplemented);
+	}
+
+	u32 parent_id = le32_to_cpu(child->v.parent);
+	if (parent_id && parent_id <= id) {
+		prt_printf(&msg.m, "cannot undelete: parent of child < node to undelete");
+		return bch_err_throw(c, fsck_repair_unimplemented);
+	}
+
+	child->v.parent = cpu_to_le32(id);
 
 	if (parent_id) {
 		struct bkey_i_snapshot *parent =
 			bch2_bkey_get_mut_typed(trans, BTREE_ID_snapshots,
 						POS(0, parent_id), 0, snapshot);
 		int ret = PTR_ERR_OR_ZERO(parent);
-		if (bch2_err_matches(ret, ENOENT))
-			return 0;
-		if (ret)
+		if (ret && !bch2_err_matches(ret, ENOENT))
 			return ret;
 
-		if (bch2_snapshot_state(&parent->v) != SNAPSHOT_STATE_live)
-			return 0;
+		if (ret) {
+			prt_printf(&msg.m, "cannot undelete: parent no longer exists");
+			return bch_err_throw(c, fsck_repair_unimplemented);
+		}
+
+		prt_printf(&msg.m, "attaching to parent ");
+		bch2_bkey_val_to_text(&msg.m, c, bkey_i_to_s_c(&parent->k_i));
+		prt_newline(&msg.m);
+
+		if (bch2_snapshot_state_compat(&parent->v) != SNAPSHOT_STATE_live &&
+		    bch2_snapshot_state_compat(&parent->v) != SNAPSHOT_STATE_will_delete) {
+			prt_printf(&msg.m, "cannot undelete: parent not live");
+			return bch_err_throw(c, fsck_repair_unimplemented);
+		}
 
 		for (unsigned i = 0; i < 2; i++) {
 			u32 p_child = le32_to_cpu(parent->v.children[i]);
 
-			if (p_child &&
-			    (p_child == le32_to_cpu(u->v.children[0]) ||
-			     p_child == le32_to_cpu(u->v.children[1]))) {
-				child_id = p_child;
+			if (p_child == child_id) {
 				parent->v.children[i] = cpu_to_le32(id);
 				normalize_snapshot_child_pointers(&parent->v);
 				break;
 			}
 		}
-		if (!child_id)
-			return 0;
-	} else if (u->v.tree) {
+	} else if (child->v.tree) {
 		struct bkey_i_snapshot_tree *s_t =
 			bch2_bkey_get_mut_typed(trans, BTREE_ID_snapshot_trees,
-						POS(0, le32_to_cpu(u->v.tree)),
+						POS(0, le32_to_cpu(child->v.tree)),
 						0, snapshot_tree);
 		int ret = PTR_ERR_OR_ZERO(s_t);
-		if (bch2_err_matches(ret, ENOENT))
-			return 0;
-		if (ret)
+		if (ret && !bch2_err_matches(ret, ENOENT))
 			return ret;
 
-		u32 root_id = le32_to_cpu(s_t->v.root_snapshot);
-		if (root_id != le32_to_cpu(u->v.children[0]) &&
-		    root_id != le32_to_cpu(u->v.children[1]))
-			return 0;
+		if (!ret && le32_to_cpu(s_t->v.root_snapshot) == child_id) {
+			s_t->v.root_snapshot = cpu_to_le32(id);
 
-		child_id = root_id;
-		s_t->v.root_snapshot = cpu_to_le32(id);
-	} else {
-		return 0;
+			prt_printf(&msg.m, "updated tree ");
+			bch2_bkey_val_to_text(&msg.m, c, bkey_i_to_s_c(&s_t->k_i));
+			prt_newline(&msg.m);
+		}
 	}
+
+	u->v.parent	= cpu_to_le32(parent_id);
+	u->v.tree	= child->v.tree;
+	bch2_snapshot_state_set(&u->v, SNAPSHOT_STATE_live);
 
 	u->v.depth = cpu_to_le32(bch2_snapshot_depth(c, parent_id));
 	for (unsigned j = 0; j < ARRAY_SIZE(u->v.skip); j++)
 		u->v.skip[j] = cpu_to_le32(bch2_snapshot_skiplist_get(c, parent_id));
 	bubble_sort(u->v.skip, ARRAY_SIZE(u->v.skip), cmp_le32);
-
-	struct bkey_i_snapshot *child =
-		errptr_try(bch2_bkey_get_mut_typed(trans, BTREE_ID_snapshots,
-					POS(0, child_id), 0, snapshot));
-
-	if (le32_to_cpu(child->v.parent) == parent_id) {
-		child->v.parent	= cpu_to_le32(id);
-		child->v.depth	= cpu_to_le32(le32_to_cpu(u->v.depth) + 1);
-	}
 
 	return 0;
 }

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -259,6 +259,15 @@ static int bch2_snapshot_node_check_no_data(struct btree_trans *trans, u32 id)
 
 	bch_err(c, "%s", msg.buf);
 
+	/*
+	 * At runtime the passes can't rewind - but the requirement was
+	 * persisted to the superblock before cannot_rewind_recovery was
+	 * returned, so they run at next mount and the refusal below is the
+	 * complete runtime response:
+	 */
+	if (bch2_err_matches(ret, BCH_ERR_cannot_rewind_recovery))
+		ret = 0;
+
 	return ret ?: bch_err_throw(c, EINVAL_snapshot_delete_with_data);
 }
 
@@ -1082,13 +1091,24 @@ static int delete_dead_snapshots_locked(struct bch_fs *c)
 	 */
 	try(bch2_btree_write_buffer_flush_sync(trans));
 
-	darray_for_each(d->delete_leaves, i)
-		try(commit_do(trans, NULL, NULL, 0,
-			bch2_snapshot_node_delete(trans, *i, false)));
+	darray_for_each(d->delete_leaves, i) {
+		int ret = commit_do(trans, NULL, NULL, 0,
+			bch2_snapshot_node_delete(trans, *i, false));
+		/* Refused - repair scheduled; other nodes are unaffected: */
+		if (ret == -BCH_ERR_EINVAL_snapshot_delete_with_data)
+			continue;
+		if (ret)
+			return ret;
+	}
 
-	darray_for_each(d->delete_interior, i)
-		try(commit_do(trans, NULL, NULL, 0,
-			bch2_snapshot_node_set_no_keys(trans, i->id)));
+	darray_for_each(d->delete_interior, i) {
+		int ret = commit_do(trans, NULL, NULL, 0,
+			bch2_snapshot_node_set_no_keys(trans, i->id));
+		if (ret == -BCH_ERR_EINVAL_snapshot_delete_with_data)
+			continue;
+		if (ret)
+			return ret;
+	}
 
 	return 0;
 }
@@ -1211,6 +1231,8 @@ int bch2_delete_dead_interior_snapshots(struct bch_fs *c)
 		darray_for_each(delete, i) {
 			int ret = commit_do(trans, NULL, NULL, 0,
 				bch2_snapshot_node_delete(trans, i->id, true));
+			if (ret == -BCH_ERR_EINVAL_snapshot_delete_with_data)
+				continue;
 			if (!bch2_err_matches(ret, EROFS))
 				bch_err_msg(c, ret, "deleting snapshot %u", i->id);
 			if (ret)

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -6,6 +6,7 @@
 
 #include "btree/bbpos.h"
 #include "btree/update.h"
+#include "btree/write_buffer.h"
 
 #include "init/error.h"
 #include "init/progress.h"
@@ -186,10 +187,11 @@ int bch2_snapshot_node_set_deleted(struct btree_trans *trans, u32 id)
  * btrees, with a per-btree breakdown appended to @breakdown if non-NULL.
  * (nr_keys counters exist only post-upgrade and read as zero before.)
  */
-void bch2_snapshot_accounting_totals(struct bch_fs *c, u32 id,
-				     u64 *total_keys, u64 *total_sectors,
-				     struct printbuf *breakdown)
+int bch2_snapshot_accounting_totals(struct btree_trans *trans, u32 id,
+				    u64 *total_keys, u64 *total_sectors,
+				    struct printbuf *breakdown)
 {
+	struct bch_fs *c = trans->c;
 	bool trust_keys = c->sb.version_upgrade_complete >=
 		bcachefs_metadata_version_per_dev_fragmentation_lru;
 
@@ -205,8 +207,15 @@ void bch2_snapshot_accounting_totals(struct bch_fs *c, u32 id,
 		acc.snapshot.id = id;
 		acc.snapshot.btree = btree;
 
+		/*
+		 * Snapshot accounting is not in-mem (bch2_accounting_is_mem());
+		 * reading it through bch2_accounting_mem_read() returned silent
+		 * zeros, so every caller's "no data accounted" check has passed
+		 * unconditionally since it was added. Callers are responsible
+		 * for a write buffer flush (once per pass, not per call):
+		 */
 		u64 v[3] = {};
-		bch2_accounting_mem_read(c, disk_accounting_pos_to_bpos(&acc), v, ARRAY_SIZE(v));
+		try(bch2_accounting_btree_read(trans, disk_accounting_pos_to_bpos(&acc), v, ARRAY_SIZE(v)));
 
 		u64 nr_keys	= trust_keys ? v[0] : 0;
 		u64 key_bytes	= trust_keys ? v[1] : 0;
@@ -225,6 +234,8 @@ void bch2_snapshot_accounting_totals(struct bch_fs *c, u32 id,
 				   nr_keys, key_bytes, sectors);
 		}
 	}
+
+	return 0;
 }
 
 static int bch2_snapshot_node_check_no_data(struct btree_trans *trans, u32 id)
@@ -234,7 +245,7 @@ static int bch2_snapshot_node_check_no_data(struct btree_trans *trans, u32 id)
 	CLASS(printbuf, buf)();
 	u64 total_keys, total_sectors;
 
-	bch2_snapshot_accounting_totals(c, id, &total_keys, &total_sectors, &buf);
+	try(bch2_snapshot_accounting_totals(trans, id, &total_keys, &total_sectors, &buf));
 
 	if (likely(!total_keys && !total_sectors))
 		return 0;
@@ -1061,6 +1072,15 @@ static int delete_dead_snapshots_locked(struct bch_fs *c)
 	try(!bch2_request_incompat_feature(c, bcachefs_metadata_version_snapshot_deletion_v2)
 	    ? delete_dead_snapshot_keys_v2(trans)
 	    : delete_dead_snapshot_keys_v1(trans));
+
+	/*
+	 * The check_no_data licenses below read snapshot accounting from the
+	 * accounting btree; flush the sweep's buffered deltas so they see
+	 * them. Once per invocation: the node loops below generate no key
+	 * accounting, and a stale read only over-counts, which fails
+	 * conservative (refuses the transition, next pass retries):
+	 */
+	try(bch2_btree_write_buffer_flush_sync(trans));
 
 	darray_for_each(d->delete_leaves, i)
 		try(commit_do(trans, NULL, NULL, 0,

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -189,6 +189,7 @@ int bch2_snapshot_node_set_deleted(struct btree_trans *trans, u32 id)
  */
 int bch2_snapshot_accounting_totals(struct btree_trans *trans, u32 id,
 				    u64 *total_keys, u64 *total_sectors,
+				    u64 *btrees_with_keys,
 				    struct printbuf *breakdown)
 {
 	struct bch_fs *c = trans->c;
@@ -226,6 +227,8 @@ int bch2_snapshot_accounting_totals(struct btree_trans *trans, u32 id,
 
 		*total_keys	+= nr_keys;
 		*total_sectors	+= sectors;
+		if (btrees_with_keys)
+			*btrees_with_keys |= BIT_ULL(btree);
 
 		if (breakdown) {
 			prt_str(breakdown, "\n  ");
@@ -243,9 +246,10 @@ static int bch2_snapshot_node_check_no_data(struct btree_trans *trans, u32 id)
 	struct bch_fs *c = trans->c;
 
 	CLASS(printbuf, buf)();
-	u64 total_keys, total_sectors;
+	u64 total_keys, total_sectors, btrees_with_keys = 0;
 
-	try(bch2_snapshot_accounting_totals(trans, id, &total_keys, &total_sectors, &buf));
+	try(bch2_snapshot_accounting_totals(trans, id, &total_keys, &total_sectors,
+					    &btrees_with_keys, &buf));
 
 	if (likely(!total_keys && !total_sectors))
 		return 0;
@@ -254,8 +258,29 @@ static int bch2_snapshot_node_check_no_data(struct btree_trans *trans, u32 id)
 	prt_printf(&msg, "snapshot node %u still has %llu keys / %llu sectors accounted to it - refusing to delete/empty, to prevent data loss; scheduling repair:%s\n",
 		   id, total_keys, total_sectors, buf.buf);
 
+	/*
+	 * Schedule the passes whose key_has_snapshot repairs can actually
+	 * remove the stranded keys - per btree, from the accounting breakdown.
+	 * check_inodes alone can't repair a stranded dirent; scheduling only
+	 * it left the refusal firing forever:
+	 */
 	int ret = bch2_require_recovery_pass(c, &msg, BCH_RECOVERY_PASS_check_allocations);
-	ret = bch2_require_recovery_pass(c, &msg, BCH_RECOVERY_PASS_check_inodes) ?: ret;
+
+	for (unsigned btree = 0; btree < BTREE_ID_NR; btree++) {
+		if (!(btrees_with_keys & BIT_ULL(btree)))
+			continue;
+
+		enum bch_recovery_pass pass;
+		switch (btree) {
+		case BTREE_ID_extents:	pass = BCH_RECOVERY_PASS_check_extents; break;
+		case BTREE_ID_inodes:	pass = BCH_RECOVERY_PASS_check_inodes;	break;
+		case BTREE_ID_dirents:	pass = BCH_RECOVERY_PASS_check_dirents;	break;
+		case BTREE_ID_xattrs:	pass = BCH_RECOVERY_PASS_check_xattrs;	break;
+		default:		continue;
+		}
+
+		ret = bch2_require_recovery_pass(c, &msg, pass) ?: ret;
+	}
 
 	bch_err(c, "%s", msg.buf);
 

--- a/fs/snapshots/snapshot.c
+++ b/fs/snapshots/snapshot.c
@@ -549,24 +549,43 @@ __cold void bch2_snapshot_to_text(struct printbuf *out, const struct bch_snapsho
 		   le32_to_cpu(s->skip[1]),
 		   le32_to_cpu(s->skip[2]));
 
-	prt_printf(out, " %s", bch2_snapshot_state_str(bch2_snapshot_state_compat(s)));
+	static const char * const obsolete_flag_strs[] = {
+		"will_delete", "subvol", "deleted", "no_keys", NULL
+	};
+	u32 state = le32_to_cpu(s->state);
+	u32 flags = le32_to_cpu(s->flags);
 
-	/*
-	 * The obsolete flags are dual-written shadows of the state field and
-	 * subvol pointer (bch2_snapshot_state_set()); recompute what the
-	 * dual-write would produce and print only divergence:
-	 */
-	struct bch_snapshot expect = *s;
-	bch2_snapshot_state_set(&expect, bch2_snapshot_state_compat(s));
+	if (!state) {
+		/* Not upgraded: no state field, the obsolete flags are the truth */
+		prt_printf(out, " %s (not upgraded, flags 0x%x:",
+			   bch2_snapshot_state_str(bch2_snapshot_state_from_flags(s)),
+			   flags);
+		prt_bitflags(out, obsolete_flag_strs, flags);
+		prt_printf(out, ")");
+	} else if (!bch2_snapshot_state_valid(state)) {
+		prt_printf(out, " state 0x%x invalid (flags 0x%x:", state, flags);
+		prt_bitflags(out, obsolete_flag_strs, flags);
+		prt_printf(out, ")");
+	} else {
+		prt_printf(out, " %s", bch2_snapshot_state_str(state));
 
-	if (BCH_SNAPSHOT_WILL_DELETE_OBSOLETE(s) != BCH_SNAPSHOT_WILL_DELETE_OBSOLETE(&expect))
-		prt_printf(out, " will_delete_obsolete=%llu", BCH_SNAPSHOT_WILL_DELETE_OBSOLETE(s));
-	if (BCH_SNAPSHOT_SUBVOL_OBSOLETE(s) != BCH_SNAPSHOT_SUBVOL_OBSOLETE(&expect))
-		prt_printf(out, " subvol_obsolete=%llu", BCH_SNAPSHOT_SUBVOL_OBSOLETE(s));
-	if (BCH_SNAPSHOT_DELETED_OBSOLETE(s) != BCH_SNAPSHOT_DELETED_OBSOLETE(&expect))
-		prt_printf(out, " deleted_obsolete=%llu", BCH_SNAPSHOT_DELETED_OBSOLETE(s));
-	if (BCH_SNAPSHOT_NO_KEYS_OBSOLETE(s) != BCH_SNAPSHOT_NO_KEYS_OBSOLETE(&expect))
-		prt_printf(out, " no_keys_obsolete=%llu", BCH_SNAPSHOT_NO_KEYS_OBSOLETE(s));
+		/*
+		 * The obsolete flags are dual-written shadows of the state field
+		 * and subvol pointer (bch2_snapshot_state_set()); recompute what
+		 * the dual-write would produce and print only divergence:
+		 */
+		struct bch_snapshot expect = *s;
+		bch2_snapshot_state_set(&expect, state);
+
+		if (BCH_SNAPSHOT_WILL_DELETE_OBSOLETE(s) != BCH_SNAPSHOT_WILL_DELETE_OBSOLETE(&expect))
+			prt_printf(out, " will_delete_obsolete=%llu", BCH_SNAPSHOT_WILL_DELETE_OBSOLETE(s));
+		if (BCH_SNAPSHOT_SUBVOL_OBSOLETE(s) != BCH_SNAPSHOT_SUBVOL_OBSOLETE(&expect))
+			prt_printf(out, " subvol_obsolete=%llu", BCH_SNAPSHOT_SUBVOL_OBSOLETE(s));
+		if (BCH_SNAPSHOT_DELETED_OBSOLETE(s) != BCH_SNAPSHOT_DELETED_OBSOLETE(&expect))
+			prt_printf(out, " deleted_obsolete=%llu", BCH_SNAPSHOT_DELETED_OBSOLETE(s));
+		if (BCH_SNAPSHOT_NO_KEYS_OBSOLETE(s) != BCH_SNAPSHOT_NO_KEYS_OBSOLETE(&expect))
+			prt_printf(out, " no_keys_obsolete=%llu", BCH_SNAPSHOT_NO_KEYS_OBSOLETE(s));
+	}
 }
 
 __cold void bch2_snapshot_key_to_text(struct printbuf *out, struct bch_fs *c,

--- a/fs/snapshots/snapshot.c
+++ b/fs/snapshots/snapshot.c
@@ -219,6 +219,52 @@ bool bch2_snapshot_is_ancestor_early(struct bch_fs *c, u32 id, u32 ancestor)
 	return __bch2_snapshot_is_ancestor_early(rcu_dereference(c->snapshots.table), id, ancestor);
 }
 
+/*
+ * A redundant interior node: a live interior node with exactly one child that
+ * isn't being deleted. delete_dead_snapshots will collapse it into that child,
+ * migrating its keys down; interrupted, that leaves half-migrated keys split
+ * between the node and the child.
+ *
+ * fsck uses this to check such a node's keys/paths in the live child's view -
+ * the state the subtree is provably collapsing into - so a half-migrated key
+ * isn't a false positive. On a healthy fs there are none: taking a snapshot
+ * always makes a 2-child split, so a single-child interior only exists as the
+ * residue of a deletion.
+ *
+ * Walks the collapse chain and returns the live terminal it collapses into, or
+ * 0 if @id isn't a redundant interior.
+ */
+u32 bch2_snapshot_redundant_interior(struct bch_fs *c, u32 id)
+{
+	u32 orig = id;
+	guard(rcu)();
+	struct snapshot_table *t = rcu_dereference(c->snapshots.table);
+	const struct snapshot_t *s = __snapshot_t(t, id);
+	if (!s)
+		return 0;
+
+	while (true) {
+		u32 child = 0;
+
+		for (unsigned i = 0; i < ARRAY_SIZE(s->children); i++) {
+			enum snapshot_id_state state = __bch2_snapshot_id_state(t, s->children[i]);
+			if (state == SNAPSHOT_ID_live || state == SNAPSHOT_ID_no_keys) {
+				if (child) {
+					child = 0;
+					break;
+				}
+				child = s->children[i];
+			}
+		}
+
+		if (!child)
+			return s->state != SNAPSHOT_ID_no_keys && id != orig ? id : 0;
+
+		id = child;
+		s = __snapshot_t(t, id);
+	}
+}
+
 static inline u32 get_ancestor_below(struct snapshot_table *t, u32 id, u32 ancestor)
 {
 	const struct snapshot_t *s = __snapshot_t(t, id);

--- a/fs/snapshots/snapshot.c
+++ b/fs/snapshots/snapshot.c
@@ -616,12 +616,21 @@ static int bch2_mark_snapshot(struct btree_trans *trans, struct bkey_s_c new)
 		bkey_val_copy_pad(&s, bkey_s_c_to_snapshot(new));
 		enum bch_snapshot_state state = bch2_snapshot_state_compat(&s);
 
-		t->state	= state == SNAPSHOT_STATE_no_keys ||
-				  state == SNAPSHOT_STATE_deleted
-			? SNAPSHOT_ID_deleted
-			: state == SNAPSHOT_STATE_will_delete
-			? SNAPSHOT_ID_will_delete
-			: SNAPSHOT_ID_live;
+		switch (state) {
+		case SNAPSHOT_STATE_live:
+			t->state = SNAPSHOT_ID_live;
+			break;
+		case SNAPSHOT_STATE_will_delete:
+			t->state = SNAPSHOT_ID_will_delete;
+			break;
+		case SNAPSHOT_STATE_no_keys:
+			t->state = SNAPSHOT_ID_no_keys;
+			break;
+		case SNAPSHOT_STATE_deleted:
+			t->state = SNAPSHOT_ID_deleted;
+			break;
+		}
+
 		t->parent	= le32_to_cpu(s.parent);
 		t->children[0]	= le32_to_cpu(s.children[0]);
 		t->children[1]	= le32_to_cpu(s.children[1]);

--- a/fs/snapshots/snapshot.c
+++ b/fs/snapshots/snapshot.c
@@ -265,6 +265,51 @@ u32 bch2_snapshot_redundant_interior(struct bch_fs *c, u32 id)
 	}
 }
 
+/*
+ * True if a key in this snapshot is about to be dropped by
+ * delete_dead_snapshots - its whole subtree is being deleted (a will_delete
+ * leaf, or an interior node the mark was propagated up to). fsck content passes
+ * call this right after bch2_check_key_has_snapshot() to skip repairing state
+ * that's about to vanish. Deliberately not folded into bch2_check_key_has_snapshot()
+ * itself: the deletion and data-move paths call that too and must still see and
+ * act on these keys.
+ */
+bool bch2_snapshot_will_delete(struct bch_fs *c, u32 id, snapshot_id_list *seen)
+{
+	guard(rcu)();
+	struct snapshot_table *t = rcu_dereference(c->snapshots.table);
+	const struct snapshot_t *s = __snapshot_t(t, id);
+	if (!s)
+		return true;
+
+	if (s->state == SNAPSHOT_ID_will_delete)
+		return true;
+
+	while (true) {
+		u32 child = 0;
+
+		for (unsigned i = 0; i < ARRAY_SIZE(s->children); i++) {
+			enum snapshot_id_state state = __bch2_snapshot_id_state(t, s->children[i]);
+			if (state == SNAPSHOT_ID_live || state == SNAPSHOT_ID_no_keys) {
+				if (child) {
+					child = 0;
+					break;
+				}
+				child = s->children[i];
+			}
+		}
+
+		if (!child)
+			return false;
+
+		if (snapshot_list_has_id(seen, child))
+			return true;
+
+		id = child;
+		s = __snapshot_t(t, id);
+	}
+}
+
 static inline u32 get_ancestor_below(struct snapshot_table *t, u32 id, u32 ancestor)
 {
 	const struct snapshot_t *s = __snapshot_t(t, id);

--- a/fs/snapshots/snapshot.c
+++ b/fs/snapshots/snapshot.c
@@ -643,15 +643,31 @@ int bch2_snapshot_validate(struct bch_fs *c, struct bkey_s_c k,
 	 * touched:
 	 */
 	if (from->from == BKEY_VALIDATE_commit && !c->opts.no_commit_validate) {
-		if (bkey_val_bytes(k.k) > offsetof(struct bch_snapshot, state))
-			bkey_fsck_err_on(s.v->state &&
-					 !bch2_snapshot_state_valid(bch2_snapshot_state(s.v)),
-					 c, snapshot_state_bad,
-					 "invalid state 0x%x", le32_to_cpu(s.v->state));
+		u32 state = bkey_val_bytes(k.k) > offsetof(struct bch_snapshot, state)
+			? bch2_snapshot_state(s.v)
+			: 0;
 
-		bkey_fsck_err_on(s.v->children[0] && s.v->subvol,
+		bkey_fsck_err_on(state && !bch2_snapshot_state_valid(state),
+				 c, snapshot_state_bad,
+				 "invalid state 0x%x", state);
+
+		/*
+		 * A subvol backref is only legal on a live or will_delete leaf:
+		 * subvolumes only reference leaves, and no_keys/deleted nodes
+		 * were interior when they were emptied - a dead leaf is deleted
+		 * outright; the no_keys parking state exists only because an
+		 * interior node can't be removed from the tree at runtime.
+		 * will_delete retains the backref: it points at the subvolume's
+		 * tombstone, testimony the deletion path requires
+		 * (check_should_delete_leaf()).
+		 */
+		bkey_fsck_err_on(s.v->subvol &&
+				 (s.v->children[0] ||
+				  (state &&
+				   state != SNAPSHOT_STATE_live &&
+				   state != SNAPSHOT_STATE_will_delete)),
 				 c, snapshot_should_not_have_subvol,
-				 "interior node with subvol (subvolumes only reference leaves)");
+				 "snapshot with subvol must be a live or will_delete leaf");
 	}
 fsck_err:
 	return ret;

--- a/fs/snapshots/snapshot.c
+++ b/fs/snapshots/snapshot.c
@@ -302,7 +302,7 @@ bool bch2_snapshot_will_delete(struct bch_fs *c, u32 id, snapshot_id_list *seen)
 		if (!child)
 			return false;
 
-		if (snapshot_list_has_id(seen, child))
+		if (seen && snapshot_list_has_id(seen, child))
 			return true;
 
 		id = child;

--- a/fs/snapshots/snapshot.c
+++ b/fs/snapshots/snapshot.c
@@ -241,7 +241,7 @@ u32 bch2_snapshot_redundant_interior(struct bch_fs *c, u32 id)
 	struct snapshot_table *t = rcu_dereference(c->snapshots.table);
 	const struct snapshot_t *s = __snapshot_t(t, id);
 	if (!s)
-		return 0;
+		return orig;
 
 	while (true) {
 		u32 child = 0;
@@ -258,7 +258,7 @@ u32 bch2_snapshot_redundant_interior(struct bch_fs *c, u32 id)
 		}
 
 		if (!child)
-			return s->state != SNAPSHOT_ID_no_keys && id != orig ? id : 0;
+			return s->state != SNAPSHOT_ID_no_keys ? id : orig;
 
 		id = child;
 		s = __snapshot_t(t, id);

--- a/fs/snapshots/snapshot.c
+++ b/fs/snapshots/snapshot.c
@@ -568,6 +568,38 @@ fsck_err:
 
 /* Snapshot btree triggers: */
 
+/*
+ * An interior node whose entire subtree is being deleted is itself dead.
+ * will_delete is only stored on disk for leaves (set at subvol unlink), so
+ * interior dead-subtree nodes are derived here. SNAPSHOT_ID_will_delete only
+ * ever overrides a would-be-live node, so a node in {live, will_delete} always
+ * has live underneath and {deleted, empty} are outside the overlay - which is
+ * what lets us both set and clear the mark by recomputing from the children,
+ * with no stored base state.
+ *
+ * A child counts as dead only if it's will_delete: that's the one state that
+ * means "no live descendant". deleted/no_keys nodes both retain a live
+ * descendant (a spliced-out tombstone forwards to one; a collapsing no_keys
+ * node still has its child), so they must not count - else we'd mark a node
+ * with a live descendant and wrongly silence a collapsing subtree.
+ */
+static bool snapshot_subtree_dead(struct snapshot_table *t, const struct snapshot_t *s)
+{
+	if (!s->children[0])
+		return false;
+
+	for (unsigned i = 0; i < ARRAY_SIZE(s->children); i++)
+		if (s->children[i]) {
+			const struct snapshot_t *c = __snapshot_t(t, s->children[i]);
+			enum snapshot_id_state cs = c ? c->state : SNAPSHOT_ID_empty;
+
+			if (cs != SNAPSHOT_ID_will_delete)
+				return false;
+		}
+
+	return true;
+}
+
 static int bch2_mark_snapshot(struct btree_trans *trans, struct bkey_s_c new)
 {
 	struct bch_fs *c = trans->c;
@@ -584,10 +616,12 @@ static int bch2_mark_snapshot(struct btree_trans *trans, struct bkey_s_c new)
 		bkey_val_copy_pad(&s, bkey_s_c_to_snapshot(new));
 		enum bch_snapshot_state state = bch2_snapshot_state_compat(&s);
 
-		t->state	= (state != SNAPSHOT_STATE_no_keys &&
-				   state != SNAPSHOT_STATE_deleted)
-			? SNAPSHOT_ID_live
-			: SNAPSHOT_ID_deleted;
+		t->state	= state == SNAPSHOT_STATE_no_keys ||
+				  state == SNAPSHOT_STATE_deleted
+			? SNAPSHOT_ID_deleted
+			: state == SNAPSHOT_STATE_will_delete
+			? SNAPSHOT_ID_will_delete
+			: SNAPSHOT_ID_live;
 		t->parent	= le32_to_cpu(s.parent);
 		t->children[0]	= le32_to_cpu(s.children[0]);
 		t->children[1]	= le32_to_cpu(s.children[1]);
@@ -614,6 +648,45 @@ static int bch2_mark_snapshot(struct btree_trans *trans, struct bkey_s_c new)
 		 */
 		barrier_data(is_ancestor);
 		memcpy(t->is_ancestor, is_ancestor, sizeof(t->is_ancestor));
+
+		/*
+		 * Derive/refresh the will_delete overlay: mark this node if it's
+		 * an interior node over a fully-dead subtree, then recompute each
+		 * ancestor from its children - propagating the mark up when a
+		 * subtree just went dead, or clearing it when a child revived.
+		 * snapshots_read builds in reverse (parents first), so the
+		 * ancestor chain is already resident (bch2_snapshot_t_mut won't
+		 * reallocate below us); a not-yet-built lower-id sibling reads as
+		 * empty and just defers the mark until it's processed.
+		 */
+		struct snapshot_table *table =
+			rcu_dereference_protected(c->snapshots.table,
+					lockdep_is_held(&c->snapshots.table_lock));
+
+		if (t->state == SNAPSHOT_ID_live && snapshot_subtree_dead(table, t))
+			t->state = SNAPSHOT_ID_will_delete;
+
+		u32 p = t->parent;
+		while (p) {
+			struct snapshot_t *pt = bch2_snapshot_t_mut(c, p);
+			/* _mut may reallocate the table (ancestors are resident so
+			 * it shouldn't, but don't depend on that) - refetch */
+			table = rcu_dereference_protected(c->snapshots.table,
+					lockdep_is_held(&c->snapshots.table_lock));
+			if (!pt ||
+			    (pt->state != SNAPSHOT_ID_live &&
+			     pt->state != SNAPSHOT_ID_will_delete))
+				break;
+
+			enum snapshot_id_state want = snapshot_subtree_dead(table, pt)
+				? SNAPSHOT_ID_will_delete
+				: SNAPSHOT_ID_live;
+			if (pt->state == want)
+				break;
+
+			pt->state = want;
+			p = pt->parent;
+		}
 
 		if (state == SNAPSHOT_STATE_will_delete) {
 			/*

--- a/fs/snapshots/snapshot.c
+++ b/fs/snapshots/snapshot.c
@@ -232,7 +232,8 @@ bool bch2_snapshot_is_ancestor_early(struct bch_fs *c, u32 id, u32 ancestor)
  * residue of a deletion.
  *
  * Walks the collapse chain and returns the live terminal it collapses into, or
- * 0 if @id isn't a redundant interior.
+ * @id unchanged if it isn't a redundant interior - never 0 for a nonzero @id,
+ * so callers don't need a fallback.
  */
 u32 bch2_snapshot_redundant_interior(struct bch_fs *c, u32 id)
 {

--- a/fs/snapshots/snapshot.h
+++ b/fs/snapshots/snapshot.h
@@ -393,6 +393,7 @@ static inline int bch2_get_snapshot_overwrites(struct btree_trans *trans,
 
 int bch2_snapshot_node_set_deleted(struct btree_trans *, u32);
 int bch2_snapshot_node_delete(struct btree_trans *, u32, bool);
+int bch2_snapshot_node_undelete(struct btree_trans *, struct bkey_i_snapshot *);
 void bch2_snapshot_accounting_totals(struct bch_fs *, u32, u64 *, u64 *,
 				     struct printbuf *);
 

--- a/fs/snapshots/snapshot.h
+++ b/fs/snapshots/snapshot.h
@@ -393,7 +393,7 @@ static inline int bch2_get_snapshot_overwrites(struct btree_trans *trans,
 
 int bch2_snapshot_node_set_deleted(struct btree_trans *, u32);
 int bch2_snapshot_node_delete(struct btree_trans *, u32, bool);
-int bch2_snapshot_node_undelete(struct btree_trans *, struct bkey_i_snapshot *);
+int bch2_snapshot_node_undelete(struct btree_trans *, struct bkey_i_snapshot *, bool *);
 void bch2_snapshot_accounting_totals(struct bch_fs *, u32, u64 *, u64 *,
 				     struct printbuf *);
 

--- a/fs/snapshots/snapshot.h
+++ b/fs/snapshots/snapshot.h
@@ -211,21 +211,8 @@ static inline bool bch2_snapshot_exists(struct bch_fs *c, u32 id)
 	return bch2_snapshot_id_state(c, id) == SNAPSHOT_ID_live;
 }
 
-/*
- * True if a key in this snapshot is about to be dropped by
- * delete_dead_snapshots - its whole subtree is being deleted (a will_delete
- * leaf, or an interior node the mark was propagated up to). fsck content passes
- * call this right after bch2_check_key_has_snapshot() to skip repairing state
- * that's about to vanish. Deliberately not folded into bch2_check_key_has_snapshot()
- * itself: the deletion and data-move paths call that too and must still see and
- * act on these keys.
- */
-static inline bool bch2_snapshot_will_delete(struct bch_fs *c, u32 id)
-{
-	return bch2_snapshot_id_state(c, id) == SNAPSHOT_ID_will_delete;
-}
-
 u32 bch2_snapshot_redundant_interior(struct bch_fs *, u32);
+bool bch2_snapshot_will_delete(struct bch_fs *, u32, snapshot_id_list *);
 
 static inline int bch2_snapshot_is_internal_node(struct bch_fs *c, u32 id)
 {

--- a/fs/snapshots/snapshot.h
+++ b/fs/snapshots/snapshot.h
@@ -392,6 +392,9 @@ static inline int bch2_get_snapshot_overwrites(struct btree_trans *trans,
 }
 
 int bch2_snapshot_node_set_deleted(struct btree_trans *, u32);
+int bch2_snapshot_node_delete(struct btree_trans *, u32, bool);
+void bch2_snapshot_accounting_totals(struct bch_fs *, u32, u64 *, u64 *,
+				     struct printbuf *);
 
 int __bch2_key_has_snapshot_overwrites(struct btree_trans *, enum btree_id, struct bpos);
 

--- a/fs/snapshots/snapshot.h
+++ b/fs/snapshots/snapshot.h
@@ -211,6 +211,20 @@ static inline bool bch2_snapshot_exists(struct bch_fs *c, u32 id)
 	return bch2_snapshot_id_state(c, id) == SNAPSHOT_ID_live;
 }
 
+/*
+ * True if a key in this snapshot is about to be dropped by
+ * delete_dead_snapshots - its whole subtree is being deleted (a will_delete
+ * leaf, or an interior node the mark was propagated up to). fsck content passes
+ * call this right after bch2_check_key_has_snapshot() to skip repairing state
+ * that's about to vanish. Deliberately not folded into bch2_check_key_has_snapshot()
+ * itself: the deletion and data-move paths call that too and must still see and
+ * act on these keys.
+ */
+static inline bool bch2_snapshot_will_delete(struct bch_fs *c, u32 id)
+{
+	return bch2_snapshot_id_state(c, id) == SNAPSHOT_ID_will_delete;
+}
+
 static inline int bch2_snapshot_is_internal_node(struct bch_fs *c, u32 id)
 {
 	guard(rcu)();

--- a/fs/snapshots/snapshot.h
+++ b/fs/snapshots/snapshot.h
@@ -225,6 +225,8 @@ static inline bool bch2_snapshot_will_delete(struct bch_fs *c, u32 id)
 	return bch2_snapshot_id_state(c, id) == SNAPSHOT_ID_will_delete;
 }
 
+u32 bch2_snapshot_redundant_interior(struct bch_fs *, u32);
+
 static inline int bch2_snapshot_is_internal_node(struct bch_fs *c, u32 id)
 {
 	guard(rcu)();

--- a/fs/snapshots/snapshot.h
+++ b/fs/snapshots/snapshot.h
@@ -394,8 +394,8 @@ static inline int bch2_get_snapshot_overwrites(struct btree_trans *trans,
 int bch2_snapshot_node_set_deleted(struct btree_trans *, u32);
 int bch2_snapshot_node_delete(struct btree_trans *, u32, bool);
 int bch2_snapshot_node_undelete(struct btree_trans *, struct bkey_i_snapshot *, bool *);
-void bch2_snapshot_accounting_totals(struct bch_fs *, u32, u64 *, u64 *,
-				     struct printbuf *);
+int bch2_snapshot_accounting_totals(struct btree_trans *, u32, u64 *, u64 *,
+				    struct printbuf *);
 
 int __bch2_key_has_snapshot_overwrites(struct btree_trans *, enum btree_id, struct bpos);
 

--- a/fs/snapshots/snapshot.h
+++ b/fs/snapshots/snapshot.h
@@ -393,7 +393,7 @@ static inline int bch2_get_snapshot_overwrites(struct btree_trans *trans,
 
 int bch2_snapshot_node_set_deleted(struct btree_trans *, u32);
 int bch2_snapshot_node_delete(struct btree_trans *, u32, bool);
-int bch2_snapshot_node_undelete(struct btree_trans *, struct bkey_i_snapshot *, bool *);
+int bch2_snapshot_node_undelete(struct btree_trans *, struct bkey_i_snapshot *);
 int bch2_snapshot_accounting_totals(struct btree_trans *, u32, u64 *, u64 *,
 				    u64 *, struct printbuf *);
 

--- a/fs/snapshots/snapshot.h
+++ b/fs/snapshots/snapshot.h
@@ -395,7 +395,7 @@ int bch2_snapshot_node_set_deleted(struct btree_trans *, u32);
 int bch2_snapshot_node_delete(struct btree_trans *, u32, bool);
 int bch2_snapshot_node_undelete(struct btree_trans *, struct bkey_i_snapshot *, bool *);
 int bch2_snapshot_accounting_totals(struct btree_trans *, u32, u64 *, u64 *,
-				    struct printbuf *);
+				    u64 *, struct printbuf *);
 
 int __bch2_key_has_snapshot_overwrites(struct btree_trans *, enum btree_id, struct bpos);
 

--- a/fs/snapshots/subvolume.c
+++ b/fs/snapshots/subvolume.c
@@ -662,7 +662,16 @@ static int __bch2_subvolume_set_deleted(struct btree_trans *trans, u32 subvolid)
 
 static int bch2_subvolume_set_deleted(struct btree_trans *trans, u32 subvolid)
 {
-	int ret = bch2_subvolumes_reparent(trans, subvolid) ?:
+	/*
+	 * The fsck caller (check_subvol's unlinked branch) can arrive with
+	 * repairs - and their fsck_err journal log entries - still queued;
+	 * reparent's lockrestart_do would drop them at trans_begin (the
+	 * iter.c dropped-updates WARN). Flush first: commit_lazy is free
+	 * when nothing is queued, and its restart-on-success re-drives
+	 * check_subvol, whose committed fixes don't refire:
+	 */
+	int ret = bch2_trans_commit_lazy(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc) ?:
+		bch2_subvolumes_reparent(trans, subvolid) ?:
 		commit_do(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc,
 			  __bch2_subvolume_set_deleted(trans, subvolid));
 	return ret;

--- a/fs/snapshots/subvolume.c
+++ b/fs/snapshots/subvolume.c
@@ -514,37 +514,26 @@ int bch2_subvolume_get(struct btree_trans *trans, unsigned subvol,
 }
 
 /*
- * Is this subvolume in the process of being deleted? True in every
- * window of the deletion sequence: subvolume unlinked (waiting on VFS
- * eviction), tombstoned as deleted + snapshot marked will_delete
- * (bch2_subvolume_get() reports tombstones as ENOENT, so that window
- * arrives here via the snapshot check), and mid-sweep with the
- * subvolume key already gone.
+ * BCH_INODE_unlinked is allowed on a directory only if it's a subvolume
+ * root and the subvolume is unlinked - this answers the second half.
  *
- * @snapshot is the subvolume's snapshot - for a caller holding the root
- * inode, its bi_snapshot - used to classify once the subvolume key is
- * unreadable. Subvolume gone but snapshot still live is NOT pending
- * deletion: the deletion sequence never produces that state, so it's
- * damage the caller should repair.
+ * That's the only window fsck can see a legitimately flagged directory:
+ * once the subvolume is tombstoned its snapshot is will_delete and
+ * check_inode skips those keys - the sweep owns them. A tombstoned or
+ * missing subvolume here is the caller's cue to repair, not exempt.
  *
  * Returns: < 0 error, 0 no, 1 yes
  */
-int bch2_subvolume_deletion_pending(struct btree_trans *trans, u32 subvolid, u32 snapshot)
+int bch2_subvolume_is_unlinked(struct btree_trans *trans, u32 subvolid)
 {
 	struct bch_subvolume s;
 	int ret = bch2_subvolume_get(trans, subvolid, false, &s);
-	if (!ret)
-		return bch2_subvolume_state_compat(&s) != SUBVOLUME_STATE_live;
-	if (!bch2_err_matches(ret, ENOENT))
+	if (bch2_err_matches(ret, ENOENT))
+		return 0;
+	if (ret)
 		return ret;
 
-	struct bch_snapshot snap;
-	ret = bch2_snapshot_lookup(trans, snapshot, &snap);
-	if (!ret)
-		return bch2_snapshot_state_compat(&snap) != SNAPSHOT_STATE_live;
-	if (!bch2_err_matches(ret, ENOENT))
-		return ret;
-	return 0;
+	return bch2_subvolume_state_compat(&s) == SUBVOLUME_STATE_unlinked;
 }
 
 int bch2_subvol_is_ro_trans(struct btree_trans *trans, u32 subvol, u32 *snapid)

--- a/fs/snapshots/subvolume.c
+++ b/fs/snapshots/subvolume.c
@@ -448,7 +448,24 @@ __cold void bch2_subvolume_to_text(struct printbuf *out, struct bch_fs *c,
 
 	struct bch_subvolume v;
 	bkey_val_copy_pad(&v, s);
-	prt_printf(out, " %s", bch2_subvolume_state_str(bch2_subvolume_state_compat(&v)));
+
+	u32 state = le32_to_cpu(v.state);
+	if (!state) {
+		/* Not upgraded: no state field, the obsolete flag is the truth */
+		prt_printf(out, " %s (not upgraded, unlinked_obsolete=%llu)",
+			   bch2_subvolume_state_str(bch2_subvolume_state_from_flags(&v)),
+			   BCH_SUBVOLUME_UNLINKED_OBSOLETE(&v));
+	} else if (!bch2_subvolume_state_valid(state)) {
+		prt_printf(out, " state 0x%x invalid (unlinked_obsolete=%llu)",
+			   state, BCH_SUBVOLUME_UNLINKED_OBSOLETE(&v));
+	} else {
+		prt_printf(out, " %s", bch2_subvolume_state_str(state));
+
+		/* dual-written shadow (bch2_subvolume_state_set()); print divergence: */
+		if (BCH_SUBVOLUME_UNLINKED_OBSOLETE(&v) != (state != SUBVOLUME_STATE_live))
+			prt_printf(out, " unlinked_obsolete=%llu",
+				   BCH_SUBVOLUME_UNLINKED_OBSOLETE(&v));
+	}
 }
 
 static int subvolume_children_mod(struct btree_trans *trans, struct bpos pos, bool set)

--- a/fs/snapshots/subvolume.c
+++ b/fs/snapshots/subvolume.c
@@ -513,6 +513,40 @@ int bch2_subvolume_get(struct btree_trans *trans, unsigned subvol,
 	return bch2_subvolume_get_inlined(trans, subvol, inconsistent_if_not_found, s);
 }
 
+/*
+ * Is this subvolume in the process of being deleted? True in every
+ * window of the deletion sequence: subvolume unlinked (waiting on VFS
+ * eviction), tombstoned as deleted + snapshot marked will_delete
+ * (bch2_subvolume_get() reports tombstones as ENOENT, so that window
+ * arrives here via the snapshot check), and mid-sweep with the
+ * subvolume key already gone.
+ *
+ * @snapshot is the subvolume's snapshot - for a caller holding the root
+ * inode, its bi_snapshot - used to classify once the subvolume key is
+ * unreadable. Subvolume gone but snapshot still live is NOT pending
+ * deletion: the deletion sequence never produces that state, so it's
+ * damage the caller should repair.
+ *
+ * Returns: < 0 error, 0 no, 1 yes
+ */
+int bch2_subvolume_deletion_pending(struct btree_trans *trans, u32 subvolid, u32 snapshot)
+{
+	struct bch_subvolume s;
+	int ret = bch2_subvolume_get(trans, subvolid, false, &s);
+	if (!ret)
+		return bch2_subvolume_state_compat(&s) != SUBVOLUME_STATE_live;
+	if (!bch2_err_matches(ret, ENOENT))
+		return ret;
+
+	struct bch_snapshot snap;
+	ret = bch2_snapshot_lookup(trans, snapshot, &snap);
+	if (!ret)
+		return bch2_snapshot_state_compat(&snap) != SNAPSHOT_STATE_live;
+	if (!bch2_err_matches(ret, ENOENT))
+		return ret;
+	return 0;
+}
+
 int bch2_subvol_is_ro_trans(struct btree_trans *trans, u32 subvol, u32 *snapid)
 {
 	struct bch_subvolume s;

--- a/fs/snapshots/subvolume.h
+++ b/fs/snapshots/subvolume.h
@@ -75,6 +75,7 @@ int bch2_subvolume_trigger(struct btree_trans *, struct btree_trigger_op);
 int bch2_subvol_has_children(struct btree_trans *, u32);
 int bch2_subvolume_get(struct btree_trans *, unsigned,
 		       bool, struct bch_subvolume *);
+int bch2_subvolume_deletion_pending(struct btree_trans *, u32, u32);
 int __bch2_subvolume_get_snapshot(struct btree_trans *, u32,
 				  u32 *, bool);
 int bch2_subvolume_get_snapshot(struct btree_trans *, u32, u32 *);

--- a/fs/snapshots/subvolume.h
+++ b/fs/snapshots/subvolume.h
@@ -75,7 +75,7 @@ int bch2_subvolume_trigger(struct btree_trans *, struct btree_trigger_op);
 int bch2_subvol_has_children(struct btree_trans *, u32);
 int bch2_subvolume_get(struct btree_trans *, unsigned,
 		       bool, struct bch_subvolume *);
-int bch2_subvolume_deletion_pending(struct btree_trans *, u32, u32);
+int bch2_subvolume_is_unlinked(struct btree_trans *, u32);
 int __bch2_subvolume_get_snapshot(struct btree_trans *, u32,
 				  u32 *, bool);
 int bch2_subvolume_get_snapshot(struct btree_trans *, u32, u32 *);

--- a/fs/snapshots/types.h
+++ b/fs/snapshots/types.h
@@ -32,6 +32,7 @@ struct snapshot_t {
 		SNAPSHOT_ID_empty,
 		SNAPSHOT_ID_live,
 		SNAPSHOT_ID_will_delete,
+		SNAPSHOT_ID_no_keys,
 		SNAPSHOT_ID_deleted,
 	}			state;
 	u32			parent;

--- a/fs/snapshots/types.h
+++ b/fs/snapshots/types.h
@@ -31,6 +31,7 @@ struct snapshot_t {
 	enum snapshot_id_state {
 		SNAPSHOT_ID_empty,
 		SNAPSHOT_ID_live,
+		SNAPSHOT_ID_will_delete,
 		SNAPSHOT_ID_deleted,
 	}			state;
 	u32			parent;

--- a/fs/util/time_stats.c
+++ b/fs/util/time_stats.c
@@ -104,8 +104,15 @@ static inline void time_stats_update_one(struct bch2_time_stats *stats,
 void __bch2_time_stats_clear_buffer(struct bch2_time_stats *stats,
 				    struct time_stat_buffer *b)
 {
+	/*
+	 * The to_seq_buf paths flush other cpus' partially-full buffers:
+	 * only [0, nr) hold real entries, the tail is leftovers from the
+	 * previous fill cycle. (nr is read racily against the owning cpu's
+	 * append; the bound also keeps a bad value from walking off the
+	 * array.)
+	 */
 	for (struct time_stat_buffer_entry *i = b->entries;
-	     i < b->entries + ARRAY_SIZE(b->entries);
+	     i < b->entries + min_t(size_t, b->nr, ARRAY_SIZE(b->entries));
 	     i++)
 		time_stats_update_one(stats, i->start, i->end);
 	b->nr = 0;
@@ -140,7 +147,17 @@ void __bch2_time_stats_update(struct bch2_time_stats *stats, u64 start, u64 end)
 		guard(irqsave)();
 		struct time_stat_buffer *b = this_cpu_ptr(stats->buffer);
 
-		BUG_ON(b->nr >= ARRAY_SIZE(b->entries));
+		/*
+		 * Can't happen via the update paths themselves (per-cpu, irqs
+		 * off, flushed at exactly capacity): a bad nr means the buffer
+		 * was scribbled or freed under us. Seen in the field (7.1.3,
+		 * read completion path) - note it and discard rather than
+		 * taking down the machine for a stats glitch.
+		 */
+		if (WARN_ONCE(b->nr >= ARRAY_SIZE(b->entries),
+			      "bch2_time_stats: pcpu buffer nr %u >= %zu (corrupt), discarding",
+			      b->nr, ARRAY_SIZE(b->entries)))
+			b->nr = 0;
 		b->entries[b->nr++] = (struct time_stat_buffer_entry) {
 			.start = start,
 			.end = end

--- a/fs/util/time_stats.c
+++ b/fs/util/time_stats.c
@@ -138,21 +138,34 @@ void __bch2_time_stats_update(struct bch2_time_stats *stats, u64 start, u64 end)
 
 		if (!stats->buffer &&
 		    mean_and_variance_get_median(stats->freq_stats_weighted) < 32000 &&
-		    stats->duration_stats.n > 1024)
-			stats->buffer =
+		    stats->duration_stats.n > 1024) {
+			struct time_stat_buffer __percpu *b =
 				alloc_percpu_gfp(struct time_stat_buffer,
 						 GFP_ATOMIC);
+			if (b) {
+				int cpu;
+				for_each_possible_cpu(cpu)
+					local_lock_init(&per_cpu_ptr(b, cpu)->lock);
+				stats->buffer = b;
+			}
+		}
 		spin_unlock_irqrestore(&stats->lock, flags);
 	} else {
-		guard(irqsave)();
+		/*
+		 * local_lock rather than plain irqsave: pins the cpu and
+		 * excludes same-cpu updaters on all preemption models, and on
+		 * PREEMPT_RT it's a sleeping lock, making the nested
+		 * stats->lock in the buffer-full flush below legal there.
+		 */
+		local_lock_irqsave(&stats->buffer->lock, flags);
 		struct time_stat_buffer *b = this_cpu_ptr(stats->buffer);
 
 		/*
-		 * Can't happen via the update paths themselves (per-cpu, irqs
-		 * off, flushed at exactly capacity): a bad nr means the buffer
-		 * was scribbled or freed under us. Seen in the field (7.1.3,
-		 * read completion path) - note it and discard rather than
-		 * taking down the machine for a stats glitch.
+		 * Can't happen via the update paths themselves (per-cpu
+		 * locked, flushed at exactly capacity): a bad nr means the
+		 * buffer was scribbled or freed under us. Seen in the field
+		 * (7.1.3, read completion path) - note it and discard rather
+		 * than taking down the machine for a stats glitch.
 		 */
 		if (WARN_ONCE(b->nr >= ARRAY_SIZE(b->entries),
 			      "bch2_time_stats: pcpu buffer nr %u >= %zu (corrupt), discarding",
@@ -165,6 +178,7 @@ void __bch2_time_stats_update(struct bch2_time_stats *stats, u64 start, u64 end)
 
 		if (unlikely(b->nr == ARRAY_SIZE(b->entries)))
 			time_stats_clear_buffer(stats, b);
+		local_unlock_irqrestore(&stats->buffer->lock, flags);
 	}
 }
 

--- a/fs/util/time_stats.h
+++ b/fs/util/time_stats.h
@@ -24,6 +24,7 @@
 #ifndef _BCACHEFS_TIME_STATS_H
 #define _BCACHEFS_TIME_STATS_H
 
+#include <linux/local_lock.h>
 #include <linux/sched/clock.h>
 #include <linux/spinlock_types.h>
 #include <linux/string.h>
@@ -60,6 +61,14 @@ struct quantiles {
 };
 
 struct time_stat_buffer {
+	/*
+	 * Protects nr/entries on the owning cpu: irq/preempt disable on
+	 * !PREEMPT_RT, a real per-cpu lock on RT - which is what makes
+	 * taking stats->lock (sleeping on RT) from the buffer-full flush
+	 * legal there. Cross-cpu readers (to_seq_buf, reset) don't take
+	 * it; they race the owner by design, bounded by nr.
+	 */
+	local_lock_t	lock;
 	unsigned	nr;
 	struct time_stat_buffer_entry {
 		u64	start;

--- a/fs/util/varint.c
+++ b/fs/util/varint.c
@@ -26,7 +26,7 @@ int bch2_varint_encode(u8 *out, u64 v)
 
 	if (likely(bytes < 9)) {
 		v <<= bytes;
-		v |= ~(~0 << (bytes - 1));
+		v |= ~(~0U << (bytes - 1));
 		v_le = cpu_to_le64(v);
 		memcpy(out, &v_le, bytes);
 	} else {
@@ -39,17 +39,18 @@ int bch2_varint_encode(u8 *out, u64 v)
 }
 
 /**
- * bch2_varint_decode - encode a variable length integer
+ * bch2_varint_decode - decode a variable length integer
  * @in:		varint to decode
  * @end:	end of buffer to decode from
  * @out:	on success, decoded integer
- * Returns:	size in bytes of the decoded integer - or -1 on failure (would
- * have read past the end of the buffer)
+ * Returns:	size in bytes of the decoded integer - or
+ * -BCH_ERR_varint_decode_error on failure (would have read past the end of
+ * the buffer)
  */
 int bch2_varint_decode(const u8 *in, const u8 *end, u64 *out)
 {
 	unsigned bytes = likely(in < end)
-		? ffz(*in & 255) + 1
+		? ffz(*in) + 1
 		: 1;
 	u64 v;
 
@@ -101,8 +102,9 @@ int bch2_varint_encode_fast(u8 *out, u64 v)
  * @in:		varint to decode
  * @end:	end of buffer to decode from
  * @out:	on success, decoded integer
- * Returns:	size in bytes of the decoded integer - or -1 on failure (would
- * have read past the end of the buffer)
+ * Returns:	size in bytes of the decoded integer - or
+ * -BCH_ERR_varint_decode_error on failure (would have read past the end of
+ * the buffer)
  *
  * This version assumes that it is safe to read at most 8 bytes past the end of
  * @end (we still return an error if the varint extends past @end).

--- a/fs/vendor/kernel-rust/bindings/bindings_helper.h
+++ b/fs/vendor/kernel-rust/bindings/bindings_helper.h
@@ -53,6 +53,7 @@
 #include <linux/fs.h>
 #include <linux/jiffies.h>
 #include <linux/jump_label.h>
+#include <linux/local_lock.h>	// vendored: local_lock_t, embedded in time_stat_buffer
 #include <linux/mm.h>
 #include <linux/pid_namespace.h>
 #include <linux/poll.h>

--- a/fs/vfs/buffered.c
+++ b/fs/vfs/buffered.c
@@ -253,33 +253,21 @@ static void bchfs_read(struct btree_trans *trans,
 
 		ret = bch2_read_extent(trans, rbio, iter.pos,
 				       data_btree, k, offset_into_extent, flags);
-		if (ret)
-			goto err;
-		/*
-		 * Careful there's a landmine here if bch2_read_extent() ever
-		 * starts returning transaction restarts here.
-		 *
-		 * We've changed rbio->bi_iter.bi_size to be "bytes we can read
-		 * from this extent" with the swap call, and we restore it
-		 * below. That restore needs to come before checking for
-		 * errors.
-		 *
-		 * But unlike bch2_read(), we use the rbio bvec iter, not one
-		 * on the stack, so we can't do the restore right after the
-		 * bch2_read_extent() call: we don't own that iterator anymore
-		 * if BCH_READ_last_fragment is set, since we may have submitted
-		 * that rbio instead of cloning it.
-		 */
 
-		if (flags & BCH_READ_last_fragment)
+		/* On successful BCH_READ_last_fragment submit we no longer own rbio: */
+		if (!ret && (flags & BCH_READ_last_fragment))
 			break;
 
 		swap(rbio->bio.bi_iter.bi_size, bytes);
-		bio_advance(&rbio->bio, bytes);
 err:
-		if (ret &&
-		    !bch2_err_matches(ret, BCH_ERR_transaction_restart))
+		if (bch2_err_matches(ret, BCH_ERR_transaction_restart)) {
+			flags &= ~BCH_READ_last_fragment;
+			continue;
+		}
+		if (ret)
 			break;
+
+		bio_advance(&rbio->bio, bytes);
 	}
 
 	if (ret) {

--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -2257,7 +2257,15 @@ static void bch2_evict_inode(struct inode *vinode)
 {
 	struct bch_fs *c = vinode->i_sb->s_fs_info;
 	struct bch_inode_info *inode = to_bch_ei(vinode);
-	bool delete = !inode->v.i_nlink && !is_bad_inode(&inode->v);
+	/*
+	 * An unlinked subvolume's root inode reads i_nlink == 0, but its
+	 * deletion belongs to the subvolume deletion path, not us (see
+	 * bch2_inode_is_subvolume_root()): this eviction completing is what
+	 * bch2_subvolume_wait_for_pagecache_and_delete() is waiting on to
+	 * tombstone the subvolume and hand the keys to the snapshot sweep.
+	 */
+	bool delete = !inode->v.i_nlink && !is_bad_inode(&inode->v) &&
+		!bch2_inode_is_subvolume_root(&inode->ei_inode);
 
 	/*
 	 * evict() has waited for outstanding writeback, we'll do no more IO

--- a/include/linux/bits.h
+++ b/include/linux/bits.h
@@ -54,7 +54,6 @@
 #define GENMASK_U16(h, l)	GENMASK_TYPE(u16, h, l)
 #define GENMASK_U32(h, l)	GENMASK_TYPE(u32, h, l)
 #define GENMASK_U64(h, l)	GENMASK_TYPE(u64, h, l)
-#define GENMASK_U128(h, l)	GENMASK_TYPE(u128, h, l)
 
 #else /* defined(__ASSEMBLY__) */
 

--- a/include/linux/kernel.h
+++ b/include/linux/kernel.h
@@ -52,7 +52,6 @@ typedef unsigned gfp_t;
 
 typedef __u64 u64;
 typedef __s64 s64;
-typedef unsigned __int128 u128;
 typedef __u32 u32;
 typedef __s32 s32;
 typedef __u16 u16;

--- a/include/linux/local_lock.h
+++ b/include/linux/local_lock.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef __LINUX_LOCAL_LOCK_H
+#define __LINUX_LOCAL_LOCK_H
+
+/*
+ * Userspace shim: in the kernel, local_lock pins the cpu and provides
+ * per-cpu mutual exclusion (a real lock on PREEMPT_RT, irq/preempt
+ * disable otherwise). The userspace tools don't have percpu data in the
+ * kernel sense - these are the same no-ops the irqsave shim provides.
+ */
+
+typedef struct local_lock {
+	unsigned char	pad;	/* zero-sized structs confuse bindgen */
+} local_lock_t;
+
+#define INIT_LOCAL_LOCK(name)	{}
+
+#define local_lock_init(l)		do {} while (0)
+
+#define local_lock_irqsave(l, flags)		\
+	do { (void) (l); flags = 0; } while (0)
+
+#define local_unlock_irqrestore(l, flags)	\
+	do { (void) (l); (void) (flags); } while (0)
+
+#endif /* __LINUX_LOCAL_LOCK_H */

--- a/include/linux/math64.h
+++ b/include/linux/math64.h
@@ -56,10 +56,51 @@ static inline u64 div64_u64(u64 dividend, u64 divisor)
  * mul_u64_u64_div_u64 - unsigned 64bit multiply then divide, with a 128bit
  * intermediate
  */
+#ifdef __SIZEOF_INT128__
 static inline u64 mul_u64_u64_div_u64(u64 a, u64 b, u64 c)
 {
 	return (unsigned __int128) a * b / c;
 }
+#else
+/*
+ * Portable fallback for targets without __int128 (32-bit): full 128-bit
+ * product by parts, then restoring shift-subtract division. Slow but
+ * obviously correct; saturates when the quotient won't fit 64 bits (a
+ * caller bug either way).
+ */
+static inline u64 mul_u64_u64_div_u64(u64 a, u64 b, u64 c)
+{
+	u64 t1  = (a >> 32) * (b & 0xffffffff);
+	u64 t2  = (a & 0xffffffff) * (b >> 32);
+	u64 lo  = (a & 0xffffffff) * (b & 0xffffffff);
+	u64 hi  = (a >> 32) * (b >> 32);
+
+	u64 mid = t1 + t2;
+	if (mid < t1)
+		hi += 1ULL << 32;
+	hi += mid >> 32;
+
+	u64 mid_lo = mid << 32;
+	lo += mid_lo;
+	if (lo < mid_lo)
+		hi++;
+
+	if (hi >= c)
+		return U64_MAX;
+
+	u64 rem = hi, q = 0;
+	for (int i = 63; i >= 0; i--) {
+		int ovf = rem >> 63;
+
+		rem = (rem << 1) | ((lo >> i) & 1);
+		if (ovf || rem >= c) {
+			rem -= c;
+			q |= 1ULL << i;
+		}
+	}
+	return q;
+}
+#endif
 
 /**
  * div64_s64 - signed 64bit divide with 64bit divisor

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -323,7 +323,16 @@ fn parse_format_args(argv: Vec<String>) -> Result<FormatConfig> {
                             }
                         }
                         Some(v) => {
-                            if opt.flags as u32 & c::opt_flags::OPT_DEVICE as u32 != 0 {
+                            // String-member options (failure_domain) parse to a
+                            // placeholder 0 - the parse is validation only, the
+                            // value is the string itself, applied to the
+                            // bch_member at superblock write time (the
+                            // Opt_failure_domain arm in format_util.rs).
+                            // Routing the placeholder into bch_opts would drop
+                            // the string silently:
+                            if opt.type_ == c::opt_type::BCH_OPT_STR_MEMBER {
+                                push_dev_opt_str!(opt_id, val_str);
+                            } else if opt.flags as u32 & c::opt_flags::OPT_DEVICE as u32 != 0 {
                                 bcachefs_kernel::opts::opt_set_by_id(&mut cur_dev_opts, opt_id, v);
                                 unconsumed_dev_option = true;
                             } else if opt.flags as u32 & c::opt_flags::OPT_FS as u32 != 0 {

--- a/src/commands/format_util.rs
+++ b/src/commands/format_util.rs
@@ -294,21 +294,32 @@ pub fn format(
         sb.member_mut(idx as u32).unwrap().set_member_rotational_set(1);
     }
 
-    // Deferred device options - labels: resolve against the sb we just built
+    // Deferred device options: labels resolve to a disk path against the sb we
+    // just built; the failure domain is a plain string stored in the member.
     for (idx, dev) in dev_slice.iter().enumerate() {
         for (opt_id, val) in &dev.opt_strs {
-            let path_idx = unsafe { c::bch2_disk_path_find_or_create(&mut *sb, val.as_ptr()) };
-            if path_idx < 0 {
-                die(&format!(
-                    "error creating disk path: {}",
-                    std::io::Error::from_raw_os_error(-path_idx)
-                ));
-            }
-
-            // Recompute m after sb modification (memory may have been reallocated)
-            let m = sb.member_mut(idx as u32).unwrap();
             match *opt_id {
-                c::bch_opt_id::Opt_label => m.set_member_group(path_idx as u64 + 1),
+                c::bch_opt_id::Opt_label => {
+                    let path_idx = unsafe { c::bch2_disk_path_find_or_create(&mut *sb, val.as_ptr()) };
+                    if path_idx < 0 {
+                        die(&format!(
+                            "error creating disk path: {}",
+                            std::io::Error::from_raw_os_error(-path_idx)
+                        ));
+                    }
+                    // Recompute m after sb modification (may have been reallocated)
+                    sb.member_mut(idx as u32).unwrap().set_member_group(path_idx as u64 + 1);
+                }
+                c::bch_opt_id::Opt_failure_domain => {
+                    let bytes = val.to_bytes();
+                    let m = sb.member_mut(idx as u32).unwrap();
+                    if bytes.len() > m.failure_domain.len() {
+                        die(&format!("failure domain name too long (max {} bytes)",
+                                     m.failure_domain.len()));
+                    }
+                    m.failure_domain.fill(0);
+                    m.failure_domain[..bytes.len()].copy_from_slice(bytes);
+                }
                 _ => die(&format!("can't resolve option {:?} at format time", opt_id)),
             }
         }

--- a/src/commands/fs_failure_domains.rs
+++ b/src/commands/fs_failure_domains.rs
@@ -1,0 +1,602 @@
+//! bcachefs fs failure-domains - what failure domain losses would cost,
+//! from the replicas accounting.
+//!
+//! The replicas accounting gives us, for every distinct replica set in the
+//! filesystem, the exact device list and sector count: a complete inventory
+//! of what fails together, entirely in userspace.
+//!
+//! An entry tolerates some number of failed devices among its set:
+//!   - replicated data (nr_required <= 1): all but one may fail
+//!   - erasure coded stripes (nr_required = nr_data): nr_redundant may fail
+//!
+//! One table: the failure domains, with what losing each would cost. A
+//! nonzero 'lost' cell is a separation violation - data that a single domain
+//! failure would take out. Devices with no failure domain set are their own
+//! domains, so with none configured this is the per device view.
+//!
+//! Limits: this is aggregate - it says how much data is exposed, not which
+//! extents (that's reconcile's job to find and fix). Extents whose copies
+//! are partly in stripes (nr_required = 0 entries) are protected by their
+//! stripes and reported via the stripe entries.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt::Write as FmtWrite;
+
+use anyhow::{anyhow, Result};
+use clap::Parser;
+
+use crate::commands::DeviceNameArgs;
+use crate::wrappers::accounting::{AccountingEntry, DiskAccountingKind, data_type, disk_accounting_type};
+use crate::wrappers::handle::BcachefsHandle;
+use crate::wrappers::sysfs::{self, DeviceNameMode, DevInfo};
+use bcachefs_kernel::util::printbuf::Printbuf;
+
+#[derive(Parser, Debug)]
+#[command(name = "failure-domains",
+    about = "Show failure domains and what losing each would cost",
+    long_about = "Analyzes the replicas accounting to show, for each failure \
+domain, the data that would be lost if it failed - too few copies or stripe \
+blocks left to reconstruct - and the data that would survive degraded. Lost \
+data means failure domain separation is being violated. Devices with no \
+failure domain set are their own failure domains.",
+    disable_help_flag = true)]
+pub struct Cli {
+    /// Print help
+    #[arg(long = "help", action = clap::ArgAction::Help)]
+    _help: (),
+
+    /// Human-readable units
+    #[arg(short = 'h', long = "human-readable", default_value = "true")]
+    human_readable: bool,
+
+    /// JSON output: sizes in bytes; named domains carry a "devices" count,
+    /// single-device rows don't
+    #[arg(long = "json")]
+    json: bool,
+
+    /// Render a synthetic demo scenario instead of a filesystem:
+    /// domains, no-domains, partly-off
+    #[arg(long = "demo", hide = true)]
+    demo: Option<String>,
+
+    #[command(flatten)]
+    device_names: DeviceNameArgs,
+
+    /// Filesystem mountpoint
+    #[arg(default_value = ".")]
+    mountpoint: String,
+}
+
+// ── The exposure engine ──────────────────────────────────────────────
+
+/// One replicas accounting entry, reduced to what failure analysis needs.
+struct Entry {
+    devs: Vec<u8>,
+    /// Failed devices tolerated before data is lost:
+    tolerates: u8,
+    sectors: u64,
+}
+
+struct Exposure {
+    entries: Vec<Entry>,
+    /// dev idx -> indices into entries, for scoring device sets:
+    by_dev: HashMap<u8, Vec<u32>>,
+    /// All sectors with durability to lose - replicated + stripes:
+    total: u64,
+}
+
+fn accounting_replicas_entries(acct: &[&AccountingEntry]) -> Vec<Entry> {
+    let mut ret = Vec::new();
+
+    for e in acct {
+        let DiskAccountingKind::Replicas { data_type: dt, nr_devs, nr_required, devs } = e.pos.decode()
+            else { continue };
+        let sectors = e.counter(0);
+
+        // Cached data has no durability to lose; nr_required == 0 extents
+        // are backed by stripes, accounted via the stripe entries:
+        if sectors == 0 || dt == data_type::cached || nr_required == 0 {
+            continue;
+        }
+
+        let devs: Vec<u8> = devs[..nr_devs as usize].iter()
+            .copied()
+            .filter(|&d| d != 255)  /* BCH_SB_MEMBER_INVALID: dead stripe blocks */
+            .collect();
+        if devs.is_empty() {
+            continue;
+        }
+
+        // Replicated: survives until every copy is gone. Erasure coded
+        // (nr_required = nr_data > 1): survives nr_redundant failures.
+        let tolerates = if nr_required > 1 {
+            nr_devs - nr_required
+        } else {
+            devs.len() as u8 - 1
+        };
+
+        ret.push(Entry { devs, tolerates, sectors });
+    }
+
+    ret
+}
+
+/// What failing a device set does, per bucket of sectors:
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Debug)]
+struct Score {
+    /// Unreadable - too few copies or stripe blocks survive:
+    lost: u64,
+    /// Survives, with less redundancy:
+    degraded: u64,
+}
+
+impl Exposure {
+    fn new(acct: &[&AccountingEntry]) -> Exposure {
+        Self::from_entries(accounting_replicas_entries(acct))
+    }
+
+    fn from_entries(entries: Vec<Entry>) -> Exposure {
+        let mut by_dev: HashMap<u8, Vec<u32>> = HashMap::new();
+        let mut total = 0;
+
+        for (i, e) in entries.iter().enumerate() {
+            total += e.sectors;
+
+            for &d in &e.devs {
+                by_dev.entry(d).or_default().push(i as u32);
+            }
+        }
+
+        Exposure { entries, by_dev, total }
+    }
+
+    /// What failing exactly the devices in @f does:
+    fn score(&self, f: &[u8]) -> Score {
+        let mut seen = HashSet::new();
+        let mut s = Score::default();
+
+        for &d in f {
+            let Some(list) = self.by_dev.get(&d) else { continue };
+            for &i in list {
+                if !seen.insert(i) {
+                    continue;
+                }
+                let e = &self.entries[i as usize];
+                let nr_failed = e.devs.iter().filter(|d| f.contains(d)).count();
+                if nr_failed > e.tolerates as usize {
+                    s.lost += e.sectors;
+                } else {
+                    s.degraded += e.sectors;
+                }
+            }
+        }
+
+        s
+    }
+}
+
+// ── The failure domains ──────────────────────────────────────────────
+
+/// One row of the report: a named failure domain, or a single device with no
+/// failure domain set (which is a domain of its own).
+struct Row {
+    name: String,
+    /// Device count for named domains, None for a lone unlabeled device:
+    nr_devs: Option<usize>,
+    nr_offline: usize,
+    score: Score,
+}
+
+/// One row per failure domain: devices sharing a failure_domain string are
+/// grouped and scored together; a device with none set is its own single
+/// device domain. Named domains first (sorted), then the lone devices.
+fn domain_rows(e: &Exposure, devs: &[DevInfo]) -> Vec<Row> {
+    let mut domains: BTreeMap<&str, Vec<&DevInfo>> = BTreeMap::new();
+    let mut loners: Vec<&DevInfo> = Vec::new();
+
+    for d in devs {
+        match d.failure_domain.as_deref() {
+            Some(fd) => domains.entry(fd).or_default().push(d),
+            None => loners.push(d),
+        }
+    }
+
+    let mut rows = Vec::new();
+
+    for (name, members) in domains {
+        let mut f: Vec<u8> = members.iter().map(|d| d.idx as u8).collect();
+        f.sort();
+        rows.push(Row {
+            name: name.to_string(),
+            nr_devs: Some(f.len()),
+            nr_offline: members.iter().filter(|d| !d.online).count(),
+            score: e.score(&f),
+        });
+    }
+
+    for d in loners {
+        rows.push(Row {
+            name: d.dev.clone(),
+            nr_devs: None,
+            nr_offline: !d.online as usize,
+            score: e.score(&[d.idx as u8]),
+        });
+    }
+
+    rows
+}
+
+// ── Output ───────────────────────────────────────────────────────────
+
+fn header_to_text(out: &mut Printbuf, e: &Exposure, devs: &[DevInfo]) {
+    let offline = devs.iter().filter(|d| !d.online).count();
+
+    write!(out, "Devices: {}", devs.len()).unwrap();
+    if offline != 0 {
+        write!(out, " ({} offline)", offline).unwrap();
+    }
+    writeln!(out).unwrap();
+
+    write!(out, "Data: ").unwrap();
+    out.units_sectors(e.total);
+    writeln!(out).unwrap();
+}
+
+/// The same report as machine-readable JSON: what the tests and scripts
+/// consume, so they parse data rather than table formatting. Sizes are in
+/// bytes; "devices" is present only on named domain rows.
+fn report_to_json(e: &Exposure, devs: &[DevInfo]) -> serde_json::Value {
+    let rows = domain_rows(e, devs);
+
+    let domains: Vec<serde_json::Value> = rows.iter().map(|r| {
+        let mut o = serde_json::json!({
+            "domain":           r.name,
+            "offline_devices":  r.nr_offline,
+            "lost_bytes":       r.score.lost << 9,
+            "degraded_bytes":   r.score.degraded << 9,
+        });
+        if let Some(n) = r.nr_devs {
+            o["devices"] = n.into();
+        }
+        o
+    }).collect();
+
+    serde_json::json!({
+        "devices":              devs.len(),
+        "offline_devices":      devs.iter().filter(|d| !d.online).count(),
+        "data_bytes":           e.total << 9,
+        "separation_violated":  rows.iter().any(|r| r.score.lost != 0),
+        "domains":              domains,
+    })
+}
+
+fn report_to_text(out: &mut Printbuf, e: &Exposure, devs: &[DevInfo]) {
+    let rows = domain_rows(e, devs);
+    let unlabeled = devs.iter().all(|d| d.failure_domain.is_none());
+
+    writeln!(out).unwrap();
+    if unlabeled {
+        writeln!(out, "No failure domains configured: each device is its own failure domain").unwrap();
+    }
+
+    /* The verdict: does any single domain failure lose data? */
+    if let Some(worst) = rows.iter().max_by_key(|r| r.score.lost) {
+        let what = if unlabeled { "device" } else { "failure domain" };
+
+        if worst.score.lost != 0 {
+            write!(out, "Failure domain separation violated: ").unwrap();
+            out.units_sectors(worst.score.lost);
+            writeln!(out, " lost if {} {} fails", what, worst.name).unwrap();
+        } else {
+            writeln!(out, "All data survives losing any one {}", what).unwrap();
+        }
+    }
+
+    writeln!(out, "\nWhat losing each failure domain would cost:").unwrap();
+    out.aligned(|sub| {
+        writeln!(sub, "domain\tdevices\rlost\rdegraded\r").unwrap();
+
+        for r in rows {
+            write!(sub, "{}\t", r.name).unwrap();
+            /* online/total: */
+            match (r.nr_devs, r.nr_offline) {
+                (Some(n), o) => write!(sub, "{}/{}", n - o, n).unwrap(),
+                (None, 0)    => (),
+                (None, _)    => write!(sub, "0/1").unwrap(),
+            }
+            write!(sub, "\r").unwrap();
+            sub.units_sectors(r.score.lost);
+            write!(sub, "\r").unwrap();
+            sub.units_sectors(r.score.degraded);
+            write!(sub, "\r\n").unwrap();
+        }
+    });
+}
+
+fn fs_failure_domains_to_text(out: &mut Printbuf, cli: &Cli, name_mode: DeviceNameMode) -> Result<()> {
+    let path = &cli.mountpoint;
+
+    let handle = BcachefsHandle::open(path)
+        .map_err(|e| anyhow!("opening filesystem '{}': {}", path, e))?;
+    let sysfs_path = sysfs::sysfs_path_from_fd(handle.sysfs_fd())?;
+    let devs = sysfs::fs_get_devices(&sysfs_path, name_mode)?;
+
+    let acct = handle.query_accounting(disk_accounting_type::replicas.bit())
+        .map_err(|e| anyhow!("query_accounting ioctl failed (kernel too old?): {}", e))?;
+    let acct_refs: Vec<&AccountingEntry> = acct.entries.iter().collect();
+
+    let e = Exposure::new(&acct_refs);
+    let uuid = uuid::Uuid::from_bytes(handle.uuid());
+
+    if cli.json {
+        let mut j = report_to_json(&e, &devs);
+        j["filesystem"] = uuid.hyphenated().to_string().into();
+        writeln!(out, "{:#}", j).unwrap();
+        return Ok(());
+    }
+
+    writeln!(out, "Filesystem: {}", uuid.hyphenated()).unwrap();
+    header_to_text(out, &e, &devs);
+    report_to_text(out, &e, &devs);
+    Ok(())
+}
+
+// ── Demo scenarios - synthetic replica sets, no filesystem needed ────
+
+mod demo {
+    use super::*;
+
+    /// Deterministic - same output every run:
+    struct Rng(u64);
+
+    impl Rng {
+        fn next(&mut self, bound: u64) -> u64 {
+            self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            (self.0 >> 33) % bound
+        }
+    }
+
+    fn dev(idx: u32, rack: Option<u32>) -> DevInfo {
+        DevInfo {
+            idx,
+            dev: format!("dev{}", idx),
+            label: None,
+            failure_domain: rack.map(|r| format!("rack{}", r)),
+            durability: 1,
+            online: true,
+        }
+    }
+
+    fn entries_from_pairs(pairs: HashMap<[u8; 2], u64>) -> Vec<Entry> {
+        pairs.into_iter()
+            .map(|(devs, sectors)| Entry {
+                devs: devs.to_vec(),
+                tolerates: 1,
+                sectors,
+            })
+            .collect()
+    }
+
+    /// Six racks of ten, replicas=2 spread correctly: copies always cross
+    /// racks. No whole rack failure loses anything.
+    fn racks_spread() -> (Vec<Entry>, Vec<DevInfo>) {
+        let devs: Vec<DevInfo> = (0..60).map(|i| dev(i, Some(i / 10))).collect();
+        let mut rng = Rng(1);
+        let mut pairs: HashMap<[u8; 2], u64> = HashMap::new();
+
+        for _ in 0..6000 {
+            let a = rng.next(60) as u8;
+            let b = loop {
+                let b = rng.next(60) as u8;
+                if b / 10 != a / 10 {
+                    break b;
+                }
+            };
+            let mut key = [a, b];
+            key.sort();
+            *pairs.entry(key).or_default() += (rng.next(7) + 1) * 2048;
+        }
+
+        (entries_from_pairs(pairs), devs)
+    }
+
+    /// No failure domains, and the filesystem grew in stages: heavy old
+    /// data on the first eight devices, later data spread wider. The old
+    /// device pairs carry correlated risk:
+    fn grew_in_stages() -> (Vec<Entry>, Vec<DevInfo>) {
+        let devs: Vec<DevInfo> = (0..60).map(|i| dev(i, None)).collect();
+        let mut rng = Rng(2);
+        let mut pairs: HashMap<[u8; 2], u64> = HashMap::new();
+
+        let mut era = |nr_devs: u64, writes: u64, size: u64| {
+            for _ in 0..writes {
+                let a = rng.next(nr_devs) as u8;
+                let b = loop {
+                    let b = rng.next(nr_devs) as u8;
+                    if b != a {
+                        break b;
+                    }
+                };
+                let mut key = [a, b];
+                key.sort();
+                *pairs.entry(key).or_default() += (rng.next(7) + 1) * size;
+            }
+        };
+
+        era(8, 3000, 4096);   /* the early days: 8 devices, lots of data */
+        era(28, 1500, 2048);  /* first expansion */
+        era(60, 800, 2048);   /* current */
+
+        (entries_from_pairs(pairs), devs)
+    }
+
+    /// Failure domains, but partly off: a stretch of data was written with
+    /// copies landing in one rack (domains misconfigured, a rack's worth of
+    /// devices down, data predating the labels...):
+    fn partly_off() -> (Vec<Entry>, Vec<DevInfo>) {
+        let mut devs: Vec<DevInfo> = (0..60).map(|i| dev(i, Some(i / 10))).collect();
+
+        /* rack5 is down - one of the ways data ends up under-spread: */
+        for d in &mut devs[50..60] {
+            d.online = false;
+        }
+        let devs = devs;
+        let mut rng = Rng(3);
+        let mut pairs: HashMap<[u8; 2], u64> = HashMap::new();
+
+        for i in 0..6000 {
+            let a = rng.next(60) as u8;
+            let same_rack = i % 8 == 0;
+            let b = loop {
+                let b = rng.next(60) as u8;
+                if b != a && ((b / 10 == a / 10) == same_rack) {
+                    break b;
+                }
+            };
+            let mut key = [a, b];
+            key.sort();
+            *pairs.entry(key).or_default() += (rng.next(7) + 1) * 2048;
+        }
+
+        (entries_from_pairs(pairs), devs)
+    }
+
+    pub fn scenario(name: &str) -> Option<(Vec<Entry>, Vec<DevInfo>)> {
+        match name {
+            "domains" => Some(racks_spread()),
+            "no-domains" => Some(grew_in_stages()),
+            "partly-off" => Some(partly_off()),
+            _ => None,
+        }
+    }
+}
+
+fn fs_failure_domains(cli: Cli) -> Result<()> {
+    let mut out = Printbuf::new();
+    out.set_human_readable(cli.human_readable);
+    let name_mode = cli.device_names.name_mode();
+
+    if let Some(name) = &cli.demo {
+        let (entries, devs) = demo::scenario(name)
+            .ok_or_else(|| anyhow!("unknown scenario '{}' (have: domains, no-domains, partly-off)", name))?;
+
+        let e = Exposure::from_entries(entries);
+        if cli.json {
+            writeln!(out, "{:#}", report_to_json(&e, &devs)).unwrap();
+        } else {
+            writeln!(out, "Demo scenario: {}", name).unwrap();
+            header_to_text(&mut out, &e, &devs);
+            report_to_text(&mut out, &e, &devs);
+        }
+    } else {
+        fs_failure_domains_to_text(&mut out, &cli, name_mode)?;
+    }
+    print!("{}", out);
+    Ok(())
+}
+
+pub const CMD: super::CmdDef = typed_cmd!("failure-domains",
+    "Show failure domains and what losing each would cost",
+    Cli, fs_failure_domains);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(devs: &[u8], tolerates: u8, sectors: u64) -> Entry {
+        Entry { devs: devs.to_vec(), tolerates, sectors }
+    }
+
+    /// Two racks of two devices ({0,2} and {1,3}), replicas=2 spread
+    /// correctly: every entry crosses racks.
+    fn cross_rack() -> Exposure {
+        Exposure::from_entries(vec![
+            entry(&[0, 1], 1, 100),
+            entry(&[0, 3], 1, 100),
+            entry(&[1, 2], 1, 100),
+            entry(&[2, 3], 1, 100),
+        ])
+    }
+
+    fn rack_devs() -> Vec<DevInfo> {
+        (0..4).map(|i| DevInfo {
+            idx: i,
+            dev: format!("dev{}", i),
+            label: None,
+            failure_domain: Some(format!("rack{}", i % 2)),
+            durability: 1,
+            online: true,
+        }).collect()
+    }
+
+    #[test]
+    fn spread_replicas() {
+        let e = cross_rack();
+
+        /* failing a whole rack: everything survives, degraded: */
+        assert_eq!(e.score(&[0, 2]),
+                   Score { lost: 0, degraded: 400 });
+
+        /* a cross rack pair kills its entry, degrades the overlapping
+         * entries, never touches the disjoint one: */
+        assert_eq!(e.score(&[0, 1]),
+                   Score { lost: 100, degraded: 200 });
+    }
+
+    #[test]
+    fn domains() {
+        let rows = domain_rows(&cross_rack(), &rack_devs());
+
+        /* two racks, nothing lost if either fails whole: */
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].name, "rack0");
+        assert_eq!(rows[0].nr_devs, Some(2));
+        assert_eq!(rows[0].score, Score { lost: 0, degraded: 400 });
+        assert_eq!(rows[1].name, "rack1");
+        assert_eq!(rows[1].score.lost, 0);
+    }
+
+    #[test]
+    fn violation_shows_as_lost() {
+        /* both copies in rack 0 (devices 0 and 2): */
+        let e = Exposure::from_entries(vec![
+            entry(&[0, 2], 1, 100),
+            entry(&[0, 1], 1, 100),
+        ]);
+
+        let rows = domain_rows(&e, &rack_devs());
+
+        assert_eq!(rows[0].name, "rack0");
+        assert_eq!(rows[0].score.lost, 100);
+    }
+
+    #[test]
+    fn ec_stripe() {
+        /* one 4+2 stripe across six devices: */
+        let e = Exposure::from_entries(vec![entry(&[0, 1, 2, 3, 4, 5], 2, 600)]);
+
+        assert_eq!(e.score(&[0]), Score { lost: 0, degraded: 600 });
+        assert_eq!(e.score(&[0, 1]), Score { lost: 0, degraded: 600 });
+        assert_eq!(e.score(&[0, 1, 2]), Score { lost: 600, degraded: 0 });
+    }
+
+    #[test]
+    fn unlabeled_devices_are_domains() {
+        let e = Exposure::from_entries(vec![entry(&[0, 1], 1, 100)]);
+        let devs: Vec<DevInfo> = (0..2).map(|i| DevInfo {
+            idx: i,
+            dev: format!("dev{}", i),
+            label: None,
+            failure_domain: None,
+            durability: 1,
+            online: true,
+        }).collect();
+
+        let rows = domain_rows(&e, &devs);
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].name, "dev0");
+        assert_eq!(rows[0].nr_devs, None);
+        assert_eq!(rows[0].score, Score { lost: 0, degraded: 100 });
+    }
+}

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -415,6 +415,7 @@ fn cmd_set(
     pos: c::bpos,
     type_name: &str,
     assigns: &[(&str, FieldVal)],
+    in_snapshot: bool,
 ) -> Result<String> {
     let ti = typeinfo::bkey_type_info_by_name(type_name)
         .ok_or_else(|| anyhow!("unknown key type '{type_name}'"))?;
@@ -433,6 +434,29 @@ fn cmd_set(
         None,
         CommitOpts::new().flags(CommitFlags::NO_ENOSPC),
         |t| {
+            // Deletion has two meanings. Raw (the default): remove this
+            // exact key - a filtered iter would have bch2_trans_update()
+            // convert the deletion into a whiteout whenever the key is
+            // visible in an ancestor snapshot, so deleting a whiteout
+            // silently rewrites it as itself. -s: delete within pos's
+            // snapshot - the filtered iter gets exactly that conversion,
+            // the same semantics as a runtime delete. The peek is just
+            // the traverse bch2_trans_update() requires.
+            let (iter_flags, update_flags) = if in_snapshot {
+                (BtreeIterFlags::INTENT, UpdateTriggerFlags::empty())
+            } else {
+                (RAW_EXACT | BtreeIterFlags::INTENT,
+                 UpdateTriggerFlags::INTERNAL_SNAPSHOT_NODE)
+            };
+            let mut iter = BtreeIter::new(
+                t.trans(),
+                btree,
+                pos,
+                iter_flags,
+            );
+            iter.peek_max_flags(SPOS_MAX, BtreeIterFlags::SLOTS)
+                .map_err(TransError::from)?;
+
             let mut new = t.bkey_alloc((BKEY_U64S + val_u64s) as u32)
                 .map_err(TransError::from)?;
             new.as_mut_u64s().fill(0);
@@ -459,7 +483,7 @@ fn cmd_set(
                 }
             }
 
-            t.insert_nonextent(btree, new, UpdateTriggerFlags::INTERNAL_SNAPSHOT_NODE)
+            t.update(&mut iter, new, update_flags)
         },
     );
 
@@ -518,9 +542,11 @@ peek      <btree> <pos>                        first key >= pos
 peek_prev <btree> <pos>                        last key <= pos
 list      <btree> [start] [end]                keys in range
 update    <btree> <pos> <field=val>...         modify fields of an existing key
-set       <btree> <pos> <type> [field=val]...  insert a whole new key
+set  [-s] <btree> <pos> <type> [field=val]...  insert a whole new key
           values are integers; fields holding enum codewords (snapshot/
           subvolume state) also accept the value name, e.g. state=will_delete
+          `set <pos> deleted` removes the exact key; with -s it deletes
+          within pos's snapshot instead (whiteouts, like a runtime delete)
 sb get    <field>                              read a superblock field/flag
 sb set    <field=val>                          write one, then bch2_write_super
 help                                           this text
@@ -604,9 +630,16 @@ fn run_line(kvdb_fs: &KvdbFs, nostart: bool, line: &str) -> Result<()> {
             cmd_update(fs, parse_btree(btree)?, parse_pos(pos)?, &assigns)?
         }
         "set" => {
-            let [btree, pos, type_name, assigns @ ..] = args else {
-                bail!("usage: set <btree> <pos> <type> [field=val]...");
+            let (in_snapshot, args) = match args {
+                ["-s", rest @ ..] => (true, rest),
+                _ => (false, args),
             };
+            let [btree, pos, type_name, assigns @ ..] = args else {
+                bail!("usage: set [-s] <btree> <pos> <type> [field=val]...");
+            };
+            if in_snapshot && *type_name != "deleted" {
+                bail!("-s (delete within pos's snapshot) only applies to deletions");
+            }
             let KvdbFs::Offline(fs) = kvdb_fs else {
                 bail!("filesystem is mounted: kvdb is read-only on mounted filesystems");
             };
@@ -614,7 +647,7 @@ fn run_line(kvdb_fs: &KvdbFs, nostart: bool, line: &str) -> Result<()> {
                 .iter()
                 .map(|s| parse_assign(s))
                 .collect::<Result<Vec<_>>>()?;
-            cmd_set(fs, parse_btree(btree)?, parse_pos(pos)?, type_name, &assigns)?
+            cmd_set(fs, parse_btree(btree)?, parse_pos(pos)?, type_name, &assigns, in_snapshot)?
         }
         "sb" => {
             let (&sub, rest) = args.split_first()

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -89,6 +89,12 @@ pub struct Cli {
     #[arg(long)]
     nostart: bool,
 
+    /// Open read-only without journal replay or repair passes (recovery
+    /// capped at snapshots_read; journal keys still overlay reads). For
+    /// inspecting a filesystem's state before repair touches it.
+    #[arg(long)]
+    norecovery: bool,
+
     #[arg(required(true))]
     devices: Vec<PathBuf>,
 }
@@ -910,6 +916,9 @@ fn kvdb(cli: Cli) -> Result<()> {
     // sb-only mode: open the sb but don't run recovery or touch the btree.
     if cli.nostart {
         opt_set!(fs_opts, nostart, 1);
+    }
+    if cli.norecovery {
+        opt_set!(fs_opts, norecovery, 1);
     }
 
     let kvdb_fs = match crate::device_scan::open_online_or_offline(&cli.devices, fs_opts)? {

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -104,7 +104,7 @@ in memory: listings then show a root inode that does not exist on disk.
 
 Commands:
 
-    get       [-k] <btree> <pos>                   exact lookup, dump fields
+    get       [-k] <btree> <pos>                   exact lookup (slot iteration)
     peek      [-k] <btree> <pos>                   first key >= pos
     peek_prev [-k] <btree> <pos>                   last key <= pos
     list      [-k] <btree> [start] [end]           keys in range
@@ -311,39 +311,15 @@ fn field_val(type_: u8, path: &str, v: &FieldVal) -> Result<u64> {
     }
 }
 
-// ---------------------------------------------------------------------------
-// value access
-
-fn val_bytes<'a>(k: &BkeySC<'a>) -> &'a [u8] {
-    let len = k.k.u64s as usize * 8 - size_of::<c::bkey>();
-    unsafe { std::slice::from_raw_parts(k.v as *const c::bch_val as *const u8, len) }
-}
-
-/// One rendering of the value, not two: with a typeinfo field table the
-/// dump is the authoritative view (field names match update's syntax), so
-/// the header is the key alone; the C to_text - which renders the value
-/// inline - is the fallback for types the field engine can't decompose
-/// (entry-stream values like extents), and the whole line for plain reads.
-fn render_key(fs: &Fs, k: &BkeySC<'_>, fields: bool, key_only: bool) -> String {
+/// The bcachefs to_text methods are the faithful rendering of the on-disk
+/// structs - that is their purpose. The typeinfo field tables are for
+/// addressing fields on the write side (update/set), not for display.
+fn render_key(fs: &Fs, k: &BkeySC<'_>, key_only: bool) -> String {
     if key_only {
-        return format!("{}\n", k.to_text_key());
+        format!("{}\n", k.to_text_key())
+    } else {
+        format!("{}\n", k.to_text(fs))
     }
-    if fields {
-        if let Some(info) = typeinfo::bkey_val_info(k.k.type_ as u32) {
-            if !info.fields.is_empty() {
-                let mut out = format!("{}\n", k.to_text_key());
-                let mut dump = String::new();
-                let _ = typeinfo::struct_to_text(&mut dump, info, val_bytes(k));
-                for l in dump.lines() {
-                    out.push_str("  ");
-                    out.push_str(l);
-                    out.push('\n');
-                }
-                return out;
-            }
-        }
-    }
-    format!("{}\n", k.to_text(fs))
 }
 
 /// A resolved assignment target: a field, or a declared bit range within one
@@ -405,7 +381,7 @@ fn cmd_get(fs: &Fs, btree: c::btree_id, pos: c::bpos, filtered: bool,
         let out = iter
             .peek_max_flags(SPOS_MAX, BtreeIterFlags::SLOTS)
             .map(|k| match k {
-                Some(k) => render_key(fs, &k, true, key_only),
+                Some(k) => render_key(fs, &k, key_only),
                 None => "(no key)\n".to_string(),
             });
         t.result_value(out)
@@ -424,7 +400,7 @@ fn cmd_peek(fs: &Fs, btree: c::btree_id, pos: c::bpos, prev: bool, filtered: boo
             iter.peek()
         }
         .map(|k| match k {
-            Some(k) => render_key(fs, &k, true, key_only),
+            Some(k) => render_key(fs, &k, key_only),
             None => "(no key)\n".to_string(),
         });
         t.result_value(out)
@@ -520,14 +496,14 @@ fn cmd_list(fs: &Fs, btree: c::btree_id, start: c::bpos, end: c::bpos,
 /// exact pos; peek/peek_prev: first key at/after (at/before) pos.
 fn online_one_key(handle: &BcachefsHandle, fs: &Fs,
 		  btree: c::btree_id, pos: c::bpos,
-		  flags: OnlineIterFlags, fields: bool, key_only: bool) -> Result<String> {
+		  flags: OnlineIterFlags, key_only: bool) -> Result<String> {
     // Small buffer: the kernel fills the whole thing per call, and we only
     // want one key (it grows automatically if the key doesn't fit):
     let mut iter = OnlineBtreeIter::with_buf_size(handle, btree, 0, pos,
 					if flags.0 & OnlineIterFlags::PREV.0 != 0 { POS_MIN } else { SPOS_MAX },
 					flags, 4096);
     Ok(match iter.next().map_err(|e| anyhow!("BCH_IOCTL_QUERY_BTREE_KEYS: {e}"))? {
-        Some(k) => render_key(fs, &k, fields, key_only),
+        Some(k) => render_key(fs, &k, key_only),
         None => "(no key)\n".to_string(),
     })
 }
@@ -548,7 +524,7 @@ fn cmd_get_online(handle: &BcachefsHandle, fs: &Fs,
 		  btree: c::btree_id, pos: c::bpos, filtered: bool,
 		  key_only: bool) -> Result<String> {
     online_one_key(handle, fs, btree, pos,
-		   OnlineIterFlags::SLOTS | online_snapshots_flag(filtered), true, key_only)
+		   OnlineIterFlags::SLOTS | online_snapshots_flag(filtered), key_only)
 }
 
 fn cmd_peek_online(handle: &BcachefsHandle, fs: &Fs,
@@ -558,7 +534,7 @@ fn cmd_peek_online(handle: &BcachefsHandle, fs: &Fs,
     if prev {
         flags = flags | OnlineIterFlags::PREV;
     }
-    online_one_key(handle, fs, btree, pos, flags, true, key_only)
+    online_one_key(handle, fs, btree, pos, flags, key_only)
 }
 
 fn cmd_list_online(handle: &BcachefsHandle, fs: &Fs,
@@ -807,7 +783,7 @@ fn cmd_sb_set(fs: &Fs, field: &str, v: u64) -> Result<String> {
 // command dispatch + REPL
 
 const HELP: &str = "\
-get  [-k] <btree> <pos>                        exact lookup, dump fields
+get  [-k] <btree> <pos>                        exact lookup (slot iteration)
 peek [-k] <btree> <pos>                        first key >= pos
 peek_prev <btree> <pos>                        last key <= pos ([-k] too)
 list [-k] <btree> [start] [end]                keys in range

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -236,10 +236,23 @@ fn write_field(
 /// a snapshot field, so passing it unconditionally is fine.
 const RAW_EXACT: BtreeIterFlags = BtreeIterFlags::SLOTS.union(BtreeIterFlags::ALL_SNAPSHOTS);
 
-fn cmd_get(fs: &Fs, btree: c::btree_id, pos: c::bpos) -> Result<String> {
+/// With a snapshot context active, reads drop ALL_SNAPSHOTS: the iterator
+/// runs snapshot-filtered (iter init adds BTREE_ITER_filter_snapshots for
+/// btrees with snapshot fields) at pos.snapshot, so lookups resolve
+/// visibility the way runtime lookups do. Harmless on btrees without
+/// snapshot fields - iteration is simply positional there.
+fn iter_flags(base: BtreeIterFlags, filtered: bool) -> BtreeIterFlags {
+    if filtered {
+        base.difference(BtreeIterFlags::ALL_SNAPSHOTS)
+    } else {
+        base
+    }
+}
+
+fn cmd_get(fs: &Fs, btree: c::btree_id, pos: c::bpos, filtered: bool) -> Result<String> {
     let trans = BtreeTrans::new(fs);
     Ok(lockrestart_do(&trans, |t| {
-        let mut iter = BtreeIter::new(t.trans(), btree, pos, RAW_EXACT);
+        let mut iter = BtreeIter::new(t.trans(), btree, pos, iter_flags(RAW_EXACT, filtered));
         let out = iter
             .peek_max_flags(SPOS_MAX, BtreeIterFlags::SLOTS)
             .map(|k| match k {
@@ -250,10 +263,11 @@ fn cmd_get(fs: &Fs, btree: c::btree_id, pos: c::bpos) -> Result<String> {
     })?)
 }
 
-fn cmd_peek(fs: &Fs, btree: c::btree_id, pos: c::bpos, prev: bool) -> Result<String> {
+fn cmd_peek(fs: &Fs, btree: c::btree_id, pos: c::bpos, prev: bool, filtered: bool) -> Result<String> {
     let trans = BtreeTrans::new(fs);
     Ok(lockrestart_do(&trans, |t| {
-        let mut iter = BtreeIter::new(t.trans(), btree, pos, BtreeIterFlags::ALL_SNAPSHOTS);
+        let mut iter = BtreeIter::new(t.trans(), btree, pos,
+                                      iter_flags(BtreeIterFlags::ALL_SNAPSHOTS, filtered));
         let out = if prev {
             iter.peek_prev()
         } else {
@@ -328,14 +342,15 @@ fn take_interrupt() -> bool {
     INTERRUPTED.swap(false, Ordering::Relaxed)
 }
 
-fn cmd_list(fs: &Fs, btree: c::btree_id, start: c::bpos, end: c::bpos) -> Result<String> {
+fn cmd_list(fs: &Fs, btree: c::btree_id, start: c::bpos, end: c::bpos,
+            filtered: bool) -> Result<String> {
     let trans = BtreeTrans::new(fs);
     let mut out = String::new();
     let mut iter = BtreeIter::new(
         &trans,
         btree,
         start,
-        BtreeIterFlags::ALL_SNAPSHOTS | BtreeIterFlags::PREFETCH,
+        iter_flags(BtreeIterFlags::ALL_SNAPSHOTS | BtreeIterFlags::PREFETCH, filtered),
     );
     iter.for_each_max(&trans, end, |k| {
         if take_interrupt() {
@@ -364,15 +379,26 @@ fn online_one_key(handle: &BcachefsHandle, fs: &Fs,
     })
 }
 
+/// Online counterpart of iter_flags(): the ioctl maps its flags 1:1 into
+/// btree iter flags, so omitting all_snapshots gets filtered iteration
+/// kernel-side.
+fn online_snapshots_flag(filtered: bool) -> OnlineIterFlags {
+    if filtered {
+        OnlineIterFlags::default()
+    } else {
+        OnlineIterFlags::ALL_SNAPSHOTS
+    }
+}
+
 fn cmd_get_online(handle: &BcachefsHandle, fs: &Fs,
-		  btree: c::btree_id, pos: c::bpos) -> Result<String> {
+		  btree: c::btree_id, pos: c::bpos, filtered: bool) -> Result<String> {
     online_one_key(handle, fs, btree, pos,
-		   OnlineIterFlags::SLOTS | OnlineIterFlags::ALL_SNAPSHOTS, true)
+		   OnlineIterFlags::SLOTS | online_snapshots_flag(filtered), true)
 }
 
 fn cmd_peek_online(handle: &BcachefsHandle, fs: &Fs,
-		   btree: c::btree_id, pos: c::bpos, prev: bool) -> Result<String> {
-    let mut flags = OnlineIterFlags::ALL_SNAPSHOTS;
+		   btree: c::btree_id, pos: c::bpos, prev: bool, filtered: bool) -> Result<String> {
+    let mut flags = online_snapshots_flag(filtered);
     if prev {
         flags = flags | OnlineIterFlags::PREV;
     }
@@ -380,10 +406,11 @@ fn cmd_peek_online(handle: &BcachefsHandle, fs: &Fs,
 }
 
 fn cmd_list_online(handle: &BcachefsHandle, fs: &Fs,
-		   btree: c::btree_id, start: c::bpos, end: c::bpos) -> Result<String> {
+		   btree: c::btree_id, start: c::bpos, end: c::bpos,
+		   filtered: bool) -> Result<String> {
     let mut out = String::new();
     let mut iter = OnlineBtreeIter::new(handle, btree, 0, start, end,
-					OnlineIterFlags::ALL_SNAPSHOTS);
+					online_snapshots_flag(filtered));
     iter.for_each(|k| {
         if take_interrupt() {
             out.push_str("(interrupted)\n");
@@ -633,8 +660,10 @@ set  [-s] <btree> <pos> <type> [field=val]...  insert a whole new key
 sb get    <field>                              read a superblock field/flag
 sb set    <field=val>                          write one, then bch2_write_super
 snapshot  [<id>|none]                          set/show/clear the session snapshot
-                                               context: a <pos> without :snapshot
-                                               uses it (list start/end included)
+                                               context: reads (get/peek/list) run
+                                               snapshot-filtered in that view, and
+                                               a <pos> without :snapshot uses it;
+                                               writes (update/set) stay exact-key
 help                                           this text
 quit                                           exit (also ^D)
 ";
@@ -696,16 +725,17 @@ fn run_line(
                 bail!("usage: {op} <btree> <pos>");
             };
             let (btree, pos) = (parse_btree(btree)?, parse_pos_ctx(pos, *snapshot)?);
+            let filtered = snapshot.is_some();
             match kvdb_fs {
                 KvdbFs::Offline(fs) => match op {
-                    "get" => cmd_get(fs, btree, pos)?,
-                    "peek" => cmd_peek(fs, btree, pos, false)?,
-                    _ => cmd_peek(fs, btree, pos, true)?,
+                    "get" => cmd_get(fs, btree, pos, filtered)?,
+                    "peek" => cmd_peek(fs, btree, pos, false, filtered)?,
+                    _ => cmd_peek(fs, btree, pos, true, filtered)?,
                 },
                 KvdbFs::Online(handle, fs) => match op {
-                    "get" => cmd_get_online(handle, fs, btree, pos)?,
-                    "peek" => cmd_peek_online(handle, fs, btree, pos, false)?,
-                    _ => cmd_peek_online(handle, fs, btree, pos, true)?,
+                    "get" => cmd_get_online(handle, fs, btree, pos, filtered)?,
+                    "peek" => cmd_peek_online(handle, fs, btree, pos, false, filtered)?,
+                    _ => cmd_peek_online(handle, fs, btree, pos, true, filtered)?,
                 },
             }
         }
@@ -713,12 +743,20 @@ fn run_line(
             let (btree, rest) = args
                 .split_first()
                 .ok_or_else(|| anyhow!("usage: list <btree> [start] [end]"))?;
-            let start = rest.first().map_or(Ok(POS_MIN), |s| parse_pos_ctx(s, *snapshot))?;
+            // A filtered iterator's snapshot comes from pos.snapshot, so the
+            // default start must carry the context (POS_MIN's snapshot 0 is
+            // never a valid view):
+            let default_start = match *snapshot {
+                Some(snap) => c::bpos { inode: 0, offset: 0, snapshot: snap },
+                None => POS_MIN,
+            };
+            let start = rest.first().map_or(Ok(default_start), |s| parse_pos_ctx(s, *snapshot))?;
             let end = rest.get(1).map_or(Ok(SPOS_MAX), |s| parse_pos_ctx(s, *snapshot))?;
+            let filtered = snapshot.is_some();
             let btree = parse_btree(btree)?;
             match kvdb_fs {
-                KvdbFs::Offline(fs) => cmd_list(fs, btree, start, end)?,
-                KvdbFs::Online(handle, fs) => cmd_list_online(handle, fs, btree, start, end)?,
+                KvdbFs::Offline(fs) => cmd_list(fs, btree, start, end, filtered)?,
+                KvdbFs::Online(handle, fs) => cmd_list_online(handle, fs, btree, start, end, filtered)?,
             }
         }
         "update" => {

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -768,11 +768,43 @@ fn cmd_sb_get(fs: &Fs, field: &str) -> Result<String> {
 
 fn cmd_sb_set(fs: &Fs, field: &str, v: u64) -> Result<String> {
     let target = sb_field(field)?;
+
+    let _lock = unsafe { crate::wrappers::sb_lock(fs.raw) };
+
+    // bch2_write_super() silently skips uninitialized superblocks (the gate
+    // that keeps format from writing a half-built sb). An opened-from-disk
+    // sb is complete, but never-started images (fresh format) still have
+    // INITIALIZED unset - fail loudly rather than claim success.
+    {
+        let (r, bm) = sb_field("initialized")?;
+        let (p, len) = sb_bytes(fs);
+        let buf = unsafe { std::slice::from_raw_parts(p, len) };
+        let initialized = match bm {
+            Some(bm) => typeinfo::read_bits(buf, &r, bm),
+            None => typeinfo::read_scalar(buf, &r),
+        }.map_err(|e| anyhow!("initialized: {e}"))?;
+        if initialized == 0 {
+            bail!("superblock not initialized (filesystem has never been started): \
+                   bch2_write_super would silently skip the write; \
+                   start the fs once (mount, or kvdb --rw) first");
+        }
+    }
+
     let (p, len) = sb_bytes(fs);
     let buf = unsafe { std::slice::from_raw_parts_mut(p, len) };
     write_field(buf, &target, v).map_err(|e| anyhow!("{field}: {e}"))?;
 
+    // Every kvdb open short of --rw runs with nochanges (norecovery implies
+    // it, init/fs.c), which turns bch2_write_super() into a silent no-op.
+    // That protection is load-bearing - the open path makes version-upgrade
+    // decisions an inspection-mode open must never persist - so don't weaken
+    // the open; lift nochanges around this one write, which is the user's
+    // explicit request.
+    let saved = unsafe { (*fs.raw).opts.nochanges };
+    unsafe { (*fs.raw).opts.nochanges = 0 };
     let ret = unsafe { c::bch2_write_super(fs.raw) };
+    unsafe { (*fs.raw).opts.nochanges = saved };
+
     if ret != 0 {
         bail!("bch2_write_super failed: {ret}");
     }

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -254,6 +254,51 @@ fn cmd_peek(fs: &Fs, btree: c::btree_id, pos: c::bpos, prev: bool) -> Result<Str
     })?)
 }
 
+/// Tab completion: command names for the first word, btree names (from the
+/// same string table FromStr parses) after a key command, get/set after sb.
+struct KvdbHelper {
+    btrees: Vec<String>,
+}
+
+const OPS: &[&str] = &["get", "peek", "peek_prev", "list", "update", "set", "sb", "help"];
+const KEY_OPS: &[&str] = &["get", "peek", "peek_prev", "list", "update", "set"];
+
+impl rustyline::completion::Completer for KvdbHelper {
+    type Candidate = String;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _: &rustyline::Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<String>)> {
+        let start = line[..pos].rfind(char::is_whitespace).map_or(0, |i| i + 1);
+        let word = &line[start..pos];
+        let prior: Vec<&str> = line[..start].split_whitespace().collect();
+
+        let candidates: Vec<String> = match prior.as_slice() {
+            [] => OPS.iter().map(|s| s.to_string()).collect(),
+            [op] if KEY_OPS.contains(op) => self.btrees.clone(),
+            ["sb"] => vec!["get".to_string(), "set".to_string()],
+            _ => vec![],
+        };
+        Ok((
+            start,
+            candidates
+                .into_iter()
+                .filter(|c| c.starts_with(word))
+                .collect(),
+        ))
+    }
+}
+
+impl rustyline::hint::Hinter for KvdbHelper {
+    type Hint = String;
+}
+impl rustyline::highlight::Highlighter for KvdbHelper {}
+impl rustyline::validate::Validator for KvdbHelper {}
+impl rustyline::Helper for KvdbHelper {}
+
 /// ^C during a long-running command: the REPL installs a SIGINT handler that
 /// sets this flag (rustyline's raw mode swallows ^C at the prompt itself, so
 /// the handler only ever fires mid-command). Iteration loops poll it and stop,
@@ -778,7 +823,14 @@ fn kvdb(cli: Cli) -> Result<()> {
         libc::signal(libc::SIGINT, kvdb_sigint as *const () as libc::sighandler_t);
     }
 
-    let mut rl = rustyline::DefaultEditor::new()?;
+    let mut rl: rustyline::Editor<KvdbHelper, rustyline::history::DefaultHistory> =
+        rustyline::Editor::new()?;
+    rl.set_helper(Some(KvdbHelper {
+        btrees: bcachefs_kernel::BTREE_IDS_KNOWN
+            .iter()
+            .map(|id| id.to_string())
+            .collect(),
+    }));
     let history = std::env::var_os("HOME")
         .map(|home| PathBuf::from(home).join(".cache/bcachefs-kvdb-history"));
     if let Some(h) = &history {

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -1081,6 +1081,9 @@ fn h_sb(repl: &mut Repl, cmd: &Cmd, args: &[&str]) -> Result<ControlFlow<(), Str
 fn h_list_journal(repl: &mut Repl, cmd: &Cmd, args: &[&str]) -> Result<ControlFlow<(), String>> {
     let fs = repl.fs.offline()?;
     let mut f = super::list_journal::JournalFilter::default();
+    // Searching the journal, not auditing it: gaps in the sequence aren't
+    // what we're here for, and on a damaged fs they're endless spam.
+    f.print_missing = false;
     let mut args = args;
     while let Some((&flag, rest)) = args.split_first() {
         match flag {

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -852,6 +852,45 @@ impl KvdbFs {
             KvdbFs::Offline(fs) | KvdbFs::Online(_, fs) => fs,
         }
     }
+
+    /// The offline Fs, for operations that need libbcachefs btree/journal
+    /// access (writes, list_journal).
+    fn offline(&self) -> Result<&Fs> {
+        match self {
+            KvdbFs::Offline(fs) => Ok(fs),
+            KvdbFs::Online(..) => bail!(
+                "filesystem is mounted: this command needs offline access \
+                 (online kvdb reads via the kernel, read-only)"
+            ),
+        }
+    }
+
+    fn get(&self, btree: c::btree_id, pos: c::bpos, filtered: bool,
+           key_only: bool) -> Result<String> {
+        match self {
+            KvdbFs::Offline(fs) => cmd_get(fs, btree, pos, filtered, key_only),
+            KvdbFs::Online(handle, fs) =>
+                cmd_get_online(handle, fs, btree, pos, filtered, key_only),
+        }
+    }
+
+    fn peek(&self, btree: c::btree_id, pos: c::bpos, prev: bool, filtered: bool,
+            key_only: bool) -> Result<String> {
+        match self {
+            KvdbFs::Offline(fs) => cmd_peek(fs, btree, pos, prev, filtered, key_only),
+            KvdbFs::Online(handle, fs) =>
+                cmd_peek_online(handle, fs, btree, pos, prev, filtered, key_only),
+        }
+    }
+
+    fn list(&self, btree: c::btree_id, start: c::bpos, end: c::bpos, filtered: bool,
+            key_only: bool) -> Result<String> {
+        match self {
+            KvdbFs::Offline(fs) => cmd_list(fs, btree, start, end, filtered, key_only),
+            KvdbFs::Online(handle, fs) =>
+                cmd_list_online(handle, fs, btree, start, end, filtered, key_only),
+        }
+    }
 }
 
 fn run_line(
@@ -904,17 +943,10 @@ fn run_line(
                 pos.snapshot = snap;
             }
             let filtered = ctx.is_some();
-            match kvdb_fs {
-                KvdbFs::Offline(fs) => match op {
-                    "get" => cmd_get(fs, btree, pos, filtered, key_only)?,
-                    "peek" => cmd_peek(fs, btree, pos, false, filtered, key_only)?,
-                    _ => cmd_peek(fs, btree, pos, true, filtered, key_only)?,
-                },
-                KvdbFs::Online(handle, fs) => match op {
-                    "get" => cmd_get_online(handle, fs, btree, pos, filtered, key_only)?,
-                    "peek" => cmd_peek_online(handle, fs, btree, pos, false, filtered, key_only)?,
-                    _ => cmd_peek_online(handle, fs, btree, pos, true, filtered, key_only)?,
-                },
+            match op {
+                "get" => kvdb_fs.get(btree, pos, filtered, key_only)?,
+                "peek" => kvdb_fs.peek(btree, pos, false, filtered, key_only)?,
+                _ => kvdb_fs.peek(btree, pos, true, filtered, key_only)?,
             }
         }
         "list" => {
@@ -939,11 +971,7 @@ fn run_line(
                 start.snapshot = snap;
             }
             let filtered = ctx.is_some();
-            match kvdb_fs {
-                KvdbFs::Offline(fs) => cmd_list(fs, btree, start, end, filtered, key_only)?,
-                KvdbFs::Online(handle, fs) =>
-                    cmd_list_online(handle, fs, btree, start, end, filtered, key_only)?,
-            }
+            kvdb_fs.list(btree, start, end, filtered, key_only)?
         }
         "update" => {
             let [btree, pos, assigns @ ..] = args else {
@@ -955,9 +983,7 @@ fn run_line(
             if !rw {
                 bail!("read-only (the default is norecovery): reopen with --rw to edit");
             }
-            let KvdbFs::Offline(fs) = kvdb_fs else {
-                bail!("filesystem is mounted: kvdb is read-only on mounted filesystems");
-            };
+            let fs = kvdb_fs.offline()?;
             let assigns = assigns
                 .iter()
                 .map(|s| parse_assign(s))
@@ -980,9 +1006,7 @@ fn run_line(
             if !rw {
                 bail!("read-only (the default is norecovery): reopen with --rw to edit");
             }
-            let KvdbFs::Offline(fs) = kvdb_fs else {
-                bail!("filesystem is mounted: kvdb is read-only on mounted filesystems");
-            };
+            let fs = kvdb_fs.offline()?;
             let assigns = assigns
                 .iter()
                 .map(|s| parse_assign(s))
@@ -1008,9 +1032,7 @@ fn run_line(
                         bail!("read-only (the default is norecovery): \
                                reopen with --rw, or --nostart for sb-only edits");
                     }
-                    let KvdbFs::Offline(fs) = kvdb_fs else {
-                        bail!("filesystem is mounted: kvdb is read-only on mounted filesystems");
-                    };
+                    let fs = kvdb_fs.offline()?;
                     let (field, val) = parse_assign(assign)?;
                     let FieldVal::Int(v) = val else {
                         bail!("sb set: expected an integer value");
@@ -1025,9 +1047,7 @@ fn run_line(
                 bail!("list_journal: reopen with --journal \
                        (retains the whole journal in memory)");
             }
-            let KvdbFs::Offline(fs) = kvdb_fs else {
-                bail!("list_journal: only supported on offline filesystems");
-            };
+            let fs = kvdb_fs.offline()?;
             let mut f = super::list_journal::JournalFilter::default();
             let mut args = args;
             while let Some((&flag, rest)) = args.split_first() {

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -437,11 +437,6 @@ struct KvdbHelper {
     btrees: Vec<String>,
 }
 
-const OPS: &[&str] = &[
-    "get", "peek", "peek_prev", "list", "update", "set", "sb", "snapshot", "list_journal",
-    "help", "quit",
-];
-const KEY_OPS: &[&str] = &["get", "peek", "peek_prev", "list", "update", "set"];
 
 impl rustyline::completion::Completer for KvdbHelper {
     type Candidate = String;
@@ -457,9 +452,12 @@ impl rustyline::completion::Completer for KvdbHelper {
         let prior: Vec<&str> = line[..start].split_whitespace().collect();
 
         let candidates: Vec<String> = match prior.as_slice() {
-            [] => OPS.iter().map(|s| s.to_string()).collect(),
-            [op] if KEY_OPS.contains(op) => self.btrees.clone(),
-            ["sb"] => vec!["get".to_string(), "set".to_string()],
+            [] => COMMANDS.iter().map(|c| c.name.to_string()).collect(),
+            [op] => match COMMANDS.iter().find(|c| c.name == *op || c.aliases.contains(op)) {
+                Some(c) if c.completes_btree => self.btrees.clone(),
+                Some(c) => c.subcommands.iter().map(|s| s.to_string()).collect(),
+                None => vec![],
+            },
             _ => vec![],
         };
         Ok((
@@ -893,192 +891,273 @@ impl KvdbFs {
     }
 }
 
-fn run_line(
-    kvdb_fs: &KvdbFs,
+/// Session state threaded to command handlers: the open filesystem, the
+/// open-mode capabilities, and the snapshot context.
+struct Repl<'a> {
+    fs: &'a KvdbFs,
     nostart: bool,
     journal: bool,
     rw: bool,
-    snapshot: &mut Option<u32>,
-    line: &str,
-) -> Result<ControlFlow<()>> {
+    snapshot: Option<u32>,
+}
+
+type CmdHandler = fn(&mut Repl, &Cmd, &[&str]) -> Result<ControlFlow<(), String>>;
+
+/// One entry per command; dispatch, capability gating, usage messages, and
+/// tab completion all read from this table, so they can't drift.
+struct Cmd {
+    name: &'static str,
+    aliases: &'static [&'static str],
+    usage: &'static str,
+    /// second word completes as a btree name
+    completes_btree: bool,
+    /// second-word completions for commands with subcommands
+    subcommands: &'static [&'static str],
+    /// available under --nostart (superblock-only open)
+    nostart_ok: bool,
+    /// write command: requires --rw
+    needs_rw: bool,
+    /// requires --journal
+    needs_journal: bool,
+    handler: CmdHandler,
+}
+
+const COMMANDS: &[Cmd] = &[
+    Cmd { name: "get", aliases: &[], usage: "get [-k] <btree> <pos>",
+          completes_btree: true, subcommands: &[],
+          nostart_ok: false, needs_rw: false, needs_journal: false, handler: h_read },
+    Cmd { name: "peek", aliases: &[], usage: "peek [-k] <btree> <pos>",
+          completes_btree: true, subcommands: &[],
+          nostart_ok: false, needs_rw: false, needs_journal: false, handler: h_read },
+    Cmd { name: "peek_prev", aliases: &[], usage: "peek_prev [-k] <btree> <pos>",
+          completes_btree: true, subcommands: &[],
+          nostart_ok: false, needs_rw: false, needs_journal: false, handler: h_read },
+    Cmd { name: "list", aliases: &[], usage: "list [-k] <btree> [start] [end]",
+          completes_btree: true, subcommands: &[],
+          nostart_ok: false, needs_rw: false, needs_journal: false, handler: h_list },
+    Cmd { name: "update", aliases: &[], usage: "update <btree> <pos> <field=val>...",
+          completes_btree: true, subcommands: &[],
+          nostart_ok: false, needs_rw: true, needs_journal: false, handler: h_update },
+    Cmd { name: "set", aliases: &[], usage: "set [-s] <btree> <pos> <type> [field=val]...",
+          completes_btree: true, subcommands: &[],
+          nostart_ok: false, needs_rw: true, needs_journal: false, handler: h_set },
+    Cmd { name: "sb", aliases: &[], usage: "sb get <field> | sb set <field=val>",
+          completes_btree: false, subcommands: &["get", "set"],
+          nostart_ok: true, needs_rw: false, needs_journal: false, handler: h_sb },
+    Cmd { name: "snapshot", aliases: &[], usage: "snapshot [<id>|none]",
+          completes_btree: false, subcommands: &[],
+          nostart_ok: true, needs_rw: false, needs_journal: false, handler: h_snapshot },
+    Cmd { name: "list_journal", aliases: &[],
+          usage: "list_journal [-k [+-]<btree>:<pos>[-<btree>:<pos>],...]",
+          completes_btree: false, subcommands: &[],
+          nostart_ok: false, needs_rw: false, needs_journal: true, handler: h_list_journal },
+    Cmd { name: "help", aliases: &["?"], usage: "help",
+          completes_btree: false, subcommands: &[],
+          nostart_ok: true, needs_rw: false, needs_journal: false, handler: h_help },
+    Cmd { name: "quit", aliases: &["exit", "q"], usage: "quit",
+          completes_btree: false, subcommands: &[],
+          nostart_ok: true, needs_rw: false, needs_journal: false, handler: h_quit },
+];
+
+fn h_quit(_: &mut Repl, _: &Cmd, _: &[&str]) -> Result<ControlFlow<(), String>> {
+    Ok(ControlFlow::Break(()))
+}
+
+fn h_help(_: &mut Repl, _: &Cmd, _: &[&str]) -> Result<ControlFlow<(), String>> {
+    Ok(ControlFlow::Continue(HELP.to_string()))
+}
+
+fn h_snapshot(repl: &mut Repl, cmd: &Cmd, args: &[&str]) -> Result<ControlFlow<(), String>> {
+    Ok(ControlFlow::Continue(match args {
+        [] => match repl.snapshot {
+            Some(s) => format!("snapshot context: {s}\n"),
+            None => "no snapshot context\n".to_string(),
+        },
+        ["none"] | ["clear"] => {
+            repl.snapshot = None;
+            String::new()
+        }
+        [s] => {
+            repl.snapshot = Some(u32::try_from(parse_int(s)?)?);
+            String::new()
+        }
+        _ => bail!("usage: {}", cmd.usage),
+    }))
+}
+
+fn h_read(repl: &mut Repl, cmd: &Cmd, args: &[&str]) -> Result<ControlFlow<(), String>> {
+    let (key_only, args) = match args {
+        ["-k", rest @ ..] => (true, rest),
+        _ => (false, args),
+    };
+    let [btree, pos] = args else {
+        bail!("usage: {}", cmd.usage);
+    };
+    let btree = parse_btree(btree)?;
+    let ctx = repl.snapshot
+        .filter(|_| btree_uses_snapshots(btree) && !pos_has_explicit_snapshot(pos));
+    let mut pos = parse_pos(pos)?;
+    if let Some(snap) = ctx {
+        pos.snapshot = snap;
+    }
+    let filtered = ctx.is_some();
+    Ok(ControlFlow::Continue(match cmd.name {
+        "get" => repl.fs.get(btree, pos, filtered, key_only)?,
+        "peek" => repl.fs.peek(btree, pos, false, filtered, key_only)?,
+        _ => repl.fs.peek(btree, pos, true, filtered, key_only)?,
+    }))
+}
+
+fn h_list(repl: &mut Repl, cmd: &Cmd, args: &[&str]) -> Result<ControlFlow<(), String>> {
+    let (key_only, args) = match args {
+        ["-k", rest @ ..] => (true, rest),
+        _ => (false, args),
+    };
+    let (btree, rest) = args
+        .split_first()
+        .ok_or_else(|| anyhow!("usage: {}", cmd.usage))?;
+    let btree = parse_btree(btree)?;
+    let ctx = repl.snapshot.filter(|_| {
+        btree_uses_snapshots(btree)
+            && !rest.iter().take(2).any(|s| pos_has_explicit_snapshot(s))
+    });
+    let mut start = rest.first().map_or(Ok(POS_MIN), |s| parse_pos(s))?;
+    let end = rest.get(1).map_or(Ok(SPOS_MAX), |s| parse_pos_ctx(s, ctx))?;
+    // A filtered iterator's snapshot comes from the start pos - it's the
+    // view - so it must carry the context whether the start was given,
+    // defaulted, or POS_MIN (snapshot 0 is never a valid view):
+    if let Some(snap) = ctx {
+        start.snapshot = snap;
+    }
+    let filtered = ctx.is_some();
+    Ok(ControlFlow::Continue(repl.fs.list(btree, start, end, filtered, key_only)?))
+}
+
+fn h_update(repl: &mut Repl, cmd: &Cmd, args: &[&str]) -> Result<ControlFlow<(), String>> {
+    let [btree, pos, assigns @ ..] = args else {
+        bail!("usage: {}", cmd.usage);
+    };
+    if assigns.is_empty() {
+        bail!("usage: {}", cmd.usage);
+    }
+    let fs = repl.fs.offline()?;
+    let assigns = assigns
+        .iter()
+        .map(|s| parse_assign(s))
+        .collect::<Result<Vec<_>>>()?;
+    let btree = parse_btree(btree)?;
+    let ctx = repl.snapshot.filter(|_| btree_uses_snapshots(btree));
+    Ok(ControlFlow::Continue(cmd_update(fs, btree, parse_pos_ctx(pos, ctx)?, &assigns)?))
+}
+
+fn h_set(repl: &mut Repl, cmd: &Cmd, args: &[&str]) -> Result<ControlFlow<(), String>> {
+    let (in_snapshot, args) = match args {
+        ["-s", rest @ ..] => (true, rest),
+        _ => (false, args),
+    };
+    let [btree, pos, type_name, assigns @ ..] = args else {
+        bail!("usage: {}", cmd.usage);
+    };
+    if in_snapshot && *type_name != "deleted" {
+        bail!("-s (delete within pos's snapshot) only applies to deletions");
+    }
+    let fs = repl.fs.offline()?;
+    let assigns = assigns
+        .iter()
+        .map(|s| parse_assign(s))
+        .collect::<Result<Vec<_>>>()?;
+    let btree = parse_btree(btree)?;
+    let ctx = repl.snapshot.filter(|_| btree_uses_snapshots(btree));
+    Ok(ControlFlow::Continue(
+        cmd_set(fs, btree, parse_pos_ctx(pos, ctx)?, type_name, &assigns, in_snapshot)?,
+    ))
+}
+
+fn h_sb(repl: &mut Repl, cmd: &Cmd, args: &[&str]) -> Result<ControlFlow<(), String>> {
+    let (&sub, rest) = args.split_first()
+        .ok_or_else(|| anyhow!("usage: {}", cmd.usage))?;
+    Ok(ControlFlow::Continue(match sub {
+        "get" => {
+            let [field] = rest else { bail!("usage: sb get <field>"); };
+            cmd_sb_get(repl.fs.fs(), field)?
+        }
+        "set" => {
+            let [assign] = rest else { bail!("usage: sb set <field=val>"); };
+            // Under the default norecovery open, nochanges makes
+            // bch2_write_super() a silent no-op - refuse rather than claim
+            // success. (Not table-gated needs_rw: sb get is fine read-only,
+            // and --nostart is the sb-editing mode and never sets nochanges.)
+            if !repl.rw && !repl.nostart {
+                bail!("read-only (the default is norecovery): \
+                       reopen with --rw, or --nostart for sb-only edits");
+            }
+            let fs = repl.fs.offline()?;
+            let (field, val) = parse_assign(assign)?;
+            let FieldVal::Int(v) = val else {
+                bail!("sb set: expected an integer value");
+            };
+            cmd_sb_set(fs, field, v)?
+        }
+        _ => bail!("usage: {}", cmd.usage),
+    }))
+}
+
+fn h_list_journal(repl: &mut Repl, cmd: &Cmd, args: &[&str]) -> Result<ControlFlow<(), String>> {
+    let fs = repl.fs.offline()?;
+    let mut f = super::list_journal::JournalFilter::default();
+    let mut args = args;
+    while let Some((&flag, rest)) = args.split_first() {
+        match flag {
+            "-k" => {
+                let Some((&ranges, rest)) = rest.split_first() else {
+                    bail!("usage: {}", cmd.usage);
+                };
+                let (sign, r) = super::list_journal::parse_sign(ranges);
+                for part in r.split(',') {
+                    let range = bcachefs_kernel::bbpos_range_parse(part)
+                        .map_err(|e| anyhow!("{e}: {part}"))?;
+                    f.key.ranges.push((sign, range));
+                }
+                f.filtering = true;
+                args = rest;
+            }
+            _ => bail!("list_journal: unknown arg '{flag}' (supported: -k <range>)"),
+        }
+    }
+    let interrupt: &dyn Fn() -> bool = &take_interrupt;
+    super::list_journal::list_journal_run(fs.raw, &f, false, 0, u64::MAX, None,
+                                          Some(interrupt))?;
+    Ok(ControlFlow::Continue(String::new()))
+}
+
+fn run_line(repl: &mut Repl, line: &str) -> Result<ControlFlow<()>> {
     let args: Vec<&str> = line.split_whitespace().collect();
     let Some((&op, args)) = args.split_first() else {
         return Ok(ControlFlow::Continue(()));
     };
 
-    if nostart && !matches!(op, "sb" | "help" | "?" | "snapshot" | "quit" | "exit" | "q") {
-        bail!("--nostart: the btree isn't started, only sb commands are available");
-    }
-
-    let out = match op {
-        "quit" | "exit" | "q" => return Ok(ControlFlow::Break(())),
-        "snapshot" => match args {
-            [] => match snapshot {
-                Some(s) => format!("snapshot context: {s}\n"),
-                None => "no snapshot context\n".to_string(),
-            },
-            ["none"] | ["clear"] => {
-                *snapshot = None;
-                String::new()
-            }
-            [s] => {
-                *snapshot = Some(u32::try_from(parse_int(s)?)?);
-                String::new()
-            }
-            _ => bail!("usage: snapshot [<id>|none]"),
-        },
-        "get" | "peek" | "peek_prev" => {
-            let (key_only, args) = match args {
-                ["-k", rest @ ..] => (true, rest),
-                _ => (false, args),
-            };
-            let [btree, pos] = args else {
-                bail!("usage: {op} [-k] <btree> <pos>");
-            };
-            let btree = parse_btree(btree)?;
-            let ctx = snapshot
-                .filter(|_| btree_uses_snapshots(btree) && !pos_has_explicit_snapshot(pos));
-            let mut pos = parse_pos(pos)?;
-            if let Some(snap) = ctx {
-                pos.snapshot = snap;
-            }
-            let filtered = ctx.is_some();
-            match op {
-                "get" => kvdb_fs.get(btree, pos, filtered, key_only)?,
-                "peek" => kvdb_fs.peek(btree, pos, false, filtered, key_only)?,
-                _ => kvdb_fs.peek(btree, pos, true, filtered, key_only)?,
-            }
-        }
-        "list" => {
-            let (key_only, args) = match args {
-                ["-k", rest @ ..] => (true, rest),
-                _ => (false, args),
-            };
-            let (btree, rest) = args
-                .split_first()
-                .ok_or_else(|| anyhow!("usage: list [-k] <btree> [start] [end]"))?;
-            let btree = parse_btree(btree)?;
-            let ctx = snapshot.filter(|_| {
-                btree_uses_snapshots(btree)
-                    && !rest.iter().take(2).any(|s| pos_has_explicit_snapshot(s))
-            });
-            let mut start = rest.first().map_or(Ok(POS_MIN), |s| parse_pos(s))?;
-            let end = rest.get(1).map_or(Ok(SPOS_MAX), |s| parse_pos_ctx(s, ctx))?;
-            // A filtered iterator's snapshot comes from the start pos - it's
-            // the view - so it must carry the context whether the start was
-            // given, defaulted, or POS_MIN (snapshot 0 is never a valid view):
-            if let Some(snap) = ctx {
-                start.snapshot = snap;
-            }
-            let filtered = ctx.is_some();
-            kvdb_fs.list(btree, start, end, filtered, key_only)?
-        }
-        "update" => {
-            let [btree, pos, assigns @ ..] = args else {
-                bail!("usage: update <btree> <pos> <field=val>...");
-            };
-            if assigns.is_empty() {
-                bail!("usage: update <btree> <pos> <field=val>...");
-            }
-            if !rw {
-                bail!("read-only (the default is norecovery): reopen with --rw to edit");
-            }
-            let fs = kvdb_fs.offline()?;
-            let assigns = assigns
-                .iter()
-                .map(|s| parse_assign(s))
-                .collect::<Result<Vec<_>>>()?;
-            let btree = parse_btree(btree)?;
-            let ctx = snapshot.filter(|_| btree_uses_snapshots(btree));
-            cmd_update(fs, btree, parse_pos_ctx(pos, ctx)?, &assigns)?
-        }
-        "set" => {
-            let (in_snapshot, args) = match args {
-                ["-s", rest @ ..] => (true, rest),
-                _ => (false, args),
-            };
-            let [btree, pos, type_name, assigns @ ..] = args else {
-                bail!("usage: set [-s] <btree> <pos> <type> [field=val]...");
-            };
-            if in_snapshot && *type_name != "deleted" {
-                bail!("-s (delete within pos's snapshot) only applies to deletions");
-            }
-            if !rw {
-                bail!("read-only (the default is norecovery): reopen with --rw to edit");
-            }
-            let fs = kvdb_fs.offline()?;
-            let assigns = assigns
-                .iter()
-                .map(|s| parse_assign(s))
-                .collect::<Result<Vec<_>>>()?;
-            let btree = parse_btree(btree)?;
-            let ctx = snapshot.filter(|_| btree_uses_snapshots(btree));
-            cmd_set(fs, btree, parse_pos_ctx(pos, ctx)?, type_name, &assigns, in_snapshot)?
-        }
-        "sb" => {
-            let (&sub, rest) = args.split_first()
-                .ok_or_else(|| anyhow!("usage: sb get <field> | sb set <field=val>"))?;
-            match sub {
-                "get" => {
-                    let [field] = rest else { bail!("usage: sb get <field>"); };
-                    cmd_sb_get(kvdb_fs.fs(), field)?
-                }
-                "set" => {
-                    let [assign] = rest else { bail!("usage: sb set <field=val>"); };
-                    // Under the default norecovery open, nochanges makes
-                    // bch2_write_super() a silent no-op - refuse rather than
-                    // claim success:
-                    if !rw && !nostart {
-                        bail!("read-only (the default is norecovery): \
-                               reopen with --rw, or --nostart for sb-only edits");
-                    }
-                    let fs = kvdb_fs.offline()?;
-                    let (field, val) = parse_assign(assign)?;
-                    let FieldVal::Int(v) = val else {
-                        bail!("sb set: expected an integer value");
-                    };
-                    cmd_sb_set(fs, field, v)?
-                }
-                _ => bail!("usage: sb get <field> | sb set <field=val>"),
-            }
-        }
-        "list_journal" => {
-            if !journal {
-                bail!("list_journal: reopen with --journal \
-                       (retains the whole journal in memory)");
-            }
-            let fs = kvdb_fs.offline()?;
-            let mut f = super::list_journal::JournalFilter::default();
-            let mut args = args;
-            while let Some((&flag, rest)) = args.split_first() {
-                match flag {
-                    "-k" => {
-                        let Some((&ranges, rest)) = rest.split_first() else {
-                            bail!("usage: list_journal [-k [+-]<btree>:<pos>[-<btree>:<pos>],...]");
-                        };
-                        let (sign, r) = super::list_journal::parse_sign(ranges);
-                        for part in r.split(',') {
-                            let range = bcachefs_kernel::bbpos_range_parse(part)
-                                .map_err(|e| anyhow!("{e}: {part}"))?;
-                            f.key.ranges.push((sign, range));
-                        }
-                        f.filtering = true;
-                        args = rest;
-                    }
-                    _ => bail!("list_journal: unknown arg '{flag}' (supported: -k <range>)"),
-                }
-            }
-            let interrupt: &dyn Fn() -> bool = &take_interrupt;
-            super::list_journal::list_journal_run(fs.raw, &f, false, 0, u64::MAX, None,
-                                                  Some(interrupt))?;
-            String::new()
-        }
-        "help" | "?" => HELP.to_string(),
-        _ => bail!("unknown command '{op}' (try: help)"),
+    let Some(cmd) = COMMANDS.iter()
+        .find(|c| c.name == op || c.aliases.contains(&op)) else {
+        bail!("unknown command '{op}' (try: help)");
     };
 
-    print!("{out}");
-    Ok(ControlFlow::Continue(()))
+    if repl.nostart && !cmd.nostart_ok {
+        bail!("--nostart: the btree isn't started, only sb commands are available");
+    }
+    if cmd.needs_rw && !repl.rw {
+        bail!("read-only (the default is norecovery): reopen with --rw to edit");
+    }
+    if cmd.needs_journal && !repl.journal {
+        bail!("{}: reopen with --journal (retains the whole journal in memory)", cmd.name);
+    }
+
+    match (cmd.handler)(repl, cmd, args)? {
+        ControlFlow::Continue(out) => {
+            print!("{out}");
+            Ok(ControlFlow::Continue(()))
+        }
+        ControlFlow::Break(()) => Ok(ControlFlow::Break(())),
+    }
 }
 
 fn kvdb(cli: Cli) -> Result<()> {
@@ -1148,11 +1227,17 @@ fn kvdb(cli: Cli) -> Result<()> {
         }
     };
     let fs = &kvdb_fs;
-    let mut snapshot_ctx: Option<u32> = None;
+    let mut repl = Repl {
+        fs,
+        nostart: cli.nostart,
+        journal: cli.journal,
+        rw: cli.rw,
+        snapshot: None,
+    };
 
     if !cli.commands.is_empty() {
         for line in &cli.commands {
-            if run_line(fs, cli.nostart, cli.journal, cli.rw, &mut snapshot_ctx, line)?.is_break() {
+            if run_line(&mut repl, line)?.is_break() {
                 break;
             }
         }
@@ -1163,7 +1248,7 @@ fn kvdb(cli: Cli) -> Result<()> {
     // depend on earlier ones); interactively, report and go on.
     if !stdin().is_terminal() {
         for line in stdin().lines() {
-            if run_line(fs, cli.nostart, cli.journal, cli.rw, &mut snapshot_ctx, &line?)?.is_break() {
+            if run_line(&mut repl, &line?)?.is_break() {
                 break;
             }
         }
@@ -1188,7 +1273,7 @@ fn kvdb(cli: Cli) -> Result<()> {
         let _ = rl.load_history(h);
     }
     loop {
-        let prompt = match snapshot_ctx {
+        let prompt = match repl.snapshot {
             Some(s) => format!("kvdb[{s}]> "),
             None => "kvdb> ".to_string(),
         };
@@ -1198,7 +1283,7 @@ fn kvdb(cli: Cli) -> Result<()> {
                     let _ = rl.add_history_entry(&line);
                 }
                 INTERRUPTED.store(false, Ordering::Relaxed);
-                match run_line(fs, cli.nostart, cli.journal, cli.rw, &mut snapshot_ctx, &line) {
+                match run_line(&mut repl, &line) {
                     Ok(ControlFlow::Break(())) => break,
                     Ok(ControlFlow::Continue(())) => {}
                     Err(e) => eprintln!("{e}"),

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -10,17 +10,27 @@
 //!
 //! Ops: get / peek / peek_prev / list (read), update (read-modify-write
 //! fields of an existing key), set (construct and insert a whole key —
-//! `set <btree> <pos> deleted` deletes). One-shot via -c, REPL on stdin
-//! otherwise; the REPL reads commands line by line, so tests can pipe a
-//! script in.
+//! `set <btree> <pos> deleted` deletes), snapshot (session view context),
+//! list_journal (transaction search, --journal opens). One-shot via -c,
+//! REPL on stdin otherwise; the REPL reads commands line by line, so tests
+//! can pipe a script in.
 //!
-//! Scope notes: values are addressed raw (BTREE_ITER_all_snapshots — the
-//! position's snapshot field is taken literally, no visibility filtering;
-//! harmlessly dropped on btrees without a snapshot field). Fixed-layout vals
-//! are fully editable; varint-packed (inode) and entry-stream (extent) vals
-//! only up to their fixed header. Updates run the normal triggers and key
-//! validation — per-key-invalid keys are (correctly) rejected; whether we
-//! want a validation-bypass mode for injecting those is an open question.
+//! The default open is norecovery (read-only, no replay, no repair passes) -
+//! inspection must not disturb the state under inspection; --rw opts into
+//! full recovery for editing sessions.
+//!
+//! Visibility: without a snapshot context, reads are raw
+//! (BTREE_ITER_all_snapshots - positions taken literally). With a context,
+//! reads without an explicit :snapshot run snapshot-filtered at the context
+//! (runtime visibility resolution, whiteouts shown); an explicit :snapshot
+//! makes that command raw again. Writes always target the exact key.
+//! Full semantics: doc/kvdb.md.
+//!
+//! Fixed-layout vals are fully editable; varint-packed (inode) and
+//! entry-stream (extent) vals only up to their fixed header. Updates run the
+//! normal triggers and key validation — per-key-invalid keys are (correctly)
+//! rejected; whether we want a validation-bypass mode for injecting those is
+//! an open question.
 
 use std::io::{stdin, stdout, IsTerminal};
 use std::ops::ControlFlow;
@@ -54,13 +64,20 @@ const BKEY_U64S: usize = size_of::<c::bkey>() / size_of::<u64>();
 Read and write btree keys by field name, using generated runtime type \
 information for the on-disk structs. Without -c, reads commands from stdin \
 (a REPL; pipe a script in for non-interactive use).\n\n\
+Opens read-only with recovery capped (norecovery) by default: inspection \
+must not disturb the state under inspection. --rw runs full recovery and \
+enables editing.\n\n\
 Commands:\n\
-  get       <btree> <pos>                    exact lookup, dump fields\n\
-  peek      <btree> <pos>                    first key >= pos\n\
+  get       [-k] <btree> <pos>               exact lookup, dump fields\n\
+  peek      [-k] <btree> <pos>               first key >= pos\n\
   peek_prev <btree> <pos>                    last key <= pos\n\
-  list      <btree> [start] [end]            keys in range\n\
+  list      [-k] <btree> [start] [end]       keys in range\n\
   update    <btree> <pos> <field=val>...     modify fields of an existing key\n\
-  set       <btree> <pos> <type> [field=val]...  insert a whole new key\n\n\
+  set       <btree> <pos> <type> [field=val]...  insert a whole new key\n\
+  snapshot  [<id>|none]                      session snapshot context\n\
+  list_journal [-k <ranges>]                 journal transactions (--journal)\n\n\
+Full documentation, including the snapshot-context visibility semantics: \
+doc/kvdb.md.\n\n\
 pos is inode:offset[:snapshot], or POS_MIN/POS_MAX/SPOS_MAX. Fields are \
 val struct fields: parent, children[1], btime.hi, ... Declared flag bits \
 (LE*_BITMASK) resolve by name too: no_keys=1, or qualified as flags.subvol=0 \
@@ -89,11 +106,18 @@ pub struct Cli {
     #[arg(long)]
     nostart: bool,
 
-    /// Open read-only without journal replay or repair passes (recovery
-    /// capped at snapshots_read; journal keys still overlay reads). For
-    /// inspecting a filesystem's state before repair touches it.
+    /// Read-only, no journal replay or repair passes (recovery capped at
+    /// snapshots_read; journal keys still overlay reads). This is the
+    /// default; the flag is accepted for compatibility.
     #[arg(long)]
     norecovery: bool,
+
+    /// Open read-write with full recovery: journal replay, scheduled repair
+    /// passes, version upgrades. Required for update/set/sb set. On a
+    /// damaged filesystem this can repair - rewrite - the state you may
+    /// have wanted to inspect.
+    #[arg(long)]
+    rw: bool,
 
     /// Retain the entire journal in memory for the list_journal command
     /// (costs memory proportional to journal size).
@@ -740,6 +764,7 @@ fn run_line(
     kvdb_fs: &KvdbFs,
     nostart: bool,
     journal: bool,
+    rw: bool,
     snapshot: &mut Option<u32>,
     line: &str,
 ) -> Result<ControlFlow<()>> {
@@ -833,6 +858,9 @@ fn run_line(
             if assigns.is_empty() {
                 bail!("usage: update <btree> <pos> <field=val>...");
             }
+            if !rw {
+                bail!("read-only (the default is norecovery): reopen with --rw to edit");
+            }
             let KvdbFs::Offline(fs) = kvdb_fs else {
                 bail!("filesystem is mounted: kvdb is read-only on mounted filesystems");
             };
@@ -855,6 +883,9 @@ fn run_line(
             if in_snapshot && *type_name != "deleted" {
                 bail!("-s (delete within pos's snapshot) only applies to deletions");
             }
+            if !rw {
+                bail!("read-only (the default is norecovery): reopen with --rw to edit");
+            }
             let KvdbFs::Offline(fs) = kvdb_fs else {
                 bail!("filesystem is mounted: kvdb is read-only on mounted filesystems");
             };
@@ -876,6 +907,13 @@ fn run_line(
                 }
                 "set" => {
                     let [assign] = rest else { bail!("usage: sb set <field=val>"); };
+                    // Under the default norecovery open, nochanges makes
+                    // bch2_write_super() a silent no-op - refuse rather than
+                    // claim success:
+                    if !rw && !nostart {
+                        bail!("read-only (the default is norecovery): \
+                               reopen with --rw, or --nostart for sb-only edits");
+                    }
                     let KvdbFs::Offline(fs) = kvdb_fs else {
                         bail!("filesystem is mounted: kvdb is read-only on mounted filesystems");
                     };
@@ -960,7 +998,12 @@ fn kvdb(cli: Cli) -> Result<()> {
     if cli.nostart {
         opt_set!(fs_opts, nostart, 1);
     }
-    if cli.norecovery {
+    if cli.rw && cli.norecovery {
+        bail!("--rw and --norecovery are mutually exclusive");
+    }
+    // Inspection is the primary use, and a full-recovery open can repair -
+    // rewrite - the state under inspection; rw is opt-in.
+    if !cli.rw {
         opt_set!(fs_opts, norecovery, 1);
     }
     if cli.journal {
@@ -995,7 +1038,7 @@ fn kvdb(cli: Cli) -> Result<()> {
 
     if !cli.commands.is_empty() {
         for line in &cli.commands {
-            if run_line(fs, cli.nostart, cli.journal, &mut snapshot_ctx, line)?.is_break() {
+            if run_line(fs, cli.nostart, cli.journal, cli.rw, &mut snapshot_ctx, line)?.is_break() {
                 break;
             }
         }
@@ -1006,7 +1049,7 @@ fn kvdb(cli: Cli) -> Result<()> {
     // depend on earlier ones); interactively, report and go on.
     if !stdin().is_terminal() {
         for line in stdin().lines() {
-            if run_line(fs, cli.nostart, cli.journal, &mut snapshot_ctx, &line?)?.is_break() {
+            if run_line(fs, cli.nostart, cli.journal, cli.rw, &mut snapshot_ctx, &line?)?.is_break() {
                 break;
             }
         }
@@ -1041,7 +1084,7 @@ fn kvdb(cli: Cli) -> Result<()> {
                     let _ = rl.add_history_entry(&line);
                 }
                 INTERRUPTED.store(false, Ordering::Relaxed);
-                match run_line(fs, cli.nostart, cli.journal, &mut snapshot_ctx, &line) {
+                match run_line(fs, cli.nostart, cli.journal, cli.rw, &mut snapshot_ctx, &line) {
                     Ok(ControlFlow::Break(())) => break,
                     Ok(ControlFlow::Continue(())) => {}
                     Err(e) => eprintln!("{e}"),

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -185,7 +185,10 @@ fn val_bytes<'a>(k: &BkeySC<'a>) -> &'a [u8] {
     unsafe { std::slice::from_raw_parts(k.v as *const c::bch_val as *const u8, len) }
 }
 
-fn render_key(fs: &Fs, k: &BkeySC<'_>, fields: bool) -> String {
+fn render_key(fs: &Fs, k: &BkeySC<'_>, fields: bool, key_only: bool) -> String {
+    if key_only {
+        return format!("{}\n", k.to_text_key());
+    }
     let mut out = format!("{}\n", k.to_text(fs));
     if !fields {
         return out;
@@ -257,21 +260,23 @@ fn iter_flags(base: BtreeIterFlags, filtered: bool) -> BtreeIterFlags {
     }
 }
 
-fn cmd_get(fs: &Fs, btree: c::btree_id, pos: c::bpos, filtered: bool) -> Result<String> {
+fn cmd_get(fs: &Fs, btree: c::btree_id, pos: c::bpos, filtered: bool,
+           key_only: bool) -> Result<String> {
     let trans = BtreeTrans::new(fs);
     Ok(lockrestart_do(&trans, |t| {
         let mut iter = BtreeIter::new(t.trans(), btree, pos, iter_flags(RAW_EXACT, filtered));
         let out = iter
             .peek_max_flags(SPOS_MAX, BtreeIterFlags::SLOTS)
             .map(|k| match k {
-                Some(k) => render_key(fs, &k, true),
+                Some(k) => render_key(fs, &k, true, key_only),
                 None => "(no key)\n".to_string(),
             });
         t.result_value(out)
     })?)
 }
 
-fn cmd_peek(fs: &Fs, btree: c::btree_id, pos: c::bpos, prev: bool, filtered: bool) -> Result<String> {
+fn cmd_peek(fs: &Fs, btree: c::btree_id, pos: c::bpos, prev: bool, filtered: bool,
+            key_only: bool) -> Result<String> {
     let trans = BtreeTrans::new(fs);
     Ok(lockrestart_do(&trans, |t| {
         let mut iter = BtreeIter::new(t.trans(), btree, pos,
@@ -282,7 +287,7 @@ fn cmd_peek(fs: &Fs, btree: c::btree_id, pos: c::bpos, prev: bool, filtered: boo
             iter.peek()
         }
         .map(|k| match k {
-            Some(k) => render_key(fs, &k, true),
+            Some(k) => render_key(fs, &k, true, key_only),
             None => "(no key)\n".to_string(),
         });
         t.result_value(out)
@@ -351,7 +356,7 @@ fn take_interrupt() -> bool {
 }
 
 fn cmd_list(fs: &Fs, btree: c::btree_id, start: c::bpos, end: c::bpos,
-            filtered: bool) -> Result<String> {
+            filtered: bool, key_only: bool) -> Result<String> {
     let trans = BtreeTrans::new(fs);
     let mut out = String::new();
     let mut iter = BtreeIter::new(
@@ -365,7 +370,11 @@ fn cmd_list(fs: &Fs, btree: c::btree_id, start: c::bpos, end: c::bpos,
             out.push_str("(interrupted)\n");
             return ControlFlow::Break(());
         }
-        out.push_str(&format!("{}\n", k.to_text(fs)));
+        if key_only {
+            out.push_str(&format!("{}\n", k.to_text_key()));
+        } else {
+            out.push_str(&format!("{}\n", k.to_text(fs)));
+        }
         ControlFlow::Continue(())
     })?;
     Ok(out)
@@ -375,14 +384,14 @@ fn cmd_list(fs: &Fs, btree: c::btree_id, start: c::bpos, end: c::bpos,
 /// exact pos; peek/peek_prev: first key at/after (at/before) pos.
 fn online_one_key(handle: &BcachefsHandle, fs: &Fs,
 		  btree: c::btree_id, pos: c::bpos,
-		  flags: OnlineIterFlags, fields: bool) -> Result<String> {
+		  flags: OnlineIterFlags, fields: bool, key_only: bool) -> Result<String> {
     // Small buffer: the kernel fills the whole thing per call, and we only
     // want one key (it grows automatically if the key doesn't fit):
     let mut iter = OnlineBtreeIter::with_buf_size(handle, btree, 0, pos,
 					if flags.0 & OnlineIterFlags::PREV.0 != 0 { POS_MIN } else { SPOS_MAX },
 					flags, 4096);
     Ok(match iter.next().map_err(|e| anyhow!("BCH_IOCTL_QUERY_BTREE_KEYS: {e}"))? {
-        Some(k) => render_key(fs, &k, fields),
+        Some(k) => render_key(fs, &k, fields, key_only),
         None => "(no key)\n".to_string(),
     })
 }
@@ -400,23 +409,25 @@ fn online_snapshots_flag(filtered: bool) -> OnlineIterFlags {
 }
 
 fn cmd_get_online(handle: &BcachefsHandle, fs: &Fs,
-		  btree: c::btree_id, pos: c::bpos, filtered: bool) -> Result<String> {
+		  btree: c::btree_id, pos: c::bpos, filtered: bool,
+		  key_only: bool) -> Result<String> {
     online_one_key(handle, fs, btree, pos,
-		   OnlineIterFlags::SLOTS | online_snapshots_flag(filtered), true)
+		   OnlineIterFlags::SLOTS | online_snapshots_flag(filtered), true, key_only)
 }
 
 fn cmd_peek_online(handle: &BcachefsHandle, fs: &Fs,
-		   btree: c::btree_id, pos: c::bpos, prev: bool, filtered: bool) -> Result<String> {
+		   btree: c::btree_id, pos: c::bpos, prev: bool, filtered: bool,
+		   key_only: bool) -> Result<String> {
     let mut flags = online_snapshots_flag(filtered);
     if prev {
         flags = flags | OnlineIterFlags::PREV;
     }
-    online_one_key(handle, fs, btree, pos, flags, true)
+    online_one_key(handle, fs, btree, pos, flags, true, key_only)
 }
 
 fn cmd_list_online(handle: &BcachefsHandle, fs: &Fs,
 		   btree: c::btree_id, start: c::bpos, end: c::bpos,
-		   filtered: bool) -> Result<String> {
+		   filtered: bool, key_only: bool) -> Result<String> {
     let mut out = String::new();
     let mut iter = OnlineBtreeIter::new(handle, btree, 0, start, end,
 					online_snapshots_flag(filtered));
@@ -425,7 +436,11 @@ fn cmd_list_online(handle: &BcachefsHandle, fs: &Fs,
             out.push_str("(interrupted)\n");
             return ControlFlow::Break(());
         }
-        out.push_str(&format!("{}\n", k.to_text(fs)));
+        if key_only {
+            out.push_str(&format!("{}\n", k.to_text_key()));
+        } else {
+            out.push_str(&format!("{}\n", k.to_text(fs)));
+        }
         ControlFlow::Continue(())
     }).map_err(|e| anyhow!("BCH_IOCTL_QUERY_BTREE_KEYS: {e}"))?;
     Ok(out)
@@ -656,10 +671,11 @@ fn cmd_sb_set(fs: &Fs, field: &str, v: u64) -> Result<String> {
 // command dispatch + REPL
 
 const HELP: &str = "\
-get       <btree> <pos>                        exact lookup, dump fields
-peek      <btree> <pos>                        first key >= pos
-peek_prev <btree> <pos>                        last key <= pos
-list      <btree> [start] [end]                keys in range
+get  [-k] <btree> <pos>                        exact lookup, dump fields
+peek [-k] <btree> <pos>                        first key >= pos
+peek_prev <btree> <pos>                        last key <= pos ([-k] too)
+list [-k] <btree> [start] [end]                keys in range
+          -k prints keys only, without rendering values
 update    <btree> <pos> <field=val>...         modify fields of an existing key
 set  [-s] <btree> <pos> <type> [field=val]...  insert a whole new key
           values are integers; fields holding enum codewords (snapshot/
@@ -730,8 +746,12 @@ fn run_line(
             _ => bail!("usage: snapshot [<id>|none]"),
         },
         "get" | "peek" | "peek_prev" => {
+            let (key_only, args) = match args {
+                ["-k", rest @ ..] => (true, rest),
+                _ => (false, args),
+            };
             let [btree, pos] = args else {
-                bail!("usage: {op} <btree> <pos>");
+                bail!("usage: {op} [-k] <btree> <pos>");
             };
             let btree = parse_btree(btree)?;
             let ctx = snapshot.filter(|_| btree_uses_snapshots(btree));
@@ -739,21 +759,25 @@ fn run_line(
             let filtered = ctx.is_some();
             match kvdb_fs {
                 KvdbFs::Offline(fs) => match op {
-                    "get" => cmd_get(fs, btree, pos, filtered)?,
-                    "peek" => cmd_peek(fs, btree, pos, false, filtered)?,
-                    _ => cmd_peek(fs, btree, pos, true, filtered)?,
+                    "get" => cmd_get(fs, btree, pos, filtered, key_only)?,
+                    "peek" => cmd_peek(fs, btree, pos, false, filtered, key_only)?,
+                    _ => cmd_peek(fs, btree, pos, true, filtered, key_only)?,
                 },
                 KvdbFs::Online(handle, fs) => match op {
-                    "get" => cmd_get_online(handle, fs, btree, pos, filtered)?,
-                    "peek" => cmd_peek_online(handle, fs, btree, pos, false, filtered)?,
-                    _ => cmd_peek_online(handle, fs, btree, pos, true, filtered)?,
+                    "get" => cmd_get_online(handle, fs, btree, pos, filtered, key_only)?,
+                    "peek" => cmd_peek_online(handle, fs, btree, pos, false, filtered, key_only)?,
+                    _ => cmd_peek_online(handle, fs, btree, pos, true, filtered, key_only)?,
                 },
             }
         }
         "list" => {
+            let (key_only, args) = match args {
+                ["-k", rest @ ..] => (true, rest),
+                _ => (false, args),
+            };
             let (btree, rest) = args
                 .split_first()
-                .ok_or_else(|| anyhow!("usage: list <btree> [start] [end]"))?;
+                .ok_or_else(|| anyhow!("usage: list [-k] <btree> [start] [end]"))?;
             let btree = parse_btree(btree)?;
             let ctx = snapshot.filter(|_| btree_uses_snapshots(btree));
             // A filtered iterator's snapshot comes from pos.snapshot, so the
@@ -767,8 +791,9 @@ fn run_line(
             let end = rest.get(1).map_or(Ok(SPOS_MAX), |s| parse_pos_ctx(s, ctx))?;
             let filtered = ctx.is_some();
             match kvdb_fs {
-                KvdbFs::Offline(fs) => cmd_list(fs, btree, start, end, filtered)?,
-                KvdbFs::Online(handle, fs) => cmd_list_online(handle, fs, btree, start, end, filtered)?,
+                KvdbFs::Offline(fs) => cmd_list(fs, btree, start, end, filtered, key_only)?,
+                KvdbFs::Online(handle, fs) =>
+                    cmd_list_online(handle, fs, btree, start, end, filtered, key_only)?,
             }
         }
         "update" => {

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -101,6 +101,19 @@ fn parse_btree(s: &str) -> Result<c::btree_id> {
         .map_err(|_| anyhow!("invalid btree '{s}' (try: snapshots, subvolumes, extents, ...)"))
 }
 
+/// Position parse honoring the session snapshot context: a pos written
+/// without the :snapshot component picks it up from the context. Explicit
+/// :snapshot and the named positions (POS_MIN etc.) are left alone.
+fn parse_pos_ctx(s: &str, snapshot: Option<u32>) -> Result<c::bpos> {
+    let mut pos = parse_pos(s)?;
+    if let Some(snap) = snapshot {
+        if s.matches(':').count() == 1 {
+            pos.snapshot = snap;
+        }
+    }
+    Ok(pos)
+}
+
 fn parse_pos(s: &str) -> Result<c::bpos> {
     s.parse()
         .map_err(|_| anyhow!("invalid pos '{s}' (inode:offset[:snapshot], POS_MIN, SPOS_MAX)"))
@@ -260,7 +273,9 @@ struct KvdbHelper {
     btrees: Vec<String>,
 }
 
-const OPS: &[&str] = &["get", "peek", "peek_prev", "list", "update", "set", "sb", "help"];
+const OPS: &[&str] = &[
+    "get", "peek", "peek_prev", "list", "update", "set", "sb", "snapshot", "help", "quit",
+];
 const KEY_OPS: &[&str] = &["get", "peek", "peek_prev", "list", "update", "set"];
 
 impl rustyline::completion::Completer for KvdbHelper {
@@ -617,7 +632,11 @@ set  [-s] <btree> <pos> <type> [field=val]...  insert a whole new key
           within pos's snapshot instead (whiteouts, like a runtime delete)
 sb get    <field>                              read a superblock field/flag
 sb set    <field=val>                          write one, then bch2_write_super
+snapshot  [<id>|none]                          set/show/clear the session snapshot
+                                               context: a <pos> without :snapshot
+                                               uses it (list start/end included)
 help                                           this text
+quit                                           exit (also ^D)
 ";
 
 /// A kvdb session: fully offline (read + write via libbcachefs), or against
@@ -640,22 +659,43 @@ impl KvdbFs {
     }
 }
 
-fn run_line(kvdb_fs: &KvdbFs, nostart: bool, line: &str) -> Result<()> {
+fn run_line(
+    kvdb_fs: &KvdbFs,
+    nostart: bool,
+    snapshot: &mut Option<u32>,
+    line: &str,
+) -> Result<ControlFlow<()>> {
     let args: Vec<&str> = line.split_whitespace().collect();
     let Some((&op, args)) = args.split_first() else {
-        return Ok(());
+        return Ok(ControlFlow::Continue(()));
     };
 
-    if nostart && !matches!(op, "sb" | "help" | "?") {
+    if nostart && !matches!(op, "sb" | "help" | "?" | "snapshot" | "quit" | "exit" | "q") {
         bail!("--nostart: the btree isn't started, only sb commands are available");
     }
 
     let out = match op {
+        "quit" | "exit" | "q" => return Ok(ControlFlow::Break(())),
+        "snapshot" => match args {
+            [] => match snapshot {
+                Some(s) => format!("snapshot context: {s}\n"),
+                None => "no snapshot context\n".to_string(),
+            },
+            ["none"] | ["clear"] => {
+                *snapshot = None;
+                String::new()
+            }
+            [s] => {
+                *snapshot = Some(u32::try_from(parse_int(s)?)?);
+                String::new()
+            }
+            _ => bail!("usage: snapshot [<id>|none]"),
+        },
         "get" | "peek" | "peek_prev" => {
             let [btree, pos] = args else {
                 bail!("usage: {op} <btree> <pos>");
             };
-            let (btree, pos) = (parse_btree(btree)?, parse_pos(pos)?);
+            let (btree, pos) = (parse_btree(btree)?, parse_pos_ctx(pos, *snapshot)?);
             match kvdb_fs {
                 KvdbFs::Offline(fs) => match op {
                     "get" => cmd_get(fs, btree, pos)?,
@@ -673,8 +713,8 @@ fn run_line(kvdb_fs: &KvdbFs, nostart: bool, line: &str) -> Result<()> {
             let (btree, rest) = args
                 .split_first()
                 .ok_or_else(|| anyhow!("usage: list <btree> [start] [end]"))?;
-            let start = rest.first().map_or(Ok(POS_MIN), |s| parse_pos(s))?;
-            let end = rest.get(1).map_or(Ok(SPOS_MAX), |s| parse_pos(s))?;
+            let start = rest.first().map_or(Ok(POS_MIN), |s| parse_pos_ctx(s, *snapshot))?;
+            let end = rest.get(1).map_or(Ok(SPOS_MAX), |s| parse_pos_ctx(s, *snapshot))?;
             let btree = parse_btree(btree)?;
             match kvdb_fs {
                 KvdbFs::Offline(fs) => cmd_list(fs, btree, start, end)?,
@@ -695,7 +735,7 @@ fn run_line(kvdb_fs: &KvdbFs, nostart: bool, line: &str) -> Result<()> {
                 .iter()
                 .map(|s| parse_assign(s))
                 .collect::<Result<Vec<_>>>()?;
-            cmd_update(fs, parse_btree(btree)?, parse_pos(pos)?, &assigns)?
+            cmd_update(fs, parse_btree(btree)?, parse_pos_ctx(pos, *snapshot)?, &assigns)?
         }
         "set" => {
             let (in_snapshot, args) = match args {
@@ -715,7 +755,7 @@ fn run_line(kvdb_fs: &KvdbFs, nostart: bool, line: &str) -> Result<()> {
                 .iter()
                 .map(|s| parse_assign(s))
                 .collect::<Result<Vec<_>>>()?;
-            cmd_set(fs, parse_btree(btree)?, parse_pos(pos)?, type_name, &assigns, in_snapshot)?
+            cmd_set(fs, parse_btree(btree)?, parse_pos_ctx(pos, *snapshot)?, type_name, &assigns, in_snapshot)?
         }
         "sb" => {
             let (&sub, rest) = args.split_first()
@@ -744,7 +784,7 @@ fn run_line(kvdb_fs: &KvdbFs, nostart: bool, line: &str) -> Result<()> {
     };
 
     print!("{out}");
-    Ok(())
+    Ok(ControlFlow::Continue(()))
 }
 
 fn kvdb(cli: Cli) -> Result<()> {
@@ -802,10 +842,13 @@ fn kvdb(cli: Cli) -> Result<()> {
         }
     };
     let fs = &kvdb_fs;
+    let mut snapshot_ctx: Option<u32> = None;
 
     if !cli.commands.is_empty() {
         for line in &cli.commands {
-            run_line(fs, cli.nostart, line)?;
+            if run_line(fs, cli.nostart, &mut snapshot_ctx, line)?.is_break() {
+                break;
+            }
         }
         return Ok(());
     }
@@ -814,7 +857,9 @@ fn kvdb(cli: Cli) -> Result<()> {
     // depend on earlier ones); interactively, report and go on.
     if !stdin().is_terminal() {
         for line in stdin().lines() {
-            run_line(fs, cli.nostart, &line?)?;
+            if run_line(fs, cli.nostart, &mut snapshot_ctx, &line?)?.is_break() {
+                break;
+            }
         }
         return Ok(());
     }
@@ -837,14 +882,20 @@ fn kvdb(cli: Cli) -> Result<()> {
         let _ = rl.load_history(h);
     }
     loop {
-        match rl.readline("kvdb> ") {
+        let prompt = match snapshot_ctx {
+            Some(s) => format!("kvdb[{s}]> "),
+            None => "kvdb> ".to_string(),
+        };
+        match rl.readline(&prompt) {
             Ok(line) => {
                 if !line.trim().is_empty() {
                     let _ = rl.add_history_entry(&line);
                 }
                 INTERRUPTED.store(false, Ordering::Relaxed);
-                if let Err(e) = run_line(fs, cli.nostart, &line) {
-                    eprintln!("{e}");
+                match run_line(fs, cli.nostart, &mut snapshot_ctx, &line) {
+                    Ok(ControlFlow::Break(())) => break,
+                    Ok(ControlFlow::Continue(())) => {}
+                    Err(e) => eprintln!("{e}"),
                 }
             }
             Err(rustyline::error::ReadlineError::Interrupted) => continue,

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -372,6 +372,18 @@ fn render_key_fields(k: &BkeySC<'_>, paths: &[&str]) -> Result<String> {
                         .collect::<Result<Vec<_>>>()?
                         .join(" ")
                 }
+                // A vartail's length is however much value remains:
+                FieldKind::VarTail { elem, stride }
+                        if matches!(elem, FieldKind::Int { .. }) => {
+                    (0..(val.len().saturating_sub(r.offset) / stride))
+                        .map(|i| read_int(path, &FieldRef {
+                            offset: r.offset + i * stride,
+                            kind: elem,
+                            len: *stride,
+                        }))
+                        .collect::<Result<Vec<_>>>()?
+                        .join(" ")
+                }
                 _ => bail!("{path}: not a scalar or integer-array field"),
             },
         };
@@ -750,7 +762,15 @@ fn cmd_set(
 ) -> Result<String> {
     let ti = typeinfo::bkey_type_info_by_name(type_name)
         .ok_or_else(|| anyhow!("unknown key type '{type_name}'"))?;
-    let val_u64s = ti.info.size.div_ceil(8);
+
+    // The value needs the struct's fixed size, extended by whatever the
+    // assignments reach - vartail elements (damage errors[n]) lie beyond it:
+    let mut need = ti.info.size;
+    for (path, _) in assigns {
+        let (r, _) = resolve_field(ti.type_ as u8, path)?;
+        need = need.max(r.offset + r.len);
+    }
+    let val_u64s = need.div_ceil(8);
 
     let assigns = assigns
         .iter()

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -58,35 +58,126 @@ use crate::wrappers::online_iter::{OnlineBtreeIter, OnlineIterFlags};
 
 const BKEY_U64S: usize = size_of::<c::bkey>() / size_of::<u64>();
 
+// The canonical kvdb documentation: this constant is the --help long text,
+// and docgen extracts it into the Principles of Operation (doc/generated/
+// kvdb.tex, included from the Debugging tools section). Markup: blank-line
+// paragraphs, `- ` bullets, [term] description items, backticks for code,
+// 4-space-indented lines render verbatim.
+// DOC_STRING(kvdb)
+const KVDB_DOC: &str = "\
+kvdb is an interactive debugger for bcachefs metadata: it reads and writes
+btree keys by field name, using generated runtime type information for the
+on-disk structs. Its two jobs are forensics - inspecting a damaged
+filesystem's state precisely, without disturbing it - and injection:
+constructing exact corruption for fsck/repair tests, or performing
+field-level surgery on a filesystem wedged in the field.
+
+Commands come from the REPL (readline editing, history, tab completion for
+command and btree names), from -c arguments, or from piped stdin. In a
+piped script an error aborts, since later commands likely depend on earlier
+ones; interactively, errors are reported and the session continues. ctrl-C
+interrupts a long-running command and returns to the prompt; ctrl-D or
+`quit` exits.
+
+Opening modes: the default open is read-only with recovery capped
+(norecovery). Inspection is the primary use, and a full-recovery open of a
+damaged filesystem can repair - rewrite - the very state under inspection;
+the default is guaranteed not to write. The journal is still read and
+overlaid on btree reads, so listings show current state, but it is never
+replayed and no repair passes run.
+
+- `--rw`: full recovery - journal replay, repair passes scheduled in the
+  superblock, version upgrades - and writes enabled. Required for
+  update/set/sb set.
+- `--journal`: retain the entire journal in memory for `list_journal`;
+  costs memory proportional to journal size.
+- `--nostart`: superblock only, the btree is never started. For sb get/set
+  on an image that can't or shouldn't be started.
+- On a mounted filesystem, reads go through the kernel query ioctl and
+  writes are refused.
+
+Two traps: an `--rw` open of a not-yet-upgraded filesystem rewrites
+metadata via the version upgrade (for example the snapshot and subvolume
+state fields), destroying not-upgraded evidence. And the default open of a
+formatted-but-never-started image silently runs first-start initialization
+in memory: listings then show a root inode that does not exist on disk.
+
+Commands:
+
+    get       [-k] <btree> <pos>                   exact lookup, dump fields
+    peek      [-k] <btree> <pos>                   first key >= pos
+    peek_prev [-k] <btree> <pos>                   last key <= pos
+    list      [-k] <btree> [start] [end]           keys in range
+    update    <btree> <pos> <field=val>...         modify fields of a key
+    set  [-s] <btree> <pos> <type> [field=val]...  insert a whole new key
+    sb get    <field>                              read a superblock field
+    sb set    <field=val>                          write one
+    snapshot  [<id>|none]                          session snapshot context
+    list_journal [-k <ranges>]                     journal transactions
+    help, quit
+
+Positions are inode:offset[:snapshot], or POS_MIN/POS_MAX/SPOS_MAX. `-k` on
+the read commands prints keys only - type, position, size - without
+rendering values; useful when mapping out what exists.
+
+Fields are value-struct fields addressed by path (parent, children[1],
+btime.hi). Declared flag bits (LE*_BITMASK) resolve by name, qualified as
+flags.subvol when a name collides, and fields holding enum codewords accept
+value names: state=will_delete. Values are decimal, 0x hex, or negative
+decimal. `set <btree> <pos> deleted` removes the exact key; with -s it
+deletes within pos's snapshot instead (inserting whiteouts, like a runtime
+delete).
+
+The snapshot context. Snapshot visibility is the subtle dimension of every
+bcachefs lookup: a key at snapshot S is visible at S and its descendants
+unless overwritten, and a lookup in a snapshot resolves to the nearest
+visible version. The `snapshot` command gives the session a view, and reads
+then answer 'what does this view see?' instead of 'what is at this exact
+position?'. Precisely:
+
+- No context: reads are raw (all snapshots, positions taken literally); an
+  omitted :snapshot parses as 0.
+- Context set, pos written without :snapshot: the pos picks up the context
+  and the read runs snapshot-filtered at it - ancestor versions resolve,
+  siblings and descendants are invisible - exactly what a runtime lookup in
+  that snapshot sees. Whiteouts are shown, not skipped: in forensics the
+  whiteout doing the shadowing is data.
+- Context set, pos written with an explicit :snapshot: that command is
+  fully raw - unfiltered, exact position, context bypassed. Explicit means
+  exact.
+- The context only applies to btrees whose keys are snapshotted, and never
+  filters writes: update/set target the exact key, the context only fills
+  an omitted :snapshot.
+
+For a filtered `list`, the start position names the view: its snapshot
+field carries the context whether given, defaulted, or POS_MIN.
+
+Journal search: with `--journal` at open, `list_journal -k <ranges>` prints
+only the journal transactions containing updates to the given key ranges -
+the who-touched-this-key question. Ranges are btree:pos or
+btree:pos-btree:pos, comma separated, optionally prefixed + or -, the same
+syntax as the standalone list_journal command. Each transaction prints with
+its name, overwrites, and new keys.
+
+Editing goes through the normal transactional path - journalled, triggers
+run, key validation applies - in an instance opened with commit-time
+validation relaxed and background workers (snapshot deletion, copygc,
+reconcile) disabled, so the tool neither refuses the states fsck is being
+tested against nor consumes its own injections. This tool can corrupt a
+filesystem in precise, surgical ways; that is its purpose.
+
+One editing trap: snapshot IDs allocate descending from U32_MAX and the
+in-memory snapshot table is id-indexed; inserting a snapshot key with an
+unrealistically low id asks the table to span billions of entries and fails
+with ENOMEM_mark_snapshot. Use realistic, near-U32_MAX ids when fabricating
+snapshots. Varint-packed values (inodes) and entry-stream values (extents)
+are editable only up to their fixed header; fixed-layout values are fully
+editable.
+";
+
 /// Btree read/write REPL (debug)
 #[derive(Parser, Debug)]
-#[command(long_about = "\
-Read and write btree keys by field name, using generated runtime type \
-information for the on-disk structs. Without -c, reads commands from stdin \
-(a REPL; pipe a script in for non-interactive use).\n\n\
-Opens read-only with recovery capped (norecovery) by default: inspection \
-must not disturb the state under inspection. --rw runs full recovery and \
-enables editing.\n\n\
-Commands:\n\
-  get       [-k] <btree> <pos>               exact lookup, dump fields\n\
-  peek      [-k] <btree> <pos>               first key >= pos\n\
-  peek_prev <btree> <pos>                    last key <= pos\n\
-  list      [-k] <btree> [start] [end]       keys in range\n\
-  update    <btree> <pos> <field=val>...     modify fields of an existing key\n\
-  set       <btree> <pos> <type> [field=val]...  insert a whole new key\n\
-  snapshot  [<id>|none]                      session snapshot context\n\
-  list_journal [-k <ranges>]                 journal transactions (--journal)\n\n\
-Full documentation, including the snapshot-context visibility semantics: \
-doc/kvdb.md.\n\n\
-pos is inode:offset[:snapshot], or POS_MIN/POS_MAX/SPOS_MAX. Fields are \
-val struct fields: parent, children[1], btime.hi, ... Declared flag bits \
-(LE*_BITMASK) resolve by name too: no_keys=1, or qualified as flags.subvol=0 \
-when the name collides with a field. get decodes them: flags: 10 (subvol|no_keys). \
-Values are decimal, 0x hex, or negative decimal. `set <btree> <pos> deleted` \
-deletes a key.\n\n\
-Updates go through the normal transactional path: journalled, triggers run, \
-key validation applies. This tool can corrupt a filesystem in precise, \
-surgical ways - that is its purpose. Use accordingly.")]
+#[command(long_about = KVDB_DOC)]
 pub struct Cli {
     /// Command to run (repeatable; skips the REPL)
     #[arg(short = 'c', long = "command")]

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -22,9 +22,10 @@
 //! validation — per-key-invalid keys are (correctly) rejected; whether we
 //! want a validation-bypass mode for injecting those is an open question.
 
-use std::io::{stdin, stdout, IsTerminal, Write};
+use std::io::{stdin, stdout, IsTerminal};
 use std::ops::ControlFlow;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use anyhow::{anyhow, bail, Result};
 use bcachefs_kernel::btree::bkey::{BkeySC, POS_MIN, SPOS_MAX};
@@ -253,6 +254,20 @@ fn cmd_peek(fs: &Fs, btree: c::btree_id, pos: c::bpos, prev: bool) -> Result<Str
     })?)
 }
 
+/// ^C during a long-running command: the REPL installs a SIGINT handler that
+/// sets this flag (rustyline's raw mode swallows ^C at the prompt itself, so
+/// the handler only ever fires mid-command). Iteration loops poll it and stop,
+/// returning what they've collected; the flag is cleared before each command.
+static INTERRUPTED: AtomicBool = AtomicBool::new(false);
+
+extern "C" fn kvdb_sigint(_: libc::c_int) {
+    INTERRUPTED.store(true, Ordering::Relaxed);
+}
+
+fn take_interrupt() -> bool {
+    INTERRUPTED.swap(false, Ordering::Relaxed)
+}
+
 fn cmd_list(fs: &Fs, btree: c::btree_id, start: c::bpos, end: c::bpos) -> Result<String> {
     let trans = BtreeTrans::new(fs);
     let mut out = String::new();
@@ -263,6 +278,10 @@ fn cmd_list(fs: &Fs, btree: c::btree_id, start: c::bpos, end: c::bpos) -> Result
         BtreeIterFlags::ALL_SNAPSHOTS | BtreeIterFlags::PREFETCH,
     );
     iter.for_each_max(&trans, end, |k| {
+        if take_interrupt() {
+            out.push_str("(interrupted)\n");
+            return ControlFlow::Break(());
+        }
         out.push_str(&format!("{}\n", k.to_text(fs)));
         ControlFlow::Continue(())
     })?;
@@ -306,6 +325,10 @@ fn cmd_list_online(handle: &BcachefsHandle, fs: &Fs,
     let mut iter = OnlineBtreeIter::new(handle, btree, 0, start, end,
 					OnlineIterFlags::ALL_SNAPSHOTS);
     iter.for_each(|k| {
+        if take_interrupt() {
+            out.push_str("(interrupted)\n");
+            return ControlFlow::Break(());
+        }
         out.push_str(&format!("{}\n", k.to_text(fs)));
         ControlFlow::Continue(())
     }).map_err(|e| anyhow!("BCH_IOCTL_QUERY_BTREE_KEYS: {e}"))?;
@@ -742,24 +765,46 @@ fn kvdb(cli: Cli) -> Result<()> {
         return Ok(());
     }
 
-    let interactive = stdin().is_terminal();
-    let mut lines = stdin().lines();
-    loop {
-        if interactive {
-            print!("kvdb> ");
-            stdout().flush()?;
+    // In a piped script an error must abort (a test's later commands likely
+    // depend on earlier ones); interactively, report and go on.
+    if !stdin().is_terminal() {
+        for line in stdin().lines() {
+            run_line(fs, cli.nostart, &line?)?;
         }
-        let Some(line) = lines.next() else { break };
-        let line = line?;
-        // In a piped script an error must abort (a test's later commands
-        // likely depend on earlier ones); interactively, report and go on.
-        match run_line(fs, cli.nostart, &line) {
-            Err(e) if interactive => eprintln!("{e}"),
-            other => other?,
+        return Ok(());
+    }
+
+    unsafe {
+        libc::signal(libc::SIGINT, kvdb_sigint as *const () as libc::sighandler_t);
+    }
+
+    let mut rl = rustyline::DefaultEditor::new()?;
+    let history = std::env::var_os("HOME")
+        .map(|home| PathBuf::from(home).join(".cache/bcachefs-kvdb-history"));
+    if let Some(h) = &history {
+        let _ = rl.load_history(h);
+    }
+    loop {
+        match rl.readline("kvdb> ") {
+            Ok(line) => {
+                if !line.trim().is_empty() {
+                    let _ = rl.add_history_entry(&line);
+                }
+                INTERRUPTED.store(false, Ordering::Relaxed);
+                if let Err(e) = run_line(fs, cli.nostart, &line) {
+                    eprintln!("{e}");
+                }
+            }
+            Err(rustyline::error::ReadlineError::Interrupted) => continue,
+            Err(rustyline::error::ReadlineError::Eof) => break,
+            Err(e) => return Err(e.into()),
         }
     }
-    if interactive {
-        println!();      // ^D at the prompt: don't glue it to the shell's
+    if let Some(h) = &history {
+        if let Some(dir) = h.parent() {
+            let _ = std::fs::create_dir_all(dir);
+        }
+        let _ = rl.save_history(h);
     }
     Ok(())
 }

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -322,6 +322,64 @@ fn render_key(fs: &Fs, k: &BkeySC<'_>, key_only: bool) -> String {
     }
 }
 
+/// The read half of the field engine: selected fields of a key's value as
+/// bare values, one line per path - the same paths update addresses for
+/// writes, so scripts get a stable contract instead of scraping the
+/// human-oriented to_text display. Whole arrays print space-separated.
+/// A field beyond the end of a short (older-format) value reads as zero,
+/// mirroring update's grow-zero-filled write semantics.
+fn render_key_fields(k: &BkeySC<'_>, paths: &[&str]) -> Result<String> {
+    use std::fmt::Write as _;
+    use typeinfo::{AccessError, FieldKind, FieldRef};
+
+    let val_u64s = k.k.u64s as usize - BKEY_U64S;
+    let val: &[u8] = unsafe {
+        std::slice::from_raw_parts(k.v as *const c::bch_val as *const u8, val_u64s * 8)
+    };
+
+    let read_int = |path: &str, r: &FieldRef| -> Result<String> {
+        let v = match typeinfo::read_scalar(val, r) {
+            Ok(v) => v,
+            Err(AccessError::OutOfBounds { .. }) => 0,
+            Err(e) => bail!("{path}: {e}"),
+        };
+        Ok(match r.kind {
+            FieldKind::Int { signed: true, bytes, .. } =>
+                typeinfo::sign_extend(v, *bytes).to_string(),
+            _ => v.to_string(),
+        })
+    };
+
+    let mut out = String::new();
+    for path in paths {
+        let (r, bm) = resolve_field(k.k.type_, path)?;
+        let line = match bm {
+            Some(bm) => match typeinfo::read_bits(val, &r, bm) {
+                Ok(v) => v.to_string(),
+                Err(AccessError::OutOfBounds { .. }) => "0".to_string(),
+                Err(e) => bail!("{path}: {e}"),
+            },
+            None => match r.kind {
+                FieldKind::Int { .. } => read_int(path, &r)?,
+                FieldKind::Array { elem, n, stride }
+                        if matches!(elem, FieldKind::Int { .. }) => {
+                    (0..*n)
+                        .map(|i| read_int(path, &FieldRef {
+                            offset: r.offset + i * stride,
+                            kind: elem,
+                            len: *stride,
+                        }))
+                        .collect::<Result<Vec<_>>>()?
+                        .join(" ")
+                }
+                _ => bail!("{path}: not a scalar or integer-array field"),
+            },
+        };
+        writeln!(out, "{line}").unwrap();
+    }
+    Ok(out)
+}
+
 /// A resolved assignment target: a field, or a declared bit range within one
 /// (`no_keys`, `flags.subvol`).
 type FieldTarget = (typeinfo::FieldRef, Option<&'static typeinfo::BitmaskField>);
@@ -373,38 +431,71 @@ fn iter_flags(base: BtreeIterFlags, filtered: bool) -> BtreeIterFlags {
     }
 }
 
-fn cmd_get(fs: &Fs, btree: c::btree_id, pos: c::bpos, filtered: bool,
-           key_only: bool) -> Result<String> {
-    let trans = BtreeTrans::new(fs);
-    Ok(lockrestart_do(&trans, |t| {
-        let mut iter = BtreeIter::new(t.trans(), btree, pos, iter_flags(RAW_EXACT, filtered));
-        let out = iter
-            .peek_max_flags(SPOS_MAX, BtreeIterFlags::SLOTS)
-            .map(|k| match k {
-                Some(k) => render_key(fs, &k, key_only),
-                None => "(no key)\n".to_string(),
-            });
-        t.result_value(out)
-    })?)
+/// What a read command prints for a matched key: the C to_text line (the
+/// faithful display), the key alone (-k), or selected value fields as bare
+/// values (trailing field paths). A deleted slot is "no key" for a field
+/// read - scripts reading fields need the miss to fail, not to read zeros -
+/// while the display modes do show deleted slots and whiteouts.
+#[derive(Clone, Copy)]
+enum Render<'a> {
+    Full,
+    KeyOnly,
+    Fields(&'a [&'a str]),
 }
 
-fn cmd_peek(fs: &Fs, btree: c::btree_id, pos: c::bpos, prev: bool, filtered: bool,
-            key_only: bool) -> Result<String> {
-    let trans = BtreeTrans::new(fs);
-    Ok(lockrestart_do(&trans, |t| {
-        let mut iter = BtreeIter::new(t.trans(), btree, pos,
-                                      iter_flags(BtreeIterFlags::ALL_SNAPSHOTS, filtered));
-        let out = if prev {
-            iter.peek_prev()
-        } else {
-            iter.peek()
+fn render_read(fs: &Fs, k: &BkeySC<'_>, how: Render<'_>) -> Result<String> {
+    match how {
+        Render::Full => Ok(render_key(fs, k, false)),
+        Render::KeyOnly => Ok(render_key(fs, k, true)),
+        Render::Fields(_) if k.is_deleted() => {
+            let (inode, offset, snapshot) = (k.k.p.inode, k.k.p.offset, k.k.p.snapshot);
+            Err(anyhow!("no key at {inode}:{offset}:{snapshot}"))
         }
-        .map(|k| match k {
-            Some(k) => render_key(fs, &k, key_only),
-            None => "(no key)\n".to_string(),
+        Render::Fields(paths) => render_key_fields(k, paths),
+    }
+}
+
+/// The one-key read commands differ only in how they position the
+/// iterator: get is an exact slot lookup, peek/peek_prev scan for the
+/// nearest key.
+#[derive(Clone, Copy, PartialEq)]
+enum ReadOp {
+    Get,
+    Peek,
+    PeekPrev,
+}
+
+fn cmd_read(fs: &Fs, op: ReadOp, btree: c::btree_id, pos: c::bpos, filtered: bool,
+            how: Render<'_>) -> Result<String> {
+    let trans = BtreeTrans::new(fs);
+    let mut user_err: Option<anyhow::Error> = None;
+    let out = lockrestart_do(&trans, |t| {
+        let base = match op {
+            ReadOp::Get => RAW_EXACT,
+            _ => BtreeIterFlags::ALL_SNAPSHOTS,
+        };
+        let mut iter = BtreeIter::new(t.trans(), btree, pos, iter_flags(base, filtered));
+        let out = match op {
+            ReadOp::Get => iter.peek_max_flags(SPOS_MAX, BtreeIterFlags::SLOTS),
+            ReadOp::Peek => iter.peek(),
+            ReadOp::PeekPrev => iter.peek_prev(),
+        }
+        .and_then(|k| match k {
+            Some(k) => render_read(fs, &k, how).map_err(|e| {
+                // Render errors (bad field path, no key for a field read)
+                // are the user's, not the transaction's: stash and abort
+                // the retry loop with a stand-in errcode.
+                user_err = Some(e);
+                BchError::from_errcode(bch_errcode::BCH_ERR_ENOENT_bkey_type_mismatch)
+            }),
+            None => Ok("(no key)\n".to_string()),
         });
         t.result_value(out)
-    })?)
+    });
+    match user_err {
+        Some(e) => Err(e),
+        None => Ok(out?),
+    }
 }
 
 /// Tab completion: command names for the first word, btree names (from the
@@ -496,16 +587,16 @@ fn cmd_list(fs: &Fs, btree: c::btree_id, start: c::bpos, end: c::bpos,
 /// exact pos; peek/peek_prev: first key at/after (at/before) pos.
 fn online_one_key(handle: &BcachefsHandle, fs: &Fs,
 		  btree: c::btree_id, pos: c::bpos,
-		  flags: OnlineIterFlags, key_only: bool) -> Result<String> {
+		  flags: OnlineIterFlags, how: Render<'_>) -> Result<String> {
     // Small buffer: the kernel fills the whole thing per call, and we only
     // want one key (it grows automatically if the key doesn't fit):
     let mut iter = OnlineBtreeIter::with_buf_size(handle, btree, 0, pos,
 					if flags.0 & OnlineIterFlags::PREV.0 != 0 { POS_MIN } else { SPOS_MAX },
 					flags, 4096);
-    Ok(match iter.next().map_err(|e| anyhow!("BCH_IOCTL_QUERY_BTREE_KEYS: {e}"))? {
-        Some(k) => render_key(fs, &k, key_only),
-        None => "(no key)\n".to_string(),
-    })
+    match iter.next().map_err(|e| anyhow!("BCH_IOCTL_QUERY_BTREE_KEYS: {e}"))? {
+        Some(k) => render_read(fs, &k, how),
+        None => Ok("(no key)\n".to_string()),
+    }
 }
 
 /// Online counterpart of iter_flags(): the ioctl maps its flags 1:1 into
@@ -520,21 +611,15 @@ fn online_snapshots_flag(filtered: bool) -> OnlineIterFlags {
     }
 }
 
-fn cmd_get_online(handle: &BcachefsHandle, fs: &Fs,
-		  btree: c::btree_id, pos: c::bpos, filtered: bool,
-		  key_only: bool) -> Result<String> {
-    online_one_key(handle, fs, btree, pos,
-		   OnlineIterFlags::SLOTS | online_snapshots_flag(filtered), key_only)
-}
-
-fn cmd_peek_online(handle: &BcachefsHandle, fs: &Fs,
-		   btree: c::btree_id, pos: c::bpos, prev: bool, filtered: bool,
-		   key_only: bool) -> Result<String> {
-    let mut flags = online_snapshots_flag(filtered);
-    if prev {
-        flags = flags | OnlineIterFlags::PREV;
-    }
-    online_one_key(handle, fs, btree, pos, flags, key_only)
+fn cmd_read_online(handle: &BcachefsHandle, fs: &Fs, op: ReadOp,
+		   btree: c::btree_id, pos: c::bpos, filtered: bool,
+		   how: Render<'_>) -> Result<String> {
+    let flags = online_snapshots_flag(filtered) | match op {
+        ReadOp::Get => OnlineIterFlags::SLOTS,
+        ReadOp::Peek => OnlineIterFlags(0),
+        ReadOp::PeekPrev => OnlineIterFlags::PREV,
+    };
+    online_one_key(handle, fs, btree, pos, flags, how)
 }
 
 fn cmd_list_online(handle: &BcachefsHandle, fs: &Fs,
@@ -815,11 +900,15 @@ fn cmd_sb_set(fs: &Fs, field: &str, v: u64) -> Result<String> {
 // command dispatch + REPL
 
 const HELP: &str = "\
-get  [-k] <btree> <pos>                        exact lookup (slot iteration)
-peek [-k] <btree> <pos>                        first key >= pos
-peek_prev <btree> <pos>                        last key <= pos ([-k] too)
+get  [-k] <btree> <pos> [<field>..]            exact lookup (slot iteration)
+peek [-k] <btree> <pos> [<field>..]            first key >= pos
+peek_prev <btree> <pos> [<field>..]            last key <= pos ([-k] too)
 list [-k] <btree> [start] [end]                keys in range
           -k prints keys only, without rendering values
+          trailing field paths print those fields as bare values, one per
+          line, instead of the display rendering - the same paths update
+          takes (depth, btime.lo, skip[1]); a whole array prints its
+          elements space-separated
 update    <btree> <pos> <field=val>...         modify fields of an existing key
 set  [-s] <btree> <pos> <type> [field=val]...  insert a whole new key
           values are integers; fields holding enum codewords (snapshot/
@@ -871,21 +960,12 @@ impl KvdbFs {
         }
     }
 
-    fn get(&self, btree: c::btree_id, pos: c::bpos, filtered: bool,
-           key_only: bool) -> Result<String> {
+    fn read(&self, op: ReadOp, btree: c::btree_id, pos: c::bpos, filtered: bool,
+            how: Render<'_>) -> Result<String> {
         match self {
-            KvdbFs::Offline(fs) => cmd_get(fs, btree, pos, filtered, key_only),
+            KvdbFs::Offline(fs) => cmd_read(fs, op, btree, pos, filtered, how),
             KvdbFs::Online(handle, fs) =>
-                cmd_get_online(handle, fs, btree, pos, filtered, key_only),
-        }
-    }
-
-    fn peek(&self, btree: c::btree_id, pos: c::bpos, prev: bool, filtered: bool,
-            key_only: bool) -> Result<String> {
-        match self {
-            KvdbFs::Offline(fs) => cmd_peek(fs, btree, pos, prev, filtered, key_only),
-            KvdbFs::Online(handle, fs) =>
-                cmd_peek_online(handle, fs, btree, pos, prev, filtered, key_only),
+                cmd_read_online(handle, fs, op, btree, pos, filtered, how),
         }
     }
 
@@ -931,13 +1011,13 @@ struct Cmd {
 }
 
 const COMMANDS: &[Cmd] = &[
-    Cmd { name: "get", aliases: &[], usage: "get [-k] <btree> <pos>",
+    Cmd { name: "get", aliases: &[], usage: "get [-k] <btree> <pos> [<field>..]",
           completes_btree: true, subcommands: &[],
           nostart_ok: false, needs_rw: false, needs_journal: false, handler: h_read },
-    Cmd { name: "peek", aliases: &[], usage: "peek [-k] <btree> <pos>",
+    Cmd { name: "peek", aliases: &[], usage: "peek [-k] <btree> <pos> [<field>..]",
           completes_btree: true, subcommands: &[],
           nostart_ok: false, needs_rw: false, needs_journal: false, handler: h_read },
-    Cmd { name: "peek_prev", aliases: &[], usage: "peek_prev [-k] <btree> <pos>",
+    Cmd { name: "peek_prev", aliases: &[], usage: "peek_prev [-k] <btree> <pos> [<field>..]",
           completes_btree: true, subcommands: &[],
           nostart_ok: false, needs_rw: false, needs_journal: false, handler: h_read },
     Cmd { name: "list", aliases: &[], usage: "list [-k] <btree> [start] [end]",
@@ -998,8 +1078,14 @@ fn h_read(repl: &mut Repl, cmd: &Cmd, args: &[&str]) -> Result<ControlFlow<(), S
         ["-k", rest @ ..] => (true, rest),
         _ => (false, args),
     };
-    let [btree, pos] = args else {
+    let [btree, pos, fields @ ..] = args else {
         bail!("usage: {}", cmd.usage);
+    };
+    let how = match (key_only, fields) {
+        (false, []) => Render::Full,
+        (true, []) => Render::KeyOnly,
+        (false, fields) => Render::Fields(fields),
+        (true, _) => bail!("-k and field selection are mutually exclusive"),
     };
     let btree = parse_btree(btree)?;
     let ctx = repl.snapshot
@@ -1009,11 +1095,12 @@ fn h_read(repl: &mut Repl, cmd: &Cmd, args: &[&str]) -> Result<ControlFlow<(), S
         pos.snapshot = snap;
     }
     let filtered = ctx.is_some();
-    Ok(ControlFlow::Continue(match cmd.name {
-        "get" => repl.fs.get(btree, pos, filtered, key_only)?,
-        "peek" => repl.fs.peek(btree, pos, false, filtered, key_only)?,
-        _ => repl.fs.peek(btree, pos, true, filtered, key_only)?,
-    }))
+    let op = match cmd.name {
+        "get" => ReadOp::Get,
+        "peek" => ReadOp::Peek,
+        _ => ReadOp::PeekPrev,
+    };
+    Ok(ControlFlow::Continue(repl.fs.read(op, btree, pos, filtered, how)?))
 }
 
 fn h_list(repl: &mut Repl, cmd: &Cmd, args: &[&str]) -> Result<ControlFlow<(), String>> {

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -319,28 +319,31 @@ fn val_bytes<'a>(k: &BkeySC<'a>) -> &'a [u8] {
     unsafe { std::slice::from_raw_parts(k.v as *const c::bch_val as *const u8, len) }
 }
 
+/// One rendering of the value, not two: with a typeinfo field table the
+/// dump is the authoritative view (field names match update's syntax), so
+/// the header is the key alone; the C to_text - which renders the value
+/// inline - is the fallback for types the field engine can't decompose
+/// (entry-stream values like extents), and the whole line for plain reads.
 fn render_key(fs: &Fs, k: &BkeySC<'_>, fields: bool, key_only: bool) -> String {
     if key_only {
         return format!("{}\n", k.to_text_key());
     }
-    let mut out = format!("{}\n", k.to_text(fs));
-    if !fields {
-        return out;
+    if fields {
+        if let Some(info) = typeinfo::bkey_val_info(k.k.type_ as u32) {
+            if !info.fields.is_empty() {
+                let mut out = format!("{}\n", k.to_text_key());
+                let mut dump = String::new();
+                let _ = typeinfo::struct_to_text(&mut dump, info, val_bytes(k));
+                for l in dump.lines() {
+                    out.push_str("  ");
+                    out.push_str(l);
+                    out.push('\n');
+                }
+                return out;
+            }
+        }
     }
-    let Some(info) = typeinfo::bkey_val_info(k.k.type_ as u32) else {
-        return out;
-    };
-    if info.fields.is_empty() {
-        return out;
-    }
-    let mut dump = String::new();
-    let _ = typeinfo::struct_to_text(&mut dump, info, val_bytes(k));
-    for l in dump.lines() {
-        out.push_str("  ");
-        out.push_str(l);
-        out.push('\n');
-    }
-    out
+    format!("{}\n", k.to_text(fs))
 }
 
 /// A resolved assignment target: a field, or a declared bit range within one

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -389,10 +389,11 @@ fn online_one_key(handle: &BcachefsHandle, fs: &Fs,
 
 /// Online counterpart of iter_flags(): the ioctl maps its flags 1:1 into
 /// btree iter flags, so omitting all_snapshots gets filtered iteration
-/// kernel-side.
+/// kernel-side. (nofilter_whiteouts is rejected by kernels predating the
+/// bit - run a matching kernel for online filtered reads.)
 fn online_snapshots_flag(filtered: bool) -> OnlineIterFlags {
     if filtered {
-        OnlineIterFlags::default()
+        OnlineIterFlags::NOFILTER_WHITEOUTS
     } else {
         OnlineIterFlags::ALL_SNAPSHOTS
     }

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -114,6 +114,14 @@ fn parse_pos_ctx(s: &str, snapshot: Option<u32>) -> Result<c::bpos> {
     Ok(pos)
 }
 
+/// An explicit :snapshot in a pos means a raw lookup at exactly that
+/// position - it disables the snapshot context for the command, rather than
+/// the command running filtered (which would resolve visibility and could
+/// return a different version than the one asked for).
+fn pos_has_explicit_snapshot(s: &str) -> bool {
+    s.matches(':').count() >= 2
+}
+
 fn parse_pos(s: &str) -> Result<c::bpos> {
     s.parse()
         .map_err(|_| anyhow!("invalid pos '{s}' (inode:offset[:snapshot], POS_MIN, SPOS_MAX)"))
@@ -754,8 +762,12 @@ fn run_line(
                 bail!("usage: {op} [-k] <btree> <pos>");
             };
             let btree = parse_btree(btree)?;
-            let ctx = snapshot.filter(|_| btree_uses_snapshots(btree));
-            let pos = parse_pos_ctx(pos, ctx)?;
+            let ctx = snapshot
+                .filter(|_| btree_uses_snapshots(btree) && !pos_has_explicit_snapshot(pos));
+            let mut pos = parse_pos(pos)?;
+            if let Some(snap) = ctx {
+                pos.snapshot = snap;
+            }
             let filtered = ctx.is_some();
             match kvdb_fs {
                 KvdbFs::Offline(fs) => match op {
@@ -779,16 +791,18 @@ fn run_line(
                 .split_first()
                 .ok_or_else(|| anyhow!("usage: list [-k] <btree> [start] [end]"))?;
             let btree = parse_btree(btree)?;
-            let ctx = snapshot.filter(|_| btree_uses_snapshots(btree));
-            // A filtered iterator's snapshot comes from pos.snapshot, so the
-            // default start must carry the context (POS_MIN's snapshot 0 is
-            // never a valid view):
-            let default_start = match ctx {
-                Some(snap) => c::bpos { inode: 0, offset: 0, snapshot: snap },
-                None => POS_MIN,
-            };
-            let start = rest.first().map_or(Ok(default_start), |s| parse_pos_ctx(s, ctx))?;
+            let ctx = snapshot.filter(|_| {
+                btree_uses_snapshots(btree)
+                    && !rest.iter().take(2).any(|s| pos_has_explicit_snapshot(s))
+            });
+            let mut start = rest.first().map_or(Ok(POS_MIN), |s| parse_pos(s))?;
             let end = rest.get(1).map_or(Ok(SPOS_MAX), |s| parse_pos_ctx(s, ctx))?;
+            // A filtered iterator's snapshot comes from the start pos - it's
+            // the view - so it must carry the context whether the start was
+            // given, defaulted, or POS_MIN (snapshot 0 is never a valid view):
+            if let Some(snap) = ctx {
+                start.snapshot = snap;
+            }
             let filtered = ctx.is_some();
             match kvdb_fs {
                 KvdbFs::Offline(fs) => cmd_list(fs, btree, start, end, filtered, key_only)?,

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -236,14 +236,22 @@ fn write_field(
 /// a snapshot field, so passing it unconditionally is fine.
 const RAW_EXACT: BtreeIterFlags = BtreeIterFlags::SLOTS.union(BtreeIterFlags::ALL_SNAPSHOTS);
 
-/// With a snapshot context active, reads drop ALL_SNAPSHOTS: the iterator
-/// runs snapshot-filtered (iter init adds BTREE_ITER_filter_snapshots for
-/// btrees with snapshot fields) at pos.snapshot, so lookups resolve
-/// visibility the way runtime lookups do. Harmless on btrees without
-/// snapshot fields - iteration is simply positional there.
+/// The snapshot context only applies to btrees whose keys are actually
+/// snapshotted - on anything else it would corrupt positions (snapshots
+/// btree keys live at snapshot 0) and filtering is meaningless.
+fn btree_uses_snapshots(btree: c::btree_id) -> bool {
+    bcachefs_kernel::BTREE_HAS_SNAPSHOTS_MASK & (1u64 << btree as u64) != 0
+}
+
+/// With a snapshot context active, reads drop ALL_SNAPSHOTS - the iterator
+/// runs snapshot-filtered (BTREE_ITER_filter_snapshots) at pos.snapshot, so
+/// lookups resolve visibility the way runtime lookups do - and set
+/// NOFILTER_WHITEOUTS: a forensics tool must show the whiteout doing the
+/// shadowing, not silently hide the deletion.
 fn iter_flags(base: BtreeIterFlags, filtered: bool) -> BtreeIterFlags {
     if filtered {
         base.difference(BtreeIterFlags::ALL_SNAPSHOTS)
+            .union(BtreeIterFlags::NOFILTER_WHITEOUTS)
     } else {
         base
     }
@@ -724,8 +732,10 @@ fn run_line(
             let [btree, pos] = args else {
                 bail!("usage: {op} <btree> <pos>");
             };
-            let (btree, pos) = (parse_btree(btree)?, parse_pos_ctx(pos, *snapshot)?);
-            let filtered = snapshot.is_some();
+            let btree = parse_btree(btree)?;
+            let ctx = snapshot.filter(|_| btree_uses_snapshots(btree));
+            let pos = parse_pos_ctx(pos, ctx)?;
+            let filtered = ctx.is_some();
             match kvdb_fs {
                 KvdbFs::Offline(fs) => match op {
                     "get" => cmd_get(fs, btree, pos, filtered)?,
@@ -743,17 +753,18 @@ fn run_line(
             let (btree, rest) = args
                 .split_first()
                 .ok_or_else(|| anyhow!("usage: list <btree> [start] [end]"))?;
+            let btree = parse_btree(btree)?;
+            let ctx = snapshot.filter(|_| btree_uses_snapshots(btree));
             // A filtered iterator's snapshot comes from pos.snapshot, so the
             // default start must carry the context (POS_MIN's snapshot 0 is
             // never a valid view):
-            let default_start = match *snapshot {
+            let default_start = match ctx {
                 Some(snap) => c::bpos { inode: 0, offset: 0, snapshot: snap },
                 None => POS_MIN,
             };
-            let start = rest.first().map_or(Ok(default_start), |s| parse_pos_ctx(s, *snapshot))?;
-            let end = rest.get(1).map_or(Ok(SPOS_MAX), |s| parse_pos_ctx(s, *snapshot))?;
-            let filtered = snapshot.is_some();
-            let btree = parse_btree(btree)?;
+            let start = rest.first().map_or(Ok(default_start), |s| parse_pos_ctx(s, ctx))?;
+            let end = rest.get(1).map_or(Ok(SPOS_MAX), |s| parse_pos_ctx(s, ctx))?;
+            let filtered = ctx.is_some();
             match kvdb_fs {
                 KvdbFs::Offline(fs) => cmd_list(fs, btree, start, end, filtered)?,
                 KvdbFs::Online(handle, fs) => cmd_list_online(handle, fs, btree, start, end, filtered)?,
@@ -773,7 +784,9 @@ fn run_line(
                 .iter()
                 .map(|s| parse_assign(s))
                 .collect::<Result<Vec<_>>>()?;
-            cmd_update(fs, parse_btree(btree)?, parse_pos_ctx(pos, *snapshot)?, &assigns)?
+            let btree = parse_btree(btree)?;
+            let ctx = snapshot.filter(|_| btree_uses_snapshots(btree));
+            cmd_update(fs, btree, parse_pos_ctx(pos, ctx)?, &assigns)?
         }
         "set" => {
             let (in_snapshot, args) = match args {
@@ -793,7 +806,9 @@ fn run_line(
                 .iter()
                 .map(|s| parse_assign(s))
                 .collect::<Result<Vec<_>>>()?;
-            cmd_set(fs, parse_btree(btree)?, parse_pos_ctx(pos, *snapshot)?, type_name, &assigns, in_snapshot)?
+            let btree = parse_btree(btree)?;
+            let ctx = snapshot.filter(|_| btree_uses_snapshots(btree));
+            cmd_set(fs, btree, parse_pos_ctx(pos, ctx)?, type_name, &assigns, in_snapshot)?
         }
         "sb" => {
             let (&sub, rest) = args.split_first()

--- a/src/commands/kvdb.rs
+++ b/src/commands/kvdb.rs
@@ -95,6 +95,11 @@ pub struct Cli {
     #[arg(long)]
     norecovery: bool,
 
+    /// Retain the entire journal in memory for the list_journal command
+    /// (costs memory proportional to journal size).
+    #[arg(long)]
+    journal: bool,
+
     #[arg(required(true))]
     devices: Vec<PathBuf>,
 }
@@ -315,7 +320,8 @@ struct KvdbHelper {
 }
 
 const OPS: &[&str] = &[
-    "get", "peek", "peek_prev", "list", "update", "set", "sb", "snapshot", "help", "quit",
+    "get", "peek", "peek_prev", "list", "update", "set", "sb", "snapshot", "list_journal",
+    "help", "quit",
 ];
 const KEY_OPS: &[&str] = &["get", "peek", "peek_prev", "list", "update", "set"];
 
@@ -698,6 +704,9 @@ set  [-s] <btree> <pos> <type> [field=val]...  insert a whole new key
           within pos's snapshot instead (whiteouts, like a runtime delete)
 sb get    <field>                              read a superblock field/flag
 sb set    <field=val>                          write one, then bch2_write_super
+list_journal [-k [+-]<bbpos>[-<bbpos>],...]    journal transactions, filtered to
+                                               those referencing the given key
+                                               ranges (needs --journal at open)
 snapshot  [<id>|none]                          set/show/clear the session snapshot
                                                context: reads (get/peek/list) run
                                                snapshot-filtered in that view, and
@@ -730,6 +739,7 @@ impl KvdbFs {
 fn run_line(
     kvdb_fs: &KvdbFs,
     nostart: bool,
+    journal: bool,
     snapshot: &mut Option<u32>,
     line: &str,
 ) -> Result<ControlFlow<()>> {
@@ -878,6 +888,39 @@ fn run_line(
                 _ => bail!("usage: sb get <field> | sb set <field=val>"),
             }
         }
+        "list_journal" => {
+            if !journal {
+                bail!("list_journal: reopen with --journal \
+                       (retains the whole journal in memory)");
+            }
+            let KvdbFs::Offline(fs) = kvdb_fs else {
+                bail!("list_journal: only supported on offline filesystems");
+            };
+            let mut f = super::list_journal::JournalFilter::default();
+            let mut args = args;
+            while let Some((&flag, rest)) = args.split_first() {
+                match flag {
+                    "-k" => {
+                        let Some((&ranges, rest)) = rest.split_first() else {
+                            bail!("usage: list_journal [-k [+-]<btree>:<pos>[-<btree>:<pos>],...]");
+                        };
+                        let (sign, r) = super::list_journal::parse_sign(ranges);
+                        for part in r.split(',') {
+                            let range = bcachefs_kernel::bbpos_range_parse(part)
+                                .map_err(|e| anyhow!("{e}: {part}"))?;
+                            f.key.ranges.push((sign, range));
+                        }
+                        f.filtering = true;
+                        args = rest;
+                    }
+                    _ => bail!("list_journal: unknown arg '{flag}' (supported: -k <range>)"),
+                }
+            }
+            let interrupt: &dyn Fn() -> bool = &take_interrupt;
+            super::list_journal::list_journal_run(fs.raw, &f, false, 0, u64::MAX, None,
+                                                  Some(interrupt))?;
+            String::new()
+        }
         "help" | "?" => HELP.to_string(),
         _ => bail!("unknown command '{op}' (try: help)"),
     };
@@ -920,6 +963,10 @@ fn kvdb(cli: Cli) -> Result<()> {
     if cli.norecovery {
         opt_set!(fs_opts, norecovery, 1);
     }
+    if cli.journal {
+        opt_set!(fs_opts, retain_recovery_info, 1);
+        opt_set!(fs_opts, read_entire_journal, 1);
+    }
 
     let kvdb_fs = match crate::device_scan::open_online_or_offline(&cli.devices, fs_opts)? {
         OpenedFs::Offline(fs) => KvdbFs::Offline(fs),
@@ -948,7 +995,7 @@ fn kvdb(cli: Cli) -> Result<()> {
 
     if !cli.commands.is_empty() {
         for line in &cli.commands {
-            if run_line(fs, cli.nostart, &mut snapshot_ctx, line)?.is_break() {
+            if run_line(fs, cli.nostart, cli.journal, &mut snapshot_ctx, line)?.is_break() {
                 break;
             }
         }
@@ -959,7 +1006,7 @@ fn kvdb(cli: Cli) -> Result<()> {
     // depend on earlier ones); interactively, report and go on.
     if !stdin().is_terminal() {
         for line in stdin().lines() {
-            if run_line(fs, cli.nostart, &mut snapshot_ctx, &line?)?.is_break() {
+            if run_line(fs, cli.nostart, cli.journal, &mut snapshot_ctx, &line?)?.is_break() {
                 break;
             }
         }
@@ -994,7 +1041,7 @@ fn kvdb(cli: Cli) -> Result<()> {
                     let _ = rl.add_history_entry(&line);
                 }
                 INTERRUPTED.store(false, Ordering::Relaxed);
-                match run_line(fs, cli.nostart, &mut snapshot_ctx, &line) {
+                match run_line(fs, cli.nostart, cli.journal, &mut snapshot_ctx, &line) {
                     Ok(ControlFlow::Break(())) => break,
                     Ok(ControlFlow::Continue(())) => {}
                     Err(e) => eprintln!("{e}"),

--- a/src/commands/list_journal.rs
+++ b/src/commands/list_journal.rs
@@ -89,29 +89,49 @@ fn entry_is_non_transaction(entry: &c::jset_entry) -> bool {
 
 // ---- filter types ----
 
-struct TransactionMsgFilter {
-    sign: i32,
-    patterns: Vec<String>,
+pub(crate) struct TransactionMsgFilter {
+    pub(crate) sign: i32,
+    pub(crate) patterns: Vec<String>,
 }
 
-struct TransactionKeyFilter {
-    ranges: Vec<(i32, BbposRange)>,  // (sign, range)
+pub(crate) struct TransactionKeyFilter {
+    pub(crate) ranges: Vec<(i32, BbposRange)>,  // (sign, range)
 }
 
-struct JournalFilter {
-    blacklisted: bool,
-    flush_only: bool,
-    datetime_only: bool,
-    headers_only: bool,
-    all_headers: bool,
-    log: bool,
-    log_only: bool,
-    print_offset: bool,
-    filtering: bool,
-    btree_filter: u64,
-    transaction: TransactionMsgFilter,
-    key: TransactionKeyFilter,
-    bkey_val: bool,
+pub(crate) struct JournalFilter {
+    pub(crate) blacklisted: bool,
+    pub(crate) flush_only: bool,
+    pub(crate) datetime_only: bool,
+    pub(crate) headers_only: bool,
+    pub(crate) all_headers: bool,
+    pub(crate) log: bool,
+    pub(crate) log_only: bool,
+    pub(crate) print_offset: bool,
+    pub(crate) filtering: bool,
+    pub(crate) btree_filter: u64,
+    pub(crate) transaction: TransactionMsgFilter,
+    pub(crate) key: TransactionKeyFilter,
+    pub(crate) bkey_val: bool,
+}
+
+impl Default for JournalFilter {
+    fn default() -> Self {
+        JournalFilter {
+            blacklisted: false,
+            flush_only: false,
+            datetime_only: false,
+            headers_only: false,
+            all_headers: false,
+            log: false,
+            log_only: false,
+            print_offset: false,
+            filtering: false,
+            btree_filter: !0u64,
+            transaction: TransactionMsgFilter { sign: 0, patterns: Vec::new() },
+            key: TransactionKeyFilter { ranges: Vec::new() },
+            bkey_val: true,
+        }
+    }
 }
 
 // ---- filter logic ----
@@ -521,7 +541,7 @@ fn parse_seq_range(arg: &str) -> Result<(u64, u64)> {
 
 // ---- sign parsing ----
 
-fn parse_sign(s: &str) -> (i32, &str) {
+pub(crate) fn parse_sign(s: &str) -> (i32, &str) {
     if let Some(rest) = s.strip_prefix('+') {
         (1, rest)
     } else if let Some(rest) = s.strip_prefix('-') {
@@ -738,6 +758,20 @@ fn cmd_list_journal(cli: Cli) -> Result<()> {
 
     let c_fs = fs.raw;
 
+    list_journal_run(c_fs, &f, contiguous_only, seq_start, seq_end, cli.nr_entries, None)
+}
+
+/// The listing core, shared with kvdb's list_journal command. @interrupted
+/// is polled per journal entry so a ^C can stop a long dump.
+pub(crate) fn list_journal_run(
+    c_fs: *mut c::bch_fs,
+    f: &JournalFilter,
+    contiguous_only: bool,
+    seq_start: u64,
+    seq_end: u64,
+    nr_entries: Option<u32>,
+    interrupted: Option<&dyn Fn() -> bool>,
+) -> Result<()> {
     let je = JournalEntries::collect(c_fs);
     let entries = je.as_slice();
 
@@ -769,7 +803,7 @@ fn cmd_list_journal(cli: Cli) -> Result<()> {
         }
     }
 
-    if let Some(nr) = cli.nr_entries {
+    if let Some(nr) = nr_entries {
         // journal.seq isn't set in read_journal_only mode, so compute
         // the max seq from the entries we actually collected
         let max_seq = entries.iter()
@@ -785,6 +819,11 @@ fn cmd_list_journal(cli: Cli) -> Result<()> {
     let last_seq_ondisk = unsafe { (*c_fs).journal.last_seq_ondisk };
 
     for &ep in entries {
+        if interrupted.is_some_and(|i| i()) {
+            println!("(interrupted)");
+            break;
+        }
+
         let p = unsafe { &*ep };
         let p_seq = u64::from_le(p.j.seq);
 

--- a/src/commands/list_journal.rs
+++ b/src/commands/list_journal.rs
@@ -107,6 +107,10 @@ pub(crate) struct JournalFilter {
     pub(crate) log: bool,
     pub(crate) log_only: bool,
     pub(crate) print_offset: bool,
+    /// Report gaps in the journal sequence ("missing N entries at ..."):
+    /// wanted when auditing the journal itself, spam when searching it
+    /// (kvdb's list_journal, on a damaged filesystem, disables this).
+    pub(crate) print_missing: bool,
     pub(crate) filtering: bool,
     pub(crate) btree_filter: u64,
     pub(crate) transaction: TransactionMsgFilter,
@@ -125,6 +129,7 @@ impl Default for JournalFilter {
             log: false,
             log_only: false,
             print_offset: false,
+            print_missing: true,
             filtering: false,
             btree_filter: !0u64,
             transaction: TransactionMsgFilter { sign: 0, patterns: Vec::new() },
@@ -700,6 +705,7 @@ fn cmd_list_journal(cli: Cli) -> Result<()> {
         log: cli.log,
         log_only: cli.log_only,
         print_offset: cli.offset,
+        print_missing: true,
         filtering: false,
         btree_filter: !0u64,
         transaction: TransactionMsgFilter {
@@ -851,17 +857,19 @@ pub(crate) fn list_journal_run(
             if missing.start == 0 {
                 break;
             }
-            println!(
-                "missing {} entries at {}-{}{}",
-                missing.end - missing.start,
-                missing.start,
-                missing.end - 1,
-                if missing.end < last_seq_ondisk {
-                    " (not dirty)"
-                } else {
-                    ""
-                },
-            );
+            if f.print_missing {
+                println!(
+                    "missing {} entries at {}-{}{}",
+                    missing.end - missing.start,
+                    missing.start,
+                    missing.end - 1,
+                    if missing.end < last_seq_ondisk {
+                        " (not dirty)"
+                    } else {
+                        ""
+                    },
+                );
+            }
             seq = missing.end;
         }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -94,6 +94,7 @@ pub mod device;
 pub mod dump;
 pub mod format;
 pub mod format_util;
+pub mod fs_failure_domains;
 pub mod fs_usage;
 pub mod fsck;
 #[cfg(feature = "fuse")]
@@ -212,7 +213,7 @@ pub fn defers_shrinkers(name: &str) -> bool {
 
 static FS_CMD: CmdDef = CmdDef {
     name: "fs", about: "Manage a running filesystem", aliases: &[],
-    kind: CmdKind::Group { children: &[&fs_usage::CMD, &top::CMD, &timestats::CMD] },
+    kind: CmdKind::Group { children: &[&fs_usage::CMD, &fs_failure_domains::CMD, &top::CMD, &timestats::CMD] },
 };
 
 // ── Version (no module, trivial) ─────────────────────────────────────

--- a/src/commands/set_option.rs
+++ b/src/commands/set_option.rs
@@ -152,7 +152,7 @@ fn set_option_offline(
                 eprintln!("Error setting {name}: {ret}");
                 continue;
             }
-            unsafe { c::bch2_opt_set_sb(fs.raw, std::ptr::null_mut(), opt, val); }
+            unsafe { c::bch2_opt_set_sb(fs.raw, std::ptr::null_mut(), opt, val, c_value.as_ptr()); }
         }
 
         if flags & c::opt_flags::OPT_DEVICE as u32 != 0 {
@@ -178,7 +178,7 @@ fn set_option_offline(
                     eprintln!("Error setting {name}: {ret}");
                     continue;
                 }
-                unsafe { c::bch2_opt_set_sb(fs.raw, ca, opt, val); }
+                unsafe { c::bch2_opt_set_sb(fs.raw, ca, opt, val, c_value.as_ptr()); }
             }
         }
     }

--- a/src/commands/wait_devices.rs
+++ b/src/commands/wait_devices.rs
@@ -107,8 +107,14 @@ impl WaitInitialized {
             return Ok(());
         }
         let dev_idx = sb.dev_idx;
-	if u32::from(dev_idx) >= sb.number_of_devices() {
-	    warn!("superblock with invalid dev_idx: {dev_idx} >= {}", sb.number_of_devices());
+        // dev_idx indexes the member array, sb.nr_devices long;
+        // number_of_devices() counts only live members - smaller whenever a
+        // removed device left a tombstoned slot behind:
+        if u32::from(dev_idx) >= sb.nr_devices as u32 {
+            warn!(
+                "superblock with invalid dev_idx: {dev_idx} >= {}",
+                sb.nr_devices
+            );
             return Ok(());
         }
 

--- a/src/wrappers/online_iter.rs
+++ b/src/wrappers/online_iter.rs
@@ -28,6 +28,8 @@ impl OnlineIterFlags {
     pub const SLOTS: Self         = Self(c::BCH_IOCTL_QUERY_BTREE_KEYS_slots);
     pub const PREV: Self          = Self(c::BCH_IOCTL_QUERY_BTREE_KEYS_prev);
     pub const ALL_SNAPSHOTS: Self = Self(c::BCH_IOCTL_QUERY_BTREE_KEYS_all_snapshots);
+    pub const NOFILTER_WHITEOUTS: Self =
+        Self(c::BCH_IOCTL_QUERY_BTREE_KEYS_nofilter_whiteouts);
 }
 
 impl std::ops::BitOr for OnlineIterFlags {

--- a/src/wrappers/sysfs.rs
+++ b/src/wrappers/sysfs.rs
@@ -114,6 +114,8 @@ pub struct DevInfo {
     /// Human-facing device name selected by [`DeviceNameMode`].
     pub dev:        String,
     pub label:      Option<String>,
+    /// Failure domain name - see bch_member.failure_domain.
+    pub failure_domain: Option<String>,
     pub durability: u32,
     pub online:     bool,
 }
@@ -144,15 +146,19 @@ pub fn fs_get_devices(
         let online = fs::metadata(dev_path.join("block")).is_ok();
         let dev = dev_display_name_from_sysfs(&dev_path, name_mode);
 
-        let label = fs::read_to_string(dev_path.join("label"))
-            .ok()
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+        let read_label = |name: &str| {
+            fs::read_to_string(dev_path.join(name))
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty() && s != "none")
+        };
+        let label = read_label("label");
+        let failure_domain = read_label("failure_domain");
 
         let durability = read_sysfs_u64(&dev_path.join("durability"))
             .unwrap_or(1) as u32;
 
-        devs.push(DevInfo { idx, dev, label, durability, online });
+        devs.push(DevInfo { idx, dev, label, failure_domain, durability, online });
     }
     devs.sort_by_key(|d| d.idx);
     Ok(devs)


### PR DESCRIPTION
**Reframed 2026-07-28.** 43d0bd5d1 ("bcachefs: fix checksum type changes on
compressed extents") landed on 2026-07-10, after this was opened, and fixes the
livelock in the write path — the fast path now rechecksums compressed extents
rather than preserving the old type. So this PR no longer fixes a hang, and
koverstreet/bcachefs#1190 is addressed by that commit rather than this one.

What it still does is avoid rewriting the data at all when the only thing wrong
is the checksum type. On a base that includes 43d0bd5d1, where both paths
converge, the difference is amplification and passes:

| | metadata-only (this PR) | full rewrite |
|---|---|---|
| passes to settle | 1 | 2 |
| bytes written | 229,376 | 1,728,512 |
| extents converted | 300/300 | 300/300 |

300 compressed extents at the 4k floor (`c_size 8`), crc32c to xxhash. Measured
by toggling only the dispatch this patch adds — `if (0 && r && r->need_rb ==
...)` — rebuilding, and comparing blocks actually allocated to the image, so the
comparison isolates this change and nothing else. **7.5x less written, and one
pass instead of two.**

That ratio is what matters on a filesystem with a real backlog: converting a
checksum type currently costs a rewrite of every affected extent, and this
makes it cost a btree update.

## What it does

When the only defect is the checksum type, do a metadata-only update: read the
extent, verify the old checksum, compute the new one, update the btree key. No
data write, so the encoded-data fast path is never entered. A `nodecode` read
flag makes the read return raw on-disk bytes, which is what the checksum covers
for compressed extents.

The dispatch is deliberately an exact-equality test on `need_rb`. If anything
else about the extent also needs fixing, it has to be rewritten anyway, and with
43d0bd5d1 that rewrite corrects the checksum for free — so widening this guard
to combined `need_rb` sets would add a metadata pass in front of a rewrite that
was going to happen regardless. It is scoped to the case where the rewrite is
pure overhead.

Read buffers use `bch2_bio_alloc_pages()` / `bch2_bio_free_pages_pool()`,
matching `bch2_data_update_bios_init()`, so this builds for the userspace
libbcachefs as well as the module.

Encrypted extents deliberately fall through to the full rewrite path. The
equivalent problem for encrypted extents via `wide_macs`, exercised by
`test_csum_change_encrypted` in `tests/fs/bcachefs/reconcile-csum.ktest`, is not
addressed here and reproduces with this patch applied
(`extents still poly1305_80: 256, converted to poly1305_128: 0`). Noted in
koverstreet/bcachefs#1190; it probably deserves its own issue.

## On the original numbers

This PR previously led with 1.10 TB written and 0 of 256 extents converted,
against `ca944a61e079`. That measurement is accurate for that base, which
predates 43d0bd5d1 — it is the livelock, and it is no longer what master does.
Replaced above with a measurement taken on a base that has the fix, so the
comparison reflects what merging this would actually change.

`make libbcachefs.a` is clean, no warnings.
