### PR TITLE
bcachefs: guard backpointer to_text against unvalidated keys

### DIFF
--- a/fs/alloc/backpointers.c
+++ b/fs/alloc/backpointers.c
@@ -55,6 +55,13 @@ fsck_err:
 
 __cold void bch2_backpointer_to_text(struct printbuf *out, struct bch_fs *c, struct bkey_s_c k)
 {
+	/* We may be called on unvalidated keys: */
+	if (k.k->u64s <= BKEY_U64s ||
+	    bkey_val_u64s(k.k) * sizeof(u64) < sizeof(struct bch_backpointer)) {
+		prt_str(out, "(invalid, backpointer value truncated)");
+		return;
+	}
+
 	struct bkey_s_c_backpointer bp = bkey_s_c_to_backpointer(k);
 
 	struct bch_dev *ca;
@@ -68,16 +75,23 @@ __cold void bch2_backpointer_to_text(struct printbuf *out, struct bch_fs *c, str
 
 	if (ca)
 		prt_printf(out, "bucket=%llu:%llu:%u ", bucket.inode, bucket.offset, bucket_offset);
-	else
+	else if (c)
 		prt_printf(out, "sector=%llu:%llu ", bp.k->p.inode, bp.k->p.offset >> c->sb.extent_bp_shift);
+	else
+		prt_printf(out, "pos=%llu:%llu ", bp.k->p.inode, bp.k->p.offset);
 
 	bch2_btree_id_level_to_text(out, bp.v->btree_id, bp.v->level);
 	prt_str(out, " data_type=");
 	bch2_prt_data_type(out, bp.v->data_type);
-	prt_printf(out, " suboffset=%u len=%u gen=%u pos=",
-		   (u32) bp.k->p.offset & ~(~0U << c->sb.extent_bp_shift),
-		   bp.v->bucket_len,
-		   bp.v->bucket_gen);
+	if (c)
+		prt_printf(out, " suboffset=%u len=%u gen=%u pos=",
+			   (u32) bp.k->p.offset & ~(~0U << c->sb.extent_bp_shift),
+			   bp.v->bucket_len,
+			   bp.v->bucket_gen);
+	else
+		prt_printf(out, " len=%u gen=%u pos=",
+			   bp.v->bucket_len,
+			   bp.v->bucket_gen);
 	bch2_bpos_to_text(out, bp.v->pos);
 
 	if (BACKPOINTER_RECONCILE_PHYS(bp.v))


### PR DESCRIPTION
bch2_backpointer_to_text() can run on unvalidated keys. When a superblock
section fails validation, bch2_sb_field_validate() prints the section with
bch2_sb_field_to_text() and a NULL bch_fs; a corrupt clean section
containing a backpointer key reaches the printer through
journal_entry_btree_keys_to_text(). Two crashes follow: a backpointer value
truncated below sizeof(struct bch_backpointer) dereferences a garbage
pointer, and even a well-formed backpointer crashes on
c->sb.extent_bp_shift when c is NULL.

Found by fuzzing the offline tools with AFL++/ASAN; reproduced on an
unmodified build with a re-checksummed input.

Fix: return early with an invalid marker when the key header or value is
truncated, and print a plain position instead of dereferencing c when
there is no filesystem context. The size check runs ahead of the typed
key conversion, so an unvalidated key never reaches
bkey_s_c_to_backpointer()'s type assertion.

The kernel tree has the same fix with kunit tests in
https://github.com/koverstreet/bcachefs/pull/1201.