### PR TITLE
bcachefs: handle NULL fs in bch2_disk_path_to_text()

### DIFF
--- a/fs/alloc/disk_groups.c
+++ b/fs/alloc/disk_groups.c
@@ -552,7 +552,11 @@ __cold void bch2_disk_path_to_text(struct printbuf *out, struct bch_fs *c, unsig
 {
 	guard(printbuf_atomic)(out);
 	guard(rcu)();
-	__bch2_disk_path_to_text(out, rcu_dereference(c->disk_groups), v);
+
+	/* May be called with a NULL fs: */
+	struct bch_disk_groups_cpu *g = c ? rcu_dereference(c->disk_groups) : NULL;
+
+	__bch2_disk_path_to_text(out, g, v);
 }
 
 void bch2_disk_path_to_text_sb(struct printbuf *out, struct bch_sb *sb, unsigned v)


### PR DESCRIPTION
The sb validation error path prints sections with a NULL bch_fs. A corrupt
clean section containing an ec stripe key reaches bch2_stripe_to_text() and
then bch2_disk_path_to_text(), which dereferences c->disk_groups through
NULL.

__bch2_disk_path_to_text() already handles a NULL groups pointer and
invalid indexes; the wrapper passes NULL when there is no filesystem
context.

Found by fuzzing the offline tools with AFL++/ASAN; reproduced on an
unmodified build with a re-checksummed input.