### PR TITLE
bufferd.c: Clamp folio order to mapping_max_folio_order in readpage_bio_extend()

### DIFF
--- a/fs/vfs/buffered.c
+++ b/fs/vfs/buffered.c
@@ -141,7 +141,8 @@ static int readpage_bio_extend(struct btree_trans *trans,
 
 			/* ensure proper alignment */
 			order = min(order, __ffs(folio_offset|BIT(31)));
-
+			order = min_t(unsigned, order, mapping_max_folio_order(iter->mapping));
+			
 			folio = xa_load(&iter->mapping->i_pages, folio_offset);
 			if (folio && !xa_is_value(folio))
 				break;


### PR DESCRIPTION

##  Summary

Users running kernels compiled without Transparent Huge Pages (# CONFIG_TRANSPARENT_HUGEPAGE is not set) are encountering severe VM_WARN_ON_ONCE_FOLIO panics/warnings during routine system operations, specifically memory compaction and file truncation.

* **`dmesg` Log:** https://pastebin.com/Yhs9DN7G
* **`bcachefs show-super` Output:** https://pastebin.com/EWJZEhzG

### Step-by-Step Analysis

**Step 1: Memory Compaction crashes**
Under memory pressure, `kcompactd` attempts to migrate pages. The `dmesg` trace reveals that the memory subsystem unexpectedly encounters a large folio (`order:5`) belonging to `bcachefs`.

```text
[  112.132847] head: order:5 mapcount:0 entire_mapcount:0 nr_pages_mapped:0 pincount:0
...
[  112.133829] aops:bch_address_space_operations [bcachefs] ino:18000000000e85c8 dentry name(?):"43.js.map"
...
[  112.139512] page dumped because: VM_WARN_ON_ONCE_FOLIO(1)
[  112.139997] ------------[ cut here ]------------
[  112.140399] WARNING: ./include/linux/huge_mm.h:655 at migrate_pages_batch.isra.0+0x590/0x7bc, CPU#4: kcompactd0/67
...
[  112.155856] Call trace:
[  112.156071]  migrate_pages_batch.isra.0+0x590/0x7bc (P)
[  112.156528]  migrate_pages_sync.isra.0+0x78/0x238
[  112.157269]  compact_zone+0x340/0x49c
```

**Step 2: File Truncation crashes**
Similarly, when truncating a file, the VFS encounters a large folio (`order:1`) straddling the truncation boundary. 

```text
[  465.997874] head: order:1 mapcount:0 entire_mapcount:0 nr_pages_mapped:0 pincount:0
...
[  466.000346] aops:bch_address_space_operations [bcachefs] ino:7800000000001571 dentry name(?):"9D1A1B8FDA..."
...
[  466.017249] page dumped because: VM_WARN_ON_ONCE_FOLIO(1)
[  466.017735] ------------[ cut here ]------------
[  466.018138] WARNING: ./include/linux/huge_mm.h:662 at truncate_inode_partial_folio+0x1ac/0x1fc, CPU#5: Cache2 I/O/23475
...
[  466.033815] Call trace:
[  466.034033]  truncate_inode_partial_folio+0x1ac/0x1fc (P)
[  466.034508]  truncate_inode_pages_range+0x190/0x4a0
[  466.035621]  bchfs_truncate+0x140/0x4d4 [bcachefs]
```

**Step 3: The underlying split failure**
Both `migrate_pages_batch()` and `truncate_inode_partial_folio()` attempt to call `split_folio()` when handling a large folio on a boundary. However, because the kernel is configured without THP (`!CONFIG_TRANSPARENT_HUGEPAGE`), the core memory management subsystem lacks the logic to split large pages. `split_folio()` degrades to a stub that returns `-EINVAL` and explicitly throws a `VM_WARN_ON_ONCE_FOLIO` exception.

### 🔍 Root Cause Analysis

The core MM subsystem expects that large folios will simply *not exist* in the page cache if the system does not support them. Standard VFS readahead paths enforce this by clamping allocations to `mapping_max_folio_order()`.

However, `bcachefs` implements a custom read-extension mechanism in `readpage_bio_extend()`. It calculates the preferred folio allocation `order` based strictly on remaining extent sectors and offset alignment constraints:

```c
unsigned order = ilog2(rounddown_pow_of_two(sectors_remaining) / PAGE_SECTORS);
/* ensure proper alignment */
order = min(order, __ffs(folio_offset|BIT(31)));

folio = filemap_alloc_folio(readahead_gfp_mask(iter->mapping), order);
```

By failing to consult the core MM for the maximum allowable folio order, `bcachefs` bypasses system-wide constraints and forcefully instantiates unmanageable large folios (`order > 0`) into the pagecache on systems where they cannot be legally split. 


### 🛠️ Fix

This patch fixes the issue by introducing a single constraint:

```c
order = min_t(unsigned, order, mapping_max_folio_order(iter->mapping));
```

This change clamps the calculated allocation `order` in `readpage_bio_extend()` to the maximum folio order permitted by the underlying address space via `mapping_max_folio_order()`. By querying the mapping's limits prior to invoking `filemap_alloc_folio()`, `bcachefs` now explicitly respects system-wide capabilities, architecture limits, and kernel configurations—specifically `CONFIG_TRANSPARENT_HUGEPAGE`. 

When running on kernels where THP is disabled, `mapping_max_folio_order()` returns `0`, immediately clamping `order` down to 0 and causing `bcachefs` to allocate standard single-page folios instead. This prevents `bcachefs` from inserting unsupported large folios into the page cache that trigger kernel warnings later when core MM operations (such as migration or partial truncation) attempt to split them.