### PR TITLE
vfs: update dentry casefold flags under d_lock

### DIFF
--- a/fs/vfs/fs.c
+++ b/fs/vfs/fs.c
@@ -967,6 +967,8 @@ static void bch2_dentry_apply_casefold_flags(struct dentry *dentry,
 {
 	unsigned d_flags = READ_ONCE(dentry->d_flags);
 
+	lockdep_assert_held(&dentry->d_lock);
+
 	if (flags)
 		d_flags |= flags;
 	else
@@ -976,25 +978,16 @@ static void bch2_dentry_apply_casefold_flags(struct dentry *dentry,
 }
 
 /*
- * Set a directory dentry's casefold d_ops from its inode before the dentry is
- * published. Not yet reachable by RCU lookups, so a plain assignment is safe.
+ * Set a directory dentry's casefold d_ops from its inode. The dentry can
+ * already be visible to other threads: bch2_lookup() gets it published in
+ * the in-lookup hash by d_alloc_parallel(), and d_wait_lookup() sets
+ * DCACHE_LOOKUP_WAITERS in d_flags under d_lock. Update d_flags under
+ * d_lock too, or the read-modify-write can erase the waiters bit and the
+ * completing lookup then never wakes the waiter. Lockless readers may
+ * sample either the old or new flags, so keep the flag update to a single
+ * transition.
  */
 void bch2_dentry_set_casefold_ops(struct dentry *dentry, struct inode *vinode)
-{
-	if (!S_ISDIR(vinode->i_mode))
-		return;
-
-	dentry->d_op = &bch2_dentry_ops_casefolded;
-	bch2_dentry_apply_casefold_flags(dentry, bch2_dentry_casefold_flags(vinode));
-}
-
-/*
- * d_obtain_alias() attaches the dentry before returning it. Disconnected
- * aliases are not reachable by parent lookup yet, but existing aliases can be.
- * Hold d_lock to serialize against other writers. Lockless readers may sample
- * either the old or new flags, so keep the flag update to a single transition.
- */
-static void bch2_dentry_set_casefold_ops_locked(struct dentry *dentry, struct inode *vinode)
 {
 	unsigned flags;
 
@@ -2120,7 +2113,7 @@ static struct dentry *bch2_fh_alias(struct super_block *sb, struct inode *vinode
 	struct dentry *dentry = d_obtain_alias(vinode);
 	if (!IS_ERR(dentry)) {
 #if IS_ENABLED(CONFIG_UNICODE)
-		bch2_dentry_set_casefold_ops_locked(dentry, vinode);
+		bch2_dentry_set_casefold_ops(dentry, vinode);
 #endif
 	}
 	return dentry;


### PR DESCRIPTION
This PR previously added `d_splice_alias(NULL, dentry); d_drop(dentry);` to
finish an in-lookup dentry before returning a negative casefold lookup. That
approach is dropped here: both VFS callers that publish an in-lookup dentry
(`__lookup_slow()`, `lookup_open()`) already call `d_lookup_done()`
unconditionally right after `->lookup()` returns, so the bare `return NULL;`
already woke every parallel-lookup waiter. Worse, `d_splice_alias(NULL, ...)`
bottoms out in `__d_add()`, whose `__d_rehash()` runs unconditionally on
`inode == NULL` — it briefly rehashes the negative dentry into the real dcache
before the follow-up `d_drop()` unhashes it again, reopening exactly the
lookup-vs-concurrent-create race the surrounding `IS_CASEFOLDED` branch exists
to avoid. It fixed nothing and added a race.

The branch now carries the actual fix for the "waiters stuck behind an
in-progress dentry" symptom this PR's title described: an unlocked
read-modify-write of `d_flags` in `bch2_dentry_apply_casefold_flags()`,
called from `bch2_dentry_set_casefold_ops()` on a dentry already published in
the in-lookup hash. It races a concurrent waiter setting
`DCACHE_LOOKUP_WAITERS` under `d_lock` and can erase that bit, so the
completing lookup's wakeup gets silently skipped and the waiter sleeps in
`TASK_UNINTERRUPTIBLE` forever. This was reproduced live and confirmed with a
`/proc/kcore` post-mortem: the waiter was still parked on the `d_flags`
var-waitqueue while the dentry itself was fully healthy (positive, hashed,
`PAR_LOOKUP` and `LOOKUP_WAITERS` both clear) — a lost wakeup, not a stuck
lookup. The fix takes `d_lock` in `bch2_dentry_set_casefold_ops()` (folding in
the previously separate `_locked` variant) and asserts the lock is held in
the apply helper. It runs on every directory dentry that gets an inode
attached, not just casefolded ones, so the race window is open on every
directory lookup regardless of whether that directory has casefold enabled.

Proposed retitle: "vfs: update dentry casefold flags under d_lock"
