### PR TITLE
write: issue FUA for rotational move writes

### DIFF
--- a/fs/data/write.c
+++ b/fs/data/write.c
@@ -1273,6 +1273,25 @@ void bch2_submit_wbio_replicas(struct bch_write_bio *wbio, struct bch_fs *c,
 	}
 }
 
+static bool bch2_move_write_should_fua(struct bch_write_op *op,
+				       const struct bkey_i *k)
+{
+	struct bch_fs *c = op->c;
+
+	if (!(op->flags & BCH_WRITE_move))
+		return false;
+
+	if (c->opts.move_writes_fua)
+		return true;
+
+	bkey_for_each_ptr(bch2_bkey_ptrs_c(bkey_i_to_s_c(k)), ptr)
+		if (ptr->dev != BCH_SB_MEMBER_INVALID &&
+		    bch2_dev_rotational(c, ptr->dev))
+			return true;
+
+	return false;
+}
+
 static void __bch2_write(struct bch_write_op *);
 
 static CLOSURE_CALLBACK(__bch2_write_done)
@@ -2606,19 +2625,20 @@ err:
 		if (op->flags & BCH_WRITE_move)
 			bio->bi_opf |= REQ_SYNC|REQ_IDLE;
 
-		/*
-		 * Internal moves can be issued FUA, making the journal's cache
-		 * flush a no-op for them. Off by default: the per-write FUA
-		 * regresses background-move throughput, and the journal flushes
-		 * every device on commit regardless, so durability is unchanged.
-		 */
-		if ((op->flags & BCH_WRITE_move) && c->opts.move_writes_fua)
-			bio->bi_opf |= REQ_FUA;
-
 		closure_get(bio->bi_private);
 
 		key_to_write = (void *) (op->insert_keys.keys_p +
 					 key_to_write_offset);
+
+		/*
+		 * Rotational move writes are the usual source of dirty cache
+		 * behind journal preflush stalls: complete them durably here so
+		 * later journal commits do not have to drain them from every rw
+		 * member.  Keep non-rotational move writes on the old default
+		 * unless move_writes_fua was explicitly enabled.
+		 */
+		if (bch2_move_write_should_fua(op, key_to_write))
+			bio->bi_opf |= REQ_FUA;
 
 		bch2_submit_wbio_replicas(to_wbio(bio), c, BCH_DATA_user,
 					  key_to_write, false, NULL);


### PR DESCRIPTION
## Summary

- issue FUA for internal move writes that allocate on rotational devices
- keep the existing non-FUA default for move writes that only hit
  non-rotational devices
- preserve `move_writes_fua` as the explicit force-all option

## Why

`koverstreet/bcachefs-tools#813` reports a stall shape where a flushing journal
commit preflushes every online rw member. Background move writes can leave a
rotational member with dirty device cache; later journal commits then have to
drain that member even when the journal entry is otherwise unrelated to it.
That can pace unrelated transactions and fill the journal in-flight FIFO.

The existing `move_writes_fua` option can avoid the dirty-cache side effect, but
forcing FUA on every move write can regress background-move throughput. This
patch narrows the automatic behavior to move writes whose newly allocated
extent actually contains a rotational pointer.

## Validation

Verified live in a VM with the patched module. The ktest scratch devices
used here (qemu virtio-blk over raw files) already report as rotational
via bcachefs's own per-member superblock field by default, so no extra
setup was needed to exercise the rotational path. Formatted a 2-device
filesystem, wrote 64MB, then evacuated one member (a real move workload:
`bcachefs device evacuate`, completed in 1.15s) with the `block_rq_issue`/
`block_io_start` ftrace events enabled. The trace captured 78 write
requests carrying `REQ_FUA` (`WFSM` in `rwbs` — write, FUA, sync, meta) on
the target's block device during the evacuate, e.g.:
`block_io_start: 254,16 WFSM 8192 () 8 + 16 be,0,4 [bcachefs]`. This VM run
is a single measurement of the patched kernel, not an A/B timing
comparison against an unpatched build.
