### PR TITLE
bcachefs: guard stripe to_text and validate against unvalidated keys

### DIFF
--- a/fs/data/ec/trigger.c
+++ b/fs/data/ec/trigger.c
@@ -48,6 +48,22 @@ int bch2_stripe_validate(struct bch_fs *c, struct bkey_s_c k,
 	const struct bch_stripe *s = bkey_s_c_to_stripe(k).v;
 	int ret = 0;
 
+	/* Checked before stripe_val_u64s(), which reads the value: */
+	bkey_fsck_err_on(k.k->u64s <= BKEY_U64s ||
+			 bkey_val_u64s(k.k) * sizeof(u64) < sizeof(struct bch_stripe),
+			 c, stripe_val_size_bad,
+			 "value truncated (%u u64s)", k.k->u64s);
+
+	bkey_fsck_err_on(s->csum_type >= BCH_CSUM_NR,
+			 c, stripe_csum_type_bad,
+			 "invalid csum type (%u >= %u)",
+			 s->csum_type, BCH_CSUM_NR);
+
+	bkey_fsck_err_on(s->csum_granularity_bits >= 31,
+			 c, stripe_csum_granularity_bad,
+			 "invalid csum granularity (%u >= 31)",
+			 s->csum_granularity_bits);
+
 	bkey_fsck_err_on(bkey_eq(k.k->p, POS_MIN) ||
 			 bpos_gt(k.k->p, POS(0, U32_MAX)),
 			 c, stripe_pos_bad,
@@ -57,11 +73,6 @@ int bch2_stripe_validate(struct bch_fs *c, struct bkey_s_c k,
 			 c, stripe_val_size_bad,
 			 "incorrect value size (%zu < %u)",
 			 bkey_val_u64s(k.k), stripe_val_u64s(s));
-
-	bkey_fsck_err_on(s->csum_granularity_bits >= 64,
-			 c, stripe_csum_granularity_bad,
-			 "invalid csum granularity (%u >= 64)",
-			 s->csum_granularity_bits);
 
 	bkey_fsck_err_on(!s->sectors,
 			 c, stripe_sectors_zero,

--- a/fs/data/ec/trigger.c
+++ b/fs/data/ec/trigger.c
@@ -75,6 +75,13 @@ fsck_err:
 __cold void bch2_stripe_to_text(struct printbuf *out, struct bch_fs *c,
 			 struct bkey_s_c k)
 {
+	/* We may be called on unvalidated keys: */
+	if (k.k->u64s <= BKEY_U64s ||
+	    bkey_val_u64s(k.k) * sizeof(u64) < sizeof(struct bch_stripe)) {
+		prt_str(out, "(invalid, stripe value truncated)");
+		return;
+	}
+
 	const struct bch_stripe *sp = bkey_s_c_to_stripe(k).v;
 	struct bch_stripe s = {};
 
@@ -95,7 +102,7 @@ __cold void bch2_stripe_to_text(struct printbuf *out, struct bch_fs *c,
 		prt_printf(out, "(invalid shift %u)", s.csum_granularity_bits);
 
 	prt_str(out, " label=");
-	if (s.disk_label)
+	if (s.disk_label && c)
 		bch2_disk_path_to_text(out, c, s.disk_label - 1);
 	else
 		prt_str(out, "(none)");
@@ -120,6 +127,7 @@ __cold void bch2_stripe_to_text(struct printbuf *out, struct bch_fs *c,
 		bch2_extent_ptr_to_text(out, c, ptr);
 
 		if (s.csum_type < BCH_CSUM_NR &&
+		    s.csum_granularity_bits < 31 &&
 		    stripe_blockcount_offset(&s, i) < bkey_val_bytes(k.k))
 			prt_printf(out,  "#%u", stripe_blockcount_get(sp, i));
 	}

--- a/fs/sb/errors_format.h
+++ b/fs/sb/errors_format.h
@@ -204,6 +204,7 @@ enum bch_fsck_flags {
 	x(stripe_pos_bad,					167,	0)		\
 	x(stripe_val_size_bad,					168,	0)		\
 	x(stripe_csum_granularity_bad,				290,	0)		\
+	x(stripe_csum_type_bad,					361,	0)		\
 	x(stripe_sectors_zero,					340,	0)		\
 	x(stripe_sector_count_wrong,				169,	0)		\
 	x(stripe_parity_block_sector_count_wrong,		360,	0)		\


### PR DESCRIPTION
bch2_stripe_to_text() may be called on unvalidated keys: the sb
validation error path prints a corrupt clean section's journal entries,
and a stripe key with a truncated header or value made it read past the
key — the memcpy of struct bch_stripe picked a wrapped bkey_val_bytes(),
and the ptr loop's bkey_val_end() bound wrapped past the key as well.

Return early with an invalid marker when the header is truncated
(bkey_val_u64s() underflows when u64s < BKEY_U64s, so the header length
is checked explicitly) or the value is smaller than struct bch_stripe.
The disk_label branch additionally checks c, and the blockcount print
skips csum_granularity_bits >= 31 (the shift would be UB).

bch2_stripe_validate() had the same problem: it computed
stripe_val_u64s(s) before checking the value size, csum type, or csum
granularity — reading past a truncated value, indexing bch_crc_bytes[]
out of bounds for a corrupt csum type, and shifting an int by >= 31 (UB)
for a corrupt granularity. Check those first, and report the new
stripe_csum_type_bad errcode.

Found by fuzzing the offline tools with AFL++/ASAN.