### PR TITLE
reconcile: handle unknown csum/compression types

### DIFF
--- a/fs/data/reconcile/trigger.c
+++ b/fs/data/reconcile/trigger.c
@@ -1085,6 +1085,24 @@ int bch2_bkey_get_io_opts(struct btree_trans *trans,
 		 * read see a combination that's valid under the current rules.
 		 */
 		bch2_io_opts_fixups(opts);
+
+		/*
+		 * Extents written by newer versions may carry checksum/
+		 * compression types we don't know about - fall back to the
+		 * filesystem option for new writes, like
+		 * bch2_inode_opts_get_inode() does for inode opts. Fixups
+		 * above don't validate enum ranges, and the unchecked
+		 * conversions in bch2_bkey_needs_reconcile() would BUG() or
+		 * index out of bounds on these.
+		 */
+		if (unlikely(opts->data_checksum >= BCH_CSUM_OPT_NR)) {
+			opts->data_checksum = c->opts.data_checksum;
+			opts->data_checksum_from_inode = false;
+		}
+		if (unlikely(!bch2_compression_opt_valid(opts->background_compression))) {
+			opts->background_compression = c->opts.background_compression;
+			opts->background_compression_from_inode = false;
+		}
 	}
 
 	return 0;

--- a/fs/data/reconcile/work.c
+++ b/fs/data/reconcile/work.c
@@ -454,9 +454,20 @@ static int reconcile_set_data_opts(struct btree_trans *trans,
 	struct bkey_ptrs_c ptrs = bch2_bkey_ptrs_c(k);
 	const union bch_extent_entry *entry;
 	struct extent_ptr_decoded p;
+	struct bch_extent_reconcile rb = *r;
 
-	unsigned csum_type = bch2_data_checksum_type_rb(c, *r);
-	unsigned compression_type = bch2_compression_opt_to_type(r->background_compression);
+	/*
+	 * Extents written by newer versions may carry checksum/compression
+	 * types we don't know about - fall back to the (already fixed up)
+	 * inode options for the rewrite, instead of tripping over them:
+	 */
+	if (rb.data_checksum >= BCH_CSUM_OPT_NR)
+		rb.data_checksum = opts->data_checksum;
+	if (!bch2_compression_opt_valid(rb.background_compression))
+		rb.background_compression = opts->background_compression;
+
+	unsigned csum_type = bch2_data_checksum_type_rb(c, rb);
+	unsigned compression_type = bch2_compression_opt_to_type(rb.background_compression);
 
 	if (r->need_rb & BIT(BCH_RECONCILE_data_replicas)) {
 		struct bkey_durability durability;


### PR DESCRIPTION
The reconcile path fed the on-disk reconcile entry's `data_checksum`
and `background_compression` straight into `bch2_data_checksum_type_rb()`
and `bch2_compression_opt_to_type()`, which `BUG()` or index out of
bounds on unknown values — and extents written by newer versions may
legitimately carry checksum/compression types we do not know. The
codebase's stated policy for this exact situation (inode opts,
`bch2_inode_opts_get_inode()`) is to fall back for new writes rather
than reject, because rejection at btree read time breaks forward
compatibility.

First commit: fall back to the inode opts for the rewrite in
`reconcile_set_data_opts()`. The same crash is also reachable earlier:
for reflink extents, `bch2_bkey_get_io_opts()` copies the persisted
values into the live opts when the `*_from_inode` bits are set, and
`bch2_io_opts_fixups()` does not validate enum ranges — so the
unchecked conversions in `bch2_bkey_needs_reconcile()` still saw the
raw on-disk values. Second commit: sanitise there too, clamping to the
filesystem option and clearing the `from_inode` bits, mirroring the
inode-opts policy.
