### PR TITLE
journal: don't start the journal on a blacklisted sequence number

### DIFF
--- a/fs/journal/init.c
+++ b/fs/journal/init.c
@@ -479,8 +479,8 @@ int bch2_fs_journal_start(struct journal *j, struct journal_start_info info)
 	bool had_entries = false;
 	int ret = 0;
 
-	/* Don't reuse sequence numbers that are blacklisted: */
-	info.cur_seq = max(info.cur_seq, bch2_journal_last_blacklisted_seq(c));
+	/* Don't reuse sequence numbers that are blacklisted */
+	info.cur_seq = max(info.cur_seq, bch2_journal_last_blacklisted_seq(c) + 1);
 
 	if (info.cur_seq >= JOURNAL_SEQ_MAX) {
 		bch_err(c, "cannot start: journal seq overflow");

--- a/fs/journal/journal.c
+++ b/fs/journal/journal.c
@@ -468,7 +468,7 @@ static int __journal_entry_open_one(struct journal *j)
 	if (unlikely(bch2_journal_seq_is_blacklisted(c, journal_cur_seq(j) + 1, false))) {
 		CLASS(bch_log_msg_atomic, msg)(c);
 		prt_printf(&msg.m, "attempting to open blacklisted journal seq %llu",
-			   journal_cur_seq(j));
+			   journal_cur_seq(j) + 1);
 		bch2_fs_emergency_read_only_locked(c, &msg.m);
 		return bch_err_throw(c, journal_shutdown);
 	}


### PR DESCRIPTION
bch2_fs_journal_start() guards against reusing blacklisted sequence
numbers with

    info.cur_seq = max(info.cur_seq, bch2_journal_last_blacklisted_seq(c));

but bch2_journal_last_blacklisted_seq() returns the last blacklisted
sequence, while cur_seq is the first entry
recovery will open. When the superblock blacklist extends past the
computed cur_seq, the journal starts exactly ON the last blacklisted
sequence.

Reproduced by https://github.com/koverstreet/ktest/pull/114.

----

journal: report the seq we refused to open, not the current one

(self-explanatory)