### PR TITLE
bcachefs: remove unused bch_dev.flush_seq

### DIFF
--- a/fs/bcachefs.h
+++ b/fs/bcachefs.h
@@ -539,7 +539,6 @@ struct bch_dev {
 	struct bch_sb		*sb_read_scratch;
 	int			sb_write_error;
 	dev_t			dev;
-	atomic_t		flush_seq;
 
 	struct bch_devs_mask	self;
 


### PR DESCRIPTION
`bch_dev.flush_seq` was added in 3c7280f72956 ("bcachefs: Nocow support") and has never been read or written. No member access anywhere in the tree — in C, or in the Rust bindings beyond bindgen's generated offset assertion.

Worth removing rather than leaving in place, for a reason beyond tidiness: a field called `flush_seq` on `bch_dev` reads as per-device flush sequencing, which is exactly the bookkeeping anyone reaching for "only flush the members this commit actually depends on" would go looking for. I spent a while treating it as a foundation to build on before checking whether anything used it.

If it is a placeholder you still intend to use, say so and I will withdraw this — but then it might be worth a comment saying as much.
