### PR TITLE
bcachefs: run scrub at idle IO priority

### DIFF
--- a/fs/btree/read.c
+++ b/fs/btree/read.c
@@ -32,6 +32,7 @@
 
 #include "util/enumerated_ref.h"
 
+#include <linux/ioprio.h>
 #include <linux/moduleparam.h>
 #include <linux/sched/mm.h>
 
@@ -946,6 +947,7 @@ static void btree_node_read_work(struct work_struct *work)
 		rb->ca			= ca;
 		rb->start_time		= local_clock();
 		bio_reset(bio, NULL, REQ_OP_READ|REQ_SYNC|REQ_META);
+		bio->bi_ioprio		= get_current_ioprio();
 		bio->bi_iter.bi_sector	= rb->pick.ptr.offset;
 		bio->bi_iter.bi_size	= btree_buf_bytes(b);
 
@@ -1088,6 +1090,7 @@ void bch2_btree_node_read(struct btree_trans *trans, struct btree *b,
 	rb->start_time		= local_clock();
 	rb->pick		= pick;
 	INIT_WORK(&rb->work, btree_node_read_work);
+	bio->bi_ioprio		= get_current_ioprio();
 	bio->bi_iter.bi_sector	= pick.ptr.offset;
 	bio->bi_end_io		= btree_node_read_endio;
 	bch2_bio_map(bio, b->data, btree_buf_bytes(b));
@@ -1328,6 +1331,7 @@ int bch2_btree_node_scrub(struct btree_trans *trans,
 
 	bio_init(&scrub->bio, ca->disk_sb.bdev, scrub->inline_vecs, vecs, REQ_OP_READ);
 	bch2_bio_map(&scrub->bio, scrub->buf, c->opts.btree_node_size);
+	scrub->bio.bi_ioprio		= get_current_ioprio();
 	scrub->bio.bi_iter.bi_sector	= pick.ptr.offset;
 	scrub->bio.bi_end_io		= btree_node_scrub_endio;
 	submit_bio(&scrub->bio);

--- a/fs/init/chardev.c
+++ b/fs/init/chardev.c
@@ -31,6 +31,7 @@
 #include <linux/device.h>
 #include <linux/fs.h>
 #include <linux/ioctl.h>
+#include <linux/ioprio.h>
 #include <linux/major.h>
 #include <linux/sched/task.h>
 #include <linux/slab.h>
@@ -331,6 +332,16 @@ struct bch_data_ctx {
 static int bch2_data_thread(void *arg)
 {
 	struct bch_data_ctx *ctx = container_of(arg, struct bch_data_ctx, thr);
+
+	/*
+	 * Run scrub in background so that backpointer resolves yield to
+	 * foreground IO.
+	 *
+	 * this thread is created fresh for each job and exits with it; if we
+	 * ever reuse threads we'll need to reset the ioprio
+	 */
+	if (ctx->arg.op == BCH_DATA_OP_scrub)
+		set_task_ioprio(current, IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 0));
 
 	ctx->thr.ret = bch2_data_job(ctx->c, &ctx->stats, &ctx->arg);
 	if (ctx->thr.ret == -BCH_ERR_device_offline)

--- a/include/linux/ioprio.h
+++ b/include/linux/ioprio.h
@@ -43,4 +43,16 @@ enum {
  */
 #define IOPRIO_NORM	(4)
 
+static inline int get_current_ioprio(void)
+{
+	return IOPRIO_PRIO_VALUE(IOPRIO_CLASS_NONE, 0);
+}
+
+struct task_struct;
+
+static inline int set_task_ioprio(struct task_struct *task, int ioprio)
+{
+	return 0;
+}
+
 #endif


### PR DESCRIPTION
Scrub data reads were already issued at IOPRIO_CLASS_IDLE, but backpointers resolving against the extents btree went out at default priority, competing head-on with foreground reads for spindle time.

Set the thread to idle IO priority and pass the current thread priority along with btree node read bios so the priority actually reaches the block layer.

One known imprecision: a btree node fill is shared - an idle-priority fill populates the cache for any waiter, so a foreground reader arriving right behind scrub can wait on an idle-priority read. Rare enough in practice not to matter.