### PR TITLE
checksum: fix inverted passphrase check

### DIFF
--- a/fs/data/checksum.c
+++ b/fs/data/checksum.c
@@ -513,8 +513,8 @@ int bch2_request_key(struct bch_sb *sb, struct bch_key *key)
 		 * a checksum error somewhere further on.
 		 */
 		ret = bch2_passphrase_check(sb, passphrase, key, &sb_key)
-			? 0
-			: -ENOKEY;
+			? -ENOKEY
+			: 0;
 
 		memzero_explicit(passphrase, strlen(passphrase));
 		free(passphrase);


### PR DESCRIPTION
bch2_passphrase_check() returns true when the passphrase is wrong

Fixes: 6b6300e68c36 ("checksum: a wrong passphrase is not success")