### PR TITLE
doc: add ktest reproducer reporting guidance

### DIFF
--- a/Documentation/SubmittingPatches.rst
+++ b/Documentation/SubmittingPatches.rst
@@ -8,9 +8,10 @@ Submission checklist
 
 Patches must be tested before being submitted, either with the xfstests suite
 [0]_, or the full bcachefs test suite in ktest [1]_, depending on what's being
-touched. Note that ktest wraps xfstests and will be an easier method to running
-it for most users; it includes single-command wrappers for all the mainstream
-in-kernel local filesystems.
+touched. The bcachefs ktests live in the separate ktest repository, under
+``tests/fs/bcachefs/``. Note that ktest wraps xfstests and will be an easier
+method to running it for most users; it includes single-command wrappers for
+all the mainstream in-kernel local filesystems.
 
 Patches will undergo more testing after being merged (including
 lockdep/kasan/preempt/etc. variants), these are not generally required to be

--- a/doc/bcachefs-principles-of-operation.tex
+++ b/doc/bcachefs-principles-of-operation.tex
@@ -1501,6 +1501,24 @@ Valid hash types for string hash tables are:
 \section{Debugging tools}
 \label{sec:debugging}
 
+\subsection{Making a ktest reproducer}
+\label{sec:ktest-reproducer}
+
+When reporting a bug, first collect the facts from the machine that is failing:
+
+\begin{itemize}
+	\item what command or workload triggered it;
+	\item what happened, and what should have happened instead;
+	\item kernel version and \texttt{bcachefs-tools} version;
+	\item mount options and filesystem options;
+	\item relevant \texttt{dmesg}, journal, sysfs, or debugfs output.
+\end{itemize}
+
+A small ktest reproducer is useful even without a patch: maintainers can run it,
+debug it, and keep it as a regression test after the bug is fixed. ktest lives
+in a separate test harness repository\footnote{\url{https://evilpiepirate.org/git/ktest.git/}};
+bcachefs tests are under \texttt{tests/fs/bcachefs/}.
+
 \subsection{Sysfs interface}
 
 Mounted filesystems are available in sysfs at \texttt{/sys/fs/bcachefs/<uuid>/}

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -9,15 +9,22 @@
 
 ## ktest
 
-Tests live in `~/ktest/tests/fs/bcachefs/` (e.g. `subvol.ktest`).
+ktest is a separate test harness repository:
+<https://evilpiepirate.org/git/ktest.git/>. It is also available on GitHub as
+`koverstreet/ktest`.
+
+Clone or check out ktest at `~/ktest`; bcachefs tests live in
+`~/ktest/tests/fs/bcachefs/` (e.g. `subvol.ktest`). Change to a Linux kernel
+source tree, then run:
 
 ```bash
 # Run a test
-btk run -IP ~/ktest/tests/fs/bcachefs/<file>.ktest <test_name>
+~/ktest/build-test-kernel run -IP ~/ktest/tests/fs/bcachefs/<file>.ktest <test_name>
 ```
 
 - Test functions in the file are named `test_*`; drop the `test_` prefix
-  when running (e.g. `test_foo` in the file becomes `btk run ... foo`).
+  when running (e.g. `test_foo` in the file becomes
+  `~/ktest/build-test-kernel run ... foo`).
 - Prefix a test function with `d_` to disable it.
 - Source `bcachefs-test-libs.sh` for helpers (`config-scratch-devs`,
   `bcachefs_antagonist`, etc.).


### PR DESCRIPTION
This adds documentation for building a minimal ktest reproducer when reporting a bcachefs bug. It replaces the earlier closed koverstreet/bcachefs-tools#762, which had generated `ktest-out/` output and unrelated history mixed into the branch; this version is rebuilt clean from current master and touches only `Documentation/SubmittingPatches.rst`, `doc/bcachefs-principles-of-operation.tex`, and `doc/testing.md`. It documents what to collect from the failing machine before filing (triggering command, expected vs. actual behavior, kernel and bcachefs-tools version, mount options, relevant dmesg/journal/sysfs/debugfs output) and where the bcachefs ktests live so a report can ship a runnable reproducer alongside it. The commands and paths (`build-test-kernel run -IP <file>.ktest <test_name>`, the `-I` interactive flag, `tests/fs/bcachefs/`) were checked against a live ktest checkout and a real `build-test-kernel run` invocation, not just read off old docs. `git diff --check` is clean and the diff touches exactly the three listed tracked files, no generated build or test artifacts.
