### PR TITLE
docs: explain journal relocation during device shrink

### DIFF
--- a/doc/bcachefs.5.rst.tmpl
+++ b/doc/bcachefs.5.rst.tmpl
@@ -81,7 +81,10 @@ new size. This includes journal buckets and superblock copies, so a journal
 that was allocated on a device being shrunk is moved to the remaining journal
 devices as part of the operation. ``device resize-journal`` only grows the
 journal; it is not a substitute for device shrink and cannot be used to discard
-journal space from a member.
+journal space from a member. Shrinking a device only relocates journal buckets
+that fall in the truncated tail; it does not make an otherwise unchanged
+device journal-free. Per-device journal removal requires separate kernel
+support.
 
 Shrinking is irreversible for the discarded tail. Check ``bcachefs fs usage``
 and keep a current backup before starting. The command waits for evacuation to

--- a/doc/bcachefs.5.rst.tmpl
+++ b/doc/bcachefs.5.rst.tmpl
@@ -72,6 +72,22 @@ not be the same size - the allocator will stripe across multiple disks,
 preferring to allocate from disks with more free space so that disks all fill up
 at the same time.
 
+To shrink an online member, pass the new device size to ``device resize``::
+
+  bcachefs device resize /dev/sdb 900G
+
+The kernel evacuates allocations in the truncated tail before committing the
+new size. This includes journal buckets and superblock copies, so a journal
+that was allocated on a device being shrunk is moved to the remaining journal
+devices as part of the operation. ``device resize-journal`` only grows the
+journal; it is not a substitute for device shrink and cannot be used to discard
+journal space from a member.
+
+Shrinking is irreversible for the discarded tail. Check ``bcachefs fs usage``
+and keep a current backup before starting. The command waits for evacuation to
+finish, but after an interrupted operation remount the filesystem and verify
+it with ``bcachefs fsck -ny`` before retrying or removing the device.
+
 We generally avoid per-device options, preferring instead options that can be
 overridden on files or directories, but there are some:
 


### PR DESCRIPTION
### What
Document the supported workflow for shrinking an online member and explain that the shrink path evacuates journal buckets from the truncated tail.

### Why
`device resize-journal` currently grows journal allocation; users who need to remove journal placement from a slow member must shrink the device through `device resize`, with the kernel shrink implementation. The warning and fsck guidance make this distinction explicit.

### Validation
- `git diff --check`
- Isolated ktest `online_shrink_journal_tail` passed against the shrink implementation: live 4G to 3G resize, remount, offline fsck, remount, and final fsck.

This documentation PR is intentionally separate from the kernel shrink implementation in #796.