### PR TITLE
journal: size the stuck-warning timeout over every device it waits on

### DIFF
--- a/fs/journal/journal.c
+++ b/fs/journal/journal.c
@@ -952,7 +952,14 @@ int bch2_journal_res_get_slowpath(struct journal *j, struct journal_res *res,
 		return __journal_res_get(j, res, flags);
 
 	struct bch_fs *c = container_of(j, struct bch_fs, journal);
-	long total_wait = max(bch2_dev_latency_max(c, &c->allocator.rw_devs[BCH_DATA_journal], WRITE) * 2, HZ * 10);
+	/*
+	 * Over every online device, not just the journal's: a flushing commit
+	 * preflushes every rw member (journal_write_preflush()), so a member
+	 * that carries no journal at all still paces the wait. Sizing this from
+	 * the journal devices alone reports "stuck" routinely on an array whose
+	 * slowest member is not a journal member.
+	 */
+	long total_wait = max(bch2_dev_latency_max(c, &c->devs_online, WRITE) * 2, HZ * 10);
 	int ret;
 
 	if (trans_wait_event_timeout(trans, &j->async_wait,
@@ -1199,8 +1206,12 @@ int bch2_journal_flush_seq(struct journal *j, u64 seq, unsigned task_state)
 	 * Don't report stuck until we've waited longer than an IO could
 	 * legitimately take: twice the longest write latency we've seen, or 10s,
 	 * whichever is greater (matches bch2_journal_res_get_slowpath()).
+	 *
+	 * Over every online device: a flushing commit waits on a preflush to
+	 * every rw member, so the slowest member bounds this even when it holds
+	 * no journal.
 	 */
-	long total_wait = max(bch2_dev_latency_max(c, &c->allocator.rw_devs[BCH_DATA_journal], WRITE) * 2, HZ * 10);
+	long total_wait = max(bch2_dev_latency_max(c, &c->devs_online, WRITE) * 2, HZ * 10);
 
 	if (closure_sync_timeout(&cl, total_wait)) {
 		CLASS(printbuf, buf)();


### PR DESCRIPTION
Both journal "stuck?" timeouts are sized over the wrong set of devices.

`bch2_journal_res_get_slowpath()` and `bch2_journal_flush_seq()` compute

```c
long total_wait = max(bch2_dev_latency_max(c, &c->allocator.rw_devs[BCH_DATA_journal], WRITE) * 2, HZ * 10);
```

— twice the longest write latency over the devices that *carry journal*. But a flushing commit does not only wait on those. `journal_write_preflush()` issues a `REQ_PREFLUSH` to every rw member and waits on all of them, so a member holding no journal at all bounds how long the commit takes.

The second site's own comment says the intent plainly — "don't report stuck until we've waited longer than an IO could legitimately take" — and that is exactly what the current device set fails to capture.

On a mixed array the gap is large. Measured on a five-device filesystem whose journal lives on three SSDs while both HDDs carry `has_data=[user]` only:

```
nvme0n1  (journal)     0.3 – 1.1 ms per flush
sdd      (no journal)  356 – 1263 ms per flush
```

`sdd` is a drive-managed SMR disk — under write load its flush costs about a second, while the journal devices answer in well under one. So the threshold is computed from the fast devices and the wait is paced by the slow one. `time_stats` on that machine, since mount:

```
journal_flush_write   426085 events   max 12 s
journal_flush_seq     215378 events   max  3 m
```

against a 10 s threshold. "Journal stuck?" is reported for a journal that is not stuck; it is waiting on an unrelated disk.

The fix uses `c->devs_online`, which is what the wait actually depends on, and matches what `bch2_btree_transaction_timeout()` already does for the same kind of calculation (`btree/locking.c`). It is a superset of the rw members that get preflushed, so the threshold can only grow — the safe direction for a warning.

Nothing here gets faster. It stops a legitimate slow flush being reported as a stuck journal, which is a diagnosis problem: I spent a while treating those messages as evidence of a journal fault before finding they were pointing at a disk the journal does not live on. The underlying latency is #813.

Complements #814, which fixes the same message to print the real wait rather than a hardcoded "10 seconds" — the two touch adjacent lines in `bch2_journal_res_get_slowpath()` and may need a trivial rebase depending on order.
