### PR TITLE
accounting: add snapshot_nr_keys version so per-snapshot counters get rebuilt

### DIFF
--- a/fs/alloc/accounting.c
+++ b/fs/alloc/accounting.c
@@ -545,11 +545,19 @@ void __bch2_accounting_maybe_kill(struct bch_fs *c, struct bpos pos)
  * bch2_accounting_mem_read() would silently return zeros. Deltas buffer
  * through the btree write buffer: callers that need current values must
  * flush it first, hoisted out of their loops.
+ *
+ * @nr_counters, if non-NULL, returns the number of counters the on-disk key
+ * actually had (0 if there is no key). Counters are read into @v up to @nr and
+ * the rest zeroed, so a key written by an older version - with fewer counters
+ * than the type has now - is indistinguishable from one with trailing zeros
+ * unless the caller looks at the count.
  */
 int bch2_accounting_btree_read(struct btree_trans *trans, struct bpos p,
-			       u64 *v, unsigned nr)
+			       u64 *v, unsigned nr, unsigned *nr_counters)
 {
 	memset(v, 0, sizeof(*v) * nr);
+	if (nr_counters)
+		*nr_counters = 0;
 
 	CLASS(btree_iter, iter)(trans, BTREE_ID_accounting, p, 0);
 	struct bkey_s_c k = bkey_try(bch2_btree_iter_peek_slot(&iter));
@@ -558,6 +566,8 @@ int bch2_accounting_btree_read(struct btree_trans *trans, struct bpos p,
 		return 0;
 
 	struct bkey_s_c_accounting a = bkey_s_c_to_accounting(k);
+	if (nr_counters)
+		*nr_counters = bch2_accounting_counters(a.k);
 	memcpy(v, a.v->d,
 	       min_t(unsigned, nr, bch2_accounting_counters(a.k)) * sizeof(u64));
 	return 0;

--- a/fs/alloc/accounting.h
+++ b/fs/alloc/accounting.h
@@ -159,7 +159,7 @@ int bch2_accounting_mem_insert(struct bch_fs *, struct bkey_s_c_accounting, enum
 int bch2_accounting_mem_insert_locked(struct bch_fs *, struct bkey_s_c_accounting, enum bch_accounting_mode);
 void bch2_accounting_mem_gc(struct bch_fs *);
 
-int bch2_accounting_btree_read(struct btree_trans *, struct bpos, u64 *, unsigned);
+int bch2_accounting_btree_read(struct btree_trans *, struct bpos, u64 *, unsigned, unsigned *);
 
 static inline bool bch2_accounting_is_mem(struct disk_accounting_pos *acc)
 {

--- a/fs/bcachefs_format.h
+++ b/fs/bcachefs_format.h
@@ -1102,7 +1102,10 @@ LE64_BITMASK(BCH_SB_EXT_BTREE_CACHE_SHRINKER_SEEKS,
 	  "discard eligibility checks",				"2026-03")	\
 	x(per_dev_fragmentation_lru,	BCH_VERSION(1, 39),			\
 	  "Per-device bucket fragmentation LRUs, so copygc can reason "		\
-	  "about fragmentation per device",			"2026-07")
+	  "about fragmentation per device",			"2026-07")	\
+	x(snapshot_nr_keys,		BCH_VERSION(1, 40),			\
+	  "Per-(snapshot, btree) key counts in BCH_DISK_ACCOUNTING_snapshot, "	\
+	  "replacing the single per-snapshot sectors counter",	"2026-07")
 
 enum bcachefs_metadata_version {
 	bcachefs_metadata_version_min = 9,

--- a/fs/sb/downgrade.c
+++ b/fs/sb/downgrade.c
@@ -139,7 +139,12 @@
 	  BCH_FSCK_ERR_inode_has_access_acl_flag_wrong,		\
 	  BCH_FSCK_ERR_inode_has_default_acl_flag_wrong,	\
 	  BCH_FSCK_ERR_snapshot_state_bad,			\
-	  BCH_FSCK_ERR_subvol_state_bad)
+	  BCH_FSCK_ERR_subvol_state_bad)			\
+	x(snapshot_nr_keys,					\
+	  BIT_ULL(BCH_RECOVERY_PASS_check_allocations),		\
+	  BCH_FSCK_ERR_accounting_mismatch,			\
+	  BCH_FSCK_ERR_accounting_key_underflow,		\
+	  BCH_FSCK_ERR_accounting_key_nr_counters_wrong)
 
 #define UPGRADE_TABLE_INCOMPAT()				\
 	x(reconcile,						\
@@ -211,7 +216,12 @@
 	  BIT_ULL(BCH_RECOVERY_PASS_check_alloc_to_lru_refs),	\
 	  BCH_FSCK_ERR_lru_entry_bad,				\
 	  BCH_FSCK_ERR_alloc_key_to_missing_lru_entry,		\
-	  BCH_FSCK_ERR_accounting_mismatch)
+	  BCH_FSCK_ERR_accounting_mismatch)			\
+	x(snapshot_nr_keys,					\
+	  BIT_ULL(BCH_RECOVERY_PASS_check_allocations),		\
+	  BCH_FSCK_ERR_accounting_mismatch,			\
+	  BCH_FSCK_ERR_accounting_key_underflow,		\
+	  BCH_FSCK_ERR_accounting_key_nr_counters_wrong)
 
 struct upgrade_downgrade_entry {
 	u64		recovery_passes;

--- a/fs/snapshots/check_snapshots.c
+++ b/fs/snapshots/check_snapshots.c
@@ -546,14 +546,10 @@ static u32 snapshot_table_find_edge(struct bch_fs *c, const struct bch_snapshot 
 
 static int snapshot_data_sectors(struct btree_trans *trans, u32 id, u64 *sectors)
 {
-	struct disk_accounting_pos acc;
-	memset(&acc, 0, sizeof(acc));
-	acc.type = BCH_DISK_ACCOUNTING_snapshot;
-	acc.snapshot.id = id;
-
-	/* btree 0 (extents, the default) is the only one with external_sectors (counter 2) */
+	/* extents is the only snapshot btree with external_sectors (counter 2) */
 	u64 v[3] = {};
-	try(bch2_accounting_btree_read(trans, disk_accounting_pos_to_bpos(&acc), v, ARRAY_SIZE(v)));
+	try(bch2_snapshot_accounting_read(trans, id, BTREE_ID_extents, v));
+
 	*sectors = v[2];
 	return 0;
 }
@@ -736,7 +732,7 @@ static int check_snapshot_edge(struct btree_trans *trans,
 		 * splice below used to assume the reverse.
 		 */
 		u64 keys, sectors;
-		try(bch2_snapshot_accounting_totals(c, other_id, &keys, &sectors, NULL, NULL));
+		try(bch2_snapshot_accounting_totals(trans, other_id, &keys, &sectors, NULL, NULL));
 
 		if (keys || sectors) {
 			if (ret_fsck_err(trans, snapshot_deleted_but_has_data,
@@ -1188,7 +1184,7 @@ static int check_snapshot(struct btree_trans *trans,
 	if (bch2_snapshot_state(&s) == SNAPSHOT_STATE_deleted) {
 		u64 keys, sectors;
 		CLASS(printbuf, breakdown)();
-		try(bch2_snapshot_accounting_totals(c, k.k->p.offset, &keys, &sectors,
+		try(bch2_snapshot_accounting_totals(trans, k.k->p.offset, &keys, &sectors,
 						    NULL, &breakdown));
 
 		if (ret_fsck_err_on(keys || sectors,

--- a/fs/snapshots/delete.c
+++ b/fs/snapshots/delete.c
@@ -139,6 +139,62 @@ int bch2_snapshot_node_set_deleted(struct btree_trans *trans, u32 id)
 }
 
 /*
+ * Read one per-snapshot accounting key as [nr_keys, key_bytes,
+ * external_sectors].
+ *
+ * Every reader of per-snapshot accounting goes through this, because two
+ * things have to be undone and both are easy to forget at an individual call
+ * site:
+ *
+ *  - Before the per-(snapshot, btree) rework the key was {id} -> [sectors]:
+ *    one counter, and
+ *    the new key's btree field lands in what was the old key's zero padding,
+ *    so old and new share a bpos and the old key is silently reinterpreted
+ *    rather than ignored. Read as if it were the new layout, an old key's
+ *    sectors come back as nr_keys and external_sectors reads zero. The counter
+ *    count is what tells the layouts apart. The single old key covered the
+ *    whole snapshot, and for sectors that means the extents btree - the old
+ *    sectors must not be attributed to inodes, dirents and xattrs as well.
+ *
+ *  - nr_keys and key_bytes are only meaningful once check_allocations has
+ *    rebuilt them. A key with three counters written before that rebuild was
+ *    seeded from the aliased old key, so the counter count alone does not make
+ *    it trustworthy - which is why the nr_keys trust gate stays at the caller
+ *    that consults those counters.
+ *
+ * Reads from the accounting btree rather than the in-memory counters, so
+ * callers are responsible for a write buffer flush (once per pass, not per
+ * call).
+ */
+int bch2_snapshot_accounting_read(struct btree_trans *trans, u32 id,
+				  enum btree_id btree, u64 v[3])
+{
+	/*
+	 * Designated initializers will not reliably zero a struct that is a
+	 * union, and the btree field is the old layout's padding - it has to be
+	 * zeroed explicitly or an old key is missed:
+	 */
+	struct disk_accounting_pos acc;
+	memset(&acc, 0, sizeof(acc));
+	acc.type = BCH_DISK_ACCOUNTING_snapshot;
+	acc.snapshot.id = id;
+	acc.snapshot.btree = btree;
+
+	unsigned nr_counters = 0;
+	try(bch2_accounting_btree_read(trans, disk_accounting_pos_to_bpos(&acc), v, 3,
+				       &nr_counters));
+
+	if (nr_counters < 3) {
+		u64 sectors = btree == BTREE_ID_extents ? v[0] : 0;
+
+		v[0] = v[1] = 0;
+		v[2] = sectors;
+	}
+
+	return 0;
+}
+
+/*
  * Sanity check before a destructive snapshot-node transition (emptying or
  * deleting a node): the per-snapshot disk accounting counters must be zero.
  *
@@ -158,20 +214,20 @@ int bch2_snapshot_node_set_deleted(struct btree_trans *trans, u32 id)
  * The key count catches metadata-only stranding (dirents, xattrs, empty
  * inodes) that the sectors counter can't see. It's only trusted once
  * check_allocations has rebuilt it (scheduled by the per_dev_fragmentation_lru
- * upgrade); before that version we fall back to the sectors-only check. Either
- * way it's an in-memory read per snapshot btree, and the per-btree breakdown
+ * upgrade); before that version bch2_snapshot_accounting_read() reports it as
+ * zero and we fall back to the sectors-only check. The per-btree breakdown
  * points at where any stranded keys live.
  */
 /*
  * Total keys/sectors accounted to snapshot @id across the snapshotted
  * btrees, with a per-btree breakdown appended to @breakdown if non-NULL.
- * (nr_keys counters exist only post-upgrade and read as zero before.)
  */
-int bch2_snapshot_accounting_totals(struct bch_fs *c, u32 id,
+int bch2_snapshot_accounting_totals(struct btree_trans *trans, u32 id,
 				    u64 *total_keys, u64 *total_sectors,
 				    u64 *btrees_with_keys,
 				    struct printbuf *breakdown)
 {
+	struct bch_fs *c = trans->c;
 	bool trust_keys = c->sb.version_upgrade_complete >=
 		bcachefs_metadata_version_per_dev_fragmentation_lru;
 
@@ -181,20 +237,8 @@ int bch2_snapshot_accounting_totals(struct bch_fs *c, u32 id,
 		if (!btree_type_has_snapshots(btree))
 			continue;
 
-		struct disk_accounting_pos acc;
-		memset(&acc, 0, sizeof(acc));
-		acc.type = BCH_DISK_ACCOUNTING_snapshot;
-		acc.snapshot.id = id;
-		acc.snapshot.btree = btree;
-
-		/*
-		 * In-mem: bch2_accounting_is_mem() covers everything but
-		 * BCH_DISK_ACCOUNTING_inum, so the counters are current as
-		 * deltas are applied. No btree read, no transaction, and no
-		 * write buffer flush to make the values trustworthy.
-		 */
 		u64 v[3] = {};
-		bch2_accounting_mem_read(c, disk_accounting_pos_to_bpos(&acc), v, ARRAY_SIZE(v));
+		try(bch2_snapshot_accounting_read(trans, id, btree, v));
 
 		u64 nr_keys	= trust_keys ? v[0] : 0;
 		u64 key_bytes	= trust_keys ? v[1] : 0;
@@ -274,7 +318,7 @@ static int bch2_snapshot_node_check_no_data(struct btree_trans *trans,
 	CLASS(printbuf, buf)();
 	u64 total_keys, total_sectors, btrees_with_keys = 0;
 
-	try(bch2_snapshot_accounting_totals(c, id, &total_keys, &total_sectors,
+	try(bch2_snapshot_accounting_totals(trans, id, &total_keys, &total_sectors,
 					    &btrees_with_keys, &buf));
 
 	if (likely(!total_keys && !total_sectors))
@@ -416,13 +460,13 @@ static void bch2_snapshot_stranded_keys_to_text(struct printbuf *out,
 	}
 }
 
-static int snapshot_node_data_to_text(struct printbuf *out, struct bch_fs *c,
+static int snapshot_node_data_to_text(struct printbuf *out, struct btree_trans *trans,
 				      u32 id, u32 live_child)
 {
 	CLASS(printbuf, breakdown)();
 	u64 nr_keys, sectors;
 
-	try(bch2_snapshot_accounting_totals(c, id, &nr_keys, &sectors, NULL, &breakdown));
+	try(bch2_snapshot_accounting_totals(trans, id, &nr_keys, &sectors, NULL, &breakdown));
 
 	prt_printf(out, "\n  %s %u", live_child ? "interior" : "leaf", id);
 	if (live_child)
@@ -438,7 +482,7 @@ static int snapshot_node_data_to_text(struct printbuf *out, struct bch_fs *c,
  * re-drive would append a second copy. Reset for that re-drive.
  */
 static int bch2_snapshot_delete_data_to_text(struct printbuf *out,
-					     struct bch_fs *c,
+					     struct btree_trans *trans,
 					     struct snapshot_delete *d)
 {
 	printbuf_reset(out);
@@ -446,10 +490,10 @@ static int bch2_snapshot_delete_data_to_text(struct printbuf *out,
 	prt_printf(out, "snapshot deletion, data accounted per node:");
 
 	darray_for_each(d->delete_leaves, i)
-		try(snapshot_node_data_to_text(out, c, *i, 0));
+		try(snapshot_node_data_to_text(out, trans, *i, 0));
 
 	darray_for_each(d->delete_interior, i)
-		try(snapshot_node_data_to_text(out, c, i->id, i->live_child));
+		try(snapshot_node_data_to_text(out, trans, i->id, i->live_child));
 
 	return 0;
 }
@@ -460,13 +504,13 @@ static int bch2_snapshot_delete_data_to_text(struct printbuf *out,
  * Pre-per_dev_fragmentation_lru the key counters aren't populated yet, so this
  * sees sectors only - a dirents- or xattrs-only stranding is invisible there.
  */
-static int snapshot_content_empty(struct bch_fs *c, u32 id,
+static int snapshot_content_empty(struct btree_trans *trans, u32 id,
 				  struct printbuf *msg, u64 *bad_btrees)
 {
 	u64 nr_keys, sectors, btrees = 0;
 	CLASS(printbuf, breakdown)();
 
-	try(bch2_snapshot_accounting_totals(c, id, &nr_keys, &sectors,
+	try(bch2_snapshot_accounting_totals(trans, id, &nr_keys, &sectors,
 					    &btrees, &breakdown));
 
 	btrees &= ~BIT_ULL(BTREE_ID_inodes);
@@ -488,16 +532,16 @@ static int snapshot_content_empty(struct bch_fs *c, u32 id,
  * mask. Nothing may remain in them by the time we delete the inode keys - see
  * the caller.
  */
-static int dying_snapshots_content_btrees(struct bch_fs *c,
+static int dying_snapshots_content_btrees(struct btree_trans *trans,
 					  struct snapshot_delete *d,
 					  struct printbuf *msg,
 					  u64 *bad_btrees)
 {
 	darray_for_each(d->delete_leaves, i)
-		try(snapshot_content_empty(c, *i, msg, bad_btrees));
+		try(snapshot_content_empty(trans, *i, msg, bad_btrees));
 
 	darray_for_each(d->delete_interior, i)
-		try(snapshot_content_empty(c, i->id, msg, bad_btrees));
+		try(snapshot_content_empty(trans, i->id, msg, bad_btrees));
 
 	return 0;
 }
@@ -1070,7 +1114,7 @@ static int delete_dead_snapshot_keys_v2(struct btree_trans *trans)
 	 */
 	CLASS(printbuf, msg)();
 	u64 bad_btrees = 0;
-	try(dying_snapshots_content_btrees(c, d, &msg, &bad_btrees));
+	try(dying_snapshots_content_btrees(trans, d, &msg, &bad_btrees));
 
 	if (unlikely(bad_btrees)) {
 		/*
@@ -1098,7 +1142,7 @@ static int delete_dead_snapshot_keys_v2(struct btree_trans *trans)
 
 		printbuf_reset(&msg);
 		bad_btrees = 0;
-		try(dying_snapshots_content_btrees(c, d, &msg, &bad_btrees));
+		try(dying_snapshots_content_btrees(trans, d, &msg, &bad_btrees));
 	}
 
 	if (unlikely(bad_btrees)) {
@@ -1427,7 +1471,7 @@ static int delete_dead_snapshots_locked(struct bch_fs *c)
 	 * is what the migration didn't move.
 	 */
 	CLASS(printbuf, node_data)();
-	try(bch2_snapshot_delete_data_to_text(&node_data, c, d));
+	try(bch2_snapshot_delete_data_to_text(&node_data, trans, d));
 	bch_info(c, "%s", node_data.buf);
 
 	try(!bch2_request_incompat_feature(c, bcachefs_metadata_version_snapshot_deletion_v2)

--- a/fs/snapshots/snapshot.c
+++ b/fs/snapshots/snapshot.c
@@ -1158,12 +1158,12 @@ static int snapshot_get_print(struct printbuf *out, struct btree_trans *trans, u
 		prt_tab(out);
 
 		/*
-		 * external_sectors is counter 2, and only the extents btree
-		 * (btree 0, the default here) carries it - so this one read is
-		 * the snapshot's total on-disk usage.
+		 * external_sectors is counter 2, and extents is the only
+		 * snapshot btree that carries it - so this one read is the
+		 * snapshot's total on-disk usage.
 		 */
 		u64 v[3] = { 0 };
-		try(bch2_fs_accounting_read_key2(trans, v, snapshot, id));
+		try(bch2_snapshot_accounting_read(trans, id, BTREE_ID_extents, v));
 
 		prt_human_readable_u64(out, v[2] << 9);
 		prt_tab_rjust(out);

--- a/fs/snapshots/snapshot.h
+++ b/fs/snapshots/snapshot.h
@@ -393,7 +393,8 @@ static inline int bch2_get_snapshot_overwrites(struct btree_trans *trans,
 int bch2_snapshot_node_set_deleted(struct btree_trans *, u32);
 int bch2_snapshot_node_delete(struct btree_trans *, u32, bool);
 int bch2_snapshot_node_undelete(struct btree_trans *, struct bkey_i_snapshot *);
-int bch2_snapshot_accounting_totals(struct bch_fs *, u32, u64 *, u64 *,
+int bch2_snapshot_accounting_read(struct btree_trans *, u32, enum btree_id, u64 [3]);
+int bch2_snapshot_accounting_totals(struct btree_trans *, u32, u64 *, u64 *,
 				    u64 *, struct printbuf *);
 
 int __bch2_key_has_snapshot_overwrites(struct btree_trans *, enum btree_id, struct bpos);

--- a/fs/vfs/ioctl.c
+++ b/fs/vfs/ioctl.c
@@ -1292,8 +1292,7 @@ static long __bch2_ioctl_snapshot_tree(struct bch_fs *c, struct file *filp,
 				continue;
 
 			u64 v[3] = {};
-			_ret = bch2_fs_accounting_read_key2(trans, v, snapshot,
-					.id = k.k->p.offset, .btree = btree);
+			_ret = bch2_snapshot_accounting_read(trans, k.k->p.offset, btree, v);
 			nr_keys		+= v[0];
 			key_bytes	+= v[1];
 			sectors		+= v[2];


### PR DESCRIPTION
Rebuilt on current `master`. It previously showed 156 commits and 111 files, which was an artefact rather than a proposal: the branch forked from master on 2026-07-20, master is rebased rather than merged, so the 128 commits that were on master at fork time now exist upstream under different SHAs and git read the stale copies as new work. Two commits were ever mine.

Fixes the aliasing described in #816. A per-snapshot accounting key written by any released bcachefs is `{id} -> [sectors]`; the rework made it `{id, btree} -> [nr_keys, key_bytes, external_sectors]` with the new `btree` field carved from the old key's zero padding. An old key is therefore byte-identical to a new key with `btree == 0` and is reinterpreted rather than skipped — its sector count reads back as `nr_keys`, and `external_sectors`, which does not exist on disk, reads zero. Every consumer asking "does this snapshot hold data?" gets zero for a snapshot that holds data, and `bch2_snapshot_node_check_no_data()` licenses a destructive transition on that answer.

The first commit adds the metadata version with `check_allocations` in the upgrade table, as the six previous accounting layout changes did. The second routes every per-snapshot reader through one helper that puts an old key's sectors back in the slot callers expect, discriminating on the on-disk counter count, and applies the trust gate in one place so no caller can forget it.

**Both commits are needed, and I checked rather than assumed.** I tried building this as the reader fix alone, without a new version, on the theory that the counter count is on-disk evidence and needs no version to interpret. That is true but insufficient: a plain read-write mount promotes the legacy key without rebuilding it, leaving three counters with the sector count in `nr_keys`, after which the counter count no longer distinguishes anything. Measured — `counters after: 1024 0 0`. Only a rebuild scheduled by a version bump recovers it. `fsck` does repair it, because it runs every pass including `check_allocations`; the 1.38→1.39 upgrade schedules `check_lrus, check_alloc_to_lru_refs, check_snapshots, check_subvols, delete_dead_snapshots, check_inodes, check_xattrs` and no `check_allocations`, so the mount path does not.

The open question is which version. This assigns 1.40, restoring the `snapshot_nr_keys` you briefly published and withdrew. The alternative is reusing 1.39, which master's `trust_keys` gate already does — but 1.39 predates the counters by thirteen days, so a filesystem formatted by master in that window is at 1.39 with one-counter keys, `trust_keys` is true, and the old sector count read as `nr_keys` is a spurious refusal to delete rather than a spurious permission. That is the decision I asked about in #816; say which you prefer and I will reshape this.

Builds clean; `format` and offline `fsck` pass.
