### PR TITLE
bcachefs: bch2_bkey_replicas() should honour KEY_TYPE_reservation

### DIFF
--- a/fs/data/extents.c
+++ b/fs/data/extents.c
@@ -829,23 +829,27 @@ void bch2_bkey_propagate_incompressible(const struct bch_fs *c, struct bkey_i *d
 
 unsigned bch2_bkey_replicas(struct bch_fs *c, struct bkey_s_c k)
 {
-	struct bkey_ptrs_c ptrs = bch2_bkey_ptrs_c(k);
-	const union bch_extent_entry *entry;
-	struct extent_ptr_decoded p = { 0 };
-	unsigned replicas = 0;
+	if (k.k->type == KEY_TYPE_reservation) {
+		return bkey_s_c_to_reservation(k).v->nr_replicas;
+	} else {
+		struct bkey_ptrs_c ptrs = bch2_bkey_ptrs_c(k);
+		const union bch_extent_entry *entry;
+		struct extent_ptr_decoded p = { 0 };
+		unsigned replicas = 0;
 
-	bkey_for_each_ptr_decode(k.k, ptrs, p, entry) {
-		if (p.ptr.cached)
-			continue;
+		bkey_for_each_ptr_decode(k.k, ptrs, p, entry) {
+			if (p.ptr.cached)
+				continue;
 
-		if (p.has_ec)
-			replicas += p.ec.redundancy;
+			if (p.has_ec)
+				replicas += p.ec.redundancy;
 
-		replicas++;
+			replicas++;
 
+		}
+
+		return replicas;
 	}
-
-	return replicas;
 }
 
 unsigned bch2_dev_durability(struct bch_fs *c, unsigned dev)


### PR DESCRIPTION
`bch2_bkey_replicas()` is the one member of its family that does not special-case `KEY_TYPE_reservation`. Its two immediate neighbours in the same file both do — `bch2_bkey_nr_ptrs_allocated()` and `bch2_bkey_nr_ptrs_fully_allocated()` each open by returning `bkey_s_c_to_reservation(k).v->nr_replicas`. `bch2_bkey_replicas()` has no such case and is written purely in terms of `bch2_bkey_ptrs_c()`, whose `default:` returns `{NULL, NULL}` for a reservation key, so the pointer loop runs zero times and a fallocated extent reports zero replicas.

The visible consequence is in `bch2_check_range_allocated()`, which rejects a range unless `nr_replicas <= bch2_bkey_replicas(c, k)`. A non-nocow fallocate creates `KEY_TYPE_reservation` keys whose trigger genuinely and durably raises `persistent_reserved` — the space really is walled off from other writers — but the code deciding whether a write may proceed without taking a fresh reservation cannot see that. A fallocated block is indistinguishable from a hole, so the first write to each block either pays again for space already paid for, or fails with ENOSPC on a full filesystem when it should not have to.

This surfaced in review of swap file support. For a swap file the natural way to guarantee that COW rewrites can always find space is to fallocate it up front, which is what the review of koverstreet/bcachefs-tools#787 asked for: "For #4, disk reservation at swapon - that should just be fallocate." That does not work today, and this asymmetry is why. With it fixed, no swap-specific reservation code is needed at all and the swapon-time reservation in #787 can be deleted outright.

There are exactly three callers, all asking a space-accounting question rather than a durability one. `bch2_check_range_allocated()` is the case above. The other two are `new_replicas` for the key being inserted and the same quantity compared against the old key, both in `bch2_sum_sector_overwrites()`; they feed only `*usage_increasing`, which selects `NOFAIL` on `bch2_disk_reservation_add()` and only on the branch taken when `disk_sectors_delta` exceeds what the caller already reserved. `disk_sectors_delta` does not move, because it is computed from the two sibling functions that already honour reservation keys.

Fallocate inserts its own reservation keys through that same `bch2_extent_update()` path, so it now accounts for itself differently too — but not in a way that changes behaviour. Within one snapshot `bch2_extent_fallocate()` reserves exactly `sectors * (data_replicas - nr_ptrs_fully_allocated(old))`, which is `disk_sectors_delta`, so the `reservation_add` branch is not reached; across snapshots `usage_increasing` was already true via the snapshot clause. What does change is the case this patch is about — overwriting a fallocated reservation with an equally-replicated extent now correctly reports usage as not increasing, which is the same judgement `bch2_check_range_allocated()` makes up front.

Tested in userspace with no kernel involved: a program linking `libbcachefs` creates a file, fallocates 1 MiB through `bch2_extent_fallocate()`, and applies `bch2_check_range_allocated()`'s per-key test to the keys fallocate actually left in the extents btree. Before the patch the range is one `KEY_TYPE_reservation` key spanning all 2048 sectors, reporting 0 replicas against a required 1, and the test fails; after, it passes, with everything else about the run identical.

The test, an A/B runner that builds and runs it against two trees in one command, and a README covering the build are on a separate branch so they stay out of this diff: [`reproducers/fallocate-replicas`](https://github.com/matthiasgoergens/bcachefs-tools/tree/repro/fallocate-replicas-test/reproducers/fallocate-replicas) at commit [`2622943`](https://github.com/matthiasgoergens/bcachefs-tools/commit/262294329292). No kernel, no VM, no loopback device, a few seconds per run:

```sh
./reproducers/fallocate-replicas/run-test.sh /path/to/tree-without-fix /path/to/tree-with-fix
```

The README also records two traps that cost real time and are documented nowhere else: a program linking `libbcachefs` must call `linux_shrinkers_init()` first, or `_totalram_pages` stays 0, the journal's `mem_limit` becomes 0, the watermark pins at `reclaim`, and the first normal-priority transaction blocks on `journal_full` forever — while recovery and fsck still succeed, so the filesystem looks healthy. And a 512 MiB image gives journal buckets smaller than one journal entry reservation, which wedges the same way; the runner uses 2 GiB.
