### PR TITLE
fs/Makefile: add a bcachefs C -Werror knob

### DIFF
--- a/fs/Makefile
+++ b/fs/Makefile
@@ -50,6 +50,16 @@ ifdef BCACHEFS_TESTS
 	bcachefs-config-cppflags += -DCONFIG_BCACHEFS_TESTS=1
 endif
 
+# Make bcachefs's own warnings fatal without CONFIG_WERROR for the whole
+# tree: make BCACHEFS_WERROR=1. subdir-ccflags-y scopes it to this directory
+# and below, so nothing else the invocation happens to compile is affected;
+# per-file CFLAGS_* -Wno-* waivers (e.g. rust/extern.o's) still apply on top.
+# For CI that wants exactly this subtree warning-clean, whatever kernel it is
+# built into.
+ifeq ($(BCACHEFS_WERROR),1)
+subdir-ccflags-y += -Werror
+endif
+
 # Verify the hand-copied struct getdents_callback64 in fs/dirent.c against
 # the target kernel's real layout (fs/scripts/getdents-layout.sh, pahole on
 # $(objtree)/vmlinux - present in external builds since kbuild needs it for


### PR DESCRIPTION
For CI that wants bcachefs C objects compiled with `-Werror`: passing `BCACHEFS_WERROR=1` to the kernel make adds it via `subdir-ccflags-y`, covering C compilation in fs/bcachefs and below but no other C compilation in the invocation, and later per-file `-Wno-*` waivers (such as rust/extern.o's `-Wno-duplicate-decl-specifier`) still apply on top. Off by default. First user is the build test in koverstreet/ktest#110.