### PR TITLE
fusemount: shut the filesystem down when the mount fails

### DIFF
--- a/src/commands/fusemount.rs
+++ b/src/commands/fusemount.rs
@@ -15,6 +15,8 @@
 //   requests get read-modify-write treatment in the write handler.
 
 use std::cell::Cell;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{Read, Write};
@@ -361,6 +363,16 @@ struct BcachefsFs {
     /// Write end of a pipe used to signal the parent process that the
     /// FUSE mount is established. Written in init(), None in foreground mode.
     signal_fd: Option<OwnedFd>,
+    /// Set by destroy() once bch2_fs_exit() has run.
+    ///
+    /// fuser::mount2() is Session::new().and_then(|se| se.run()), and the two
+    /// halves differ: Session::new() mounts before wrapping us in a
+    /// FilesystemHolder, whose Drop calls destroy(). So a mount failure never
+    /// shuts the filesystem down and the caller must, while a failure after
+    /// the session is established already has. mount2 returns one io::Result
+    /// for both, so the caller cannot tell them apart -- it asks this instead
+    /// of guessing, which also keeps it correct if fuser's internals change.
+    destroyed: Arc<AtomicBool>,
 }
 
 // Safety: bch_fs is internally synchronized with its own locking.
@@ -423,6 +435,7 @@ impl Filesystem for BcachefsFs {
     fn destroy(&mut self) {
         eprintln!("bcachefs fuse: destroy");
         unsafe { c::bch2_fs_exit(self.c) };
+        self.destroyed.store(true, Ordering::SeqCst);
     }
 
     fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
@@ -1054,7 +1067,7 @@ pub fn cmd_fusemount(cli: Cli) -> anyhow::Result<()> {
             unsafe { c::bch2_fs_exit(fs_raw) };
             anyhow::bail!("Error starting filesystem: {}", e);
         }
-        let bcachefs_fs = BcachefsFs { c: fs_raw, signal_fd: None };
+        let bcachefs_fs = BcachefsFs { c: fs_raw, signal_fd: None, destroyed: Arc::new(AtomicBool::new(false)) };
         fuser::mount2(bcachefs_fs, &cli.mountpoint, &config)?;
         return Ok(());
     }
@@ -1112,7 +1125,12 @@ pub fn cmd_fusemount(cli: Cli) -> anyhow::Result<()> {
     }
     eprintln!("fusemount: filesystem started, calling fuser::mount2");
 
-    let bcachefs_fs = BcachefsFs { c: fs_raw, signal_fd: Some(write_fd.try_clone()?) };
+    let destroyed = Arc::new(AtomicBool::new(false));
+    let bcachefs_fs = BcachefsFs {
+        c: fs_raw,
+        signal_fd: Some(write_fd.try_clone()?),
+        destroyed: Arc::clone(&destroyed),
+    };
 
     match fuser::mount2(bcachefs_fs, &cli.mountpoint, &config) {
         Ok(()) => {
@@ -1120,6 +1138,15 @@ pub fn cmd_fusemount(cli: Cli) -> anyhow::Result<()> {
         }
         Err(e) => {
             eprintln!("fusemount: fuser::mount2 failed: {}", e);
+            // If the mount itself failed we were never handed to a
+            // FilesystemHolder, so destroy() has not run and nothing has shut
+            // the filesystem down -- leaving the superblock dirty after
+            // recovery and any version upgrade have already been committed.
+            // If the session did start, destroy() has run and calling
+            // bch2_fs_exit() again would be a double free.
+            if !destroyed.load(Ordering::SeqCst) {
+                unsafe { c::bch2_fs_exit(fs_raw) };
+            }
             signal_parent(write_fd, 1);
             std::process::exit(1);
         }

--- a/src/commands/fusemount.rs
+++ b/src/commands/fusemount.rs
@@ -1067,8 +1067,18 @@ pub fn cmd_fusemount(cli: Cli) -> anyhow::Result<()> {
             unsafe { c::bch2_fs_exit(fs_raw) };
             anyhow::bail!("Error starting filesystem: {}", e);
         }
-        let bcachefs_fs = BcachefsFs { c: fs_raw, signal_fd: None, destroyed: Arc::new(AtomicBool::new(false)) };
-        fuser::mount2(bcachefs_fs, &cli.mountpoint, &config)?;
+        let destroyed = Arc::new(AtomicBool::new(false));
+        let bcachefs_fs = BcachefsFs {
+            c: fs_raw,
+            signal_fd: None,
+            destroyed: Arc::clone(&destroyed),
+        };
+        if let Err(e) = fuser::mount2(bcachefs_fs, &cli.mountpoint, &config) {
+            if !destroyed.load(Ordering::SeqCst) {
+                unsafe { c::bch2_fs_exit(fs_raw) };
+            }
+            anyhow::bail!("Error mounting filesystem: {}", e);
+        }
         return Ok(());
     }
 

--- a/src/commands/fusemount.rs
+++ b/src/commands/fusemount.rs
@@ -1136,9 +1136,21 @@ pub fn cmd_fusemount(cli: Cli) -> anyhow::Result<()> {
     eprintln!("fusemount: filesystem started, calling fuser::mount2");
 
     let destroyed = Arc::new(AtomicBool::new(false));
+    // Not `?`: the filesystem is started by now, and returning here without
+    // shutting it down leaves the same dirty superblock this commit exists to
+    // prevent -- just reached through fd exhaustion rather than a failed mount.
+    let signal_fd = match write_fd.try_clone() {
+        Ok(fd) => fd,
+        Err(e) => {
+            eprintln!("fusemount: couldn't duplicate the signal fd: {e}");
+            unsafe { c::bch2_fs_exit(fs_raw) };
+            signal_parent(write_fd, 1);
+            std::process::exit(1);
+        }
+    };
     let bcachefs_fs = BcachefsFs {
         c: fs_raw,
-        signal_fd: Some(write_fd.try_clone()?),
+        signal_fd: Some(signal_fd),
         destroyed: Arc::clone(&destroyed),
     };
 


### PR DESCRIPTION
Part of #808 — the on-disk-state half.

A failed `fusemount` leaves the superblock dirty. By the time the mount is attempted the filesystem has been opened, recovered and, where applicable, version-upgraded, and none of that is unwound. Reproduced with a mountpoint that does not exist:

```
$ bcachefs fusemount img.bcachefs /does/not/exist
Error: FUSE mount failed in child process
$ bcachefs show-super img.bcachefs | grep Clean
Clean:                                     0
```

I originally suggested in #808 that the fix was to call `bch2_fs_exit()` on that arm. That is wrong, and I have corrected the issue: it is a double free on one of the two paths.

`fuser::mount2()` is

```rust
    Session::new(filesystem, mountpoint.as_ref(), options).and_then(|se| se.run())
```

and `Session::new()` mounts at `session.rs:170`, only wrapping the filesystem in a `FilesystemHolder` at `:174`. That holder's `Drop` calls `Filesystem::destroy()`, which for us is `bch2_fs_exit()`. So a failure from `Session::new()` has freed nothing and the caller must clean up; a failure from `run()` has already freed and a second call is a double free. `mount2` returns one `io::Result` for both.

The nasty part is that the reproduction above only exercises the first path, so the naive fix passes its own test and corrupts the other case.

`Session::run()` is `pub(crate)`, so splitting the call is not available from outside the crate. Instead `destroy()` records that it ran and the failure arm consults that — which answers the question directly rather than by inference about fuser's internals, and stays correct if those change.

Measured, same command both ways:

```
old:  Clean: 0
new:  Clean: 1
```

The other parts of #808 are untouched here: the `pthread_atfork` crash and its socket leak are one architectural fix and want their own discussion, and the misleading "FUSE mount failed in child process" message is independent again. Happy to do either next.
