### PR TITLE
move: abort data jobs when the filesystem goes read-only

### DIFF
--- a/fs/data/move.c
+++ b/fs/data/move.c
@@ -476,6 +476,9 @@ int bch2_move_ratelimit(struct moving_context *ctxt)
 
 		try(bch2_kthread_cancelled(c));
 
+		if (unlikely(test_bit(BCH_FS_going_ro, &c->flags)))
+			return bch_err_throw(c, erofs_no_writes);
+
 		if (delay)
 			move_ctxt_wait_event_timeout(ctxt,
 					freezing(current) ||


### PR DESCRIPTION
Every data job holds a c->writes ref for the lifetime of its thread, so going read-only blocks on the job finishing on its own. bch2_move_ratelimit() now errors out when BCH_FS_going_ro is set.

Test available in https://github.com/koverstreet/ktest/pull/112.