### PR TITLE
bcachefs: omit pointer staleness without allocator state

### DIFF
--- a/fs/data/extents.c
+++ b/fs/data/extents.c
@@ -1786,7 +1786,17 @@ __cold void bch2_extent_ptr_to_text(struct printbuf *out, struct bch_fs *c, cons
 			   ca->name, ptr->dev, b, offset, ptr->generation);
 		if (ca->mi.durability != 1)
 			prt_printf(out, " d=%u", ca->mi.durability);
-		int stale = dev_ptr_stale_rcu(ca, ptr);
+
+		/*
+		 * Except for a new fs, bucket generations are not valid until
+		 * alloc_read completes. Treating a nostart fs's zero-filled table
+		 * as live state manufactures stale=N output.
+		 */
+		int stale = 0;
+
+		if (test_bit(BCH_FS_new_fs, &c->flags) ||
+		    c->recovery.passes_complete & BIT_ULL(BCH_RECOVERY_PASS_alloc_read))
+			stale = dev_ptr_stale_rcu(ca, ptr);
 		if (stale)
 			prt_printf(out, " stale=%i", stale);
 	}

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -131,9 +131,9 @@ fn list_nodes_ondisk(fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
 /// List keys from a mounted filesystem: the keys come from the kernel via
 /// BCH_IOCTL_QUERY_BTREE_KEYS, and are formatted with a userspace bch_fs
 /// opened noexcl|nostart alongside the mount - never started, so the
-/// journal is never read; everything key formatting needs (extent entry
-/// tables, member names, disk groups) comes from the superblock. Output
-/// is identical to the offline path by construction.
+/// journal is never read. Static formatting state such as member names and
+/// disk groups comes from the superblock; annotations needing live allocator
+/// state are omitted.
 fn list_keys_online(handle: &BcachefsHandle, fs: &Fs, opt: &Cli) -> anyhow::Result<()> {
     let mut flags = OnlineIterFlags::default();
     if opt.start.snapshot == 0 {


### PR DESCRIPTION
Mounted `bcachefs list` fetches live keys from the kernel but formats them with a separate nostart userspace filesystem. That filesystem has zero-filled bucket generations because it never runs `alloc_read`. Once a live pointer generation crosses 128, the signed generation comparison can manufacture a `stale=N` annotation.

Only report staleness after allocator state has been read, or for a new filesystem whose allocator state is already live. The documentation is also corrected so it no longer says that every formatting dependency comes from the superblock.

The minimal reproducer repeatedly reuses a 256 MiB filesystem, then compares online and offline formatting of one surviving pointer. Exact control `aced5322e` reports `stale=116` at generation 140; the patch reports no staleness and makes online and offline output agree. Earlier broad validation checked 128 pointers and completed no-repair fsck in both cells. The range-diff-identical presentation tree on current `testing` commit `b87c2a19b` builds the complete userspace binary.

<details>
<summary>Minimal reproducer (destroys the supplied block device)</summary>

```bash
#!/usr/bin/env bash
# Run only in a disposable VM: this destroys the supplied block device.

set -o errexit
set -o nounset

if (( $# != 1 )) || [[ ! -b $1 ]]; then
	echo "usage: $0 /dev/disposable-block-device" >&2
	exit 2
fi

dev=$1
tmp=$(mktemp -d /tmp/list-online-stale.XXXXXX)
mnt=$tmp/mnt

cleanup()
{
	umount "$mnt" 2>/dev/null || true
	rm -rf -- "$tmp"
}
trap cleanup EXIT

mkdir "$mnt"
bcachefs format --force --compression=none "$dev"
mount -t bcachefs -o nocopygc_enabled,noreconcile_enabled "$dev" "$mnt"

# Reusing this nearly-full, deliberately small filesystem advances bucket
# generations past the signed 8-bit boundary that exposes the bug.
for _ in {1..140}; do
	dd if=/dev/zero of="$mnt/churn" bs=4M count=40 \
		oflag=direct conv=fsync status=none
	rm "$mnt/churn"
	sync
done

dd if=/dev/zero of="$mnt/survivor" bs=128K count=1 \
	oflag=direct conv=fsync status=none
inode=$(stat --format='%i' "$mnt/survivor")
range=(--btree extents --start "$inode:0" --end "$((inode + 1)):0")

bcachefs list "${range[@]}" "$mnt" > "$tmp/online"

umount "$mnt"
bcachefs list "${range[@]}" "$dev" > "$tmp/offline"

gen=$(sed -nE 's/.* gen ([0-9]+).*/\1/p' "$tmp/offline")
if [[ ! $gen =~ ^[0-9]+$ ]]; then
	echo "trigger missed: expected exactly one pointer" >&2
	exit 1
fi
if (( gen <= 128 )); then
	echo "trigger missed: pointer generation is only $gen" >&2
	exit 1
fi

if ! cmp <(sed -E 's/ stale=-?[0-9]+//g' "$tmp/online") "$tmp/offline"; then
	echo "online and offline output differ beyond the stale annotation" >&2
	exit 1
fi

if grep -q ' stale=' "$tmp/online"; then
	grep -m 1 ' stale=' "$tmp/online" >&2
	echo "BUG: mounted bcachefs list falsely reported a stale pointer" >&2
	exit 1
fi

echo "PASS: online and offline output agree at pointer generation $gen"
```

</details>
