### PR TITLE
bcachefs: remove per-device lrus by range

### DIFF
--- a/fs/alloc/lru.c
+++ b/fs/alloc/lru.c
@@ -118,12 +118,11 @@ static struct bbpos lru_pos_to_bp(struct bkey_s_c lru_k)
 	}
 }
 
-int bch2_dev_remove_lrus(struct bch_fs *c, struct bch_dev *ca)
+static int bch2_dev_remove_lrus_scan(struct bch_fs *c, struct bch_dev *ca)
 {
 	CLASS(btree_trans, trans)(c);
-	int ret = bch2_btree_write_buffer_flush_sync(trans) ?:
-		for_each_btree_key(trans, iter,
-				 BTREE_ID_lru, POS_MIN, BTREE_ITER_prefetch, k, ({
+	return for_each_btree_key(trans, iter,
+				  BTREE_ID_lru, POS_MIN, BTREE_ITER_prefetch, k, ({
 		struct bbpos bp = lru_pos_to_bp(k);
 
 		bp.btree == BTREE_ID_alloc && bp.pos.inode == ca->dev_idx
@@ -131,6 +130,42 @@ int bch2_dev_remove_lrus(struct bch_fs *c, struct bch_dev *ca)
 		   bch2_trans_commit(trans, NULL, NULL, 0))
 		: 0;
 	}));
+}
+
+static int bch2_dev_remove_lru_range(struct bch_fs *c, u16 lru_id)
+{
+	return bch2_btree_delete_range(c, BTREE_ID_lru,
+				       lru_start(lru_id),
+				       lru_start(lru_id + 1), 0);
+}
+
+int bch2_dev_remove_lrus(struct bch_fs *c, struct bch_dev *ca)
+{
+	int ret;
+
+	{
+		CLASS(btree_trans, trans)(c);
+		ret = bch2_btree_write_buffer_flush_sync(trans);
+	}
+	if (ret)
+		goto err;
+
+	if (ca->dev_idx < BCH_LRU_READ_MAX) {
+		ret = bch2_dev_remove_lru_range(c, ca->dev_idx) ?:
+		      bch2_dev_remove_lru_range(c, bucket_fragmentation_lru(ca->dev_idx));
+	} else {
+		ret = bch2_dev_remove_lrus_scan(c, ca);
+	}
+	if (ret)
+		goto err;
+
+	/*
+	 * Old fs-wide fragmentation LRU entries are not grouped by device; only
+	 * pre-upgrade filesystems need the slower full scan to clean them out.
+	 */
+	if (c->sb.version_upgrade_complete < bcachefs_metadata_version_per_dev_fragmentation_lru)
+		ret = bch2_dev_remove_lrus_scan(c, ca);
+err:
 	bch_err_fn(c, ret);
 	return ret;
 }


### PR DESCRIPTION
## Summary

Device removal currently clears LRU entries by walking the whole LRU btree and decoding every key back to an alloc bucket to find entries for the device being removed.

Current read and bucket-fragmentation LRUs are already grouped by per-device LRU id:

- read LRU id: device index
- bucket-fragmentation LRU id: `BCH_LRU_BUCKET_FRAGMENTATION_START + device index`

This patch deletes those two LRU key ranges directly for current filesystems, and keeps the existing full scan as a fallback for pre-`per_dev_fragmentation_lru` filesystems where the old fs-wide fragmentation LRU is not grouped by device.

## Context

I hit a long late-device-remove stall after the device data-drop phase had already made progress. The sampled late stack was in:

```text
bch2_dev_remove_lrus
bch2_btree_iter_peek_max
bch2_btree_path_traverse_one
__bch2_btree_node_get
bch2_btree_node_wait_on_read
bch2_bit_wait_io_timeout
```

The command eventually completed, so this is not a report of a permanent hang. The useful bit is that `bch2_dev_remove_lrus()` was still doing unrelated full-LRU btree reads late in device removal.

`koverstreet/bcachefs-tools#815` improves the neighboring fsck `check_lrus` path by pinning backing keyspaces while scanning an LRU id. This patch is separate: device remove does not need to scan the other LRU ids at all on current filesystems.

## Validation

- `git diff --check`
- `make -j8 build/fs/alloc/lru.o`
- `BINDGEN=$HOME/.cargo/bin/bindgen make -j16`
