### PR TITLE
fs/Makefile: probe for rust-src when checking vendored Rust support

### DIFF
--- a/fs/Makefile
+++ b/fs/Makefile
@@ -331,6 +331,8 @@ bcachefs-rust-probe := $(shell					\
 		{ echo 'kernel tree has no scripts/generate_rust_target.rs'; exit 0; }; \
 	[ -r '$(objtree)/include/generated/rustc_cfg' ] ||		\
 		{ echo 'kernel tree has no include/generated/rustc_cfg'; exit 0; }; \
+	[ -r "$$($(RUSTC) --print sysroot)/lib/rustlib/src/rust/library/core/src/lib.rs" ] || \
+		{ echo 'rust-src not found'; exit 0; }; \
 	echo y)
 bcachefs-rust-y := $(if $(filter y,$(bcachefs-rust-probe)),y,n)
 bcachefs-rust-why := $(if $(filter y,$(bcachefs-rust-probe)),,$(bcachefs-rust-probe))


### PR DESCRIPTION
When building the out-of-tree kernel module on kernels < 7.0 without CONFIG_RUST, bcachefs builds a vendored Rust stack from standard library sources (rust-src) at $(RUST_LIB_SRC)/core/src/lib.rs.

The probe (bcachefs-rust-probe) checks whether prerequisites are present so it can fall back to building a C-only module if any are missing. However, it tested for rustc, bindgen, and kernel config files, but omitted checking for rust-src. When bindgen was installed on the system but rust-src was missing from the rustc sysroot, the probe falsely succeeded and the build failed with:

  make[5]: No rule to make target lib.rs, needed by core.o

Add the check for $(RUST_LIB_SRC)/core/src/lib.rs to bcachefs-rust-probe so that a missing rust-src triggers the intended fallback to a C-only module.

Link: https://bugs.gentoo.org/981733