### PR TITLE
scrub: cancel per-device jobs in parallel on interrupt

### DIFF
--- a/src/commands/scrub.rs
+++ b/src/commands/scrub.rs
@@ -257,6 +257,16 @@ fn scrub(cli: Cli) -> Result<()> {
             writeln!(io::stdout())?;
             eprintln!("Interrupted");
             exit_code |= 1;
+
+            // Parallelize kthread_stop() so we don't block on each thread serially
+            let stops: Vec<_> = scrub_devs
+                .iter_mut()
+                .filter_map(|dev| dev.progress_fd.take())
+                .map(|fd| thread::spawn(move || drop(fd)))
+                .collect();
+            for t in stops {
+                let _ = t.join();
+            }
             break;
         }
 


### PR DESCRIPTION
Cancelling a scrub used to stop each kthread in series, and if stopping a kthread was slow, this would result in O(n) time based on the number of threads, exacerbated if thread stopping was slow because of load caused by the other threads. This spawns a set of threads to stop all the kthreads in parallel.