### PR TITLE
scripts: verify rust/libmacros.so ELF architecture compatibility

### DIFF
--- a/fs/scripts/rust-is-available-dkms.sh
+++ b/fs/scripts/rust-is-available-dkms.sh
@@ -22,6 +22,56 @@ canonical_version()
 	echo $((100000 * $1 + 100 * $2 + $3))
 }
 
+get_elf_arch()
+{
+	_file=$1
+	[ -f "$_file" ] || return 1
+
+	# Read 20 bytes (magic + class + endian + ... + e_machine) in a single od call
+	_raw=$(od -v -An -N 20 -t x1 "$_file" 2>/dev/null) || return 1
+	set -f
+	set -- $_raw
+	set +f
+
+	[ $# -eq 20 ] || return 1
+
+	# Verify ELF magic header (\x7f E L F) using $1..$4
+	[ "$1$2$3$4" = "7f454c46" ] || return 1
+
+	_class=$5   # offset 4 (1 = 32-bit, 2 = 64-bit)
+	_endian=$6  # offset 5 (1 = Little-Endian, 2 = Big-Endian)
+	_m1=${19}   # offset 18
+	_m2=${20}   # offset 19
+
+	if [ "$_endian" = "02" ]; then
+		_m="$_m2 $_m1"
+	else
+		_m="$_m1 $_m2"
+	fi
+
+	case "$_m" in
+		"3e 00") echo "x86_64" ;;
+		"b7 00") echo "aarch64" ;;
+		"28 00") echo "arm" ;;
+		"f3 00") [ "$_class" = "01" ] && echo "riscv32" || echo "riscv64" ;;
+		"03 00") echo "x86" ;;
+		"15 00") echo "ppc64" ;;
+		"16 00") echo "s390x" ;;
+		"02 01") echo "loongarch64" ;; # EM_LOONGARCH (258 = 0x0102)
+		*)       echo "unknown (0x$_m)" ;;
+	esac
+}
+
+# Reuses get_elf_arch on native host binaries to eliminate duplicate arch tables
+get_host_arch()
+{
+	for _bin in "${HOSTRUSTC:-$RUSTC}" "$RUSTC" "${CC:-cc}" /bin/sh; do
+		_path=$(command -v "$_bin" 2>/dev/null) || continue
+		_arch=$(get_elf_arch "$_path") && [ -n "$_arch" ] && { echo "$_arch"; return 0; }
+	done
+	uname -m 2>/dev/null || echo "unknown"
+}
+
 # Fall back to the C-only module, reporting exactly what's missing. The reason
 # IS the verdict: stdout is "y", or else the reason we couldn't. The Makefile
 # bakes that into the module, so the mount-time "built without Rust support"
@@ -115,6 +165,19 @@ libcore_version=$(head -c 4096 "$libcore" 2>/dev/null | tr -c '[:print:]' '\n' |
 
 if [ -n "$libcore_version" ] && [ "$libcore_version" != "$rustc_version" ]; then
 	skip "rustc $rustc_version cannot use the kernel's Rust stdlib, which was built by rustc $libcore_version ($libcore)"
+fi
+
+# Proc-macro shared libraries (rust/libmacros.so) are dynamically loaded into
+# rustc at build time, so their architecture must match the host running rustc.
+libmacros=$KERNEL_OBJ/rust/libmacros.so
+
+if [ -r "$libmacros" ] && command -v od >/dev/null 2>&1; then
+	host_arch=$(get_host_arch)
+	macro_arch=$(get_elf_arch "$libmacros")
+
+	if [ -n "$host_arch" ] && [ -n "$macro_arch" ] && [ "$host_arch" != "$macro_arch" ]; then
+		skip "host architecture ($host_arch) does not match rust/libmacros.so ($macro_arch); native kernel headers required"
+	fi
 fi
 
 echo y


### PR DESCRIPTION
## Summary
Adds an ELF architecture compatibility check for `rust/libmacros.so` to the DKMS Rust availability script (`rust-is-available-dkms.sh`).

### Problem 
When building out-of-tree Rust modules via DKMS, `rustc` dynamically loads procedural macro shared libraries (`rust/libmacros.so`) directly into its host process at compile time via `dlopen()`.

If kernel headers or prebuilt kernel artifacts were cross-compiled on a different host architecture (e.g., compiled on `x86_64` and installed on an `aarch64` target system), host `rustc` cannot load the foreign `.so`. This causes DKMS builds to fail deep inside `rustc` with cryptic dynamic linking or crate loading errors (`E0463`).

This test catches architecture mismatches early and gracefully falls back to building the C-only module, logging the exact cause in the DKMS build log.

### **Implementation Details**
1. **`get_elf_arch()`**: Reads the first 20 bytes of an ELF header in a single POSIX `od` call, extracting ELF class, endianness, and `e_machine` (`x86_64`, `aarch64`, `arm`, `riscv`, `loongarch64`, etc.).
2. **`get_host_arch()`**: Reuses `get_elf_arch()` on native host binaries (`$HOSTRUSTC`, `$RUSTC`, `$CC`, or `/bin/sh`). This guarantees 1:1 string parity between the running toolchain and `libmacros.so`, preventing false positives on 32-bit platforms (`arm` vs `armv7l`) or in chroot/container environments.
3. **Mismatch Fallback**: If a mismatch is found (`$host_arch != $macro_arch`), `skip()` is triggered with a clear diagnostic:
   > `bcachefs: building without Rust — host architecture (aarch64) does not match rust/libmacros.so (x86_64); native kernel headers required`