### PR TITLE
opts: wire filesystem label through fs options

### DIFF
--- a/bcachefs.8
+++ b/bcachefs.8
@@ -264,6 +264,8 @@ Print superblock layout
 .El
 .It Nm Ic set-fs-option Oo Ar options Oc Ar device
 .Bl -tag -width Ds
+.It Fl -fs_label Ns = Ns Ar label
+Set the filesystem label.
 .It Fl -errors Ns = Ns ( Cm continue | ro | panic )
 Action to take on filesystem error
 .It Fl -metadata_replicas Ns = Ns Ar number

--- a/fs/opts.c
+++ b/fs/opts.c
@@ -197,6 +197,42 @@ static __cold void bch2_opt_fix_errors_to_text(struct printbuf *out,
 	.to_text = bch2_opt_fix_errors_to_text,		\
 }
 
+static int bch2_opt_fs_label_parse(struct bch_fs *c, const char *val, u64 *res,
+				   struct printbuf *err)
+{
+	if (!val) {
+		if (err)
+			prt_str(err, "fs_label: required value");
+		return -BCH_ERR_EINVAL_opt_parse_str_required;
+	}
+
+	if (strlen(val) >= BCH_SB_LABEL_SIZE) {
+		if (err)
+			prt_printf(err, "fs_label: too long (max %u bytes)",
+				   BCH_SB_LABEL_SIZE - 1);
+		return -BCH_ERR_EINVAL_setlabel_too_long;
+	}
+
+	*res = (unsigned long) val;
+	return 0;
+}
+
+static __cold void bch2_opt_fs_label_to_text(struct printbuf *out,
+					     struct bch_fs *c,
+					     struct bch_sb *sb,
+					     u64 v)
+{
+	const char *label = sb ? (const char *) sb->label : NULL;
+
+	if (label)
+		prt_printf(out, "%.*s", BCH_SB_LABEL_SIZE, label);
+}
+
+#define bch2_opt_fs_label (struct bch_opt_fn) {		\
+	.parse = bch2_opt_fs_label_parse,		\
+	.to_text = bch2_opt_fs_label_to_text,		\
+}
+
 const char * const bch2_d_types[BCH_DT_MAX] = {
 	[DT_UNKNOWN]	= "unknown",
 	[DT_FIFO]	= "fifo",
@@ -212,16 +248,18 @@ const char * const bch2_d_types[BCH_DT_MAX] = {
 
 void bch2_opts_apply(struct bch_opts *dst, struct bch_opts src)
 {
-#define x(_name, ...)						\
-	if (opt_defined(src, _name))					\
-		opt_set(*dst, _name, src._name);
-
-	BCH_OPTS()
-#undef x
+	for (unsigned id = 0; id < bch2_opts_nr; id++)
+		if (id != Opt_fs_label &&
+		    bch2_opt_defined_by_id(&src, id))
+			bch2_opt_set_by_id(dst, id,
+					   bch2_opt_get_by_id(&src, id));
 }
 
 bool bch2_opt_defined_by_id(const struct bch_opts *opts, enum bch_opt_id id)
 {
+	if (id == Opt_fs_label)
+		return false;
+
 	switch (id) {
 #define x(_name, ...)						\
 	case Opt_##_name:						\
@@ -235,6 +273,9 @@ bool bch2_opt_defined_by_id(const struct bch_opts *opts, enum bch_opt_id id)
 
 u64 bch2_opt_get_by_id(const struct bch_opts *opts, enum bch_opt_id id)
 {
+	if (id == Opt_fs_label)
+		return 0;
+
 	switch (id) {
 #define x(_name, ...)						\
 	case Opt_##_name:						\
@@ -248,6 +289,9 @@ u64 bch2_opt_get_by_id(const struct bch_opts *opts, enum bch_opt_id id)
 
 void bch2_opt_set_by_id(struct bch_opts *opts, enum bch_opt_id id, u64 v)
 {
+	if (id == Opt_fs_label)
+		return;
+
 	switch (id) {
 #define x(_name, ...)						\
 	case Opt_##_name:						\
@@ -274,6 +318,20 @@ __maybe_unused static const member_opt_get_fn	BCH2_NO_MEMBER_OPT = NULL;
 __maybe_unused static const member_opt_set_fn	SET_BCH2_NO_MEMBER_OPT = NULL;
 __maybe_unused static const ext_opt_get_fn	BCH2_NO_EXT_OPT = NULL;
 __maybe_unused static const ext_opt_set_fn	SET_BCH2_NO_EXT_OPT = NULL;
+
+static u64 BCH_SB_LABEL(const struct bch_sb *sb)
+{
+	return (unsigned long) sb->label;
+}
+
+static void SET_BCH_SB_LABEL(struct bch_sb *sb, u64 v)
+{
+	memset(sb->label, 0, BCH_SB_LABEL_SIZE);
+
+	if (v)
+		strscpy((char *) sb->label, (const char *) (unsigned long) v,
+			BCH_SB_LABEL_SIZE);
+}
 
 #define type_compatible_or_null(_p, _type)				\
 	__builtin_choose_expr(						\
@@ -936,7 +994,7 @@ int bch2_opts_from_sb(struct bch_opts *opts, struct bch_sb *sb)
 	for (unsigned id = 0; id < bch2_opts_nr; id++) {
 		const struct bch_option *opt = bch2_opt_table + id;
 
-		if (opt->get_sb || opt->get_ext)
+		if (id != Opt_fs_label && (opt->get_sb || opt->get_ext))
 			bch2_opt_set_by_id(opts, id, bch2_opt_from_sb(sb, id, -1));
 	}
 
@@ -959,7 +1017,15 @@ bool __bch2_opt_set_sb(struct bch_sb *sb, int dev_idx,
 
 	if ((opt->flags & OPT_FS) && dev_idx < 0) {
 		if (opt->set_sb) {
-			changed = v != opt->get_sb(sb);
+			if (opt == &bch2_opt_table[Opt_fs_label])
+				changed = v
+					? strncmp((const char *) opt->get_sb(sb),
+						  (const char *) (unsigned long) v,
+						  BCH_SB_LABEL_SIZE)
+					: strnlen((const char *) opt->get_sb(sb),
+						  BCH_SB_LABEL_SIZE);
+			else
+				changed = v != opt->get_sb(sb);
 			opt->set_sb(sb, v);
 		} else if (opt->set_ext) {
 			struct bch_sb_field_ext *ext = bch2_sb_field_get(sb, ext);

--- a/fs/opts.h
+++ b/fs/opts.h
@@ -135,6 +135,11 @@ enum fsck_err_opts {
 };
 
 #define BCH_OPTS()							\
+	x(fs_label,			u64,				\
+	  OPT_FS|OPT_FORMAT|OPT_RUNTIME,				\
+	  OPT_FN(bch2_opt_fs_label),					\
+	  BCH_SB_LABEL,			0,				\
+	  "label",	"Filesystem label")				\
 	x(block_size,			u16,				\
 	  OPT_FS|OPT_FORMAT|						\
 	  OPT_HUMAN_READABLE|OPT_MUST_BE_POW_2|OPT_SB_FIELD_SECTORS,	\

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -31,7 +31,7 @@ use bcachefs_kernel::{metadata_version, opt_id};
 use bcachefs_kernel::opt_set;
 
 use crate::commands::format_util::DevOpts;
-use crate::commands::opts::{bch_opt_lookup_negated, opts_usage_str, parse_opt_val};
+use crate::commands::opts::{bch_opt_lookup, bch_opt_lookup_negated, opts_usage_str, parse_opt_val};
 use crate::device_multipath::{find_multipath_holder, warn_multipath_component};
 use crate::key::Passphrase;
 use crate::util::parse_human_size;
@@ -407,7 +407,10 @@ fn parse_format_args(argv: Vec<String>) -> Result<FormatConfig> {
             // Short options
             match arg.as_bytes()[1] {
                 b'L' => {
-                    fs_label = Some(take_short_value(arg, &argv, &mut i, 'L')?);
+                    let val = take_short_value(arg, &argv, &mut i, 'L')?;
+                    let (_, opt) = bch_opt_lookup("fs_label").expect("fs_label option");
+                    parse_opt_val(opt, &val)?;
+                    fs_label = Some(val);
                 }
                 b'l' => {
                     let val = take_short_value(arg, &argv, &mut i, 'l')?;

--- a/src/commands/format_util.rs
+++ b/src/commands/format_util.rs
@@ -134,6 +134,9 @@ fn opt_set_sb_all(sb: &mut c::bch_sb, dev_idx: i32, opts: &mut c::bch_opts) {
 
     for (id, opt) in opts::opt_table().iter().enumerate() {
         let opt_id = opts::opt_id(id);
+        if opt.name() == Some("fs_label") {
+            continue;
+        }
 
         let v = if opts::opt_defined_by_id(opts, opt_id) {
             opts::opt_get_by_id(opts, opt_id)
@@ -242,9 +245,22 @@ pub fn format(
     // Internal UUID (different from user_uuid)
     sb.sb_mut().uuid.b = *uuid::Uuid::new_v4().as_bytes();
 
+    // Create ext field before setting options - some options (e.g.
+    // dev_readahead) use set_ext which requires this field to exist
+    let ext_u64s = (std::mem::size_of::<c::bch_sb_field_ext>() / std::mem::size_of::<u64>()) as u32;
+    sb.field_get_minsize::<c::bch_sb_field_ext>(ext_u64s);
+
+    opt_set_sb_all(sb.sb_mut(), -1, &mut fs_opts);
+
     // Label
-    if !opts.label.is_null() {
-        let label = unsafe { CStr::from_ptr(opts.label) };
+    let opt_strs = unsafe { &fs_opt_strs.__bindgen_anon_1.__bindgen_anon_1 };
+    let label_ptr = if !opts.label.is_null() {
+        opts.label
+    } else {
+        opt_strs.fs_label
+    };
+    if !label_ptr.is_null() {
+        let label = unsafe { CStr::from_ptr(label_ptr) };
         let label_bytes = label.to_bytes();
         if label_bytes.len() >= sb.sb().label.len() {
             die(&format!(
@@ -254,13 +270,6 @@ pub fn format(
         }
         sb.sb_mut().label[..label_bytes.len()].copy_from_slice(label_bytes);
     }
-
-    // Create ext field before setting options - some options (e.g.
-    // dev_readahead) use set_ext which requires this field to exist
-    let ext_u64s = (std::mem::size_of::<c::bch_sb_field_ext>() / std::mem::size_of::<u64>()) as u32;
-    sb.field_get_minsize::<c::bch_sb_field_ext>(ext_u64s);
-
-    opt_set_sb_all(sb.sb_mut(), -1, &mut fs_opts);
 
     // Time
     let now = std::time::SystemTime::now()

--- a/src/commands/opts.rs
+++ b/src/commands/opts.rs
@@ -34,6 +34,7 @@ pub fn opts_usage_str(flags_all: u32, flags_none: u32) -> String {
         if opt.flags as u32 & flags_all != flags_all { continue }
         if opt.flags as u32 & flags_none != 0 { continue }
         let Some(name) = opt.name() else { continue };
+        if name == "fs_label" && flags_all & c::opt_flags::OPT_FORMAT as u32 != 0 { continue }
 
         let mut col = 0;
         let s = format!("      --{name}");
@@ -150,6 +151,17 @@ pub fn bch_option_args(flag_filter: u32, allow_remove: bool) -> Vec<Arg> {
             }
         }
 
+        if name == "fs_label" {
+            let max_label_bytes = c::BCH_SB_LABEL_SIZE as usize - 1;
+            arg = arg.value_parser(move |value: &str| {
+                if value.len() > max_label_bytes {
+                    Err(format!("fs_label: too long (max {max_label_bytes} bytes)"))
+                } else {
+                    Ok(value.to_owned())
+                }
+            });
+        }
+
         args.push(arg);
     });
 
@@ -206,17 +218,113 @@ pub(crate) fn parse_opt_val(
     opt: &c::bch_option,
     val_str: &str,
 ) -> Result<Option<u64>> {
+    let fs_label = opt.name() == Some("fs_label");
     let c_val = CString::new(val_str)?;
     let mut err = Printbuf::new();
-    match bcachefs_kernel::opts::opt_parse(None, opt, &c_val, Some(&mut err)) {
-        Ok(v) => Ok(Some(v)),
-        Err(e) if e == -(c::bch_errcode::BCH_ERR_option_needs_open_fs as i32) => Ok(None),
+    let parsed = match bcachefs_kernel::opts::opt_parse(None, opt, &c_val, Some(&mut err)) {
+        Ok(v) => v,
+        Err(e) if e == -(c::bch_errcode::BCH_ERR_option_needs_open_fs as i32) => return Ok(None),
         Err(_) => {
             let msg = err.as_str();
             if msg.is_empty() {
                 bail!("invalid option: {}", val_str);
             }
             bail!("invalid option: {}", msg);
+        }
+    };
+
+    if fs_label {
+        // The parsed value is a pointer into c_val, which is only needed for
+        // validation here. Keep the owned string in bch_opt_strs instead.
+        return Ok(None);
+    }
+
+    Ok(Some(parsed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fs_label_parse_does_not_escape_into_scalar_opts() {
+        let (id, opt) = bch_opt_lookup("fs_label").unwrap();
+        let label = b"owned-superblock-label";
+        let label_len = label.len();
+        let source = unsafe { libc::malloc(label_len + 1) as *mut libc::c_char };
+        assert!(!source.is_null());
+        unsafe {
+            std::ptr::copy_nonoverlapping(label.as_ptr(), source as *mut u8, label_len);
+            *source.add(label_len) = 0;
+        }
+        let mut parsed = 0;
+
+        assert_eq!(
+            unsafe {
+                c::bch2_opt_parse(
+                    std::ptr::null_mut(),
+                    opt,
+                    source,
+                    &mut parsed,
+                    std::ptr::null_mut(),
+                )
+            },
+            0
+        );
+
+        let mut scalar_opts = c::bch_opts::default();
+        unsafe { c::bch2_opt_set_by_id(&mut scalar_opts, id, parsed) };
+        assert_eq!(unsafe { c::bch2_opt_get_by_id(&scalar_opts, id) }, 0);
+        let scalar_opts_copy = scalar_opts;
+        assert_eq!(unsafe { c::bch2_opt_get_by_id(&scalar_opts_copy, id) }, 0);
+
+        let mut sb = c::bch_sb_handle::default();
+        assert_eq!(unsafe { c::bch2_sb_realloc(&mut sb, 0) }, 0);
+        assert!(unsafe { c::__bch2_opt_set_sb(sb.sb, -1, opt, parsed) });
+
+        unsafe { libc::free(source as *mut libc::c_void) };
+        let poison = unsafe { libc::malloc(label_len + 1) as *mut libc::c_char };
+        assert_eq!(poison, source);
+        unsafe {
+            std::ptr::write_bytes(poison as *mut u8, b'X', label_len);
+            *poison.add(label_len) = 0;
+        }
+        assert_eq!(unsafe { c::bch2_sb_realloc(&mut sb, 1024) }, 0);
+
+        let mut from_sb = c::bch_opts::default();
+        assert_eq!(unsafe { c::bch2_opts_from_sb(&mut from_sb, sb.sb) }, 0);
+        assert_eq!(unsafe { c::bch2_opt_get_by_id(&from_sb, id) }, 0);
+
+        let mut no_sb = Printbuf::new();
+        unsafe {
+            c::bch2_opt_to_text(
+                no_sb.as_raw(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                opt,
+                parsed,
+                0,
+            )
+        };
+        assert_eq!(no_sb.as_str(), "");
+
+        let mut rendered = Printbuf::new();
+        unsafe {
+            c::bch2_opt_to_text(
+                rendered.as_raw(),
+                std::ptr::null_mut(),
+                sb.sb,
+                opt,
+                parsed,
+                0,
+            )
+        };
+        assert_eq!(rendered.as_str(), "owned-superblock-label");
+        assert_eq!(unsafe { *poison }, b'X' as libc::c_char);
+
+        unsafe {
+            libc::free(poison as *mut libc::c_void);
+            c::bch2_free_super(&mut sb);
         }
     }
 }


### PR DESCRIPTION
This is the clean replacement for closed PR #763.

The branch is rebuilt from current `master` and contains only the filesystem-label option wiring across the option table, format path, and CLI validation. The previous PR was closed because generated `ktest-out/` output and unrelated history had contaminated the branch; those files are absent here.

Validation: `cargo check -q -p bcachefs-tools`; `git diff --check`; six changed tracked files; no generated build/test artifacts.
