### PR TITLE
rcu_pending: fix the userspace kfree_bulk() shim

### DIFF
--- a/fs/util/rcu_pending.c
+++ b/fs/util/rcu_pending.c
@@ -180,7 +180,7 @@ static void merge_expired_lists(struct rcu_pending_pcpu *p)
 static inline void kfree_bulk(size_t nr, void ** p)
 {
 	while (nr--)
-		kfree(*p);
+		kfree(*p++);
 }
 #endif
 


### PR DESCRIPTION
Advance the pointer: the userspace `kfree_bulk()` shim calls `kfree()` on `p[0]` on every iteration and never frees the rest of the batch. Not reachable today — nothing in userspace creates a KVFREE-mode `rcu_pending`, since `rcu_pending_enqueue()` always passes `ptr = NULL` and both `rcu_pending_init()` callers use `__bkey_cached_free` — so no tool is affected; fixing it before someone wires that up.