### PR TITLE
ec: can_form_ec_stripe() must model what the allocator actually refuses

### DIFF
--- a/fs/data/ec/create.c
+++ b/fs/data/ec/create.c
@@ -877,7 +877,18 @@ bool bch2_can_form_ec_stripe(struct bch_fs *c, unsigned target, unsigned redunda
 		return false;
 
 	struct target t = target_decode(target);
-	unsigned disk_label = t.type == TARGET_GROUP && t.group <= U8_MAX
+
+	/*
+	 * A group above U8_MAX cannot be a disk label, and __ec_stripe_head_get()
+	 * refuses it outright ("cannot create a stripe when disk_label > U8_MAX").
+	 * Folding it to disk_label 0 here would ask about every device in the
+	 * filesystem and answer yes to a target the allocator will not serve --
+	 * the same shape of mismatch this function is being fixed for.
+	 */
+	if (t.type == TARGET_GROUP && t.group > U8_MAX)
+		return false;
+
+	unsigned disk_label = t.type == TARGET_GROUP
 		? t.group + 1
 		: 0;
 

--- a/fs/data/ec/create.c
+++ b/fs/data/ec/create.c
@@ -850,15 +850,26 @@ unsigned bch2_disk_label_ec_devs(struct bch_fs *c, unsigned disk_label,
 /*
  * Can a stripe with @redundancy parity blocks be formed in @target right now?
  *
- * Minimum stripe size is redundancy + 1 (one data block + parity), and all
- * blocks in a stripe must share a single bucket_size. So we need at least
- * redundancy + 1 RW devices in the target that agree on bucket_size.
+ * This must model what ec_stripe_head_devs_update() computes as
+ * insufficient_devs, because that is what actually refuses to allocate. Both
+ * of its conditions apply:
+ *
+ *  - at least redundancy + 2 devices agreeing on bucket_size. Not + 1: a
+ *    stripe of one data block plus parity is strictly worse than replication,
+ *    so that case is rejected rather than formed.
+ *  - at least redundancy + 2 distinct failure domains. One block per domain is
+ *    a hard requirement for erasure coding, not a preference - the allocator
+ *    excludes devices sharing an already-placed block's domain. With no
+ *    failure domains configured every device is its own domain and this is
+ *    the device count again, so it only bites where devices share one.
  *
  * bch2_disk_label_ec_devs already returns the filtered device mask (RW members
  * with durability > 0, narrowed to the picked best bucket_size).
  *
  * Used by reconcile to avoid queueing EC work that can't make progress —
- * otherwise reconcile spins re-queueing data_update_fail forever.
+ * otherwise reconcile spins re-queueing data_update_fail forever. Modelling
+ * only the device count let configurations through that the allocator then
+ * refused, costing one wasted rewrite of every affected extent.
  */
 bool bch2_can_form_ec_stripe(struct bch_fs *c, unsigned target, unsigned redundancy)
 {
@@ -873,7 +884,8 @@ bool bch2_can_form_ec_stripe(struct bch_fs *c, unsigned target, unsigned redunda
 	struct bch_devs_mask devs;
 	bch2_disk_label_ec_devs(c, disk_label, &devs, 0);
 
-	return dev_mask_nr(&devs) >= redundancy + 1;
+	return dev_mask_nr(&devs) >= redundancy + 2 &&
+	       bch2_target_nr_domains(c, &devs) >= redundancy + 2;
 }
 
 /*


### PR DESCRIPTION
Fixes #807.

`bch2_can_form_ec_stripe()` is the gate reconcile uses to avoid queueing EC work that cannot succeed. It asks for `redundancy + 1` eligible devices. `ec_stripe_head_devs_update()`, which is what actually sets `insufficient_devs` and refuses the allocation, asks for two stricter things:

```c
h->insufficient_devs  = h->nr_active_devs < h->redundancy + 2;
h->insufficient_devs |= nr_domains       < h->redundancy + 2;
```

So the gate is wrong twice. The threshold is `redundancy + 2`, not `+ 1`, because a stripe of one data block plus parity is strictly worse than replication and is rejected rather than formed. And the count that matters is distinct failure domains rather than devices: one block per domain is a hard requirement for erasure coding, and the allocator excludes devices sharing an already-placed block's domain.

A configuration can therefore pass the gate and still be refused. Bounded rather than an endless loop, but it costs one wasted rewrite of every affected extent — measured in #807 at 95,232 sectors of failed `data_update`, and 146,432 against 51,200 sectors of read and write for a 25 MiB dataset, on a build that already had the fix this gate was added for.

Mirroring both conditions is the whole change. `bch2_target_nr_domains()` already exists and is what `ec_stripe_head_devs_update()` uses; with no failure domains configured every device is its own domain, so the new condition reduces to the device count and only bites where devices share one.

The issue had already worked out both halves; I checked them against the source rather than taking the report on trust, and the fix is what it proposed.
