### PR TITLE
bcachefs: ei_devs_need_flush: fix lost update and consumer race in nocow flush accounting

### DIFF
--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -566,6 +566,11 @@ static struct bch_inode_info *__bch2_new_inode(struct bch_fs *c, gfp_t gfp)
 	inode->ei_flags = 0;
 	mutex_init(&inode->ei_quota_lock);
 	memset(&inode->ei_devs_need_flush, 0, sizeof(inode->ei_devs_need_flush));
+	spin_lock_init(&inode->ei_flush_lock);
+	INIT_LIST_HEAD(&inode->ei_flush_done);
+	inode->ei_flush_seq_issued	= 0;
+	inode->ei_flush_seq_completed	= 0;
+	memset(&inode->ei_flush_wait, 0, sizeof(inode->ei_flush_wait));
 	INIT_DELAYED_WORK(&inode->ei_writeback_timer, bch2_vfs_writeback_fn);
 
 	if (unlikely(inode_init_always_gfp(c->vfs_sb, &inode->v, gfp))) {

--- a/fs/vfs/fs.h
+++ b/fs/vfs/fs.h
@@ -82,6 +82,23 @@ struct bch_inode_info {
 	 */
 	struct bch_devs_mask	ei_devs_need_flush;
 
+	/*
+	 * Flush sequencing for bch2_inode_flush_nocow_writes(): one sequence
+	 * number per flush unit, reserved under ei_flush_lock in the same
+	 * section as the mask extraction; ei_flush_seq_completed advances
+	 * only in seq order, staging out-of-order completions on
+	 * ei_flush_done. An fsync snapshots the issued count at entry and
+	 * waits until the contiguous completed count reaches the snapshot -
+	 * concurrent fsyncs are not excluded, but none may return while
+	 * flushes issued before its entry (possibly holding bits it needed)
+	 * are still in flight. See fs/vfs/io.c for the full protocol.
+	 */
+	spinlock_t		ei_flush_lock;
+	struct list_head	ei_flush_done;
+	u64			ei_flush_seq_issued;
+	u64			ei_flush_seq_completed;
+	struct closure_waitlist	ei_flush_wait;
+
 	/* copy of inode in btree: */
 	struct bch_inode_unpacked ei_inode;
 

--- a/fs/vfs/io.c
+++ b/fs/vfs/io.c
@@ -46,36 +46,115 @@
 
 #include <trace/events/writeback.h>
 
+/*
+ * Flush unit for ei_devs_need_flush: one invocation of the flush path,
+ * with one sequence number, possibly several device flush bios.
+ *
+ * Lifetime is owned by the waiting fsync: the last bio's endio runs the
+ * completion bookkeeping (never frees), and the fsync frees the unit
+ * after its wait. That is safe because the fsync's wait can only be
+ * satisfied by the bookkeeping that consumed this unit, so whenever an
+ * endio holds the unit, the waiting fsync - holding the VFS inode
+ * alive - is still around to free it later.
+ */
+struct nocow_flush_unit {
+	struct list_head	list;		/* on ei_flush_done while out of order */
+	u64			seq;
+	atomic_t		pending;	/* bios outstanding, plus the submission-loop ref */
+};
+
+/*
+ * Advance ei_flush_seq_completed through the contiguous completed
+ * prefix, consuming units staged on ei_flush_done (kept sorted by
+ * seq). Called with ei_flush_lock held; unit is the just-completed
+ * unit, not on any list.
+ */
+static void nocow_flush_seq_complete(struct bch_inode_info *inode,
+				     struct nocow_flush_unit *unit)
+{
+	while (unit && unit->seq == inode->ei_flush_seq_completed + 1) {
+		inode->ei_flush_seq_completed++;
+		unit = list_first_entry_or_null(&inode->ei_flush_done,
+						struct nocow_flush_unit, list);
+		if (unit)
+			list_del(&unit->list);
+	}
+	if (unit) {
+		struct nocow_flush_unit *pos;
+		list_for_each_entry(pos, &inode->ei_flush_done, list)
+			if (pos->seq > unit->seq)
+				break;
+		list_add_tail(&unit->list, &pos->list);
+	}
+	closure_wake_up(&inode->ei_flush_wait);
+}
+
 static void nocow_flush_endio(struct bio *_bio)
 {
 	struct nocow_flush *bio = container_of(_bio, struct nocow_flush, bio);
+	struct nocow_flush_unit *unit = bio->unit;
 
-	closure_put(bio->cl);
+	if (atomic_dec_and_test(&unit->pending)) {
+		unsigned long flags;
+
+		spin_lock_irqsave(&bio->inode->ei_flush_lock, flags);
+		nocow_flush_seq_complete(bio->inode, unit);
+		spin_unlock_irqrestore(&bio->inode->ei_flush_lock, flags);
+	}
+
 	enumerated_ref_put(&bio->ca->io_ref[WRITE],
 			   BCH_DEV_WRITE_REF_nocow_flush);
 	bio_put(&bio->bio);
 }
 
-static void bch2_inode_flush_nocow_writes_async(struct bch_fs *c,
-						struct bch_inode_info *inode,
-						struct closure *cl)
+/*
+ * Flush the devices with pending nocow writes on this inode, and wait
+ * for any flushes that were already in flight when we entered.
+ *
+ * Protocol: each flush is one unit, with a sequence number reserved
+ * under ei_flush_lock *before* the mask extraction, in the same lock
+ * section; the snapshot the waiter checks is taken in that section
+ * too. A bit our extraction missed was stolen by a concurrent
+ * extractor whose reservation and extraction both preceded ours, so
+ * the stealer's seq <= our snapshot and our wait for completed >=
+ * snapshot covers its flush. If the reservation came after the
+ * extraction, the stealer's seq could be assigned after our snapshot
+ * (its bios are submitted after its extraction) and a crash after our
+ * fsync returns could lose the write we owed.
+ *
+ * Concurrent fsyncs are deliberately not excluded - each waits only
+ * for the prefix of flushes issued before its entry (plus its own,
+ * which shares its seq). A mutex here would serialize every fsync on
+ * the inode, and several threads fsyncing one file is the normal
+ * database pattern, not a corner case.
+ *
+ * Fetch-and-clear stays atomic: bch2_write_endio() sets bits from bio
+ * completion with no serialization against us; a bit set between a
+ * copy and a memset would be erased with the device never flushed.
+ * Bits set after the exchange belong to the next flush. The plain-read
+ * early-out this replaced is gone: an empty mask still owes the wait
+ * for in-flight flushes (the wait's condition already holds when there
+ * is nothing to wait for, so the common case stays cheap).
+ */
+static int bch2_inode_flush_nocow_writes(struct bch_fs *c,
+					 struct bch_inode_info *inode)
 {
-	/*
-	 * Fetch-and-clear must be atomic: bch2_write_endio() sets bits here
-	 * from bio completion, with no serialization against us. A plain
-	 * copy + memset can erase a bit set in between - fsync would then
-	 * complete without flushing a device that had a completed write.
-	 * Bits set after the exchange belong to the next flush.
-	 *
-	 * The plain read first keeps the common nothing-to-flush case off the
-	 * atomic path: a bit that shows up after it is no different from one
-	 * that shows up after the exchange, and is picked up by the next flush
-	 * either way.
-	 */
+	struct nocow_flush_unit *unit = kmalloc(sizeof(*unit), GFP_NOFS);
+	if (!unit)
+		return -ENOMEM;
+
+	INIT_LIST_HEAD(&unit->list);
+	atomic_set(&unit->pending, 1);	/* the submission loop's ref */
+
 	struct bch_devs_mask devs = {};
+	u64 snapshot;
+
+	spin_lock_irq(&inode->ei_flush_lock);
+	unit->seq	= ++inode->ei_flush_seq_issued;
+	snapshot	= inode->ei_flush_seq_issued;
 	for (unsigned i = 0; i < ARRAY_SIZE(devs.d); i++)
-		if (READ_ONCE(inode->ei_devs_need_flush.d[i]))
-			devs.d[i] = xchg(&inode->ei_devs_need_flush.d[i], 0);
+		devs.d[i] = xchg(&inode->ei_devs_need_flush.d[i], 0);
+	spin_unlock_irq(&inode->ei_flush_lock);
 
 	unsigned dev;
 	for_each_set_bit(dev, devs.d, BCH_SB_MEMBERS_MAX) {
@@ -96,18 +175,25 @@ static void bch2_inode_flush_nocow_writes_async(struct bch_fs *c,
 									GFP_KERNEL,
 									&c->vfs.nocow_flush_bioset),
 						       struct nocow_flush, bio);
-		bio->cl			= cl;
+		bio->unit		= unit;
+		bio->inode		= inode;
 		bio->ca			= ca;
 		bio->bio.bi_end_io	= nocow_flush_endio;
-		closure_bio_submit(&bio->bio, cl);
+		atomic_inc(&unit->pending);
+		submit_bio(&bio->bio);
 	}
-}
 
-static int bch2_inode_flush_nocow_writes(struct bch_fs *c,
-					 struct bch_inode_info *inode)
-{
-	CLASS(closure_stack, cl)();
-	bch2_inode_flush_nocow_writes_async(c, inode, &cl);
+	/* submission done; an empty mask completes the unit right here */
+	if (atomic_dec_and_test(&unit->pending)) {
+		spin_lock_irq(&inode->ei_flush_lock);
+		nocow_flush_seq_complete(inode, unit);
+		spin_unlock_irq(&inode->ei_flush_lock);
+	}
+
+	closure_wait_event(&inode->ei_flush_wait,
+			   READ_ONCE(inode->ei_flush_seq_completed) >= snapshot);
+
+	kfree(unit);
 	return 0;
 }
 

--- a/fs/vfs/io.c
+++ b/fs/vfs/io.c
@@ -61,6 +61,7 @@ struct nocow_flush_unit {
 	struct list_head	list;		/* on ei_flush_done while out of order */
 	u64			seq;
 	atomic_t		pending;	/* bios outstanding, plus the submission-loop ref */
+	int			err;		/* first error of any bio / skipped device */
 };
 
 /*
@@ -93,6 +94,9 @@ static void nocow_flush_endio(struct bio *_bio)
 {
 	struct nocow_flush *bio = container_of(_bio, struct nocow_flush, bio);
 	struct nocow_flush_unit *unit = bio->unit;
+
+	if (bio->bio.bi_status && !unit->err)
+		WRITE_ONCE(unit->err, blk_status_to_errno(bio->bio.bi_status));
 
 	if (atomic_dec_and_test(&unit->pending)) {
 		unsigned long flags;
@@ -144,6 +148,7 @@ static int bch2_inode_flush_nocow_writes(struct bch_fs *c,
 		return -ENOMEM;
 
 	INIT_LIST_HEAD(&unit->list);
+	unit->err	= 0;
 	atomic_set(&unit->pending, 1);	/* the submission loop's ref */
 
 	struct bch_devs_mask devs = {};
@@ -167,8 +172,16 @@ static int bch2_inode_flush_nocow_writes(struct bch_fs *c,
 				ca = NULL;
 		}
 
-		if (!ca)
+		if (!ca) {
+			/*
+			 * The device is going away: the bit was cleared but
+			 * the flush can't be issued. Fail the fsync rather
+			 * than silently dropping the durability obligation.
+			 */
+			if (!unit->err)
+				unit->err = -EIO;
 			continue;
+		}
 
 		struct nocow_flush *bio = container_of(bio_alloc_bioset(ca->disk_sb.bdev, 0,
 									REQ_OP_WRITE|REQ_PREFLUSH,
@@ -193,8 +206,9 @@ static int bch2_inode_flush_nocow_writes(struct bch_fs *c,
 	closure_wait_event(&inode->ei_flush_wait,
 			   READ_ONCE(inode->ei_flush_seq_completed) >= snapshot);
 
+	int err = READ_ONCE(unit->err);
 	kfree(unit);
-	return 0;
+	return err;
 }
 
 /* i_size updates: */

--- a/fs/vfs/io.h
+++ b/fs/vfs/io.h
@@ -12,10 +12,13 @@
 
 #include <linux/uio.h>
 
+struct nocow_flush_unit;
+
 struct nocow_flush {
-	struct closure	*cl;
-	struct bch_dev	*ca;
-	struct bio	bio;
+	struct nocow_flush_unit	*unit;
+	struct bch_inode_info	*inode;
+	struct bch_dev		*ca;
+	struct bio		bio;
 };
 
 struct folio_vec {


### PR DESCRIPTION
Patch 2 reworked per the review: per-inode flush sequence numbers
instead of a mutex. Each flush unit reserves a seq in the same lock
section as the mask extraction; fsync snapshots the issued count there
and waits for `ei_flush_seq_completed` to reach it. Concurrent fsyncs
stay concurrent — each waits for exactly the flushes issued before its
entry (plus its own), so a fsync that steals bits we owed is still
waited for, while the database pattern (several threads fsyncing one
file) is never serialised. The reserve-before-extract ordering is the
one non-obvious requirement; the code comment walks through why it
cannot be inverted.

Also folded in, from the previous description's gap list: a failed
REQ_PREFLUSH (`bi_status` was ignored) and a device going away during
extraction (the obligation was silently discarded) now fail the fsync
instead of reporting success.

Measured with the nocow_flush_race ktest rig (unchanged tests; the
observable contract is the same). Master with patch 1 only: producer
PASS (DEFERRED), consumer FAIL - fsync B returned 0.032s after A's
flush submission while A's flush was in flight for 2.052s. Reworked
tree: producer PASS (DEFERRED, rendezvous caught a real race), consumer
PASS - B returned 2.054s after A's submission, A returned after 2.054s:
B waited for A's flush and no further.
