### PR TITLE
disk groups: reject parent cycles, bound the label walk

### DIFF
--- a/fs/alloc/disk_groups.c
+++ b/fs/alloc/disk_groups.c
@@ -142,36 +142,38 @@ static int bch2_sb_disk_groups_validate(struct bch_sb *sb, struct bch_sb_field *
 	}
 
 	/*
-	 * bch2_sb_disk_groups_to_cpu() walks parent chains without a bound,
-	 * so a parent cycle would make it loop forever: reject cycles
-	 * reachable from live entries. The walk passes through deleted
-	 * entries - chains through deleted groups work - and an out of
-	 * range parent ends the chain, since deleted entries are not
-	 * validated.
+	 * bch2_sb_disk_groups_to_cpu() walks parent chains starting from
+	 * each alive member's group, without a bound, so a parent cycle
+	 * would make it loop forever: reject cycles reachable from alive
+	 * members. The walk passes through deleted entries - chains through
+	 * deleted groups work - and an out of range parent ends the chain,
+	 * since deleted entries are not validated. Cycles in groups no
+	 * member references are unreachable and are tolerated.
 	 */
 	u8 *walked __free(kfree) = kcalloc(nr_groups, sizeof(*walked), GFP_KERNEL);
 	if (!walked)
 		return -BCH_ERR_ENOMEM_disk_groups_validate;
 
-	for (unsigned i = 0; i < nr_groups; i++) {
+	for (unsigned i = 0; i < sb->nr_devices; i++) {
+		struct bch_member m = bch2_sb_member_get(sb, i);
 		u64 v;
 
-		if (BCH_GROUP_DELETED(&groups->entries[i]) || walked[i])
+		if (!bch2_member_alive(&m))
 			continue;
 
-		v = i + 1;
+		v = BCH_MEMBER_GROUP(&m);
 		while (v && v <= nr_groups && !walked[v - 1]) {
 			walked[v - 1] = 1;	/* on the current path */
 			v = BCH_GROUP_PARENT(&groups->entries[v - 1]);
 		}
 
 		if (v && v <= nr_groups && walked[v - 1] == 1) {
-			prt_printf(err, "label %u parent chain contains a cycle", i);
+			prt_printf(err, "disk %u label parent chain contains a cycle", i);
 			return -BCH_ERR_invalid_sb_disk_groups;
 		}
 
 		/* mark the chain done: it has been shown to terminate */
-		v = i + 1;
+		v = BCH_MEMBER_GROUP(&m);
 		while (v && v <= nr_groups && walked[v - 1] == 1) {
 			walked[v - 1] = 2;
 			v = BCH_GROUP_PARENT(&groups->entries[v - 1]);

--- a/fs/alloc/disk_groups.c
+++ b/fs/alloc/disk_groups.c
@@ -219,8 +219,9 @@ static __cold void bch2_sb_disk_groups_to_text(struct printbuf *out,
 		if (BCH_GROUP_DELETED(g))
 			prt_printf(out, "[deleted]");
 		else
-			prt_printf(out, "[parent %llu name %s]",
-			       BCH_GROUP_PARENT(g), g->label);
+			prt_printf(out, "[parent %llu name %.*s]",
+			       BCH_GROUP_PARENT(g),
+			       (int) sizeof(g->label), g->label);
 	}
 }
 

--- a/fs/alloc/disk_groups.c
+++ b/fs/alloc/disk_groups.c
@@ -124,10 +124,10 @@ static int bch2_sb_disk_groups_validate(struct bch_sb *sb, struct bch_sb_field *
 	}
 
 	/*
-	 * Parents are walked in bch2_sb_disk_groups_to_cpu() (bounded, so a
-	 * cycle is tolerated) and bch2_disk_path_to_text_sb(): an out of range
-	 * parent reads out of bounds, so reject those. Parents pointing at
-	 * deleted groups are tolerated - chains through deleted groups work.
+	 * Parents are walked in bch2_sb_disk_groups_to_cpu() and
+	 * bch2_disk_path_to_text_sb(): an out of range parent reads out of
+	 * bounds, so reject those. Parents pointing at deleted groups are
+	 * tolerated - chains through deleted groups work.
 	 */
 	for (unsigned i = 0; i < nr_groups; i++) {
 		if (BCH_GROUP_DELETED(&groups->entries[i]))
@@ -138,6 +138,43 @@ static int bch2_sb_disk_groups_validate(struct bch_sb *sb, struct bch_sb_field *
 			prt_printf(err, "label %u has invalid parent %llu (have %u)",
 				   i, parent - 1, nr_groups);
 			return -BCH_ERR_invalid_sb_disk_groups;
+		}
+	}
+
+	/*
+	 * bch2_sb_disk_groups_to_cpu() walks parent chains without a bound,
+	 * so a parent cycle would make it loop forever: reject cycles
+	 * reachable from live entries. The walk passes through deleted
+	 * entries - chains through deleted groups work - and an out of
+	 * range parent ends the chain, since deleted entries are not
+	 * validated.
+	 */
+	u8 *walked __free(kfree) = kcalloc(nr_groups, sizeof(*walked), GFP_KERNEL);
+	if (!walked)
+		return -BCH_ERR_ENOMEM_disk_groups_validate;
+
+	for (unsigned i = 0; i < nr_groups; i++) {
+		u64 v;
+
+		if (BCH_GROUP_DELETED(&groups->entries[i]) || walked[i])
+			continue;
+
+		v = i + 1;
+		while (v && v <= nr_groups && !walked[v - 1]) {
+			walked[v - 1] = 1;	/* on the current path */
+			v = BCH_GROUP_PARENT(&groups->entries[v - 1]);
+		}
+
+		if (v && v <= nr_groups && walked[v - 1] == 1) {
+			prt_printf(err, "label %u parent chain contains a cycle", i);
+			return -BCH_ERR_invalid_sb_disk_groups;
+		}
+
+		/* mark the chain done: it has been shown to terminate */
+		v = i + 1;
+		while (v && v <= nr_groups && walked[v - 1] == 1) {
+			walked[v - 1] = 2;
+			v = BCH_GROUP_PARENT(&groups->entries[v - 1]);
 		}
 	}
 
@@ -227,7 +264,17 @@ int bch2_sb_disk_groups_to_cpu(struct bch_fs *c)
 			continue;
 
 		g = BCH_MEMBER_GROUP(&m);
-		while (g) {
+		unsigned depth = 0;
+		while (g && depth++ <= nr_groups) {
+			/*
+			 * Defensive: never trust the on-disk graph to walk
+			 * itself - the validator rejects out-of-range parents
+			 * and cycles, but this walk must terminate and stay
+			 * in bounds even on a superblock that bypassed
+			 * validation.
+			 */
+			if (g > nr_groups)
+				break;
 			dst = &cpu_g->entries[g - 1];
 			__set_bit(i, dst->devs.d);
 			g = dst->parent;

--- a/fs/alloc/disk_groups_types.h
+++ b/fs/alloc/disk_groups_types.h
@@ -6,7 +6,7 @@
 
 struct bch_disk_group_cpu {
 	bool				deleted;
-	u16				parent;
+	u32				parent; /* on disk it's 24 bits */
 	u8				label[BCH_SB_LABEL_SIZE];
 	struct bch_devs_mask		devs;
 };


### PR DESCRIPTION
The disk_groups label tree has a parent walk, `bch2_sb_disk_groups_to_cpu()`,
that runs on every filesystem open without a bound — and the validator
explicitly tolerated parent cycles on the strength of a comment
([fs/alloc/disk_groups.c:126](https://github.com/koverstreet/bcachefs-tools/blob/76b8a0468e8607ea73367a536a0a15c0ced02ac4/fs/alloc/disk_groups.c#L126-L130))
claiming the walk was bounded. It is not: a parent cycle in the
superblock's disk_groups field makes the walk loop forever, hanging
fsck and mount, spinning on one core in userspace. An out-of-range parent on a deleted
entry that a live chain passes through also made the walk index
`cpu_g->entries` out of bounds.

Four commits:

1. Reject parent cycles in validation and give the walk a depth bound
   and an in-bounds check, so it terminates even when validation is
   bypassed. The cycle walk starts from alive members' groups,
   mirroring `to_cpu()` exactly: cycles in groups no member references
   are unreachable and stay tolerated.
2. Print group labels bounded (`%.*s`) in the superblock to_text: the
   label field is not NUL-terminated, and a full 32-byte label
   previously overread past the entry.
3. Widen the cpu parent to u32: the on-disk field is 24 bits, and the
   u16 copy truncated valid parents once there were more than 65536
   groups, silently building wrong ancestor masks.

Reproducer: format an image with `--metadata_checksum=none` and a
label, hex-patch one entry's parent to form a cycle (all superblock
copies), and run fsck. Measured against v1.38.8 and the pre-fix
master: member-reachable cycles — including one through a deleted
entry — hang before and get "label parent chain contains a cycle"
after, while an unreachable orphan cycle fscks clean on both.
