### PR TITLE
ec: drain stripe buffers only when initialised; init the closure first

### DIFF
--- a/fs/data/ec/io.c
+++ b/fs/data/ec/io.c
@@ -115,13 +115,21 @@ static void raid_rec(int nr, int *ir, int nd, int np, size_t size, void **v)
 void bch2_ec_stripe_buf_exit(struct ec_stripe_buf *buf)
 {
 	/*
+	 * Init may have failed or never run - nothing to drain, and
+	 * closure_sync() on a closure that was never initialised or
+	 * completed would sleep forever.
+	 */
+	if (!buf->c)
+		return;
+
+	/*
 	 * Drain in-flight stripe IO before freeing the buffers it reads/writes
 	 * into: the bios are mapped directly at buf->data[] and hold refs on
 	 * buf->io, so freeing first is a use-after-free.
 	 */
 	closure_sync(&buf->io);
 
-	if (buf->c) {
+	{
 		struct bch_fs *c = buf->c;
 		buf->c = NULL;
 		scoped_guard(spinlock, &c->ec.stripe_buf_lock) {
@@ -171,6 +179,15 @@ int bch2_ec_stripe_buf_init(struct bch_fs *c,
 		c->ec.stripe_buf_bytes += buf_bytes;
 	}
 
+	/*
+	 * Initialise before anything can fail from here on: the failure
+	 * paths and the callers' cleanup both run bch2_ec_stripe_buf_exit(),
+	 * which closure_sync()s this. (Not before the blocked check above:
+	 * that path returns and may retry, and reinitialising would
+	 * re-register the closure with the debug list.)
+	 */
+	closure_init(&buf->io, NULL);
+
 	buf->c		= c;
 	buf->offset	= offset;
 	buf->size	= end - offset;
@@ -179,12 +196,9 @@ int bch2_ec_stripe_buf_init(struct bch_fs *c,
 		buf->data[i] = kvmalloc(buf->size << 9, GFP_KERNEL);
 		if (!buf->data[i]) {
 			bch2_ec_stripe_buf_exit(buf);
-			buf->c = NULL;
 			return bch_err_throw(c, ENOMEM_stripe_buf);
 		}
 	}
-
-	closure_init(&buf->io, NULL);
 
 	return 0;
 }


### PR DESCRIPTION
This is a precaution, not a fix for a crash that fires today.
`bch2_ec_stripe_buf_init()`'s failure path performs teardown that is
only valid for a fully initialised buffer: it calls
`bch2_ec_stripe_buf_exit()` — which `closure_sync()`s `buf->io` —
before `closure_init()` has run, and the callers (the
`__free(ec_stripe_buf_free)` cleanup, the create worker's unconditional
exits) run `exit()` a second time. The teardown is not idempotent and
assumes it is the only caller.

Today's closure implementation happens to make the old code harmless,
and that is measured, not assumed: a TEST-ONLY fault-injection hook
fails the first stripe-buffer allocation (pinned to exactly
`bucket_size` bytes in the create path), and pre- and post-fix the
failure path behaves identically — ENOMEM propagates to the writer and
the filesystem survives. The reason is that the vendored closure's
`closure_sync()` no-ops on a zeroed closure (the remaining-refcount
guard) and the closure debug machinery no longer exists (`#if 0` in
`fs/vendor/closure.h`, with no implementation anywhere) — in the kernel
module as much as in userspace, since both compile the same vendored
closure.

Initialise the closure before anything can fail (after the
stripe_buf_mem_blocked check, which returns and may be retried), and
make `exit()` a no-op for buffers that were never charged — `buf->c` is
only set by a successful init — so each buffer drains exactly once. The
fix makes the failure path correct by construction, so a closure with
real debug machinery — or any caller that reuses a buffer — cannot
silently break against it.
