### PR TITLE
check_lrus: pin the backing keyspace while scanning each lru

### DIFF
--- a/fs/alloc/lru.c
+++ b/fs/alloc/lru.c
@@ -6,6 +6,7 @@
 #include "alloc/lru.h"
 
 #include "btree/bkey_buf.h"
+#include "btree/cache.h"
 #include "btree/iter.h"
 #include "btree/update.h"
 #include "btree/write_buffer.h"
@@ -230,6 +231,43 @@ static int bch2_check_lru_key(struct btree_trans *trans,
 	return 0;
 }
 
+/*
+ * Pin the backing keyspace for one lru: read and bucket fragmentation lrus
+ * are per-device, so their backing keys are one device's contiguous slice of
+ * the alloc btree. Entries in obsolete/bogus lru ids get no pin - their
+ * lookups miss or are scattered, and they're stragglers headed for deletion.
+ */
+static int check_lru_id_pin(struct btree_trans *trans, u16 lru_id)
+{
+	unsigned dev;
+
+	if (lru_id < BCH_LRU_READ_MAX)
+		dev = lru_id;
+	else if (lru_id >= BCH_LRU_BUCKET_FRAGMENTATION_START &&
+		 lru_id <  BCH_LRU_BUCKET_FRAGMENTATION_END)
+		dev = lru_id - BCH_LRU_BUCKET_FRAGMENTATION_START;
+	else if (lru_id == BCH_LRU_STRIPE_FRAGMENTATION)
+		return bch2_btree_cache_pin_range(trans, BTREE_ID_stripes,
+						  POS_MIN, SPOS_MAX);
+	else {
+		bch2_btree_cache_unpin(trans->c);
+		return 0;
+	}
+
+	return bch2_btree_cache_pin_range(trans, BTREE_ID_alloc,
+					  POS(dev, 0),
+					  SPOS(dev, U64_MAX, U32_MAX));
+}
+
+static int lru_peek_id(struct btree_trans *trans, struct bpos pos, int *lru_id)
+{
+	CLASS(btree_iter, iter)(trans, BTREE_ID_lru, pos, 0);
+	struct bkey_s_c k = bkey_try(bch2_btree_iter_peek(&iter));
+
+	*lru_id = k.k ? (int) lru_pos_id(k.k->p) : -1;
+	return 0;
+}
+
 int bch2_check_lrus(struct bch_fs *c)
 {
 	struct wb_maybe_flush last_flushed __cleanup(wb_maybe_flush_exit);
@@ -239,11 +277,39 @@ int bch2_check_lrus(struct bch_fs *c)
 	bch2_progress_init(&progress, __func__, c, BIT_ULL(BTREE_ID_lru), 0);
 
 	CLASS(btree_trans, trans)(c);
-	return for_each_btree_key_commit(trans, iter,
-				BTREE_ID_lru, POS_MIN, BTREE_ITER_prefetch, k,
-				NULL, NULL, BCH_TRANS_COMMIT_no_enospc, ({
-		bch2_progress_update_iter(trans, &progress, &iter) ?:
-		wb_maybe_flush_inc(&last_flushed) ?:
-		bch2_check_lru_key(trans, &iter, k, &last_flushed);
-	}));
+	struct bpos pos = POS_MIN;
+	int ret = 0;
+
+	/*
+	 * Scan one lru id at a time, with the backing keyspace prefetched and
+	 * pinned: the backing lookups are random-order, so on a cold cache
+	 * this turns per-key synchronous reads into cache hits.
+	 */
+	while (1) {
+		int lru_id;
+
+		ret = lockrestart_do(trans, lru_peek_id(trans, pos, &lru_id));
+		if (ret || lru_id < 0)
+			break;
+
+		ret = check_lru_id_pin(trans, lru_id);
+		if (ret)
+			break;
+
+		ret = for_each_btree_key_max_commit(trans, iter, BTREE_ID_lru,
+					lru_start(lru_id), lru_end(lru_id),
+					BTREE_ITER_prefetch, k,
+					NULL, NULL, BCH_TRANS_COMMIT_no_enospc, ({
+			bch2_progress_update_iter(trans, &progress, &iter) ?:
+			wb_maybe_flush_inc(&last_flushed) ?:
+			bch2_check_lru_key(trans, &iter, k, &last_flushed);
+		}));
+		if (ret || lru_id == U16_MAX)
+			break;
+
+		pos = lru_start(lru_id + 1);
+	}
+
+	bch2_btree_cache_unpin(c);
+	return ret;
 }

--- a/fs/btree/cache.c
+++ b/fs/btree/cache.c
@@ -357,6 +357,56 @@ void bch2_btree_cache_unpin(struct bch_fs *c)
 	bc->live[1].nr_dirty = 0;
 }
 
+/*
+ * Prefetch and pin one keyspace range of one btree: replaces any previously
+ * pinned range (there is only one), walks [start, end] with prefetch so the
+ * nodes are faulted in with async parallel reads rather than synchronous
+ * misses, and marks them shrinker-exempt.
+ *
+ * Best-effort: pinning stops if it would exceed fsck_memory_usage_percent of
+ * system ram. Lookups beyond the pinned portion still work, they're just
+ * slow paths. Callers must bch2_btree_cache_unpin() when done.
+ */
+int bch2_btree_cache_pin_range(struct btree_trans *trans, enum btree_id btree,
+			       struct bpos start, struct bpos end)
+{
+	struct bch_fs *c = trans->c;
+	struct bch_fs_btree_cache *bc = &c->btree.cache;
+	s64 mem_may_pin = div_u64(system_totalram_bytes() *
+				  c->opts.fsck_memory_usage_percent, 100);
+
+	bch2_btree_cache_unpin(c);
+
+	bc->pinned_nodes_mask[0]	= BIT_ULL(btree);
+	bc->pinned_nodes_mask[1]	= BIT_ULL(btree);
+	bc->pinned_nodes_start		= BBPOS(btree, start);
+	bc->pinned_nodes_end		= BBPOS(btree, end);
+
+	return for_each_btree_node(trans, iter, btree, start, 0,
+				   BTREE_ITER_prefetch, b, ({
+		if (bpos_gt(b->data->min_key, end))
+			break;
+		mem_may_pin -= btree_buf_bytes(b);
+		if (mem_may_pin <= 0) {
+			bc->pinned_nodes_end = BBPOS(btree, b->key.k.p);
+
+			CLASS(printbuf, buf)();
+			prt_printf(&buf, "memory budget (%u%% of ram) exhausted pinning btree ",
+				   c->opts.fsck_memory_usage_percent);
+			bch2_btree_id_to_text(&buf, btree);
+			prt_str(&buf, " at ");
+			bch2_bpos_to_text(&buf, b->key.k.p);
+			prt_str(&buf, ", requested range end ");
+			bch2_bpos_to_text(&buf, end);
+			prt_str(&buf, "; continuing, lookups past this point will be uncached");
+			bch_warn_ratelimited(c, "%s", buf.buf);
+			break;
+		}
+		bch2_node_pin(c, b);
+		0;
+	}));
+}
+
 /* Cache state transitions — see DOC at top of file. */
 
 static inline bool btree_node_state_hashed(enum btree_node_cache_state state)

--- a/fs/btree/cache.h
+++ b/fs/btree/cache.h
@@ -21,6 +21,8 @@ int bch2_btree_node_transition_state_locked(struct bch_fs_btree_cache *, struct 
 
 void bch2_node_pin(struct bch_fs *, struct btree *);
 void bch2_btree_cache_unpin(struct bch_fs *);
+int bch2_btree_cache_pin_range(struct btree_trans *, enum btree_id,
+			       struct bpos, struct bpos);
 
 void bch2_btree_node_set_dirty(struct bch_fs *, struct btree *);
 void bch2_btree_node_write_done_clean(struct bch_fs *, struct btree *);


### PR DESCRIPTION
Add bch2_btree_cache_pin_range(), a bounded single-btree variant of the backpointers pass's pin machinery, and use it in check_lrus to prefetch and pin each lru's backing keyspace (one device's alloc slice, or the stripes btree) before scanning that lru id: backing lookups are random-order, so on a cold cache this turns per-key synchronous reads into cache hits.

Pinning is best-effort, capped at fsck_memory_usage_percent; a warning is emitted if the budget is exhausted and lookups fall back to uncached.