### PR TITLE
fusemount: don't start the http server from a pthread_atfork handler

### DIFF
--- a/src/bcachefs.rs
+++ b/src/bcachefs.rs
@@ -8,7 +8,7 @@ mod logging;
 mod qcow2;
 mod util;
 mod wrappers;
-mod http;
+pub mod http;
 #[cfg(test)]
 mod eytzinger_test;
 

--- a/src/commands/fusemount.rs
+++ b/src/commands/fusemount.rs
@@ -1095,6 +1095,13 @@ pub fn cmd_fusemount(cli: Cli) -> anyhow::Result<()> {
     drop(read_fd);
     rustix::process::setsid()?;
 
+    // The daemon needs its own http server: only the calling thread survives
+    // fork(), so the parent's is gone. This is the call that used to happen
+    // from a pthread_atfork child handler -- which also fired in the child of
+    // every other fork, including the one that execs fusermount3, where
+    // binding a socket and spawning threads is not allowed.
+    crate::http::bch2_start_http_lazy();
+
     // Daemon mode must not inherit the caller's stderr or grow a fixed log
     // file under /tmp; foreground mode still leaves debug output visible.
     if let Ok(f) = std::fs::File::create("/dev/null") {

--- a/src/http.rs
+++ b/src/http.rs
@@ -81,18 +81,7 @@ extern "C" fn cleanup_socket() {
 
 static STARTED_FOR_PID: AtomicU32 = AtomicU32::new(0);
 static ATEXIT_REGISTERED: AtomicBool = AtomicBool::new(false);
-static ATFORK_REGISTERED: AtomicBool = AtomicBool::new(false);
 static INIT_LOCK: Mutex<()> = Mutex::new(());
-
-/*
- * pthread_atfork child handler: bind a fresh socket in the new child
- * process. The parent's http thread doesn't survive fork (only the
- * calling thread does), so the child needs its own server bound at
- * /run/.../<child-pid>.sock.
- */
-extern "C" fn child_after_fork() {
-    bch2_start_http_lazy();
-}
 
 /*
  * Bind a unix socket and spawn a thread serving sysfs/debugfs over HTTP.
@@ -106,9 +95,17 @@ extern "C" fn child_after_fork() {
  * Fork handling: process-local Once doesn't work — a child of a process
  * that already started the server would skip startup and have no http
  * thread (the parent's thread doesn't survive fork). We track the pid
- * the server started for, and a pthread_atfork child handler re-runs
- * init in any forked child. Each child binds its own socket at
- * /run/.../<child-pid>.sock.
+ * the server started for, so a forked child that wants a server calls
+ * this again and binds its own at /run/.../<child-pid>.sock.
+ *
+ * That call must be explicit. It used to happen from a pthread_atfork
+ * child handler, which is process-wide: it fired in the child of *any*
+ * fork, including the short-lived one Command::spawn makes to exec
+ * fusermount3. Allocating, binding a socket and creating threads between
+ * fork() and execve() is not allowed, and when pthread_create there
+ * returned EAGAIN the crate-wide panic = "abort" made it fatal, so the
+ * mount failed. It also leaked a socket per exec'ing child, since those
+ * never reach the atexit handler.
  *
  * Cleanup is via an atexit handler that unlinks the current pid's
  * socket on normal exit. Sockets from killed-by-signal / panicked
@@ -135,15 +132,10 @@ pub extern "C" fn bch2_start_http_lazy() {
 
     match tiny_http::Server::http_unix(std::path::Path::new(&path)) {
         Ok(server) => {
-            // atexit / pthread_atfork registrations are inherited across
-            // fork; only register once per process to avoid duplicates.
+            // atexit registrations are inherited across fork; only register
+            // once per process to avoid duplicates.
             if !ATEXIT_REGISTERED.swap(true, Ordering::AcqRel) {
                 unsafe { libc::atexit(cleanup_socket); }
-            }
-            if !ATFORK_REGISTERED.swap(true, Ordering::AcqRel) {
-                unsafe {
-                    libc::pthread_atfork(None, None, Some(child_after_fork));
-                }
             }
             STARTED_FOR_PID.store(my_pid, Ordering::Release);
             std::thread::spawn(move || http_thread(server));


### PR DESCRIPTION
Fixes the intermittent abort in #808, and the socket leak with it — they are one bug.

`bch2_start_http_lazy()` registers a `pthread_atfork` child handler so the daemonising fork in `fusemount` gets its own server, since the parent's http thread does not survive `fork()`. But `pthread_atfork` is process-wide: the handler runs in the child of *any* fork, including the short-lived one `Command::spawn` makes to exec `fusermount3`. `fuser` sets a `pre_exec` closure to clear `FD_CLOEXEC`, which forces that spawn down `fork()`+`execve()` rather than `posix_spawn`, so on every `fusemount` the handler runs between `fork()` and `execve()` — creating a directory, binding a unix socket and spawning threads, none of which is allowed there. When `pthread_create` returns `EAGAIN`, `panic = "abort"` makes it fatal to the child, `fusermount3` is never exec'd, and the mount fails.

The leak has the same origin: the fork child binds `/run/user/<uid>/bcachefs/<pid>.sock` and then execs, so its `atexit` unlink never runs.

The fix starts the server explicitly in the daemonising child. `Fs::open()` runs before the fork, so the debugfs shim has already started the server in the parent and will not fire again in the child; `STARTED_FOR_PID` is keyed on pid, so the child's own call binds its own socket. Every other fork in the tree execs immediately and never needed a server.

## Measured

The abort is probabilistic, so a few clean mounts prove nothing. Randomised blocks — one patched and one unpatched mount per block, order drawn per block, fresh image each run:

```
unpatched:  5 aborts / 40 runs
patched:    0 aborts / 40 runs
```

5 discordant blocks, all one way; exact one-sided sign test p = 0.0312, which is the floor for 5 discordant blocks. The rate here (12.5%) is higher than the 3-in-52 I originally reported, consistent with the note in the issue that IO load raises it — this machine was busy throughout.

Socket count across a mount/unmount cycle:

```
unpatched:  before 11, mounted 13, after 12   -> leaked 1
patched:    before 12, mounted 13, after 12   -> leaked 0
```

The `mounted` counts show the mechanism directly: unpatched gains two sockets (daemon plus the doomed `fusermount3` fork child), patched gains one.

## Not in this patch

The misleading `"FUSE mount failed in child process"` message, which reports the wrong subsystem for any child failure and discards the real diagnostic. That is independent of the atfork logic — it is demonstrated in the issue with a damaged image, without the crash — and is better as its own change. PR #824 handles the third piece, the filesystem being left dirty when the mount fails.
