### PR TITLE
set-fs-option: don't report success for an option the online path cannot set

### DIFF
--- a/src/commands/set_option.rs
+++ b/src/commands/set_option.rs
@@ -73,15 +73,19 @@ fn set_option_online(
         }
     }
 
+    let mut failed = 0;
+
     for (name, value) in opts {
         let Some((_id, opt)) = bch_opt_lookup(name) else {
             eprintln!("Unknown option: {name}");
+            failed += 1;
             continue;
         };
         let flags = opt.flags as u32;
 
         if flags & opt_flags() == 0 {
             eprintln!("Can't set option {name}");
+            failed += 1;
             continue;
         }
 
@@ -95,6 +99,7 @@ fn set_option_online(
         if flags & c::opt_flags::OPT_RUNTIME as u32 == 0 {
             eprintln!("{name} cannot be set while the filesystem is mounted \
                        (unmount and set it offline)");
+            failed += 1;
             continue;
         }
 
@@ -104,6 +109,7 @@ fn set_option_online(
         if is_fs_opt && !is_device_opt {
             if let Err(e) = sysfs::sysfs_write_str(fs.sysfs_fd(), &format!("options/{name}"), value) {
                 eprintln!("Error setting {name}: {e}");
+                failed += 1;
             }
         }
 
@@ -112,6 +118,7 @@ fn set_option_online(
                 for dev_idx in dev_idxs {
                     if let Err(e) = sysfs::sysfs_write_str(fs.sysfs_fd(), &format!("dev-{dev_idx}/{name}"), value) {
                         eprintln!("Error setting {name} on device {dev_idx}: {e}");
+                        failed += 1;
                     }
                 }
                 continue;
@@ -127,9 +134,16 @@ fn set_option_online(
 
                 if let Err(e) = sysfs::sysfs_write_str(fs.sysfs_fd(), &format!("dev-{dev_idx}/{name}"), value) {
                     eprintln!("Error setting {name} on device {dev_idx}: {e}");
+                    failed += 1;
                 }
             }
         }
+    }
+
+    // A configuration command that could not do what it was asked must not
+    // report success: scripts have no other way to tell.
+    if failed != 0 {
+        bail!("{failed} of {} option(s) could not be set", opts.len());
     }
 
     Ok(())
@@ -142,28 +156,33 @@ fn set_option_offline(
     opts: &[(String, String)],
 ) -> Result<()> {
     let mut modified = false;
+    let mut failed = 0;
 
     for (name, value) in opts {
         let Some((opt_id, opt)) = bch_opt_lookup(name) else {
             eprintln!("Unknown option: {name}");
+            failed += 1;
             continue;
         };
         let flags = opt.flags as u32;
 
         if flags & opt_flags() == 0 {
             eprintln!("Can't set option {name}");
+            failed += 1;
             continue;
         }
 
         let c_value = CString::new(value.as_str())?;
         let Ok(val) = bcachefs_kernel::opts::opt_parse(Some(&fs), opt, &c_value, None) else {
             eprintln!("Error parsing {name}={value}");
+            failed += 1;
             continue;
         };
 
         if flags & c::opt_flags::OPT_FS as u32 != 0 {
             if let Err(e) = fs.opt_hook_pre_set(None, opt_id, val) {
                 eprintln!("Error setting {name}: {e}");
+                failed += 1;
                 continue;
             }
             fs.opt_set_sb(None, opt, val, Some(&c_value));
@@ -182,11 +201,13 @@ fn set_option_offline(
             for idx in indices {
                 let Some(ca) = fs.dev_get(idx) else {
                     eprintln!("Couldn't look up device {idx}");
+                    failed += 1;
                     continue;
                 };
 
                 if let Err(e) = fs.opt_hook_pre_set(Some(&ca), opt_id, val) {
                     eprintln!("Error setting {name}: {e}");
+                    failed += 1;
                     continue;
                 }
                 fs.opt_set_sb(Some(&ca), opt, val, Some(&c_value));
@@ -203,6 +224,10 @@ fn set_option_offline(
         let _lock = fs.sb_lock();
         fs.write_super_force()
             .map_err(|e| anyhow::anyhow!("error writing superblock: {e}"))?;
+    }
+
+    if failed != 0 {
+        bail!("{failed} of {} option(s) could not be set", opts.len());
     }
 
     Ok(())

--- a/src/commands/set_option.rs
+++ b/src/commands/set_option.rs
@@ -85,17 +85,34 @@ fn set_option_online(
             continue;
         }
 
+        // The online path can only write sysfs, and the kernel creates an
+        // option's attribute 0444 unless it is OPT_RUNTIME (fs/opts.c:
+        // `.attr.mode = (_flags) & OPT_RUNTIME ? 0644 : 0444`). So a
+        // non-runtime option has a file that cannot be opened for writing,
+        // and testing OPT_FS|OPT_DEVICE above lets it through to fail.
+        // Many such options *can* be set with the filesystem unmounted, so
+        // say that rather than just refusing.
+        if flags & c::opt_flags::OPT_RUNTIME as u32 == 0 {
+            eprintln!("{name} cannot be set while the filesystem is mounted \
+                       (unmount and set it offline)");
+            continue;
+        }
+
         let is_fs_opt = flags & c::opt_flags::OPT_FS as u32 != 0;
         let is_device_opt = flags & c::opt_flags::OPT_DEVICE as u32 != 0;
 
         if is_fs_opt && !is_device_opt {
-            sysfs::sysfs_write_str(fs.sysfs_fd(), &format!("options/{name}"), value);
+            if let Err(e) = sysfs::sysfs_write_str(fs.sysfs_fd(), &format!("options/{name}"), value) {
+                eprintln!("Error setting {name}: {e}");
+            }
         }
 
         if is_device_opt {
             if !dev_idxs.is_empty() {
                 for dev_idx in dev_idxs {
-                    sysfs::sysfs_write_str(fs.sysfs_fd(), &format!("dev-{dev_idx}/{name}"), value);
+                    if let Err(e) = sysfs::sysfs_write_str(fs.sysfs_fd(), &format!("dev-{dev_idx}/{name}"), value) {
+                        eprintln!("Error setting {name} on device {dev_idx}: {e}");
+                    }
                 }
                 continue;
             }
@@ -108,7 +125,9 @@ fn set_option_online(
                     continue;
                 }
 
-                sysfs::sysfs_write_str(fs.sysfs_fd(), &format!("dev-{dev_idx}/{name}"), value);
+                if let Err(e) = sysfs::sysfs_write_str(fs.sysfs_fd(), &format!("dev-{dev_idx}/{name}"), value) {
+                    eprintln!("Error setting {name} on device {dev_idx}: {e}");
+                }
             }
         }
     }

--- a/src/commands/set_option.rs
+++ b/src/commands/set_option.rs
@@ -73,19 +73,20 @@ fn set_option_online(
         }
     }
 
-    let mut failed = 0;
+    let mut failed = std::collections::BTreeSet::new();
 
     for (name, value) in opts {
+
         let Some((_id, opt)) = bch_opt_lookup(name) else {
             eprintln!("Unknown option: {name}");
-            failed += 1;
+            failed.insert(name.as_str());
             continue;
         };
         let flags = opt.flags as u32;
 
         if flags & opt_flags() == 0 {
             eprintln!("Can't set option {name}");
-            failed += 1;
+            failed.insert(name.as_str());
             continue;
         }
 
@@ -99,7 +100,7 @@ fn set_option_online(
         if flags & c::opt_flags::OPT_RUNTIME as u32 == 0 {
             eprintln!("{name} cannot be set while the filesystem is mounted \
                        (unmount and set it offline)");
-            failed += 1;
+            failed.insert(name.as_str());
             continue;
         }
 
@@ -109,7 +110,7 @@ fn set_option_online(
         if is_fs_opt && !is_device_opt {
             if let Err(e) = sysfs::sysfs_write_str(fs.sysfs_fd(), &format!("options/{name}"), value) {
                 eprintln!("Error setting {name}: {e}");
-                failed += 1;
+                failed.insert(name.as_str());
             }
         }
 
@@ -118,7 +119,7 @@ fn set_option_online(
                 for dev_idx in dev_idxs {
                     if let Err(e) = sysfs::sysfs_write_str(fs.sysfs_fd(), &format!("dev-{dev_idx}/{name}"), value) {
                         eprintln!("Error setting {name} on device {dev_idx}: {e}");
-                        failed += 1;
+                        failed.insert(name.as_str());
                     }
                 }
                 continue;
@@ -129,12 +130,13 @@ fn set_option_online(
                 let dev_idx = fs2.dev_idx();
                 if dev_idx < 0 {
                     eprintln!("Couldn't determine device index for {dev}; use --dev-idx");
+                    failed.insert(name.as_str());
                     continue;
                 }
 
                 if let Err(e) = sysfs::sysfs_write_str(fs.sysfs_fd(), &format!("dev-{dev_idx}/{name}"), value) {
                     eprintln!("Error setting {name} on device {dev_idx}: {e}");
-                    failed += 1;
+                    failed.insert(name.as_str());
                 }
             }
         }
@@ -142,8 +144,10 @@ fn set_option_online(
 
     // A configuration command that could not do what it was asked must not
     // report success: scripts have no other way to tell.
-    if failed != 0 {
-        bail!("{failed} of {} option(s) could not be set", opts.len());
+    if !failed.is_empty() {
+        bail!("{} of {} option(s) could not be set: {}",
+              failed.len(), opts.len(),
+              failed.into_iter().collect::<Vec<_>>().join(", "));
     }
 
     Ok(())
@@ -156,33 +160,34 @@ fn set_option_offline(
     opts: &[(String, String)],
 ) -> Result<()> {
     let mut modified = false;
-    let mut failed = 0;
+    let mut failed = std::collections::BTreeSet::new();
 
     for (name, value) in opts {
+
         let Some((opt_id, opt)) = bch_opt_lookup(name) else {
             eprintln!("Unknown option: {name}");
-            failed += 1;
+            failed.insert(name.as_str());
             continue;
         };
         let flags = opt.flags as u32;
 
         if flags & opt_flags() == 0 {
             eprintln!("Can't set option {name}");
-            failed += 1;
+            failed.insert(name.as_str());
             continue;
         }
 
         let c_value = CString::new(value.as_str())?;
         let Ok(val) = bcachefs_kernel::opts::opt_parse(Some(&fs), opt, &c_value, None) else {
             eprintln!("Error parsing {name}={value}");
-            failed += 1;
+            failed.insert(name.as_str());
             continue;
         };
 
         if flags & c::opt_flags::OPT_FS as u32 != 0 {
             if let Err(e) = fs.opt_hook_pre_set(None, opt_id, val) {
                 eprintln!("Error setting {name}: {e}");
-                failed += 1;
+                failed.insert(name.as_str());
                 continue;
             }
             fs.opt_set_sb(None, opt, val, Some(&c_value));
@@ -193,21 +198,37 @@ fn set_option_offline(
             let indices: Vec<u32> = if !dev_idxs.is_empty() {
                 dev_idxs.to_vec()
             } else {
-                devices.iter().filter_map(|dev| {
-                    name_to_dev_idx(&fs, dev).map(|i| i as u32)
-                }).collect()
+                // Don't silently drop a device we couldn't resolve: with every
+                // name unresolved this list is empty, the loop below never
+                // runs, and the command reports success having done nothing.
+                let mut idxs = Vec::with_capacity(devices.len());
+                for dev in devices {
+                    match name_to_dev_idx(&fs, dev) {
+                        Some(i) => idxs.push(i as u32),
+                        None => {
+                            eprintln!("Couldn't find device {dev} in this filesystem");
+                            failed.insert(name.as_str());
+                        }
+                    }
+                }
+                idxs
             };
+
+            if indices.is_empty() {
+                eprintln!("No devices to set {name} on");
+                failed.insert(name.as_str());
+            }
 
             for idx in indices {
                 let Some(ca) = fs.dev_get(idx) else {
                     eprintln!("Couldn't look up device {idx}");
-                    failed += 1;
+                    failed.insert(name.as_str());
                     continue;
                 };
 
                 if let Err(e) = fs.opt_hook_pre_set(Some(&ca), opt_id, val) {
                     eprintln!("Error setting {name}: {e}");
-                    failed += 1;
+                    failed.insert(name.as_str());
                     continue;
                 }
                 fs.opt_set_sb(Some(&ca), opt, val, Some(&c_value));
@@ -226,8 +247,10 @@ fn set_option_offline(
             .map_err(|e| anyhow::anyhow!("error writing superblock: {e}"))?;
     }
 
-    if failed != 0 {
-        bail!("{failed} of {} option(s) could not be set", opts.len());
+    if !failed.is_empty() {
+        bail!("{} of {} option(s) could not be set: {}",
+              failed.len(), opts.len(),
+              failed.into_iter().collect::<Vec<_>>().join(", "));
     }
 
     Ok(())

--- a/src/wrappers/sysfs.rs
+++ b/src/wrappers/sysfs.rs
@@ -100,11 +100,21 @@ pub fn bcachefs_kernel_version() -> u64 {
 }
 
 /// Write a string value to a sysfs attribute file relative to a directory fd.
-pub fn sysfs_write_str(sysfs_fd: BorrowedFd<'_>, path: &str, value: &str) {
+/// Write a value to a sysfs attribute.
+///
+/// Both failures are returned rather than discarded: a non-runtime option's
+/// attribute is created 0444 (`fs/opts.c`: `.attr.mode = (_flags) & OPT_RUNTIME
+/// ? 0644 : 0444`), so opening it O_WRONLY fails with EACCES, and a caller that
+/// ignored that reported success while changing nothing.
+pub fn sysfs_write_str(
+    sysfs_fd: BorrowedFd<'_>,
+    path: &str,
+    value: &str,
+) -> std::io::Result<()> {
     let flags = rustix::fs::OFlags::WRONLY;
-    if let Ok(fd) = rustix::fs::openat(sysfs_fd, path, flags, rustix::fs::Mode::empty()) {
-        let _ = rustix::io::write(&fd, value.as_bytes());
-    }
+    let fd = rustix::fs::openat(sysfs_fd, path, flags, rustix::fs::Mode::empty())?;
+    rustix::io::write(&fd, value.as_bytes())?;
+    Ok(())
 }
 
 /// Info about a device in a mounted bcachefs filesystem, read from sysfs.


### PR DESCRIPTION
Part of #806 — the first of its two failure modes.

`bcachefs set-fs-option --encoded_extent_max=256k <mounted fs>` exits 0, prints nothing and changes nothing. The same command unmounted works.

While writing this I found the diagnosis in #806 is wrong, so here is the measured version. The issue says the option "is not `OPT_RUNTIME`, so there is no sysfs file to write". There is a file — the kernel creates one for every option and only varies the mode (`fs/opts.c`):

```c
	.attr.mode = (_flags) & OPT_RUNTIME ? 0644 : 0444,
```

Measured on a mounted filesystem, as root:

```
encoded_extent_max   mode=0444  open(O_WRONLY)=EACCES
foreground_target    mode=0644  open(O_WRONLY)=ok  write=ok
```

kernfs refuses the write-open on the 0444 attribute even for root, so the failure arrives at `if let Ok(fd)` in `sysfs_write_str()`, which discards it — as `let _ =` discards the write error — and `set_option_online()` returns `Ok(())` regardless.

The fix gates the online path on `OPT_RUNTIME`, which is the same predicate the kernel uses to pick the mode. The existing test asks "is this a filesystem option?" where this path needs "is this settable at runtime?". Since many of these options *can* be set with the filesystem unmounted, it says so rather than only refusing:

```
$ bcachefs set-fs-option --encoded_extent_max=256k /dev/sdd1     # before
$                                                                 # (nothing)
$ bcachefs set-fs-option --encoded_extent_max=256k /dev/sdd1     # after
encoded_extent_max cannot be set while the filesystem is mounted (unmount and set it offline)
```

and `sysfs_write_str()` now returns a `Result` so a failed write cannot pass for success again. All three call sites report it.

A second commit makes the exit status follow, because reporting the failure on stderr while still exiting 0 leaves a script no better off — and the exit status is the part a caller can act on:

```
$ bcachefs set-fs-option --encoded_extent_max=256k /dev/sdd1
encoded_extent_max cannot be set while the filesystem is mounted (unmount and set it offline)
Error: 1 of 1 option(s) could not be set
$ echo $?
1
```

It counts every option that was not applied — unknown, not settable by this path, refused by a pre-set hook, or a failed sysfs write — on both the online and offline paths, since offline behaved the same way for unknown and unparseable options. Setting a runtime option still exits 0, verified against the live filesystem with `--foreground_target` set to its current value.

That is a behavioural change to a command people script around, so it is a separate commit and can be dropped on its own if you would rather keep exit 0.

What I did not change:

#806's second failure mode — an offline multi-device filesystem gets only the named device's superblock written — is untouched. That one is a design question (write all discovered members, or refuse unless all are named) rather than a bug with an obvious fix, so it seemed better to ask than to guess.

Verified against the live mounted filesystem: the value reads 64.0k before and after both binaries, so neither changes anything; only the reporting differs.
