### PR TITLE
vfs: retry page_mkwrite around snapshot creation

### DIFF
--- a/fs/vfs/buffered.c
+++ b/fs/vfs/buffered.c
@@ -1075,6 +1075,12 @@ static ssize_t bch2_buffered_write(struct kiocb *iocb, struct iov_iter *iter)
 		unsigned offset = pos & (PAGE_SIZE - 1);
 		unsigned bytes = iov_iter_count(iter);
 again:
+
+		if (unlikely(fatal_signal_pending(current))) {
+			ret = -EINTR;
+			break;
+		}
+
 		/*
 		 * Bring in the user page that we will copy from _first_.
 		 * Otherwise there's a nasty deadlock on copying from the
@@ -1093,11 +1099,6 @@ again:
 				ret = -EFAULT;
 				break;
 			}
-		}
-
-		if (unlikely(fatal_signal_pending(current))) {
-			ret = -EINTR;
-			break;
 		}
 
 		ret = __bch2_buffered_write(c, inode, mapping, iter, pos, bytes);

--- a/fs/vfs/pagecache.c
+++ b/fs/vfs/pagecache.c
@@ -723,6 +723,7 @@ vm_fault_t bch2_page_mkwrite(struct vm_fault *vmf)
 	struct address_space *mapping = file->f_mapping;
 	struct bch_fs *c = inode->v.i_sb->s_fs_info;
 	struct bch2_folio_reservation res;
+	bool got_create_lock = false;
 	vm_fault_t ret;
 
 	loff_t file_offset = round_down(vmf->pgoff << PAGE_SHIFT, block_bytes(c));
@@ -732,8 +733,12 @@ vm_fault_t bch2_page_mkwrite(struct vm_fault *vmf)
 	BUG_ON(offset + len > folio_size(folio));
 
 	bch2_folio_reservation_init(c, inode, &res);
+	if (!percpu_down_read_trylock(&c->snapshots.create_lock)) {
+		ret = VM_FAULT_RETRY;
+		goto out;
+	}
+	got_create_lock = true;
 
-	percpu_down_read(&c->snapshots.create_lock);
 	sb_start_pagefault(inode->v.i_sb);
 	file_update_time(file);
 
@@ -774,8 +779,10 @@ vm_fault_t bch2_page_mkwrite(struct vm_fault *vmf)
 
 	ret = VM_FAULT_LOCKED;
 out:
-	sb_end_pagefault(inode->v.i_sb);
-	percpu_up_read(&c->snapshots.create_lock);
+	if (got_create_lock) {
+		sb_end_pagefault(inode->v.i_sb);
+		percpu_up_read(&c->snapshots.create_lock);
+	}
 
 	return ret;
 }


### PR DESCRIPTION
## Summary

Fix the lockdep inversion between `snapshots.create_lock` and `mmap_lock`
without moving buffered-write fault retry out of the buffered write path.

Buffered writes still take `snapshots.create_lock` around the whole buffered
write, preserving the snapshot atomicity rule. The `fault_in_iov_iter_readable()`
retry logic remains in `bch2_buffered_write()`, where the existing short-copy
retry already lives.

The lockdep cycle is avoided from the mmap side instead: `bch2_page_mkwrite()`
now tries to take `snapshots.create_lock` and returns `VM_FAULT_RETRY` if
snapshot creation is in progress. When the trylock succeeds, the page-cache
dirtying path remains serialized under `snapshots.create_lock`.

This replaces the approach from the closed koverstreet/bcachefs-tools#863, which
tried to pre-fault the write iterator before taking `snapshots.create_lock`.

## Evidence

Lockdep report:

https://gist.github.com/Komzpa/a9a0cce4b13a41fa015777994cdc1f51

Companion ktest PR:

https://github.com/koverstreet/ktest/pull/116

## Validation

- `git diff --check origin/master...HEAD`
- PR scope gate:

```text
fs/vfs/buffered.c
fs/vfs/pagecache.c
```

- negative grep: `fault_in_iov_iter_readable()` is only in
  `bch2_buffered_write()`, not in `bch2_write_iter()`
- targeted compile against `7.2.0-rc7-nucat72rc7` headers:

```text
make -C /lib/modules/7.2.0-rc7-nucat72rc7/build M=$PWD build/fs/vfs/buffered.o build/fs/vfs/pagecache.o -j8
```

I did not install or reload the built module.
