### PR TITLE
fs/Makefile: only rewrite -Zno-jump-tables when rustc accepts the stable spelling

### DIFF
--- a/fs/Makefile
+++ b/fs/Makefile
@@ -450,10 +450,23 @@ $(obj)/rust/extern.c: $(obj)/rust/bcachefs.rs ;
 CFLAGS_rust/extern.o += -Wno-missing-prototypes -Wno-missing-declarations
 
 # Kernel trees < 6.18 pass -Zno-jump-tables in KBUILD_RUSTFLAGS, written for
-# their era's pinned rustc; ours has it stabilized as -Cjump-tables=n. Rewrite
-# the underlying variable - rust_flags expands it lazily, so this covers every
-# Rust rule below and in the vendored includes.
+# their era's pinned rustc; newer rustc has it stabilized as -Cjump-tables=n.
+# Rewrite the underlying variable - rust_flags expands it lazily, so this covers
+# every Rust rule below and in the vendored includes.
+#
+# Only rewrite when $(RUSTC) actually accepts the stable spelling. rustc from
+# before the stabilization rejects it outright:
+#
+#   $ rustc -Cjump-tables=n --print=sysroot
+#   error: unknown codegen option: `jump-tables`
+#
+# so rewriting unconditionally turns a working build into a hard failure on
+# those toolchains, which is worse than leaving the flag the kernel chose.
+rustc-has-cjump-tables := $(shell $(RUSTC) -Cjump-tables=n --print=sysroot \
+	>/dev/null 2>&1 && echo y || echo n)
+ifeq ($(rustc-has-cjump-tables),y)
 KBUILD_RUSTFLAGS := $(patsubst -Zno-jump-tables,-Cjump-tables=n,$(KBUILD_RUSTFLAGS))
+endif
 
 # mod.rs keys on cfg(kernel) to source the kernel-compat types from the kernel
 # crate (vs bcachefs-shim in userspace); the kernel build doesn't set it on its


### PR DESCRIPTION
`fs/Makefile` unconditionally rewrites the kernel's `-Zno-jump-tables` to
`-Cjump-tables=n`. That is right once the flag has been stabilised, but rustc
from before the stabilisation rejects the new spelling outright:

```
$ rustc --version
rustc 1.91.0 (f8297e351 2025-10-28)
$ rustc -Cjump-tables=n --print=sysroot
error: unknown codegen option: `jump-tables`
```

so on those toolchains the rewrite converts a flag the kernel chose into one
that does not exist, and every in-tree build fails until the line is edited out
by hand.

The existing comment states the assumption plainly — "ours has it stabilized as
`-Cjump-tables=n`" — and that is the whole problem: it holds for whoever's rustc
the line was written against, and the rewrite fires regardless of whether it
holds for the rustc doing the build. Anyone on a newer rustc sees nothing wrong,
which is presumably why it has lasted.

This gates the rewrite on `$(RUSTC)` actually accepting the flag, using the same
`$(shell ... && echo y || echo n)` probe idiom the file already uses for
`RUSTC` and `BINDGEN` a couple of hundred lines up. A capability probe rather
than a version comparison, since the question is whether this particular
compiler takes the option.

Behaviour is unchanged wherever the rewrite was already correct; where it was
not, the kernel's own flag is left alone. Verified against three toolchains — a
stub that accepts the option, a stub that rejects it, and this host's real rustc
1.91:

```
RUSTC=<accepts>   probe=y  flags=... -Cjump-tables=n ...
RUSTC=<rejects>   probe=n  flags=... -Zno-jump-tables ...
RUSTC=rustc 1.91  probe=n  flags=... -Zno-jump-tables ...
```
