### PR TITLE
docs: add migration planning notes

### DIFF
--- a/doc/bcachefs-principles-of-operation.tex
+++ b/doc/bcachefs-principles-of-operation.tex
@@ -809,6 +809,36 @@ writes a standard superblock so the filesystem can be mounted normally.
 Migration from btrfs is not currently supported because its FIEMAP
 implementation does not report which device an extent resides on.
 
+For planning a staged migration, separate three cases:
+
+\begin{itemize}
+\item \textbf{Converting an existing filesystem in place.}
+  Use \texttt{bcachefs migrate} when the source filesystem and block-device
+  stack are supported. This avoids building a second full-size pool. Verify the
+  new filesystem before deleting \texttt{/old\_migrated\_filesystem} and
+  completing \texttt{migrate-superblock}; that file holds the space still
+  referenced by the old filesystem.
+\item \textbf{Juggling disks into a new pool.}
+  If an in-place conversion is not possible, create the new bcachefs filesystem
+  on the devices you can free first, copy data over, then add more devices as
+  they become available. New writes use the current target, replication, and
+  erasure-coding options; existing data that does not match the new policy is
+  repaired by reconcile in the background.
+\item \textbf{Changing layout after data already exists.}
+  To change from replicated data to erasure coding or increase redundancy,
+  change the relevant file or directory IO options, then let reconcile rewrite
+  old extents. For example, moving from two replicated copies to RAID5-style EC
+  means enabling \texttt{erasure\_code} and using
+  \texttt{data\_replicas=2}; moving to RAID6-style EC uses
+  \texttt{data\_replicas=3}. Higher parity counts are not currently supported.
+\end{itemize}
+
+Use \texttt{bcachefs fs usage} to see which layouts still exist on disk, and
+\texttt{bcachefs reconcile status} or \texttt{bcachefs reconcile wait} to track
+the rewrite. Reconcile can only make progress when the requested policy is
+possible with the currently online devices and free space; otherwise the work
+is left pending until the device topology changes.
+
 \subsection{Images}
 
 \texttt{bcachefs image create} builds a bcachefs filesystem image from a


### PR DESCRIPTION
This is the clean replacement for closed PR #712.

The branch is rebuilt from current `master` and contains only the migration-planning documentation addition in `doc/bcachefs-principles-of-operation.tex`. The previous PR was closed because generated `ktest-out/` output and unrelated scope had contaminated the branch; those files are absent here.

Validation: `git diff --check`; one changed tracked file; no generated build/test artifacts.
