### PR TITLE
bcachefs: reject unrepresentable durability values

### DIFF
--- a/doc/bcachefs.5.rst.tmpl
+++ b/doc/bcachefs.5.rst.tmpl
@@ -123,6 +123,21 @@ with ``bcachefs set-fs-option`` by passing the member device path:
 
   bcachefs set-fs-option --durability=0 /dev/nvme1n1
 
+Durability is stored as a small on-disk member field, not as a fractional or
+fixed-point value. The field has four encodings: unset means the default
+``durability=1``, and the explicit values are ``0``, ``1``, and ``2``. To model
+devices that should count as "half" a normal durable copy, scale the relevant
+replica counts and device durability values by the same factor. For example,
+leave less trusted devices at ``durability=1``, set fully trusted devices to
+``durability=2``, and change ``data_replicas=1`` to ``data_replicas=2``. If the
+filesystem also uses ``metadata_replicas=2``, scale that to
+``metadata_replicas=4`` as well so the metadata policy keeps requiring the same
+number of fully trusted copies.
+
+This is not an arbitrary fixed-point interface, so large scale factors such as
+``4096`` are not accepted. Use ``durability=0`` only for cache-like devices whose
+copies must not count toward the replica requirement at all.
+
 Multipath devices
 -----------------
 When using device-mapper multipath, use the multipath device (e.g.

--- a/fs/opts.h
+++ b/fs/opts.h
@@ -589,7 +589,7 @@ enum fsck_err_opts {
 	  "size",	"Specifies the bucket size; must be greater than the btree node size")\
 	x(durability,			u8,				\
 	  OPT_DEVICE|OPT_RUNTIME|OPT_SB_FIELD_ONE_BIAS,			\
-	  OPT_UINT(0, BCH_REPLICAS_MAX),				\
+	  OPT_UINT(0, BCH_MEMBER_DURABILITY_MAX - 1),			\
 	  BCH_MEMBER_DURABILITY,	1,				\
 	  "n",		"Data written to this device will be considered\n"\
 			"to have already been replicated n times")	\


### PR DESCRIPTION
## Summary

- reject device `durability` values that cannot be represented in the current member-field encoding
- document the current durability encoding: unset means default `1`, and explicit values are `0`, `1`, and `2`
- document the integer scaling workaround for half-trust devices and note that large fixed-point scale factors such as `4096` are outside the current format

## Details

`durability` is stored in `BCH_MEMBER_DURABILITY`, a two-bit member field using the existing one-bias/default encoding. The four encodings are already assigned: unset/default `1`, explicit `0`, explicit `1`, and explicit `2`. The previous `BCH_REPLICAS_MAX` limit allowed higher values that were then truncated by the bitfield setter and did not round-trip correctly.

## Validation

- `git diff --check`
- `make fs/opts.o`
- parsed `doc/bcachefs.5.rst.tmpl` with `docutils.core.publish_doctree`
- runtime sanity on a mounted filesystem: `durability=2` round-tripped successfully, while larger values such as `64` and `4096` were rejected with `ERANGE`
