### PR TITLE
fs/Makefile: silence duplicate-const in bindgen's generated extern.c

### DIFF
--- a/fs/Makefile
+++ b/fs/Makefile
@@ -447,7 +447,8 @@ $(obj)/rust/bcachefs.rs: $(obj)/codegen $(obj)/rust/generic-radix-tree.h $(bcach
 # with no prior prototype (bindgen doesn't emit C declarations for them), so
 # silence -Wmissing-prototypes for just this generated object.
 $(obj)/rust/extern.c: $(obj)/rust/bcachefs.rs ;
-CFLAGS_rust/extern.o += -Wno-missing-prototypes -Wno-missing-declarations
+CFLAGS_rust/extern.o += -Wno-missing-prototypes -Wno-missing-declarations \
+			-Wno-duplicate-decl-specifier
 
 # Kernel trees < 6.18 pass -Zno-jump-tables in KBUILD_RUSTFLAGS, written for
 # their era's pinned rustc; ours has it stabilized as -Cjump-tables=n. Rewrite


### PR DESCRIPTION
Fixes #819.

Building `master` as a module with `CONFIG_WERROR=y`, which is defconfig's default, fails:

```
fs/rust/extern.c:116:7: error: duplicate 'const' declaration specifier [-Werror=duplicate-decl-specifier]
  116 | const const struct bkey_ops * bch2_bkey_type_ops__extern(enum bch_bkey_type type) { ... }
```

`extern.c` is bindgen's `--wrap-static-fns` output, generated at build time and not in the tree, which is why that line appears nowhere in git. bindgen 0.72.1 builds the wrapper's return type by prepending `const` to a type that already carries one — `bch2_bkey_type_ops()` in `fs/btree/bkey_methods.h` returns `const struct bkey_ops *`.

I first assumed this was new in GCC 16 and that was wrong. GCC 15 and 16 behave identically, and neither warns without `-Wall`:

```
$ printf 'const const int *f(void);\n' > dc.c
$ gcc-15 -Wall -c dc.c        # warning: duplicate 'const' declaration specifier
$ gcc-16 -Wall -c dc.c        # warning: duplicate 'const' declaration specifier
$ gcc-16 -std=gnu11 -c dc.c   # silent
```

The trigger is `-Wall` plus `CONFIG_WERROR`. It has stayed invisible because ktest builds from allnoconfig — `new_config()` in `lib/libktest.sh` runs allnoconfig and then rewrites every surviving option to "is not set" — so `CONFIG_WERROR` is never set anywhere in the test matrix, and warnings in bcachefs are never fatal in CI while being fatal for anyone building from defconfig.

The fix suppresses it on this object, next to the two warnings the same generated file already needs suppressed. Verified with a control: `rust/extern.o` fails to build without the flag and succeeds with it, against 7.2-rc5.

The tidier place to fix this is bindgen, so it does not double the qualifier, but that is not something this tree controls and the local suppression matches what is already done for the same file.
