### PR TITLE
reconcile: bound waits on copygc progress

### DIFF
--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -1659,9 +1659,13 @@ static int do_reconcile_phase_iter(struct reconcile_pass *p, u32 kick,
 		if (bch2_err_matches(ret, BCH_ERR_data_update_fail_need_copygc)) {
 			bch2_trans_unlock_long(trans);
 			bch2_copygc_wakeup(c);
-			wait_event(c->copygc.running_wq,
+			wait_event_timeout(c->copygc.running_wq,
 				   c->copygc.run_count != *p->copygc_run_count ||
-				   kthread_should_stop());
+				   kthread_should_stop() ||
+				   test_bit(BCH_FS_going_ro, &c->flags) ||
+				   !bch2_reconcile_enabled(c) ||
+				   kick != r->kick,
+				   HZ);
 			*p->copygc_run_count = c->copygc.run_count;
 			ret = 0;
 			continue;


### PR DESCRIPTION
## Summary

- make reconcile waits for copygc progress bounded after `BCH_ERR_data_update_fail_need_copygc`
- also wake from that wait when reconcile is disabled, the fs is going read-only, the kthread is stopping, or a newer reconcile kick arrives
- retry the current key after timeout instead of parking the reconcile kthread forever on a stale `copygc.run_count`

## Validation

- Built the out-of-tree bcachefs module against `7.2.0-rc7-nucat72rc7` with `BCACHEFS_DKMS=1 BCACHEFS_RUST=1 BCACHEFS_WERROR=1`.
- Resulting module: `bcachefs.ko`, version `v1.39.1-dirty`, srcversion `D9526A506CCCE0390B57761`.
