### PR TITLE
bcachefs: report the real wait in the "Journal stuck?" message

### DIFF
--- a/fs/journal/journal.c
+++ b/fs/journal/journal.c
@@ -962,7 +962,8 @@ int bch2_journal_res_get_slowpath(struct journal *j, struct journal_res *res,
 		return ret;
 
 	CLASS(printbuf, buf)();
-	prt_printf(&buf, bch2_fmt(c, "Journal stuck? Waited for 10 seconds, err %s"), bch2_err_str(ret));
+	prt_printf(&buf, bch2_fmt(c, "Journal stuck? Waited for %lis, err %s"),
+		   total_wait / HZ, bch2_err_str(ret));
 	bch2_journal_debug_to_text(&buf, j);
 	bch2_print_str(c, KERN_ERR, buf.buf);
 


### PR DESCRIPTION
`bch2_journal_res_get_slowpath()` computes how long to wait before declaring the journal stuck:

```c
long total_wait = max(max_dev_latency(c) * 2, HZ * 10);
```

then reports a fixed `"Waited for 10 seconds"` regardless of what `total_wait` came to. `HZ * 10` is only the floor — where a journal device has shown a slow write, the real wait is twice that device's worst observed latency and can be far longer.

The message was correct when written. 8ab99395f4fb introduced both the check and the string, and the wait really was a bare `HZ * 10`. ad0676ebb54b then made the wait latency-derived and left the string alone, which is where the two parted company.

Its sibling twenty lines down had the same bug and is already fixed: f7d63944215d made `bch2_journal_flush_seq()` print the real duration, and describes its new wait as "matching `bch2_journal_res_get_slowpath()`" — so the function still carrying the bug was the model for that fix. This just makes the two agree.

Not cosmetic when reading a bug report. The printed number is the only place the derived threshold is visible, so it doubles as a readout of `max_dev_latency()`: "Waited 20s" says a journal device has been seen taking ten seconds for a write, which points at the device rather than at the filesystem. That is a much stronger signal than "the journal is stuck", and a constant throws it away.

I hit this while chasing multi-second `fsync` stalls on a five-device filesystem — reported separately as #813 — where the escalating numbers in these messages turned out to be the most useful diagnostic available.

Builds clean; no new warnings.
