### PR TITLE
bcachefs: fix build when the no-Rust reason contains an apostrophe

### DIFF
--- a/fs/Makefile
+++ b/fs/Makefile
@@ -596,8 +596,10 @@ endif
 else
 # Carry the reason into the module. Whoever hits this at mount time is on a
 # different machine, months later, with no build log - the string is the only
-# thing that will tell them what to install.
-subdir-ccflags-y += -DBCACHEFS_NO_RUST_REASON='"$(bcachefs-rust-why)"'
+# thing that will tell them what to install. Apostrophes come out: the reason is
+# single-quoted on the command line, and the script strips " \ $ ` for the same
+# reason.
+subdir-ccflags-y += -DBCACHEFS_NO_RUST_REASON='"$(subst ',,$(bcachefs-rust-why))"'
 $(warning bcachefs: building without Rust support - $(bcachefs-rust-why); set BCACHEFS_RUST=1 to force)
 endif # bcachefs-rust-y
 

--- a/fs/scripts/rust-is-available-dkms.sh
+++ b/fs/scripts/rust-is-available-dkms.sh
@@ -31,7 +31,8 @@ canonical_version()
 #
 # Stripped of the characters that would otherwise terminate the C string literal
 # it ends up inside: the reason travels through make and the shell into a -D. An
-# unusual path should mangle the message, never break the build.
+# unusual path should mangle the message, never break the build. The apostrophe
+# comes out in the Makefile, which also covers the reasons it composes itself.
 skip()
 {
 	reason=$(printf '%s' "$1" | tr -d '"\\$`')


### PR DESCRIPTION
Fixes `BCACHEFS_NO_RUST_REASON` breaking the build when the reason contains an
apostrophe. Four of the six `skip()` strings in `scripts/rust-is-available-dkms.sh`
contain one, so most ways of declining Rust fail the build instead of falling back
to the C-only module. Details in the commit message.

Tested on an aarch64 DKMS build against a 7.1.3 kernel whose `rust_is_available.sh`
reports the toolchain unusable: the module builds C-only and reports the reason at
mount time. The `'\''`-escape alternative was also verified against a real kbuild
tree with the real `fixdep` (builds, apostrophe survives, no spurious rebuild);
deletion was chosen because the reason ends up in a C string literal and the script
already deletes `` " \ $ ` `` for the same reason.
