### PR TITLE
targets: copy the target mask out of RCU, don't hand out interior pointers

### DIFF
--- a/fs/alloc/disk_groups.c
+++ b/fs/alloc/disk_groups.c
@@ -243,31 +243,50 @@ int bch2_sb_disk_groups_to_cpu(struct bch_fs *c)
 	return 0;
 }
 
-const struct bch_devs_mask *bch2_target_to_mask(struct bch_fs *c, unsigned target)
+/*
+ * Fills devs with the mask for target, under RCU, and returns true - or
+ * returns false if target is invalid or specifies nothing. The mask is
+ * copied out because the underlying objects are RCU managed and are
+ * freed (kfree_rcu) when devices or labels change, so callers must not
+ * retain interior pointers past the RCU read side section.
+ */
+bool bch2_target_to_mask(struct bch_fs *c, unsigned target, struct bch_devs_mask *devs)
 {
 	struct target t = target_decode(target);
+	bool ret = true;
 
 	guard(rcu)();
 
 	switch (t.type) {
 	case TARGET_NULL:
-		return NULL;
+		ret = false;
+		break;
 	case TARGET_DEV: {
 		struct bch_dev *ca = t.dev < c->sb.nr_devices
 			? rcu_dereference(c->devs[t.dev])
 			: NULL;
-		return ca ? &ca->self : NULL;
+		if (!ca) {
+			ret = false;
+			break;
+		}
+		*devs = ca->self;
+		break;
 	}
 	case TARGET_GROUP: {
 		struct bch_disk_groups_cpu *g = rcu_dereference(c->disk_groups);
 
-		return g && t.group < g->nr && !g->entries[t.group].deleted
-			? &g->entries[t.group].devs
-			: NULL;
+		if (!g || t.group >= g->nr || g->entries[t.group].deleted) {
+			ret = false;
+			break;
+		}
+		*devs = g->entries[t.group].devs;
+		break;
 	}
 	default:
 		BUG();
 	}
+
+	return ret;
 }
 
 /* Interned failure domain id of a device, 0 = unset. Caller holds rcu. */

--- a/fs/alloc/disk_groups.h
+++ b/fs/alloc/disk_groups.h
@@ -56,7 +56,7 @@ static inline struct target target_decode(unsigned target)
 	return (struct target) { .type = TARGET_NULL };
 }
 
-const struct bch_devs_mask *bch2_target_to_mask(struct bch_fs *, unsigned);
+bool bch2_target_to_mask(struct bch_fs *, unsigned, struct bch_devs_mask *);
 u64 bch2_dev_domain_key(struct bch_fs *, const struct bch_devs_mask *, unsigned);
 unsigned bch2_target_nr_domains(struct bch_fs *, const struct bch_devs_mask *);
 
@@ -65,10 +65,10 @@ static inline struct bch_devs_mask target_rw_devs(struct bch_fs *c,
 						  u16 target)
 {
 	struct bch_devs_mask devs = c->allocator.rw_devs[data_type];
-	const struct bch_devs_mask *t = bch2_target_to_mask(c, target);
+	struct bch_devs_mask t;
 
-	if (t)
-		bitmap_and(devs.d, devs.d, t->d, BCH_SB_MEMBERS_MAX);
+	if (bch2_target_to_mask(c, target, &t))
+		bitmap_and(devs.d, devs.d, t.d, BCH_SB_MEMBERS_MAX);
 	return devs;
 }
 

--- a/fs/alloc/foreground.c
+++ b/fs/alloc/foreground.c
@@ -2116,10 +2116,13 @@ static void dev_alloc_debug_header(struct printbuf *out, struct bch_dev *ca)
 
 static inline bool dev_may_alloc(struct bch_fs *c, struct bch_dev *ca, struct alloc_request *req)
 {
-	if ((req->flags & BCH_WRITE_only_specified_devs) &&
-	    req->target &&
-	    !test_bit(ca->dev_idx, bch2_target_to_mask(c, req->target)->d))
-		return false;
+	if ((req->flags & BCH_WRITE_only_specified_devs) && req->target) {
+		struct bch_devs_mask target_devs;
+
+		if (!bch2_target_to_mask(c, req->target, &target_devs) ||
+		    !test_bit(ca->dev_idx, target_devs.d))
+			return false;
+	}
 
 	return ca->mi.state == BCH_MEMBER_STATE_rw &&
 		bch2_dev_is_online(ca) &&

--- a/fs/data/ec/create.c
+++ b/fs/data/ec/create.c
@@ -910,14 +910,16 @@ void bch2_disk_label_ec_rw_member_devs(struct bch_fs *c, unsigned disk_label,
 				       struct bch_devs_mask *devs,
 				       unsigned blocksize)
 {
+	struct bch_devs_mask t;
+
 	guard(rcu)();
 
-	const struct bch_devs_mask *t = disk_label
-		? bch2_target_to_mask(c, group_to_target(disk_label - 1))
-		: NULL;
+	if (disk_label &&
+	    !bch2_target_to_mask(c, group_to_target(disk_label - 1), &t))
+		disk_label = 0;
 
 	memset(devs, 0, sizeof(*devs));
-	for_each_member_device_rcu(c, ca, t)
+	for_each_member_device_rcu(c, ca, disk_label ? &t : NULL)
 		if (ca->mi.state == BCH_MEMBER_STATE_rw &&
 		    (ca->mi.data_allowed & BIT(BCH_DATA_user)) &&
 		    ca->mi.durability &&

--- a/fs/data/read.c
+++ b/fs/data/read.c
@@ -93,9 +93,12 @@ static bool bch2_target_congested(struct bch_fs *c, u16 target)
 	unsigned d, nr = 0, total = 0;
 	u64 now = local_clock();
 
+	struct bch_devs_mask target_devs;
+
 	guard(rcu)();
-	devs = bch2_target_to_mask(c, target) ?:
-		&c->allocator.rw_devs[BCH_DATA_user];
+	if (!bch2_target_to_mask(c, target, &target_devs))
+		target_devs = c->allocator.rw_devs[BCH_DATA_user];
+	devs = &target_devs;
 
 	for_each_set_bit(d, devs->d, BCH_SB_MEMBERS_MAX) {
 		struct bch_dev *ca = rcu_dereference(c->devs[d]);


### PR DESCRIPTION
`bch2_target_to_mask()` returned pointers into RCU-managed objects
(`&ca->self`, `&g->entries[].devs`) after its own RCU read-side
section ended. `target_rw_devs()` dereferenced the returned mask with
no RCU protection at all — a genuine use-after-free window against the
`kfree_rcu()` frees that happen on label changes and device removal.
The other three call sites held RCU guards of their own at the point
of use, but the API shape made any future unguarded caller silently
unsafe.

Change the API to copy the mask into a caller-provided buffer under
RCU, and update the four call sites. `dev_may_alloc()` additionally
handles a target that fails to resolve by rejecting the device instead
of dereferencing NULL.

Runtime reproducer (userspace, ASAN): a TEST-ONLY rendezvous parks the
deref in `target_rw_devs()` — holding no RCU read lock, after the
interior pointer is fetched — while a second thread churns the device
label (`kfree_rcu` of the old cpu groups) and `synchronize_rcu()`s, so
the free is guaranteed to have run before the parked deref. Measured:
pre-fix, two deterministic `heap-use-after-free` reports at the
`bitmap_and` in `target_rw_devs()` (freed via `rcu_free_wrapper_cb`);
post-fix, the same driver and churn run clean (zero reports). The
driver and the TEST-ONLY hook are attached as a comment on this PR.
