### PR TITLE
bcachefs: Add promote_skip_congested and promote_congestion_mult options

### DIFF
--- a/fs/data/read.c
+++ b/fs/data/read.c
@@ -94,6 +94,9 @@ static bool bch2_target_congested(struct bch_fs *c, u16 target)
 	unsigned d, nr = 0, total = 0;
 	u64 now = local_clock();
 
+	if (!c->opts.promote_skip_congested)
+		return false;
+
 	guard(rcu)();
 	devs = bch2_target_to_mask(c, target) ?:
 		&c->allocator.rw_devs[BCH_DATA_user];

--- a/fs/data/write.c
+++ b/fs/data/write.c
@@ -761,10 +761,22 @@ MODULE_PARM_DESC(write_corrupt_ratio, "");
 static inline void bch2_congested_acct(struct bch_dev *ca, u64 io_latency,
 				       u64 now, int rw)
 {
+	/*
+	 * The threshold is a multiple of the device's fast read quantile: the
+	 * historical constant was 4 (8 for writes). On devices with a flat
+	 * latency distribution (Optane, enterprise NVMe) the median sits above
+	 * 4x the fastest quantile, so the counter pins at CONGESTED_MAX and
+	 * promotes are refused almost always; promote_congestion_mult lets the
+	 * admin widen the margin. The counter is always maintained (it is
+	 * reported in sysfs); whether promotes act on it is
+	 * promote_skip_congested.
+	 */
+	unsigned mult = ca->fs->opts.promote_congestion_mult;
+
 	u64 latency_capable =
 		ca->io_latency[rw].quantiles.entries[QUANTILE_IDX(1)].m;
 	/* ideally we'd be taking into account the device's variance here: */
-	u64 latency_threshold = latency_capable << (rw == READ ? 2 : 3);
+	u64 latency_threshold = latency_capable * (rw == READ ? mult : mult * 2);
 	s64 latency_over = io_latency - latency_threshold;
 
 	if (latency_threshold && latency_over > 0) {

--- a/fs/opts.h
+++ b/fs/opts.h
@@ -224,6 +224,16 @@ enum fsck_err_opts {
 	  OPT_FN(bch2_opt_target),					\
 	  BCH_SB_PROMOTE_TARGET,	0,				\
 	  "(target)",	"Device or label to promote data to on read")	\
+	x(promote_skip_congested,	u8,				\
+	  OPT_FS|OPT_MOUNT|OPT_RUNTIME,					\
+	  OPT_BOOL(),							\
+	  BCH2_NO_SB_OPT,		true,				\
+	  NULL,		"Skip promoting to a target whose devices are congested")\
+	x(promote_congestion_mult,	u8,				\
+	  OPT_FS|OPT_MOUNT|OPT_RUNTIME,					\
+	  OPT_UINT(1, 64),						\
+	  BCH2_NO_SB_OPT,		4,				\
+	  NULL,		"A device counts as congested when reads exceed this multiple of its fast read latency")\
 	x(erasure_code,			u16,				\
 	  OPT_FS|OPT_INODE|OPT_FORMAT|OPT_MOUNT_OLD|OPT_RUNTIME,	\
 	  OPT_BOOL(),							\


### PR DESCRIPTION
The promote path refuses to write a cached copy when the promote target is "congested". Congestion is a per-device counter fed by reads whose latency exceeds 4x the device's fast latency quantile (`bch2_congested_acct()`), and `should_promote()` draws randomly against it.

On devices with a flat latency distribution the median read sits above that 4x line, so the counter pins at `CONGESTED_MAX` and promotes are refused almost always. Measured on a 190T pool (8 HDD + 2 NAND + 1 Optane P4800X as `promote_target` for a Postgres working set), bcachefs 1.39.4:

| | |
|---|---|
| Optane read threshold (4x fast quantile) | 47 µs |
| Optane median read | 59 µs |
| promote candidates not yet cached, per minute | 39,450 |
| refused as congested | 39,079 (99%) |
| cache device growth | 127 MiB/min |
| HDD reads that were never cached | ~1,000/s, 9-35 ms each, all Postgres `DataFileRead` waits |

The heuristic is right for a consumer SSD whose reads are slow because it is busy writing, and wrong for a device whose fastest quantile is simply far below its median. Today the only way around it is `CONFIG_BCACHEFS_NO_LATENCY_ACCT`, which removes all latency accounting.

This adds two runtime filesystem options (also accepted at mount), neither stored on disk:

- `promote_skip_congested` (bool, default true): whether `should_promote()` consults the congestion counter at all. Off means promotes are never skipped for congestion; the counter is still maintained and reported in sysfs.
- `promote_congestion_mult` (1..64, default 4): the multiple of a device's fast read quantile above which a read counts as congested. Writes keep 2x that, so the default reproduces the existing behaviour exactly.

Two options rather than one with a magic value, so that a multiplier of 0 never has to mean "off" when it would naturally mean "everything is congested".

Tested on the same pool with this patch on top of v1.39.4 (module reloaded live, no reboot): with `promote_skip_congested=0`, 42,673 not-yet-cached promote candidates over two minutes, 0 refused, 2.0 GB promoted, the Optane cache growing 609 MiB in those two minutes versus 127 MiB per minute before. Defaults unchanged reproduce the previous counter values exactly.

Signed-off-by is on the commit.
